### PR TITLE
[CVCUDA] PP-OCR and PPDet preprocessor support use_cuda python API

### DIFF
--- a/python/fastdeploy/vision/detection/ppdet/__init__.py
+++ b/python/fastdeploy/vision/detection/ppdet/__init__.py
@@ -17,36 +17,28 @@ from typing import Union, List
 import logging
 from .... import FastDeployModel, ModelFormat
 from .... import c_lib_wrap as C
+from ...common import ProcessorManager
 
 
-class PaddleDetPreprocessor:
+class PaddleDetPreprocessor(ProcessorManager):
     def __init__(self, config_file):
         """Create a preprocessor for PaddleDetection Model from configuration file
 
         :param config_file: (str)Path of configuration file, e.g ppyoloe/infer_cfg.yml
         """
-        self._preprocessor = C.vision.detection.PaddleDetPreprocessor(
-            config_file)
-
-    def run(self, input_ims):
-        """Preprocess input images for PaddleDetection Model
-
-        :param: input_ims: (list of numpy.ndarray)The input image
-        :return: list of FDTensor, include image, scale_factor, im_shape
-        """
-        return self._preprocessor.run(input_ims)
+        self._manager = C.vision.detection.PaddleDetPreprocessor(config_file)
 
     def disable_normalize(self):
         """
         This function will disable normalize in preprocessing step.
         """
-        self._preprocessor.disable_normalize()
+        self._manager.disable_normalize()
 
     def disable_permute(self):
         """
         This function will disable hwc2chw in preprocessing step.
         """
-        self._preprocessor.disable_permute()
+        self._manager.disable_permute()
 
 
 class NMSOption:

--- a/python/fastdeploy/vision/ocr/ppocr/__init__.py
+++ b/python/fastdeploy/vision/ocr/ppocr/__init__.py
@@ -16,32 +16,26 @@ from __future__ import absolute_import
 import logging
 from .... import FastDeployModel, ModelFormat
 from .... import c_lib_wrap as C
+from ...common import ProcessorManager
 
 
 def sort_boxes(boxes):
     return C.vision.ocr.sort_boxes(boxes)
 
 
-class DBDetectorPreprocessor:
+class DBDetectorPreprocessor(ProcessorManager):
     def __init__(self):
         """
         Create a preprocessor for DBDetectorModel
         """
-        self._preprocessor = C.vision.ocr.DBDetectorPreprocessor()
-
-    def run(self, input_ims):
-        """Preprocess input images for DBDetectorModel
-
-        :param: input_ims: (list of numpy.ndarray) The input image
-        :return: pair(list of FDTensor, list of std::array<int, 4>)
-        """
-        return self._preprocessor.run(input_ims)
+        super(DBDetectorPreprocessor, self).__init__()
+        self._manager = C.vision.ocr.DBDetectorPreprocessor()
 
     @property
     def max_side_len(self):
         """Get max_side_len value.
         """
-        return self._preprocessor.max_side_len
+        return self._manager.max_side_len
 
     @max_side_len.setter
     def max_side_len(self, value):
@@ -50,7 +44,7 @@ class DBDetectorPreprocessor:
         """
         assert isinstance(
             value, int), "The value to set `max_side_len` must be type of int."
-        self._preprocessor.max_side_len = value
+        self._manager.max_side_len = value
 
     def set_normalize(self, mean, std, is_scale):
         """Set preprocess normalize parameters, please call this API to
@@ -60,30 +54,30 @@ class DBDetectorPreprocessor:
         :param: std: (list of float) std values
         :param: is_scale: (boolean) whether to scale
         """
-        self._preprocessor.set_normalize(mean, std, is_scale)
+        self._manager.set_normalize(mean, std, is_scale)
 
     @property
     def static_shape_infer(self):
-        return self._preprocessor.static_shape_infer
+        return self._manager.static_shape_infer
 
     @static_shape_infer.setter
     def static_shape_infer(self, value):
         assert isinstance(
             value,
             bool), "The value to set `static_shape_infer` must be type of bool."
-        self._preprocessor.static_shape_infer = value
+        self._manager.static_shape_infer = value
 
     def disable_normalize(self):
         """
         This function will disable normalize in preprocessing step.
         """
-        self._preprocessor.disable_normalize()
+        self._manager.disable_normalize()
 
     def disable_permute(self):
         """
         This function will disable hwc2chw in preprocessing step.
         """
-        self._preprocessor.disable_permute()
+        self._manager.disable_permute()
 
 
 class DBDetectorPostprocessor:
@@ -324,18 +318,12 @@ class DBDetector(FastDeployModel):
         self._model.postprocessor.use_dilation = value
 
 
-class ClassifierPreprocessor:
+class ClassifierPreprocessor(ProcessorManager):
     def __init__(self):
         """Create a preprocessor for ClassifierModel
         """
-        self._preprocessor = C.vision.ocr.ClassifierPreprocessor()
-
-    def run(self, input_ims):
-        """Preprocess input images for ClassifierModel
-        :param: input_ims: (list of numpy.ndarray)The input image
-        :return: list of FDTensor
-        """
-        return self._preprocessor.run(input_ims)
+        super(ClassifierPreprocessor, self).__init__()
+        self._manager = C.vision.ocr.ClassifierPreprocessor()
 
     def set_normalize(self, mean, std, is_scale):
         """Set preprocess normalize parameters, please call this API to
