### PR TITLE
[CVCUDA] wrap C processors in Python API

### DIFF
--- a/python/fastdeploy/vision/common/__init__.py
+++ b/python/fastdeploy/vision/common/__init__.py
@@ -15,3 +15,4 @@ from __future__ import absolute_import
 
 from .manager import ProcessorManager
 from .manager import PyProcessorManager
+from .processors import *

--- a/python/fastdeploy/vision/common/processors.py
+++ b/python/fastdeploy/vision/common/processors.py
@@ -7,6 +7,13 @@ class ResizeByShort():
         self.processor = C.vision.processors.ResizeByShort(target_size, interp,
                                                            use_scale, max_hw)
 
+    """Create a ResizeByShort operation with the given parameters.
+    :param target_size: the target short size to resize the image
+    :param interp: optionally, the interpolation mode for resizing image
+    :param use_scale: optionally, whether to scale image
+    :param max_hw: max spatial size which is used by ResizeByShort
+    """
+
     def __call__(self, mat):
         self.processor(mat)
 
@@ -14,6 +21,11 @@ class ResizeByShort():
 class CenterCrop():
     def __init__(self, width, height):
         self.processor = C.vision.processors.CenterCrop(width, height)
+
+    """Create a CenterCrop operation with the given parameters.
+    :param width: desired width of the cropped image
+    :param height: desired height of the cropped image
+    """
 
     def __call__(self, mat):
         self.processor(mat)
@@ -23,6 +35,14 @@ class Pad():
     def __init__(self, top: int, bottom: int, left: int, right: int, value=[]):
         self.processor = C.vision.processors.Pad(top, bottom, left, right,
                                                  value)
+
+    """Create a Pad operation with the given parameters.
+    :param top: the top padding
+    :param bottom: the bottom padding
+    :param left: the left padding
+    :param right: the right padding
+    :param value: the value that is used to pad on the input image
+    """
 
     def __call__(self, mat):
         self.processor(mat)
@@ -38,6 +58,14 @@ class NormalizeAndPermute():
                  swap_rb=False):
         self.processor = C.vision.processors.NormalizeAndPermute(
             mean, std, is_scale, min, max, swap_rb)
+
+    """Creae a Normalize and a Permute operation with the given parameters.
+    :param mean     A list containing the mean of each channel
+    :param std      A list containing the standard deviation of each channel
+    :param is_scale Specifies if the image are being scaled or not
+    :param min      A list containing the minimum value of each channel
+    :param max      A list containing the maximum value of each channel
+    """
 
     def __call__(self, mat):
         self.processor(mat)

--- a/python/fastdeploy/vision/common/processors.py
+++ b/python/fastdeploy/vision/common/processors.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+from ... import c_lib_wrap as C
+
+
+class ResizeByShort():
+    def __init__(self, target_size: int, interp=1, use_scale=True, max_hw=[]):
+        self.processor = C.vision.processors.ResizeByShort(target_size, interp,
+                                                           use_scale, max_hw)
+
+    def __call__(self, mat):
+        self.processor(mat)
+
+
+class CenterCrop():
+    def __init__(self, width, height):
+        self.processor = C.vision.processors.CenterCrop(width, height)
+
+    def __call__(self, mat):
+        self.processor(mat)
+
+
+class Pad():
+    def __init__(self, top: int, bottom: int, left: int, right: int, value=[]):
+        self.processor = C.vision.processors.Pad(top, bottom, left, right,
+                                                 value)
+
+    def __call__(self, mat):
+        self.processor(mat)
+
+
+class NormalizeAndPermute():
+    def __init__(self,
+                 mean=[],
+                 std=[],
+                 is_scale=True,
+                 min=[],
+                 max=[],
+                 swap_rb=False):
+        self.processor = C.vision.processors.NormalizeAndPermute(
+            mean, std, is_scale, min, max, swap_rb)
+
+    def __call__(self, mat):
+        self.processor(mat)

--- a/python/fastdeploy/vision/common/processors.py
+++ b/python/fastdeploy/vision/common/processors.py
@@ -2,7 +2,15 @@ from __future__ import absolute_import
 from ... import c_lib_wrap as C
 
 
