### PR TITLE
[Other] Integrate paddle2coreml tool into FastDeploy

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -3,6 +3,7 @@ FastDeploy提供了一系列高效易用的工具优化部署体验, 提升推�
 
 - [1.自动压缩工具包](#1)
 - [2.模型转换工具包](#2)
+- [3.paddle2coreml工具包](#3)
 
 <p id="1"></p>
 
@@ -72,3 +73,29 @@ fastdeploy convert --framework onnx --model yolov5s.onnx --save_dir pd_model
 ```
 
 更多详细内容可参考[X2Paddle](https://github.com/PaddlePaddle/X2Paddle)
+
+## paddle2coreml工具
+
+FastDeploy 基于 paddle2coreml 为用户提供了模型转换的工具, 用户可以轻松地通过一行命令将飞桨模型快速迁移至苹果电脑和手机端。
+
+### 环境准备
+
+1. PaddlePaddle 安装，可参考如下文档快速安装
+```
+https://www.paddlepaddle.org.cn/install/quick?docurl=/documentation/docs/zh/develop/install/pip/linux-pip.html
+```
+2. paddle2coreml 安装
+
+可通过pip方式安装paddle2coreml：
+```shell
+pip install paddle2coreml
+```
+3. 使用方式
+
+按照以上步骤成功安装后,即可使用 FastDeploy paddle2coreml 一键转换工具, 示例如下:
+
+```bash
+fastdeploy paddle2coreml --p2c_paddle_model_dir path/to/paddle_model --p2c_coreml_model_dir path/to/coreml_model --p2c_input_names "input1 input2" --p2c_input_shapes "1,3,224,224 1,4,64,64" --p2c_input_dtypes "float32 int32" --p2c_output_names "output1 output2" 
+```
+注意，--p2c_input_names 与 --p2c_output_names 两个参数须与paddle模型的输入输出名字一致。
+

--- a/tools/README_EN.md
+++ b/tools/README_EN.md
@@ -72,3 +72,27 @@ fastdeploy convert --framework onnx --model yolov5s.onnx --save_dir pd_model
 ```
 
 For more details, please refer to[X2Paddle](https://github.com/PaddlePaddle/X2Paddle)
+
+## paddle2coreml tool
+
+FastDeploy provides users with a model conversion tool based on paddle2coreml, which allows users to easily migrate PaddlePaddle models to Apple computers and mobile devices with a single command.
+
+### Environment Preparation
+
+1. PaddlePaddle installation, please refer to the following document for quick installation:
+```
+https://www.paddlepaddle.org.cn/install/quick?docurl=/documentation/docs/zh/develop/install/pip/linux-pip.html
+```
+2. paddle2coreml installation
+
+paddle2coreml can be installed using pip:
+```shell
+pip install paddle2coreml
+```
+3. Usage
+
+After successfully installing as described above, you can use the FastDeploy paddle2coreml one-click conversion tool, as shown below:
+
+```bash
+fastdeploy paddle2coreml --p2c_paddle_model_dir path/to/paddle_model --p2c_coreml_model_dir path/to/coreml_model --p2c_input_names "input1 input2" --p2c_input_shapes "1,3,224,224 1,4,64,64" --p2c_input_dtypes "float32 int32" --p2c_output_names "output1 output2" 
+```

--- a/tools/common_tools/common_tools.py
+++ b/tools/common_tools/common_tools.py
@@ -6,7 +6,7 @@ import uvicorn
 def argsparser():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        'tools', choices=['compress', 'convert', 'simple_serving'])
+        'tools', choices=['compress', 'convert', 'simple_serving', 'paddle2coreml'])
     ## argumentments for auto compression
     parser.add_argument(
         '--config_path',
@@ -84,6 +84,49 @@ def argsparser():
         help="Simple serving host IP address")
     parser.add_argument(
         "--port", type=int, default=8000, help="Simple serving host port")
+    ## arguments for paddle2coreml
+    parser.add_argument(
+        "--p2c_paddle_model_dir",
+        type=str,
+        default=None,
+        required=True,
+        help="define paddle model path")
+    parser.add_argument(
+        "--p2c_coreml_model_dir",
+        type=str,
+        default=None,
+        required=True,
+        help="define generated coreml model path")
+    parser.add_argument(
+        "--p2c_coreml_model_name",
+        type=str,
+        default="coreml_model",
+        required=False,
+        help="define generated coreml model name")
+    parser.add_argument(
+        "--p2c_input_names",
+        type=str,
+        default=None,
+        required=True,
+        help="define input names")
+    parser.add_argument(
+        "--p2c_input_dtypes",
+        type=str,
+        default="float32",
+        required=True,
+        help="define input dtypes")
+    parser.add_argument(
+        "--p2c_input_shapes",
+        type=str,
+        default=None,
+        required=True,
+        help="define input shapes") 
+    parser.add_argument(
+        "--p2c_output_names",
+        type=str,
+        default=None,
+        required=True,
+        help="define output names")  
     ## arguments for other tools
     return parser
 
@@ -170,6 +213,51 @@ def main():
                     port=args.port,
                     app_dir='.',
                     log_config=custom_logging_config)
+    if args.tools == "paddle2coreml":
+        import coremltools as ct
+        import os
+        import numpy as np
+        def type_to_np_dtype(dtype):
+            if dtype == 'float32':
+                return np.float32
+            elif dtype == 'float64':
+                return np.float64
+            elif dtype == 'int32':
+                return np.int32
+            elif dtype == 'int64':
+                return np.int64
+            elif dtype == 'uint8':
+                return np.uint8
+            elif dtype == 'uint16':
+                return np.uint16
+            elif dtype == 'uint32':
+                return np.uint32
+            elif dtype == 'uint64':
+                return np.uint64
+            elif dtype == 'int8':
+                return np.int8
+            elif dtype == 'int16':
+                return np.int16
+            else:
+                raise Exception("Unsupported dtype: {}".format(dtype))
+        input_names = args.p2c_input_names.split(' ')
+        input_shapes = [[int(i) for i in shape.split(',')] for shape in args.p2c_input_shapes.split(' ')]
+        input_dtypes = map(type_to_np_dtype, args.p2c_input_dtypes.split(' '))
+        output_names = args.p2c_output_names.split(' ')
+        sample_input = [ct.TensorType(
+                                name=k,
+                                shape=s,
+                                dtype=d,
+                            ) for k, s, d in zip(input_names, input_shapes, input_dtypes)]
+
+        coreml_model = ct.convert(
+            args.p2c_paddle_model_dir,
+            convert_to="mlprogram",
+            minimum_deployment_target=ct.target.macOS13,
+            inputs=sample_input,
+            outputs=[ct.TensorType(name=name) for name in output_names],
+        )
+        coreml_model.save(os.path.join(args.p2c_coreml_model_dir, args.p2c_coreml_model_name))        
 
 
 if __name__ == '__main__':

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -7,7 +7,7 @@ install_requires = ['uvicorn==0.16.0']
 
 setuptools.setup(
     name="fastdeploy-tools",  # name of package
-    version="0.0.3",  #version of package
+    version="0.0.4",  #version of package
     description="A toolkit for FastDeploy.",
     long_description=long_description,
     long_description_content_type="text/plain",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->
Other
### Description
<!-- Describe what this PR does -->
Adds the paddle2coreml tool to the FastDeploy project. Users will be able to use a single command to convert their PaddlePaddle models to CoreML models.

The environment preparation steps and an example usage command for using paddle2coreml tool are included in the documentation.

