### PR TITLE
[Bug Fix] Remove redundant parameters during OCR multi-threaded inference

### DIFF
--- a/tutorials/multi_thread/python/pipeline/multi_thread_process_ocr.py
+++ b/tutorials/multi_thread/python/pipeline/multi_thread_process_ocr.py
@@ -267,7 +267,7 @@ if __name__ == '__main__':
                     predict,
                     args=(ppocr_v3.clone(),
                           imgs_list[i * image_num_each_thread:(i + 1) *
-                                    image_num_each_thread - 1], args.topk))
+                                    image_num_each_thread - 1]))
             threads.append(t)
             t.start()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->
Bug Fix

### Description
<!-- Describe what this PR does -->
OCR inference doesn't need the "topk" arguments.

