### PR TITLE
[Model] Add skip valid backend check option -> FastDeployModel

### DIFF
--- a/fastdeploy/fastdeploy_model.cc
+++ b/fastdeploy/fastdeploy_model.cc
@@ -57,6 +57,12 @@ bool FastDeployModel::IsSupported(const std::vector<Backend>& backends,
   }
   return CheckBackendSupported(backends, backend);
 #else
+  if (!enable_valid_backend_check_) {
+    FDWARNING << "Checking for valid backend is disable, we don't"
+              << " check to see if the backend [" << backend
+              << "] is supported for current model!" << std::endl;
+    return true;
+  }
   return CheckBackendSupported(backends, backend);
 #endif
 }

--- a/fastdeploy/fastdeploy_model.cc
+++ b/fastdeploy/fastdeploy_model.cc
@@ -49,6 +49,11 @@ bool FastDeployModel::IsSupported(const std::vector<Backend>& backends,
               << "the backend [" << backend
               << "] is supported for current model!" << std::endl;
     return true;
+  } else if (!enable_valid_backend_check_) {
+    FDWARNING << "Checking for valid backend is disable, we don't"
+              << " check to see if the backend [" << backend
+              << "] is supported for current model!" << std::endl;
+    return true;
   }
   return CheckBackendSupported(backends, backend);
 #else

--- a/fastdeploy/fastdeploy_model.h
+++ b/fastdeploy/fastdeploy_model.h
@@ -121,7 +121,6 @@ class FASTDEPLOY_DECL FastDeployModel {
   virtual double GetProfileTime() {
     return runtime_->GetProfileTime();
   }
-#ifdef ENABLE_BENCHMARK
   /** \brief Enable to check if current backend set by user can be found at valid_xxx_backend.
    */
   virtual void EnableValidBackendCheck() {
@@ -132,7 +131,6 @@ class FASTDEPLOY_DECL FastDeployModel {
   virtual void DisableValidBackendCheck() {
     enable_valid_backend_check_ = false;
   }
-#endif
   /** \brief Release reused input/output buffers
   */
   virtual void ReleaseReusedBuffer() {
@@ -181,10 +179,8 @@ class FASTDEPLOY_DECL FastDeployModel {
   // whether to record inference time
   bool enable_record_time_of_runtime_ = false;
   std::vector<double> time_of_runtime_;
-#ifdef ENABLE_BENCHMARK
   // enable the check for valid backend, default true.
   bool enable_valid_backend_check_ = true;
-#endif
 };
 
 }  // namespace fastdeploy

--- a/fastdeploy/fastdeploy_model.h
+++ b/fastdeploy/fastdeploy_model.h
@@ -121,7 +121,18 @@ class FASTDEPLOY_DECL FastDeployModel {
   virtual double GetProfileTime() {
     return runtime_->GetProfileTime();
   }
-
+#ifdef ENABLE_BENCHMARK
+  /** \brief Enable to check if current backend set by user can be found at valid_xxx_backend.
+   */
+  virtual void EnableValidBackendCheck() {
+    enable_valid_backend_check_ = true;
+  }
+  /** \brief Disable to check if current backend set by user can be found at valid_xxx_backend.
+   */
+  virtual void DisableValidBackendCheck() {
+    enable_valid_backend_check_ = false;
+  }
+#endif
   /** \brief Release reused input/output buffers
   */
   virtual void ReleaseReusedBuffer() {
@@ -170,6 +181,10 @@ class FASTDEPLOY_DECL FastDeployModel {
   // whether to record inference time
   bool enable_record_time_of_runtime_ = false;
   std::vector<double> time_of_runtime_;
+#ifdef ENABLE_BENCHMARK
+  // skip the check for valid backend, default true.
+  bool enable_valid_backend_check_ = true;
+#endif
 };
 
 }  // namespace fastdeploy

--- a/fastdeploy/fastdeploy_model.h
+++ b/fastdeploy/fastdeploy_model.h
@@ -182,7 +182,7 @@ class FASTDEPLOY_DECL FastDeployModel {
   bool enable_record_time_of_runtime_ = false;
   std::vector<double> time_of_runtime_;
 #ifdef ENABLE_BENCHMARK
-  // skip the check for valid backend, default true.
+  // enable the check for valid backend, default true.
   bool enable_valid_backend_check_ = true;
 #endif
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->
Other

### Description
<!-- Describe what this PR does -->

- FastDeployModel增加enable_valid_backend_check_控制项
  - 只在ENABLE_BENCHMAEK=ON编译
  - 由于End2End的profile需要关闭enable_profile(即关闭backend infer的内循环) ，以获取包含前后处理在内每次处理的时间。在关闭enable_profile后，如果测试的是新集成后端，则会被valid backend检查拦截，无法正常测试。

