### PR TITLE
[Bug Fix] When loading model from memory, don't need CheckModelFormat

### DIFF
--- a/fastdeploy/fastdeploy_model.cc
+++ b/fastdeploy/fastdeploy_model.cc
@@ -140,9 +140,11 @@ bool FastDeployModel::InitRuntimeWithSpecifiedDevice() {
 }
 
 bool FastDeployModel::InitRuntime() {
-  FDASSERT(
-      CheckModelFormat(runtime_option.model_file, runtime_option.model_format),
-      "ModelFormatCheck Failed.");
+  if (!runtime_option.model_from_memory_) {
+    FDASSERT(
+        CheckModelFormat(runtime_option.model_file, runtime_option.model_format),
+        "ModelFormatCheck Failed.");
+  }
   if (runtime_initialized_) {
     FDERROR << "The model is already initialized, cannot be initliazed again."
             << std::endl;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->
Bug Fix

### Description
<!-- Describe what this PR does -->
- When loading model from memory, don't need CheckModelFormat

FastDeploy load model from memory usages(For now temporarily only support Paddle Inference backend):
``` python
import fastdeploy as fd
runtime_option = fd.RuntimeOption()
# runtime_option read model form memory
runtime_option.set_model_buffer(model_buffer.read(), model_size, params_buffer.read(), params_size)
runtime_option.use_paddle_backend()
# Initialize model without model path and params path
model = fd.vision.classification.PaddleClasModel( "", "", config_file, runtime_option=runtime_option)
model.predict(im)
```