### PR TITLE
[CVCUDA] Add CV-CUDA support in PaddleSeg

### DIFF
--- a/fastdeploy/vision/segmentation/ppseg/model.cc
+++ b/fastdeploy/vision/segmentation/ppseg/model.cc
@@ -79,7 +79,8 @@ bool PaddleSegModel::BatchPredict(const std::vector<cv::Mat>& imgs,
   std::vector<FDMat> fd_images = WrapMat(imgs);
   // Record the shape of input images
   std::map<std::string, std::vector<std::array<int, 2>>> imgs_info;
-  if (!preprocessor_.Run(&fd_images, &reused_input_tensors_, &imgs_info)) {
+  preprocessor_.SetImgsInfo(&imgs_info);
+  if (!preprocessor_.Run(&fd_images, &reused_input_tensors_)) {
     FDERROR << "Failed to preprocess input data while using model:"
             << ModelName() << "." << std::endl;
     return false;

--- a/fastdeploy/vision/segmentation/ppseg/preprocessor.cc
+++ b/fastdeploy/vision/segmentation/ppseg/preprocessor.cc
@@ -21,7 +21,8 @@ namespace segmentation {
 
 PaddleSegPreprocessor::PaddleSegPreprocessor(const std::string& config_file) {
   this->config_file_ = config_file;
-  FDASSERT(BuildPreprocessPipelineFromConfig(), "Failed to create PaddleSegPreprocessor.");
+  FDASSERT(BuildPreprocessPipelineFromConfig(),
+           "Failed to create PaddleSegPreprocessor.");
   initialized_ = true;
 }
 
@@ -35,7 +36,7 @@ bool PaddleSegPreprocessor::BuildPreprocessPipelineFromConfig() {
     FDERROR << "Failed to load yaml file " << config_file_
             << ", maybe you should check this file." << std::endl;
     return false;
-  }   
+  }
 
   if (cfg["Deploy"]["transforms"]) {
     auto preprocess_cfg = cfg["Deploy"]["transforms"];
@@ -76,7 +77,7 @@ bool PaddleSegPreprocessor::BuildPreprocessPipelineFromConfig() {
     if (input_height != -1 && input_width != -1 && !is_contain_resize_op_) {
       is_contain_resize_op_ = true;
       processors_.insert(processors_.begin(),
-          std::make_shared<Resize>(input_width, input_height));
+                         std::make_shared<Resize>(input_width, input_height));
     }
   }
   if (!disable_permute_) {
@@ -88,22 +89,24 @@ bool PaddleSegPreprocessor::BuildPreprocessPipelineFromConfig() {
   return true;
 }
 
-bool PaddleSegPreprocessor::Run(std::vector<FDMat>* images, std::vector<FDTensor>* outputs, std::map<std::string, std::vector<std::array<int, 2>>>* imgs_info) {
-  
+bool PaddleSegPreprocessor::Apply(FDMatBatch* image_batch,
+                                  std::vector<FDTensor>* outputs) {
+  std::vector<FDMat>* images = image_batch->mats;
   if (!initialized_) {
     FDERROR << "The preprocessor is not initialized." << std::endl;
     return false;
   }
   if (images->size() == 0) {
-    FDERROR << "The size of input images should be greater than 0." << std::endl;
+    FDERROR << "The size of input images should be greater than 0."
+            << std::endl;
     return false;
   }
   std::vector<std::array<int, 2>> shape_info;
   for (const auto& image : *images) {
-    shape_info.push_back({static_cast<int>(image.Height()),
-                          static_cast<int>(image.Width())});
+    shape_info.push_back(
+        {static_cast<int>(image.Height()), static_cast<int>(image.Width())});
   }
-  (*imgs_info)["shape_info"] = shape_info;
+  (*imgs_info_)["shape_info"] = shape_info;
   for (size_t i = 0; i < processors_.size(); ++i) {
     if (processors_[i]->Name() == "Resize") {
       auto processor = dynamic_cast<Resize*>(processors_[i].get());
@@ -123,7 +126,7 @@ bool PaddleSegPreprocessor::Run(std::vector<FDMat>* images, std::vector<FDTensor
   // Batch preprocess : resize all images to the largest image shape in batch
   if (!is_contain_resize_op_ && img_num > 1) {
     int max_width = 0;
-    int max_height = 0; 
+    int max_height = 0;
     for (size_t i = 0; i < img_num; ++i) {
       max_width = std::max(max_width, ((*images)[i]).Width());
       max_height = std::max(max_height, ((*images)[i]).Height());
@@ -158,16 +161,20 @@ bool PaddleSegPreprocessor::Run(std::vector<FDMat>* images, std::vector<FDTensor
 
 void PaddleSegPreprocessor::DisableNormalize() {
   this->disable_normalize_ = true;
-  // the DisableNormalize function will be invalid if the configuration file is loaded during preprocessing
+  // the DisableNormalize function will be invalid if the configuration file is
+  // loaded during preprocessing
   if (!BuildPreprocessPipelineFromConfig()) {
-    FDERROR << "Failed to build preprocess pipeline from configuration file." << std::endl;
+    FDERROR << "Failed to build preprocess pipeline from configuration file."
+            << std::endl;
   }
 }
 void PaddleSegPreprocessor::DisablePermute() {
   this->disable_permute_ = true;
-  // the DisablePermute function will be invalid if the configuration file is loaded during preprocessing
+  // the DisablePermute function will be invalid if the configuration file is
+  // loaded during preprocessing
   if (!BuildPreprocessPipelineFromConfig()) {
-    FDERROR << "Failed to build preprocess pipeline from configuration file." << std::endl;
+    FDERROR << "Failed to build preprocess pipeline from configuration file."
+            << std::endl;
   }
 }
 }  // namespace segmentation

--- a/fastdeploy/vision/segmentation/ppseg/preprocessor.cc
+++ b/fastdeploy/vision/segmentation/ppseg/preprocessor.cc
@@ -131,10 +131,9 @@ bool PaddleSegPreprocessor::Apply(FDMatBatch* image_batch,
       max_width = std::max(max_width, ((*images)[i]).Width());
       max_height = std::max(max_height, ((*images)[i]).Height());
     }
-    std::shared_ptr<Resize> pre_resize_op =
-        std::make_shared<Resize>(max_width, max_height);
+    pre_resize_op_->SetWidthAndHeight(max_width, max_height);
     for (size_t i = 0; i < img_num; ++i) {
-      if (!(*pre_resize_op)(&(*images)[i])) {
+      if (!(*pre_resize_op_)(&(*images)[i])) {
         FDERROR << "Failed to batch resize max_width and max_height"
                 << std::endl;
       }

--- a/fastdeploy/vision/segmentation/ppseg/preprocessor.h
+++ b/fastdeploy/vision/segmentation/ppseg/preprocessor.h
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #pragma once
+#include "fastdeploy/vision/common/processors/manager.h"
 #include "fastdeploy/vision/common/processors/transform.h"
 #include "fastdeploy/vision/common/result.h"
 
@@ -20,7 +21,7 @@ namespace vision {
 namespace segmentation {
 /*! @brief Preprocessor object for PaddleSeg serials model.
   */
-class FASTDEPLOY_DECL PaddleSegPreprocessor {
+class FASTDEPLOY_DECL PaddleSegPreprocessor : public ProcessorManager {
  public:
   /** \brief Create a preprocessor instance for PaddleSeg serials model
    *
@@ -28,17 +29,16 @@ class FASTDEPLOY_DECL PaddleSegPreprocessor {
    */
   explicit PaddleSegPreprocessor(const std::string& config_file);
 
-  /** \brief Process the input image and prepare input tensors for runtime
+  /** \brief Implement the virtual function of ProcessorManager, Apply() is the
+   *  body of Run(). Apply() contains the main logic of preprocessing, Run() is
+   *  called by users to execute preprocessing
    *
-   * \param[in] images The input image data list, all the elements are returned by cv::imread()
+   * \param[in] image_batch The input image batch
    * \param[in] outputs The output tensors which will feed in runtime
-   * \param[in] imgs_info The original input images shape info map, key is "shape_info", value is vector<array<int, 2>> a{{height, width}} 
    * \return true if the preprocess successed, otherwise false
    */
-  virtual bool Run(
-    std::vector<FDMat>* images,
-    std::vector<FDTensor>* outputs,
-    std::map<std::string, std::vector<std::array<int, 2>>>* imgs_info);
+  virtual bool Apply(FDMatBatch* image_batch,
+                     std::vector<FDTensor>* outputs);
 
   /// Get is_vertical_screen property of PP-HumanSeg model, default is false
   bool GetIsVerticalScreen() const {
@@ -54,6 +54,15 @@ class FASTDEPLOY_DECL PaddleSegPreprocessor {
   void DisableNormalize();
   /// This function will disable hwc2chw in preprocessing step.
   void DisablePermute();
+  /// This function will set imgs_info_ in PaddleSegPreprocessor
+  void SetImgsInfo(
+          std::map<std::string, std::vector<std::array<int, 2>>>* imgs_info) {
+    imgs_info_ = imgs_info;
+  }
+  /// This function will get imgs_info_ in PaddleSegPreprocessor
+  std::map<std::string, std::vector<std::array<int, 2>>>* GetImgsInfo() {
+    return imgs_info_;
+  }
 
  private:
   virtual bool BuildPreprocessPipelineFromConfig();
@@ -72,6 +81,8 @@ class FASTDEPLOY_DECL PaddleSegPreprocessor {
   bool is_contain_resize_op_ = false;
 
   bool initialized_ = false;
+
+  std::map<std::string, std::vector<std::array<int, 2>>>* imgs_info_;
 };
 
 }  // namespace segmentation

--- a/fastdeploy/vision/segmentation/ppseg/preprocessor.h
+++ b/fastdeploy/vision/segmentation/ppseg/preprocessor.h
@@ -83,6 +83,8 @@ class FASTDEPLOY_DECL PaddleSegPreprocessor : public ProcessorManager {
   bool initialized_ = false;
 
   std::map<std::string, std::vector<std::array<int, 2>>>* imgs_info_;
+  std::shared_ptr<Resize> pre_resize_op_ =
+        std::make_shared<Resize>(0, 0);
 };
 
 }  // namespace segmentation

--- a/python/fastdeploy/vision/segmentation/ppseg/__init__.py
+++ b/python/fastdeploy/vision/segmentation/ppseg/__init__.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 import logging
 from .... import FastDeployModel, ModelFormat
 from .... import c_lib_wrap as C
+from ...common import ProcessorManager
 
 
 class PaddleSegModel(FastDeployModel):
@@ -87,34 +88,26 @@ class PaddleSegModel(FastDeployModel):
         return self._model.postprocessor
 
 
-class PaddleSegPreprocessor:
+class PaddleSegPreprocessor(ProcessorManager):
     def __init__(self, config_file):
         """Create a preprocessor for PaddleSegModel from configuration file
 
         :param config_file: (str)Path of configuration file, e.g ppliteseg/deploy.yaml
         """
-        self._preprocessor = C.vision.segmentation.PaddleSegPreprocessor(
+        self._manager = C.vision.segmentation.PaddleSegPreprocessor(
             config_file)
-
-    def run(self, input_ims):
-        """Preprocess input images for PaddleSegModel
-
-        :param input_ims: (list of numpy.ndarray)The input image
-        :return: list of FDTensor
-        """
-        return self._preprocessor.run(input_ims)
 
     def disable_normalize(self):
         """
         This function will disable normalize in preprocessing step.
         """
-        self._preprocessor.disable_normalize()
+        self._manager.disable_normalize()
 
     def disable_permute(self):
         """
         This function will disable hwc2chw in preprocessing step.
         """
-        self._preprocessor.disable_permute()
+        self._manager.disable_permute()
 
     @property
     def is_vertical_screen(self):
@@ -122,7 +115,7 @@ class PaddleSegPreprocessor:
 
         :return: value of is_vertical_screen(bool)
         """
-        return self._preprocessor.is_vertical_screen
+        return self._manager.is_vertical_screen
 
     @is_vertical_screen.setter
     def is_vertical_screen(self, value):
@@ -133,7 +126,7 @@ class PaddleSegPreprocessor:
         assert isinstance(
             value,
             bool), "The value to set `is_vertical_screen` must be type of bool."
-        self._preprocessor.is_vertical_screen = value
+        self._manager.is_vertical_screen = value
 
 
 class PaddleSegPostprocessor:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->
CVCUDA
### Description
<!-- Describe what this PR does -->
#### 改动
- PaddleSegPreprocessor继承ProcessorManager
- 移除PaddleSegPreprocessor::Run()
- 实现PaddleSegPreprocessor::Apply()
- 支持开启CVCUDA

#### 性能测试

CPU: Intel(R) Xeon(R) Gold 6271C CPU @ 2.60GHz
GPU: T4
Model:

- https://bj.bcebos.com/paddlehub/fastdeploy/PP_LiteSeg_B_STDC2_cityscapes_without_argmax_infer.tgz
Batchsize: 4
Input image shapes:

```
  std::vector<cv::Mat> imgs;
  cv::resize(im, im, cv::Size(1920, 1080));
  imgs.push_back(im);
  cv::resize(im, im, cv::Size(1080, 1920));
  imgs.push_back(im);
  cv::resize(im, im, cv::Size(354, 260));
  imgs.push_back(im);
  cv::resize(im, im, cv::Size(780, 450));
  imgs.push_back(im);
```

Backend: ORT CPU/GPU
Warmup 100 rounds，tested 1000 rounds and get avg. latency.

Processor|OpenCV|CV-CUDA
------|:-------:|--------:
preprocess cost|234.50ms|12.22ms
end2end cost|1.16s|1.06s
