### PR TITLE
[Doc] Add cmake version notice in Jetson doc

### DIFF
--- a/docs/cn/build_and_install/jetson.md
+++ b/docs/cn/build_and_install/jetson.md
@@ -4,6 +4,8 @@
 
 FastDeploy当前在Jetson仅支持ONNX Runtime CPU和TensorRT GPU/Paddle Inference三种后端推理
 
+- 如若编译过程，出现错误提示`Could not find a package configuration file provided by "Python" with any of the following names: PythonConfig.cmake python-config.cmake`，请尝试将[cmake升级至3.25或最新版本](https://cmake.org/download/)解决。
+
 ## C++ SDK编译安装
 
 编译需满足

--- a/docs/en/build_and_install/jetson.md
+++ b/docs/en/build_and_install/jetson.md
@@ -4,6 +4,8 @@ English | [中文](../../cn/build_and_install/jetson.md)
 
 FastDeploy supports CPU inference with ONNX Runtime and GPU inference with Nvidia TensorRT/Paddle Inference on Nvidia Jetson platform
 
+- If there's error occurs, shows `Could not find a package configuration file provided by "Python" with any of the following names: PythonConfig.cmake python-config.cmake`, please try to [upgrade cmake to 3.25 or newer version](https://cmake.org/download/) to solve the problem.
+- 
 ## How to Build and Install FastDeploy C++ Library
 
 Prerequisite for Compiling on NVIDIA Jetson:


### PR DESCRIPTION
- 提示在Jetson上如若编译出错，可升级cmake至3.25解决。 关联issue https://github.com/PaddlePaddle/FastDeploy/issues/1291