-class ResizeByShort():
+class Processor():
+    def __init__(self):
+        self.processor
+
+    def __call__(self, mat):
+        self.processor(mat)
+
+
+class ResizeByShort(Processor):
     def __init__(self, target_size: int, interp=1, use_scale=True, max_hw=[]):
         self.processor = C.vision.processors.ResizeByShort(target_size, interp,
                                                            use_scale, max_hw)
@@ -14,11 +22,8 @@ class ResizeByShort():
         :param max_hw: max spatial size which is used by ResizeByShort
         """
 
-    def __call__(self, mat):
-        self.processor(mat)
 
-
-class CenterCrop():
+class CenterCrop(Processor):
     def __init__(self, width, height):
         self.processor = C.vision.processors.CenterCrop(width, height)
         """Create a CenterCrop operation with the given parameters.
@@ -27,11 +32,8 @@ class CenterCrop():
         :param height: desired height of the cropped image
         """
 
-    def __call__(self, mat):
-        self.processor(mat)
 
-
-class Pad():
+class Pad(Processor):
     def __init__(self, top: int, bottom: int, left: int, right: int, value=[]):
         self.processor = C.vision.processors.Pad(top, bottom, left, right,
                                                  value)
@@ -44,11 +46,8 @@ class Pad():
         :param value: the value that is used to pad on the input image
         """
 
-    def __call__(self, mat):
-        self.processor(mat)
 
