### PR TITLE
[win] fix win build error and optimize cuda version check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,9 @@ if(BUILD_EXAMPLES AND EXISTS ${PROJECT_SOURCE_DIR}/examples)
 endif()
 
 add_definitions(-DFASTDEPLOY_LIB)
+# configure files before glob sources.
+configure_file(${PROJECT_SOURCE_DIR}/${CSRCS_DIR_NAME}/fastdeploy/core/config.h.in ${PROJECT_SOURCE_DIR}/${CSRCS_DIR_NAME}/fastdeploy/core/config.h)
+configure_file(${PROJECT_SOURCE_DIR}/${CSRCS_DIR_NAME}/fastdeploy/pybind/main.cc.in ${PROJECT_SOURCE_DIR}/${CSRCS_DIR_NAME}/fastdeploy/pybind/main.cc)
 file(GLOB_RECURSE ALL_DEPLOY_SRCS ${PROJECT_SOURCE_DIR}/${CSRCS_DIR_NAME}/fastdeploy/*.cc)
 file(GLOB_RECURSE FDTENSOR_FUNC_SRCS ${PROJECT_SOURCE_DIR}/${CSRCS_DIR_NAME}/fastdeploy/function/*.cc)
 file(GLOB_RECURSE DEPLOY_ORT_SRCS ${PROJECT_SOURCE_DIR}/${CSRCS_DIR_NAME}/fastdeploy/backends/ort/*.cc)
@@ -255,8 +258,6 @@ if(ENABLE_TEXT)
   include(external/faster_tokenizer.cmake)
 endif()
 
-configure_file(${PROJECT_SOURCE_DIR}/${CSRCS_DIR_NAME}/fastdeploy/core/config.h.in ${PROJECT_SOURCE_DIR}/${CSRCS_DIR_NAME}/fastdeploy/core/config.h)
-configure_file(${PROJECT_SOURCE_DIR}/${CSRCS_DIR_NAME}/fastdeploy/pybind/main.cc.in ${PROJECT_SOURCE_DIR}/${CSRCS_DIR_NAME}/fastdeploy/pybind/main.cc)
 configure_file(${PROJECT_SOURCE_DIR}/FastDeploy.cmake.in ${PROJECT_SOURCE_DIR}/FastDeploy.cmake @ONLY)
 configure_file(${PROJECT_SOURCE_DIR}/fastdeploy/c_lib_wrap.py.in ${PROJECT_SOURCE_DIR}/fastdeploy/c_lib_wrap.py)
 

--- a/fastdeploy/c_lib_wrap.py.in
+++ b/fastdeploy/c_lib_wrap.py.in
@@ -49,6 +49,39 @@ def add_dll_search_dir(dir_path):
         os.add_dll_directory(dir_path)
 
 
+def load_dso_or_dll(dso_or_dll_name=None) -> bool:
+    from ctypes import cdll
+    if dso_or_dll_name is None:
+        dso_or_dll_name = "fastdeploy.dll"
+    try:
+        dso_or_dll = cdll.LoadLibrary(dso_or_dll_name)
+        del dso_or_dll
+        print(f"[FastDeploy][INFO]:  Successfully pre load {dso_or_dll_name}.")
+        return True
+    except Exception as e:
+        print(f"[FastDeploy][ERROR]: Can not pre load dll/dso: {dso_or_dll_name}. {e}")
+        return False
+
+
+def try_pre_load_fastdeploy_dll() -> bool:
+    # Try pre-load fastdeploy dll in windows to
+    # make sure the added custom dll directory
+    # has been activated. Reference:
+    # [1] https://github.com/conda/conda/issues/10897
+    # [2] https://github.com/dhermes/bezier/issues/237
+    # TODO(qiuyanjun): add Linux and Mac *.so|*.dylib check
+    return load_dso_or_dll("fastdeploy.dll")
+
+
+def try_pre_load_cudart_dll(cuda_version: str) -> bool:
+    if cuda_version is None:
+        print("[FastDeploy][ERROR]: CUDA version can not be NoneTpye.")
+        return False
+    major_version_number = int(cuda_version.strip().strip("v").split(".")[0])
+    # TODO(qiuyanjun): add Linux and Mac cudart *.so|*.dylib check
+    return load_dso_or_dll(f"cudart64_{major_version_number}0.dll")
+
+
 def add_cuda_shared_lib_dir_windows():
     if is_built_with_gpu():
         # if FastDeploy built with gpu and want to run
@@ -63,10 +96,10 @@ def add_cuda_shared_lib_dir_windows():
         default_cuda_dir = get_default_cuda_directory()
         default_cuda_version = os.path.basename(default_cuda_dir)  # v11.2
         cuda_shared_lib_dir = os.path.join(default_cuda_dir, "bin")
+        custom_cuda_envs = ["CUDA_DIRECTORY", "CUDA_HOME", "CUDA_ROOT", "CUDA_PATH"]
+        custom_cuda_dir = "NOTFOUNDED"
         if not os.path.exists(cuda_shared_lib_dir):
             # try to get cuda directory from user's local env
-            custom_cuda_dir = "NOTFOUNDED"
-            custom_cuda_envs = ["CUDA_DIRECTORY", "CUDA_HOME", "CUDA_ROOT", "CUDA_PATH"]
             for custom_env in custom_cuda_envs:
                 custom_cuda_dir = os.getenv(custom_env, "NOTFOUNDED")
                 custom_cuda_dir = custom_cuda_dir.strip().split(";")[0]
@@ -79,36 +112,20 @@ def add_cuda_shared_lib_dir_windows():
                     \n--- this path should look like: {default_cuda_dir}. \
                     \n--- Check FAQ: {base_url + 'develop/docs/FAQ.md'}")
                 return
-            # check cuda version
-            custom_cuda_version = os.path.basename(custom_cuda_dir) # v11.2
-            if default_cuda_version != custom_cuda_version:
-                logging.warnings.warn(
-                    f"\n--- FastDeploy was built with CUDA version {default_cuda_version}, \
-                    \n--- but found custom CUDA version {custom_cuda_version} at {custom_cuda_dir} \
-                    \n--- Please setup one of {custom_cuda_envs} manually, \
-                    \n--- this path should look like: {default_cuda_dir}. \
-                    \n--- Check FAQ: {base_url + 'develop/docs/FAQ.md'}")
-                return
             # path to cuda dlls
             cuda_shared_lib_dir = os.path.join(custom_cuda_dir, "bin")
         add_dll_search_dir(cuda_shared_lib_dir)
-        print(f"[FastDeploy][CUDA]: Found valid cuda directroy and added it: -> {cuda_shared_lib_dir}")
-
-
-def try_pre_load_fastdeploy_dll(dll_name=None):
-    # Try pre-load fastdeploy dll in windows to
-    # make sure the added custom dll directory
-    # has been activated. Reference:
-    # [1] https://github.com/conda/conda/issues/10897
-    # [2] https://github.com/dhermes/bezier/issues/237
-    from ctypes import cdll
-    if dll_name is None:
-        dll_name = "fastdeploy.dll"
-    try:
-        dll = cdll.LoadLibrary(dll_name)
-        del dll
-    except Exception as e:
-        raise RuntimeError(f"Can not pre load dll: {dso_name}. {e}")
+        # try pre load cudart with major version, e.g 11.x/10.x
+        if not try_pre_load_cudart_dll(default_cuda_version):
+            custom_cuda_version = os.path.basename(custom_cuda_dir)
+            logging.warnings.warn(
+                f"\n--- FastDeploy was built with CUDA version {default_cuda_version}, \
+                \n--- but found custom CUDA version {custom_cuda_version} at {custom_cuda_dir} \
+                \n--- Please setup one of {custom_cuda_envs} manually, \
+                \n--- this path should look like: {default_cuda_dir}. \
+                \n--- Check FAQ: {base_url + 'develop/docs/FAQ.md'}")
+            return
+        print(f"[FastDeploy][INFO]:  Successfully found CUDA ToolKit from -> {cuda_shared_lib_dir}")
 
 
 if os.name == "nt":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->  
- 修复windows下pybind编译问题
- 优化windows CUDA版本检查逻辑，兼容 11.0, 11.1, 11.2, ..., 11.x等主版本
- 优化CUDA初始化提示信息  

如果成功加载CUDA：
```shell
>>> import fastdeploy
[FastDeploy][INFO]:  Successfully pre load cudart64_110.dll.
[FastDeploy][INFO]:  Successfully found CUDA ToolKit from -> C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2\bin
[FastDeploy][INFO]:  Successfully pre load fastdeploy.dll.
```
如果加载CUDA失败，提示
```shell
>>> import fastdeploy
C:\Python38\lib\site-packages\fastdeploy\c_lib_wrap.py:122: UserWarning:
--- FastDeploy was built with CUDA version v11.2,
--- but found custom CUDA version v10.2 at C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.2
--- Please setup one of ['CUDA_DIRECTORY', 'CUDA_HOME', 'CUDA_ROOT', 'CUDA_PATH'] manually,
--- this path should look like: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2.
--- Check FAQ: https://github.com/PaddlePaddle/FastDeploy/blob/develop/docs/FAQ.md
  logging.warnings.warn(
```
