### PR TITLE
[Android] fix flycv android cmake bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -609,21 +609,21 @@ else()
         DESTINATION ${CMAKE_INSTALL_PREFIX}/third_libs/install
       )
     endif()
-  endif()
-  # only need flycv's headers (may also install libs? TODO:qiuyanjun)
-  if(ENABLE_FLYCV)
-    if(WITH_FLYCV_STATIC)
-      install(
-        DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/third_libs/install/flycv/include
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/third_libs/install/flycv
-      )
-    else()
-      install(
-        DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/third_libs/install/flycv
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/third_libs/install
-      )
+    # only need flycv's headers (may also install libs? TODO:qiuyanjun)
+    if(ENABLE_FLYCV)
+      if(WITH_FLYCV_STATIC)
+        install(
+          DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/third_libs/install/flycv/include
+          DESTINATION ${CMAKE_INSTALL_PREFIX}/third_libs/install/flycv
+        )
+      else()
+        install(
+          DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/third_libs/install/flycv
+          DESTINATION ${CMAKE_INSTALL_PREFIX}/third_libs/install
+        )
+      endif()
     endif()
-  endif()
+  endif(ENABLE_VISION)
   # fast_tokenizer's static lib is not avaliable now!
   # may support some days later(TODO:qiuyanjun)
   if(ENABLE_TEXT)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->
Bug Fix 

### Description
<!-- Describe what this PR does -->

- ENABLE_FLYCV的层级应该被ENABLE_VISION包住，原来的逻辑会导致ENABLE_VISION=OFF的时候，依然尝试install flycv从而导致cmake install 出错
