### PR TITLE
[Bug Fix] add __aarch64__ to limit int64 in armv8

### DIFF
--- a/fastdeploy/backends/lite/lite_backend.cc
+++ b/fastdeploy/backends/lite/lite_backend.cc
@@ -222,9 +222,13 @@ bool LiteBackend::Infer(std::vector<FDTensor>& inputs,
         reinterpret_cast<const uint8_t*>(const_cast<void*>(
         inputs[i].CpuData())));
     } else if (inputs[i].dtype == FDDataType::INT64) {
+#ifdef __aarch64__      
       tensor->CopyFromCpu<int64_t, paddle::lite_api::TargetType::kARM>(
         reinterpret_cast<const int64_t*>(const_cast<void*>(
         inputs[i].CpuData())));
+#else 
+      FDASSERT(false, "FDDataType::INT64 is not support for Arm v7 now!");         
+#endif        
     } else {
       FDASSERT(false, "Unexpected data type of %d.", inputs[i].dtype);
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->
Bug Fix

### Describe
<!-- Describe what this PR does -->

- 增加arm64-v8a架构判断，v7 32位架构下，lite backend CopyFromCpu接口不支持int64数据；不增加宏限制会导致v7架构下编译错误

