### PR TITLE
[Improve Serving] Add OCR det bbox in output buffer which is very important for application

### DIFF
--- a/examples/vision/ocr/PP-OCRv3/serving/client.py
+++ b/examples/vision/ocr/PP-OCRv3/serving/client.py
@@ -106,4 +106,4 @@ if __name__ == "__main__":
             bboxes = batch_bboxes[i_batch]
             for i_box in range(len(texts)):
                 print('text=', texts[i_box].decode('utf-8'), '  score=',
-                      scores[i_box], '  bboxes=', bboxes[i_box])
+                      scores[i_box], '  bbox=', bboxes[i_box])

--- a/examples/vision/ocr/PP-OCRv3/serving/client.py
+++ b/examples/vision/ocr/PP-OCRv3/serving/client.py
@@ -99,9 +99,11 @@ if __name__ == "__main__":
         result = runner.Run([im, ])
         batch_texts = result['rec_texts']
         batch_scores = result['rec_scores']
+        batch_bboxes = result['det_bboxes']
         for i_batch in range(len(batch_texts)):
             texts = batch_texts[i_batch]
             scores = batch_scores[i_batch]
+            bboxes = batch_bboxes[i_batch]
             for i_box in range(len(texts)):
                 print('text=', texts[i_box].decode('utf-8'), '  score=',
-                      scores[i_box])
+                      scores[i_box], '  bboxes=', bboxes[i_box])

--- a/examples/vision/ocr/PP-OCRv3/serving/models/det_postprocess/1/model.py
+++ b/examples/vision/ocr/PP-OCRv3/serving/models/det_postprocess/1/model.py
@@ -142,6 +142,7 @@ class TritonPythonModel:
             results = self.postprocessor.run([infer_outputs], im_infos)
             batch_rec_texts = []
             batch_rec_scores = []
+            batch_box_list = []
             for i_batch in range(len(results)):
 
                 cls_labels = []
@@ -158,6 +159,9 @@ class TritonPythonModel:
                         crop_img = get_rotate_crop_image(ori_imgs[i_batch],
                                                          box)
                         image_list.append(crop_img)
+
+                batch_box_list.append(box_list)
+
                 cls_pre_tensors = self.cls_preprocessor.run(image_list)
                 cls_dlpack_tensor = cls_pre_tensors[0].to_dlpack()
                 cls_input_tensor = pb_utils.Tensor.from_dlpack(
@@ -221,7 +225,7 @@ class TritonPythonModel:
             out_tensor_1 = pb_utils.Tensor(self.output_names[1],
                                            np.array(batch_rec_scores))
             out_tensor_2 = pb_utils.Tensor(self.output_names[2],
-                                           np.array(box_list))
+                                           np.array(batch_box_list))
             inference_response = pb_utils.InferenceResponse(
                 output_tensors=[out_tensor_0, out_tensor_1, out_tensor_2])
             responses.append(inference_response)

--- a/examples/vision/ocr/PP-OCRv3/serving/models/det_postprocess/1/model.py
+++ b/examples/vision/ocr/PP-OCRv3/serving/models/det_postprocess/1/model.py
@@ -220,8 +220,10 @@ class TritonPythonModel:
                     batch_rec_texts, dtype=np.object_))
             out_tensor_1 = pb_utils.Tensor(self.output_names[1],
                                            np.array(batch_rec_scores))
+            out_tensor_2 = pb_utils.Tensor(self.output_names[2],
+                                           np.array(box_list))
             inference_response = pb_utils.InferenceResponse(
-                output_tensors=[out_tensor_0, out_tensor_1])
+                output_tensors=[out_tensor_0, out_tensor_1, out_tensor_2])
             responses.append(inference_response)
         return responses
 

--- a/examples/vision/ocr/PP-OCRv3/serving/models/det_postprocess/config.pbtxt
+++ b/examples/vision/ocr/PP-OCRv3/serving/models/det_postprocess/config.pbtxt
@@ -33,7 +33,7 @@ output [
   {
     name: "POST_OUTPUT_2"
     data_type: TYPE_FP32
-    dims: [ -1, 1 ]
+    dims: [ -1, -1, 1 ]
   }
 ]
 

--- a/examples/vision/ocr/PP-OCRv3/serving/models/det_postprocess/config.pbtxt
+++ b/examples/vision/ocr/PP-OCRv3/serving/models/det_postprocess/config.pbtxt
@@ -29,6 +29,11 @@ output [
     name: "POST_OUTPUT_1"
     data_type: TYPE_FP32
     dims: [ -1, 1 ]
+  },
+  {
+    name: "POST_OUTPUT_2"
+    data_type: TYPE_FP32
+    dims: [ -1, 1 ]
   }
 ]
 

--- a/examples/vision/ocr/PP-OCRv3/serving/models/pp_ocr/config.pbtxt
+++ b/examples/vision/ocr/PP-OCRv3/serving/models/pp_ocr/config.pbtxt
@@ -22,7 +22,7 @@ output [
   {
     name: "det_bboxes"
     data_type: TYPE_FP32
-    dims: [ -1, 1 ]
+    dims: [ -1, -1, 1 ]
   }
 ]
 ensemble_scheduling {

--- a/examples/vision/ocr/PP-OCRv3/serving/models/pp_ocr/config.pbtxt
+++ b/examples/vision/ocr/PP-OCRv3/serving/models/pp_ocr/config.pbtxt
@@ -18,6 +18,11 @@ output [
     name: "rec_scores"
     data_type: TYPE_FP32
     dims: [ -1, 1 ]
+  },
+  {
+    name: "det_bboxes"
+    data_type: TYPE_FP32
+    dims: [ -1, 1 ]
   }
 ]
 ensemble_scheduling {
@@ -72,6 +77,10 @@ ensemble_scheduling {
       output_map {
         key: "POST_OUTPUT_1"
         value: "rec_scores"
+      }
+      output_map {
+        key: "POST_OUTPUT_2"
+        value: "det_bboxes"
       }
     }
   ]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->
Serving 

### Description
<!-- Describe what this PR does -->

在 OCR 的例子中，缺少 det bbox 的返回，这对于 OCR 来说缺少了一个很重要的特征，后续无法判断每个文字所在的位置，故需要加上 det bbox 的返回

完善后的输出，相较之前多出了对每个框文字 `bbox` 的输出：
<img width="540" alt="2304f9f878a511ea686bcf565462a74" src="https://user-images.githubusercontent.com/25873202/216205810-f836eda7-8dab-4cc5-946d-95c101f97acb.png">