-
-class NormalizeAndPermute():
+class NormalizeAndPermute(Processor):
     def __init__(self,
                  mean=[],
                  std=[],
@@ -66,6 +65,3 @@ class NormalizeAndPermute():
         :param min      A list containing the minimum value of each channel
         :param max      A list containing the maximum value of each channel
         """
-
-    def __call__(self, mat):
-        self.processor(mat)

--- a/python/fastdeploy/vision/common/processors.py
+++ b/python/fastdeploy/vision/common/processors.py
@@ -6,13 +6,13 @@ class ResizeByShort():
     def __init__(self, target_size: int, interp=1, use_scale=True, max_hw=[]):
         self.processor = C.vision.processors.ResizeByShort(target_size, interp,
                                                            use_scale, max_hw)
+        """Create a ResizeByShort operation with the given parameters.
 
-    """Create a ResizeByShort operation with the given parameters.
-    :param target_size: the target short size to resize the image
-    :param interp: optionally, the interpolation mode for resizing image
-    :param use_scale: optionally, whether to scale image
-    :param max_hw: max spatial size which is used by ResizeByShort
-    """
+        :param target_size: the target short size to resize the image
+        :param interp: optionally, the interpolation mode for resizing image
+        :param use_scale: optionally, whether to scale image
+        :param max_hw: max spatial size which is used by ResizeByShort
+        """
 
     def __call__(self, mat):
         self.processor(mat)
@@ -21,11 +21,11 @@ class ResizeByShort():
 class CenterCrop():
     def __init__(self, width, height):
         self.processor = C.vision.processors.CenterCrop(width, height)
+        """Create a CenterCrop operation with the given parameters.
 
-    """Create a CenterCrop operation with the given parameters.
-    :param width: desired width of the cropped image
-    :param height: desired height of the cropped image
-    """
+        :param width: desired width of the cropped image
+        :param height: desired height of the cropped image
+        """
 
     def __call__(self, mat):
         self.processor(mat)
@@ -35,14 +35,14 @@ class Pad():
     def __init__(self, top: int, bottom: int, left: int, right: int, value=[]):
         self.processor = C.vision.processors.Pad(top, bottom, left, right,
                                                  value)
+        """Create a Pad operation with the given parameters.
 
-    """Create a Pad operation with the given parameters.
-    :param top: the top padding
-    :param bottom: the bottom padding
-    :param left: the left padding
-    :param right: the right padding
-    :param value: the value that is used to pad on the input image
-    """
+        :param top: the top padding
+        :param bottom: the bottom padding
+        :param left: the left padding
+        :param right: the right padding
+        :param value: the value that is used to pad on the input image
+        """
 
     def __call__(self, mat):
         self.processor(mat)
@@ -58,14 +58,14 @@ class NormalizeAndPermute():
                  swap_rb=False):
         self.processor = C.vision.processors.NormalizeAndPermute(
             mean, std, is_scale, min, max, swap_rb)
+        """Creae a Normalize and a Permute operation with the given parameters.
 
-    """Creae a Normalize and a Permute operation with the given parameters.
-    :param mean     A list containing the mean of each channel
-    :param std      A list containing the standard deviation of each channel
-    :param is_scale Specifies if the image are being scaled or not
-    :param min      A list containing the minimum value of each channel
-    :param max      A list containing the maximum value of each channel
-    """
+        :param mean     A list containing the mean of each channel
+        :param std      A list containing the standard deviation of each channel
+        :param is_scale Specifies if the image are being scaled or not
+        :param min      A list containing the minimum value of each channel
+        :param max      A list containing the maximum value of each channel
+        """
 
     def __call__(self, mat):
         self.processor(mat)

--- a/tutorials/vision_processor/python/preprocess.py
+++ b/tutorials/vision_processor/python/preprocess.py
@@ -2,6 +2,7 @@ import fastdeploy as fd
 import cv2
 
 from fastdeploy.vision.common.manager import PyProcessorManager
+from fastdeploy.vision.common.processors import *
 
 
 def parse_arguments():
@@ -21,7 +22,7 @@ class CustomProcessor(PyProcessorManager):
         super().__init__()
         # create op
         hw = [500, 500]
-        self.resize_op = fd.C.vision.processors.ResizeByShort(100, 1, True, hw)
+        self.resize_op = ResizeByShort(100, 1, True, hw)
 
         mean = [0.485, 0.456, 0.406]
         std = [0.229, 0.224, 0.225]
@@ -29,20 +30,19 @@ class CustomProcessor(PyProcessorManager):
         min = []
         max = []
         swap_rb = False
-        self.normalize_permute_op = fd.C.vision.processors.NormalizeAndPermute(
-            mean, std, is_scale, min, max, swap_rb)
+        self.normalize_permute_op = NormalizeAndPermute(mean, std, is_scale,
+                                                        min, max, swap_rb)
 
         width = 50
         height = 50
-        self.centercrop_op = fd.C.vision.processors.CenterCrop(width, height)
+        self.centercrop_op = CenterCrop(width, height)
 
         top = 5
         bottom = 5
         left = 5
         right = 5
         pad_value = [225, 225, 225]
-        self.pad_op = fd.C.vision.processors.Pad(top, bottom, left, right,
-                                                 pad_value)
+        self.pad_op = Pad(top, bottom, left, right, pad_value)
 
     def apply(self, image_batch):
         outputs = []

--- a/tutorials/vision_processor/python/preprocess.py
+++ b/tutorials/vision_processor/python/preprocess.py
@@ -21,28 +21,18 @@ class CustomProcessor(PyProcessorManager):
     def __init__(self) -> None:
         super().__init__()
         # create op
-        hw = [500, 500]
-        self.resize_op = ResizeByShort(100, 1, True, hw)
-
-        mean = [0.485, 0.456, 0.406]
-        std = [0.229, 0.224, 0.225]
-        is_scale = True
-        min = []
-        max = []
-        swap_rb = False
-        self.normalize_permute_op = NormalizeAndPermute(mean, std, is_scale,
-                                                        min, max, swap_rb)
-
-        width = 50
-        height = 50
-        self.centercrop_op = CenterCrop(width, height)
-
-        top = 5
-        bottom = 5
-        left = 5
-        right = 5
-        pad_value = [225, 225, 225]
-        self.pad_op = Pad(top, bottom, left, right, pad_value)
+        self.resize_op = ResizeByShort(
+            target_size=100, interp=1, use_scale=True, max_hw=[500, 500])
+        self.normalize_permute_op = NormalizeAndPermute(
+            mean=[0.485, 0.456, 0.406],
+            std=[0.229, 0.224, 0.225],
+            is_scale=True,
+            min=[],
+            max=[],
+            swap_rb=False)
+        self.centercrop_op = CenterCrop(width=50, height=50)
+        self.pad_op = Pad(
+            top=5, bottom=5, left=5, right=5, value=[225, 225, 225])
 
     def apply(self, image_batch):
         outputs = []


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->
Vision Processor
### Description
<!-- Describe what this PR does -->
- 将C.vision.processors.*封装到Python类中，从而使得在Python中调用processors有API提示信息

