### PR TITLE
[Bug Fix] fix android log undefined in examples build

### DIFF
--- a/FastDeploy.cmake.in
+++ b/FastDeploy.cmake.in
@@ -248,6 +248,12 @@ if(WITH_XPU)
   list(APPEND FASTDEPLOY_LIBS -lpthread -lrt -ldl)
 endif()
 
+# log lib for Android
+if(ANDROID)
+  find_library(log-lib log)
+  list(APPEND FASTDEPLOY_LIBS ${log-lib})
+endif()
+
 remove_duplicate_libraries(FASTDEPLOY_LIBS)
 
 # Print compiler information


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->
Bug Fix

### Description
<!-- Describe what this PR does -->
- fix android log undefined in examples build 
```bash
[  3%] Building CXX object CMakeFiles/infer_picodet_demo.dir/infer_picodet.cc.o
[  7%] Linking CXX executable infer_picodet_demo
ld: error: undefined symbol: __android_log_print
>>> referenced by infer_picodet.cc
>>>               CMakeFiles/infer_picodet_demo.dir/infer_picodet.cc.o:(fastdeploy::FDLogger::~FDLogger())
clang-14: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [infer_picodet_demo] Error 1
```

