### PR TITLE
[build] remove un-need build option in setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ FastDeploy.cmake
 build-debug.sh
 *dist
 fastdeploy.egg-info
+fastdeploy_python.egg-info
+fastdeploy_gpu_python.egg-info
 .setuptools-cmake-build
 fastdeploy/version.py
 fastdeploy/core/config.h
@@ -15,5 +17,5 @@ fastdeploy/LICENSE*
 fastdeploy/ThirdPartyNotices*
 *.so*
 fastdeploy/libs/third_libs
-csrcs/fastdeploy/core/config.h
-csrcs/fastdeploy/pybind/main.cc
+csrc/fastdeploy/core/config.h
+csrc/fastdeploy/pybind/main.cc

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup_configs["ENABLE_PADDLE_FRONTEND"] = os.getenv("ENABLE_PADDLE_FRONTEND",
 setup_configs["ENABLE_ORT_BACKEND"] = os.getenv("ENABLE_ORT_BACKEND", "ON")
 setup_configs["ENABLE_PADDLE_BACKEND"] = os.getenv("ENABLE_PADDLE_BACKEND",
                                                    "OFF")
-setup_configs["BUILD_DEMO"] = os.getenv("BUILD_DEMO", "ON")
 setup_configs["ENABLE_VISION"] = os.getenv("ENABLE_VISION", "ON")
 setup_configs["ENABLE_TRT_BACKEND"] = os.getenv("ENABLE_TRT_BACKEND", "OFF")
 setup_configs["WITH_GPU"] = os.getenv("WITH_GPU", "OFF")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
 remove un-need build option `BUILD_DEMO` in `setup.py` for python wheel building process, `BUILD_DEMO` had been removed in CMakeLists.txt