@@ -345,30 +333,30 @@ class ClassifierPreprocessor:
         :param: std: (list of float) std values
         :param: is_scale: (boolean) whether to scale
         """
-        self._preprocessor.set_normalize(mean, std, is_scale)
+        self._manager.set_normalize(mean, std, is_scale)
 
     @property
     def cls_image_shape(self):
-        return self._preprocessor.cls_image_shape
+        return self._manager.cls_image_shape
 
     @cls_image_shape.setter
     def cls_image_shape(self, value):
         assert isinstance(
             value,
             list), "The value to set `cls_image_shape` must be type of list."
-        self._preprocessor.cls_image_shape = value
+        self._manager.cls_image_shape = value
 
     def disable_normalize(self):
         """
         This function will disable normalize in preprocessing step.
         """
-        self._preprocessor.disable_normalize()
+        self._manager.disable_normalize()
 
     def disable_permute(self):
         """
         This function will disable hwc2chw in preprocessing step.
         """
-        self._preprocessor.disable_permute()
+        self._manager.disable_permute()
 
 
 class ClassifierPostprocessor:
@@ -497,29 +485,23 @@ class Classifier(FastDeployModel):
         self._model.postprocessor.cls_thresh = value
 
 
-class RecognizerPreprocessor:
+class RecognizerPreprocessor(ProcessorManager):
     def __init__(self):
         """Create a preprocessor for RecognizerModel
         """
-        self._preprocessor = C.vision.ocr.RecognizerPreprocessor()
-
-    def run(self, input_ims):
-        """Preprocess input images for RecognizerModel
-        :param: input_ims: (list of numpy.ndarray)The input image
-        :return: list of FDTensor
-        """
-        return self._preprocessor.run(input_ims)
+        super(RecognizerPreprocessor, self).__init__()
+        self._manager = C.vision.ocr.RecognizerPreprocessor()
 
     @property
     def static_shape_infer(self):
-        return self._preprocessor.static_shape_infer
+        return self._manager.static_shape_infer
 
     @static_shape_infer.setter
     def static_shape_infer(self, value):
         assert isinstance(
             value,
             bool), "The value to set `static_shape_infer` must be type of bool."
-        self._preprocessor.static_shape_infer = value
+        self._manager.static_shape_infer = value
 
     def set_normalize(self, mean, std, is_scale):
         """Set preprocess normalize parameters, please call this API to
@@ -529,30 +511,30 @@ class RecognizerPreprocessor:
         :param: std: (list of float) std values
         :param: is_scale: (boolean) whether to scale
         """
-        self._preprocessor.set_normalize(mean, std, is_scale)
+        self._manager.set_normalize(mean, std, is_scale)
 
     @property
     def rec_image_shape(self):
-        return self._preprocessor.rec_image_shape
+        return self._manager.rec_image_shape
 
     @rec_image_shape.setter
     def rec_image_shape(self, value):
         assert isinstance(
             value,
             list), "The value to set `rec_image_shape` must be type of list."
-        self._preprocessor.rec_image_shape = value
+        self._manager.rec_image_shape = value
 
     def disable_normalize(self):
         """
         This function will disable normalize in preprocessing step.
         """
-        self._preprocessor.disable_normalize()
+        self._manager.disable_normalize()
 
     def disable_permute(self):
         """
         This function will disable hwc2chw in preprocessing step.
         """
-        self._preprocessor.disable_permute()
+        self._manager.disable_permute()
 
 
 class RecognizerPostprocessor:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->
CVCUDA
### Description
<!-- Describe what this PR does -->
- 在PPOCR和PPDet的python部署中支持CVCUDA，通过在推理代码中使用`model.preprocessor.use_cuda(True, 0)`开启CVCUDA

