### PR TITLE
[Compile] Force `GLIBCXX_USE_CXX11_ABI`=1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ include(${PROJECT_SOURCE_DIR}/cmake/utils.cmake)
 if(NOT MSVC)
   set(CMAKE_CXX_STANDARD 11)
   set(CMAKE_CXX_FLAGS "-Wno-format")
-  add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
+  add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
 endif(NOT MSVC)
 
 if(UNIX AND (NOT APPLE) AND (NOT ANDROID) AND (NOT ENABLE_TIMVX))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ include(${PROJECT_SOURCE_DIR}/cmake/utils.cmake)
 if(NOT MSVC)
   set(CMAKE_CXX_STANDARD 11)
   set(CMAKE_CXX_FLAGS "-Wno-format")
+  add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
 endif(NOT MSVC)
 
 if(UNIX AND (NOT APPLE) AND (NOT ANDROID) AND (NOT ENABLE_TIMVX))

--- a/FastDeploy.cmake.in
+++ b/FastDeploy.cmake.in
@@ -35,9 +35,12 @@ list(APPEND FASTDEPLOY_INCS ${CMAKE_CURRENT_LIST_DIR}/include)
 # Note(zhoushunjie): include some useful utils function
 include(${CMAKE_CURRENT_LIST_DIR}/utils.cmake)
 
-if(NOT CMAKE_CXX_STANDARD)
+# Set C++11 as standard for the whole project
+if(NOT MSVC)
   set(CMAKE_CXX_STANDARD 11)
-endif()
+  set(CMAKE_CXX_FLAGS "-Wno-format")
+  add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
+endif(NOT MSVC)
 
 if(ANDROID)
   add_library(fastdeploy STATIC IMPORTED GLOBAL)

--- a/FastDeploy.cmake.in
+++ b/FastDeploy.cmake.in
@@ -39,7 +39,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/utils.cmake)
 if(NOT MSVC)
   set(CMAKE_CXX_STANDARD 11)
   set(CMAKE_CXX_FLAGS "-Wno-format")
-  add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
+  add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
 endif(NOT MSVC)
 
 if(ANDROID)


### PR DESCRIPTION
- 由于FastDeploy所有依赖库均使用`GLIBCXX_USE_CXX11_ABI`=1的模式，因此强制在FastDeploy中也开启