### PR TITLE
[Bug Fix] need sphinx_book_theme in docs/api_docs/python/requirements.txt

### DIFF
--- a/docs/api_docs/python/requirements.txt
+++ b/docs/api_docs/python/requirements.txt
@@ -2,5 +2,6 @@ sphinx
 recommonmark
 sphinx_markdown_tables
 sphinx_rtd_theme
+sphinx_book_theme
 furo
 myst_parser


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->
Bug Fix
### Description
<!-- Describe what this PR does -->
- 根据docs/api_docs/README.md中构建api doc发现requirements中缺少sphinx_book_theme这一必要的包，构建失败，安装sphinx_book_theme后构建成功

