### PR TITLE
[Backend] Add collect shape for pp-trt backend

### DIFF
--- a/fastdeploy/backends/paddle/paddle_backend.cc
+++ b/fastdeploy/backends/paddle/paddle_backend.cc
@@ -215,12 +215,12 @@ void PaddleBackend::GetDynamicShapeFromOption(const PaddleBackendOption& option,
     std::ostringstream oss;
     oss << "[";
     for (int i = 0; i < shape.size(); ++i) {
-      oss << i;
+      oss << shape[i];
       if (i < shape.size() - 1) {
         oss << ", ";
       }
-      oss << "]";
     }
+    oss << "]";
     return oss.str();
   };
   for (const auto& item : option.trt_option.min_shape) {

--- a/fastdeploy/backends/paddle/paddle_backend.cc
+++ b/fastdeploy/backends/paddle/paddle_backend.cc
@@ -97,6 +97,16 @@ bool PaddleBackend::InitFromPaddle(const std::string& model_file,
   if (reader.is_quantize_model) {
     if (option.use_gpu) {
       FDWARNING << "The loaded model is a quantized model, while inference on GPU, please use TensorRT backend to get better performance." << std::endl;
+      if (option.enable_trt) {
+#ifdef ENABLE_TRT_BACKEND
+        bool use_static = false;
+        if (option.trt_option.serialize_file != "") {
+          FDWARNING << "Detect that tensorrt cache file has been set to " << option.trt_option.serialize_file << ", but while enable paddle2trt, please notice that the cache file will save to the directory where paddle model saved." << std::endl;
+          use_static = true;
+        }
+        config_.EnableTensorRtEngine(option.trt_option.max_workspace_size, 32, 3, paddle_infer::PrecisionType::kInt8, use_static, true);
+#endif
+      }
     }
     if (option.enable_mkldnn) {
       config_.EnableMkldnnInt8();

--- a/fastdeploy/backends/paddle/paddle_backend.cc
+++ b/fastdeploy/backends/paddle/paddle_backend.cc
@@ -152,18 +152,6 @@ bool PaddleBackend::InitFromPaddle(const std::string& model_file,
   return true;
 }
 
-void PaddleBackend::SetTRTDynamicShapeToConfig(const PaddleBackendOption& option) {
-    std::map<std::string, std::vector<int>> max_shape;
-    std::map<std::string, std::vector<int>> min_shape;
-    std::map<std::string, std::vector<int>> opt_shape;
-    GetDynamicShapeFromOption(option, &max_shape, &min_shape, &opt_shape);
-    FDINFO << "Start setting trt dynamic shape." << std::endl;
-    if (min_shape.size() > 0) {
-      config_.SetTRTDynamicShapeInfo(min_shape, max_shape, opt_shape);
-    }
-    FDINFO << "Finish setting trt dynamic shape." << std::endl;
-}
-
 TensorInfo PaddleBackend::GetInputInfo(int index) {
   FDASSERT(index < NumInputs(),
            "The index: %d should less than the number of inputs: %d.", index,
@@ -205,6 +193,19 @@ bool PaddleBackend::Infer(std::vector<FDTensor>& inputs,
     CopyTensorToCpu(handle, &((*outputs)[i]));
   }
   return true;
+}
+
+#ifdef ENABLE_TRT_BACKEND
+void PaddleBackend::SetTRTDynamicShapeToConfig(const PaddleBackendOption& option) {
+    std::map<std::string, std::vector<int>> max_shape;
+    std::map<std::string, std::vector<int>> min_shape;
+    std::map<std::string, std::vector<int>> opt_shape;
+    GetDynamicShapeFromOption(option, &max_shape, &min_shape, &opt_shape);
+    FDINFO << "Start setting trt dynamic shape." << std::endl;
+    if (min_shape.size() > 0) {
+      config_.SetTRTDynamicShapeInfo(min_shape, max_shape, opt_shape);
+    }
+    FDINFO << "Finish setting trt dynamic shape." << std::endl;
 }
 
 void PaddleBackend::GetDynamicShapeFromOption(const PaddleBackendOption& option,
@@ -274,5 +275,7 @@ void PaddleBackend::CollectShapeRun(paddle_infer::Predictor* predictor,
   }
   predictor->Run();
 }
+#endif
+
 
 }  // namespace fastdeploy

--- a/fastdeploy/backends/paddle/paddle_backend.h
+++ b/fastdeploy/backends/paddle/paddle_backend.h
@@ -96,6 +96,12 @@ class PaddleBackend : public BaseBackend {
   std::vector<TensorInfo> GetOutputInfos() override;
 
  private:
+  void CollectShapeRun(paddle_infer::Predictor* predictor,
+          const std::map<std::string, std::vector<int>>& shape) const;
+  void GetDynamicShapeFromOption(const PaddleBackendOption& option,
+      std::map<std::string, std::vector<int>>* max_shape,
+      std::map<std::string, std::vector<int>>* min_shape,
+      std::map<std::string, std::vector<int>>* opt_shape) const;
   paddle_infer::Config config_;
   std::shared_ptr<paddle_infer::Predictor> predictor_;
   std::vector<TensorInfo> inputs_desc_;

--- a/fastdeploy/backends/paddle/paddle_backend.h
+++ b/fastdeploy/backends/paddle/paddle_backend.h
@@ -96,6 +96,7 @@ class PaddleBackend : public BaseBackend {
   std::vector<TensorInfo> GetOutputInfos() override;
 
  private:
+#ifdef ENABLE_TRT_BACKEND
   void CollectShapeRun(paddle_infer::Predictor* predictor,
           const std::map<std::string, std::vector<int>>& shape) const;
   void GetDynamicShapeFromOption(const PaddleBackendOption& option,
@@ -103,6 +104,7 @@ class PaddleBackend : public BaseBackend {
       std::map<std::string, std::vector<int>>* min_shape,
       std::map<std::string, std::vector<int>>* opt_shape) const;
   void SetTRTDynamicShapeToConfig(const PaddleBackendOption& option);
+#endif
   paddle_infer::Config config_;
   std::shared_ptr<paddle_infer::Predictor> predictor_;
   std::vector<TensorInfo> inputs_desc_;

--- a/fastdeploy/backends/paddle/paddle_backend.h
+++ b/fastdeploy/backends/paddle/paddle_backend.h
@@ -102,6 +102,7 @@ class PaddleBackend : public BaseBackend {
       std::map<std::string, std::vector<int>>* max_shape,
       std::map<std::string, std::vector<int>>* min_shape,
       std::map<std::string, std::vector<int>>* opt_shape) const;
+  void SetTRTDynamicShapeToConfig(const PaddleBackendOption& option);
   paddle_infer::Config config_;
   std::shared_ptr<paddle_infer::Predictor> predictor_;
   std::vector<TensorInfo> inputs_desc_;

--- a/fastdeploy/backends/paddle/paddle_backend.h
+++ b/fastdeploy/backends/paddle/paddle_backend.h
@@ -44,6 +44,7 @@ struct PaddleBackendOption {
   bool enable_trt = false;
 #ifdef ENABLE_TRT_BACKEND
   TrtBackendOption trt_option;
+  bool collect_shape = false;
 #endif
 
   int mkldnn_cache_size = 1;

--- a/fastdeploy/backends/paddle/util.cc
+++ b/fastdeploy/backends/paddle/util.cc
@@ -29,16 +29,13 @@ void ShareTensorFromFDTensor(paddle_infer::Tensor* tensor,
   tensor->Reshape(shape);
   auto place = ConvertFDDeviceToPlace(fd_tensor.device);
   if (fd_tensor.dtype == FDDataType::FP32) {
-    tensor->ShareExternalData(static_cast<const float*>(fd_tensor.Data()),
-                              shape, place);
+    tensor->CopyFromCpu(static_cast<const float*>(fd_tensor.Data()));
     return;
   } else if (fd_tensor.dtype == FDDataType::INT32) {
-    tensor->ShareExternalData(static_cast<const int32_t*>(fd_tensor.Data()),
-                              shape, place);
+    tensor->CopyFromCpu(static_cast<const int32_t*>(fd_tensor.Data()));
     return;
   } else if (fd_tensor.dtype == FDDataType::INT64) {
-    tensor->ShareExternalData(static_cast<const int64_t*>(fd_tensor.Data()),
-                              shape, place);
+    tensor->CopyFromCpu(static_cast<const int64_t*>(fd_tensor.Data()));
     return;
   }
   FDASSERT(false, "Unexpected data type(%s) while infer with PaddleBackend.",

--- a/fastdeploy/backends/paddle/util.cc
+++ b/fastdeploy/backends/paddle/util.cc
@@ -29,13 +29,28 @@ void ShareTensorFromFDTensor(paddle_infer::Tensor* tensor,
   tensor->Reshape(shape);
   auto place = ConvertFDDeviceToPlace(fd_tensor.device);
   if (fd_tensor.dtype == FDDataType::FP32) {
-    tensor->CopyFromCpu(static_cast<const float*>(fd_tensor.Data()));
+    if (place == paddle_infer::PlaceType::kGPU) {
+       tensor->ShareExternalData(static_cast<const float*>(fd_tensor.Data()),
+                              shape, place);
+    } else {
+      tensor->CopyFromCpu(static_cast<const float*>(fd_tensor.Data()));
+    }
     return;
   } else if (fd_tensor.dtype == FDDataType::INT32) {
-    tensor->CopyFromCpu(static_cast<const int32_t*>(fd_tensor.Data()));
+    if (place == paddle_infer::PlaceType::kGPU) {
+       tensor->ShareExternalData(static_cast<const int32_t*>(fd_tensor.Data()),
+                              shape, place);
+    } else {
+      tensor->CopyFromCpu(static_cast<const int32_t*>(fd_tensor.Data()));
+    }
     return;
   } else if (fd_tensor.dtype == FDDataType::INT64) {
-    tensor->CopyFromCpu(static_cast<const int64_t*>(fd_tensor.Data()));
+    if (place == paddle_infer::PlaceType::kGPU) {
+       tensor->ShareExternalData(static_cast<const int64_t*>(fd_tensor.Data()),
+                              shape, place);
+    } else {
+      tensor->CopyFromCpu(static_cast<const int64_t*>(fd_tensor.Data()));
+    }
     return;
   }
   FDASSERT(false, "Unexpected data type(%s) while infer with PaddleBackend.",

--- a/fastdeploy/pybind/runtime.cc
+++ b/fastdeploy/pybind/runtime.cc
@@ -44,6 +44,8 @@ void BindRuntime(pybind11::module& m) {
       .def("enable_trt_fp16", &RuntimeOption::EnableTrtFP16)
       .def("disable_trt_fp16", &RuntimeOption::DisableTrtFP16)
       .def("set_trt_cache_file", &RuntimeOption::SetTrtCacheFile)
+      .def("enable_paddle_trt_collect_shape", &RuntimeOption::EnablePaddleTrtCollectShape)
+      .def("disable_paddle_trt_collect_shape", &RuntimeOption::DisablePaddleTrtCollectShape)
       .def_readwrite("model_file", &RuntimeOption::model_file)
       .def_readwrite("params_file", &RuntimeOption::params_file)
       .def_readwrite("model_format", &RuntimeOption::model_format)

--- a/fastdeploy/runtime.cc
+++ b/fastdeploy/runtime.cc
@@ -388,6 +388,14 @@ bool Runtime::Compile(std::vector<std::vector<FDTensor>>& prewarm_tensors,
            "ENABLE_POROS_BACKEND=ON.");
 #endif
   return true;
+}  
+
+void RuntimeOption::EnablePaddleTrtCollectShape() {
+  pd_collect_shape = true;
+}
+
+void RuntimeOption::DisablePaddleTrtCollectShape() {
+  pd_collect_shape = false;
 }
 
 bool Runtime::Init(const RuntimeOption& _option) {
@@ -498,6 +506,7 @@ void Runtime::CreatePaddleBackend() {
 #ifdef ENABLE_TRT_BACKEND
   if (pd_option.use_gpu && option.pd_enable_trt) {
     pd_option.enable_trt = true;
+    pd_option.collect_shape = option.pd_collect_shape;
     auto trt_option = TrtBackendOption();
     trt_option.gpu_id = option.device_id;
     trt_option.enable_fp16 = option.trt_enable_fp16;

--- a/fastdeploy/runtime.h
+++ b/fastdeploy/runtime.h
@@ -204,6 +204,17 @@ struct FASTDEPLOY_DECL RuntimeOption {
    */
   void SetTrtCacheFile(const std::string& cache_file_path);
 
+
+  /**
+   * @brief Enable to collect shape in paddle trt backend
+   */
+  void EnablePaddleTrtCollectShape();
+
+  /**
+   * @brief Disable to collect shape in paddle trt backend
+   */
+  void DisablePaddleTrtCollectShape();
+
   Backend backend = Backend::UNKNOWN;
   // for cpu inference and preprocess
   // default will let the backend choose their own default value
@@ -225,6 +236,7 @@ struct FASTDEPLOY_DECL RuntimeOption {
   bool pd_enable_mkldnn = true;
   bool pd_enable_log_info = false;
   bool pd_enable_trt = false;
+  bool pd_collect_shape = false;
   int pd_mkldnn_cache_size = 1;
   std::vector<std::string> pd_delete_pass_names;
 

--- a/fastdeploy/utils/path.h
+++ b/fastdeploy/utils/path.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <fstream>
+#ifdef _MSC_VER
+#define PATH_SEP "\\"
+#else
+#define PATH_SEP "/"
+#endif
+
+namespace fastdeploy {
+
+inline std::string PathJoin(const std::vector<std::string>& paths,
+                            const std::string& sep = PATH_SEP) {
+  if (paths.size() == 1) {
+    return paths[0];
+  }
+  std::string filepath = "";
+  for (const auto& path : paths) {
+    if (filepath == "") {
+      filepath += path;
+      continue;
+    }
+    if (path[0] == sep[0] || filepath.back() == sep[0]) {
+      filepath += path;
+    } else {
+      filepath += sep + path;
+    }
+  }
+  return filepath;
+}
+
+inline std::string PathJoin(const std::string& folder,
+                            const std::string& filename,
+                            const std::string& sep = PATH_SEP) {
+  return PathJoin(std::vector<std::string>{folder, filename}, sep);
+}
+
+inline std::string GetDirFromPath(const std::string& path) {
+  auto pos = path.find_last_of(PATH_SEP);
+  if (pos == std::string::npos) {
+    return "";
+  }
+  // The root path in UNIX systems
+  if (pos == 0) {
+    return "/";
+  }
+  return path.substr(0, pos);
+}
+
+inline bool CheckFileExists(const std::string& path) {
+  std::fstream fin(path, std::ios::in);
+  if (!fin) {
+    return false;
+  }
+  return true;
+}
+
+}  // namespace fastdeploy

--- a/python/fastdeploy/runtime.py
+++ b/python/fastdeploy/runtime.py
@@ -329,6 +329,12 @@ class RuntimeOption:
         """
         return self._option.set_trt_max_workspace_size(trt_max_workspace_size)
 
+    def enable_paddle_trt_collect_shape(self):
+        return self._option.enable_paddle_trt_collect_shape()
+
+    def disable_paddle_trt_collect_shape(self):
+        return self._option.disable_paddle_trt_collect_shape()
+
     def __repr__(self):
         attrs = dir(self._option)
         message = "RuntimeOption(\n"

--- a/scripts/patch_paddle_inference.py
+++ b/scripts/patch_paddle_inference.py
@@ -26,7 +26,7 @@ def process_paddle_inference(paddle_inference_so_file):
     rpaths = [
         "$ORIGIN", "$ORIGIN/../../third_party/install/mkldnn/lib/",
         "$ORIGIN/../../third_party/install/mklml/lib/",
-        "$ORIGIN/../../../tensorrt/lib"
+        "$ORIGIN/../../../tensorrt/lib/"
     ]
 
     patchelf_exe = os.getenv("PATCHELF_EXE", "patchelf")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Add collect shape for pp-trt backend

#### Usage
```python
option = fd.RuntimeOption()
option.use_trt_backend()
# Use paddle-trt backend instead of trt backend
option.enable_paddle_to_trt()
# Enable to collect shape into shape_range_info.pbtxt
option.enable_paddle_trt_collect_shape()
```