### PR TITLE
[vision] remove un-need ppmatting log info

### DIFF
--- a/csrc/fastdeploy/vision/matting/ppmatting/ppmatting.cc
+++ b/csrc/fastdeploy/vision/matting/ppmatting/ppmatting.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "fastdeploy/vision/matting/ppmatting/ppmatting.h"
+
 #include "fastdeploy/vision.h"
 #include "fastdeploy/vision/utils/utils.h"
 #include "yaml-cpp/yaml.h"
@@ -127,10 +128,11 @@ bool PPMatting::Preprocess(Mat* mat, FDTensor* output,
       int max_short = processor->GetMaxShort();
       if (runtime_option.backend != Backend::PDINFER) {
         if (input_w != input_h || input_h < max_short || input_w < max_short) {
-          FDWARNING << "Detected LimitShort processing step in yaml file and "
-                       "the size of input image is Unqualified, Fastdeploy "
-                       "will resize the input image into ("
-                    << max_short << "," << max_short << ")." << std::endl;
+          // FDWARNING << "Detected LimitShort processing step in yaml file and
+          // "
+          //              "the size of input image is Unqualified, Fastdeploy "
+          //              "will resize the input image into ("
+          //           << max_short << "," << max_short << ")." << std::endl;
           Resize::Run(mat, max_short, max_short);
         }
       }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 

### Describe
<!-- Describe what this PR does -->
先注释掉ppmatting preprocess中的警告，避免每次推理都输出过多的log
