### PR TITLE
[Backend] Remove deprecated ort api

### DIFF
--- a/fastdeploy/runtime/backends/ort/ops/adaptive_pool2d.cc
+++ b/fastdeploy/runtime/backends/ort/ops/adaptive_pool2d.cc
@@ -66,7 +66,7 @@ void AdaptivePool2dKernel::Compute(OrtKernelContext* context) {
   Ort::ConstValue input = ort_context.GetInput(0);
 #else
   Ort::CustomOpApi api{ort_};
-  const Ort::Value input{
+  Ort::Unowned<const Ort::Value> input{
       const_cast<OrtValue*>(api.KernelContext_GetInput(context, 0))};
 #endif
   auto input_data = input.GetTensorData<float>();
@@ -81,8 +81,8 @@ void AdaptivePool2dKernel::Compute(OrtKernelContext* context) {
 #if ORT_API_VERSION >= 14
   auto output = ort_context.GetOutput(0, output_size_);
 #else
-  Ort::Value output{api.KernelContext_GetOutput(context, 0, output_size_.data(),
-                                                output_size_.size())};
+  Ort::Unowned<Ort::Value> output{api.KernelContext_GetOutput(
+      context, 0, output_size_.data(), output_size_.size())};
 #endif
   float* output_data = output.GetTensorMutableData<float>();
   if (!strcmp(this->provider_, "CUDAExecutionProvider")) {

--- a/fastdeploy/runtime/backends/ort/ops/adaptive_pool2d.h
+++ b/fastdeploy/runtime/backends/ort/ops/adaptive_pool2d.h
@@ -33,12 +33,12 @@ struct AdaptivePool2dKernel {
  protected:
   std::string pooling_type_ = "avg";
   std::vector<int64_t> output_size_ = {};
-  Ort::CustomOpApi ort_;
+  OrtApi ort_;
   void* compute_stream_;
   const char* provider_;
 
  public:
-  AdaptivePool2dKernel(Ort::CustomOpApi ort, const OrtKernelInfo* info,
+  AdaptivePool2dKernel(OrtApi ort, const OrtKernelInfo* info,
                        const char* provider)
       : ort_(ort) {
     GetAttribute(info);
@@ -57,7 +57,7 @@ struct AdaptivePool2dKernel {
 struct AdaptivePool2dOp
     : Ort::CustomOpBase<AdaptivePool2dOp, AdaptivePool2dKernel> {
   explicit AdaptivePool2dOp(const char* provider) : provider_(provider) {}
-  void* CreateKernel(Ort::CustomOpApi api, const OrtKernelInfo* info) const {
+  void* CreateKernel(OrtApi api, const OrtKernelInfo* info) const {
     return new AdaptivePool2dKernel(api, info, provider_);
   }
 

--- a/fastdeploy/runtime/backends/ort/ops/multiclass_nms.cc
+++ b/fastdeploy/runtime/backends/ort/ops/multiclass_nms.cc
@@ -166,7 +166,7 @@ void MultiClassNmsKernel::Compute(OrtKernelContext* context) {
   const Ort::Value boxes{
       const_cast<OrtValue*>(api.KernelContext_GetInput(context, 0))};
   const Ort::Value scores{
-      const_cast<OrtValue*>(api.KernelContext_GetInput(context, 0))};
+      const_cast<OrtValue*>(api.KernelContext_GetInput(context, 1))};
 #endif
 
   auto boxes_data = boxes.GetTensorData<float>();

--- a/fastdeploy/runtime/backends/ort/ops/multiclass_nms.cc
+++ b/fastdeploy/runtime/backends/ort/ops/multiclass_nms.cc
@@ -23,14 +23,6 @@
 
 namespace fastdeploy {
 
-struct OrtTensorDimensions : std::vector<int64_t> {
-  OrtTensorDimensions(Ort::CustomOpApi ort, const OrtValue* value) {
-    OrtTensorTypeAndShapeInfo* info = ort.GetTensorTypeAndShape(value);
-    std::vector<int64_t>::operator=(ort.GetTensorShape(info));
-    ort.ReleaseTensorTypeAndShapeInfo(info);
-  }
-};
-
 template <class T>
 bool SortScorePairDescend(const std::pair<float, T>& pair1,
                           const std::pair<float, T>& pair2) {
@@ -165,14 +157,17 @@ int MultiClassNmsKernel::NMSForEachSample(
 }
 
 void MultiClassNmsKernel::Compute(OrtKernelContext* context) {
-  const OrtValue* boxes = ort_.KernelContext_GetInput(context, 0);
-  const OrtValue* scores = ort_.KernelContext_GetInput(context, 1);
-  const float* boxes_data =
-      reinterpret_cast<const float*>(ort_.GetTensorData<float>(boxes));
-  const float* scores_data =
-      reinterpret_cast<const float*>(ort_.GetTensorData<float>(scores));
-  OrtTensorDimensions boxes_dim(ort_, boxes);
-  OrtTensorDimensions scores_dim(ort_, scores);
+  Ort::KernelContext ort_context{context};
+
+  auto boxes = ort_context.GetInput(0);
+  auto scores = ort_context.GetInput(1);
+
+  auto boxes_data = boxes.GetTensorData<float>();
+  auto scores_data = scores.GetTensorData<float>();
+
+  auto boxes_dim = boxes.GetTensorTypeAndShapeInfo().GetShape();
+  auto scores_dim = scores.GetTensorTypeAndShapeInfo().GetShape();
+
   int score_size = scores_dim.size();
 
   int64_t batch_size = scores_dim[0];
@@ -183,12 +178,11 @@ void MultiClassNmsKernel::Compute(OrtKernelContext* context) {
   FDASSERT(score_size == 3,
            "Require rank of input scores be 3, but now it's %d.", score_size);
   FDASSERT(boxes_dim[2] == 4,
-           "Require the 3-dimension of input boxes be 4, but now it's %lld.",
+           "Require the 3-dimension of input boxes be 4, but now it's %ld.",
            box_dim);
   std::vector<int64_t> out_num_rois_dims = {batch_size};
-  OrtValue* out_num_rois = ort_.KernelContext_GetOutput(
-      context, 2, out_num_rois_dims.data(), out_num_rois_dims.size());
-  int32_t* out_num_rois_data = ort_.GetTensorMutableData<int32_t>(out_num_rois);
+  auto out_num_rois = ort_context.GetOutput(2, out_num_rois_dims);
+  int32_t* out_num_rois_data = out_num_rois.GetTensorMutableData<int32_t>();
 
   std::vector<std::map<int, std::vector<int>>> all_indices;
   for (size_t i = 0; i < batch_size; ++i) {
@@ -205,20 +199,19 @@ void MultiClassNmsKernel::Compute(OrtKernelContext* context) {
   }
   std::vector<int64_t> out_box_dims = {num_nmsed_out, 6};
   std::vector<int64_t> out_index_dims = {num_nmsed_out, 1};
-  OrtValue* out_box = ort_.KernelContext_GetOutput(
-      context, 0, out_box_dims.data(), out_box_dims.size());
-  OrtValue* out_index = ort_.KernelContext_GetOutput(
-      context, 1, out_index_dims.data(), out_index_dims.size());
+
+  auto out_box = ort_context.GetOutput(0, out_box_dims);
+  auto out_index = ort_context.GetOutput(1, out_index_dims);
+
   if (num_nmsed_out == 0) {
-    int32_t* out_num_rois_data =
-        ort_.GetTensorMutableData<int32_t>(out_num_rois);
+    int32_t* out_num_rois_data = out_num_rois.GetTensorMutableData<int32_t>();
     for (size_t i = 0; i < batch_size; ++i) {
       out_num_rois_data[i] = 0;
     }
     return;
   }
-  float* out_box_data = ort_.GetTensorMutableData<float>(out_box);
-  int32_t* out_index_data = ort_.GetTensorMutableData<int32_t>(out_index);
+  float* out_box_data = out_box.GetTensorMutableData<float>();
+  int32_t* out_index_data = out_index.GetTensorMutableData<int32_t>();
 
   int count = 0;
   for (size_t i = 0; i < batch_size; ++i) {
@@ -249,14 +242,14 @@ void MultiClassNmsKernel::Compute(OrtKernelContext* context) {
 }
 
 void MultiClassNmsKernel::GetAttribute(const OrtKernelInfo* info) {
-  background_label =
-      ort_.KernelInfoGetAttribute<int64_t>(info, "background_label");
-  keep_top_k = ort_.KernelInfoGetAttribute<int64_t>(info, "keep_top_k");
-  nms_eta = ort_.KernelInfoGetAttribute<float>(info, "nms_eta");
-  nms_threshold = ort_.KernelInfoGetAttribute<float>(info, "nms_threshold");
-  nms_top_k = ort_.KernelInfoGetAttribute<int64_t>(info, "nms_top_k");
-  normalized = ort_.KernelInfoGetAttribute<int64_t>(info, "normalized");
-  score_threshold = ort_.KernelInfoGetAttribute<float>(info, "score_threshold");
+  Ort::ConstKernelInfo ort_info{info};
+  background_label = ort_info.GetAttribute<int64_t>("background_label");
+  keep_top_k = ort_info.GetAttribute<int64_t>("keep_top_k");
+  nms_eta = ort_info.GetAttribute<float>("nms_eta");
+  nms_threshold = ort_info.GetAttribute<float>("nms_threshold");
+  nms_top_k = ort_info.GetAttribute<float>("nms_top_k");
+  normalized = ort_info.GetAttribute<float>("normalized");
+  score_threshold = ort_info.GetAttribute<float>("score_threshold");
 }
 }  // namespace fastdeploy
 

--- a/fastdeploy/runtime/backends/ort/ops/multiclass_nms.cc
+++ b/fastdeploy/runtime/backends/ort/ops/multiclass_nms.cc
@@ -163,9 +163,9 @@ void MultiClassNmsKernel::Compute(OrtKernelContext* context) {
   Ort::ConstValue scores = ort_context.GetInput(1);
 #else
   Ort::CustomOpApi api{ort_};
-  const Ort::Value boxes{
+  Ort::Unowned<const Ort::Value> boxes{
       const_cast<OrtValue*>(api.KernelContext_GetInput(context, 0))};
-  const Ort::Value scores{
+  Ort::Unowned<const Ort::Value> scores{
       const_cast<OrtValue*>(api.KernelContext_GetInput(context, 1))};
 #endif
 
@@ -191,7 +191,7 @@ void MultiClassNmsKernel::Compute(OrtKernelContext* context) {
 #if ORT_API_VERSION >= 14
   auto out_num_rois = ort_context.GetOutput(2, out_num_rois_dims);
 #else
-  Ort::Value out_num_rois{api.KernelContext_GetOutput(
+  Ort::Unowned<Ort::Value> out_num_rois{api.KernelContext_GetOutput(
       context, 2, out_num_rois_dims.data(), out_num_rois_dims.size())};
 #endif
   int32_t* out_num_rois_data = out_num_rois.GetTensorMutableData<int32_t>();
@@ -216,9 +216,9 @@ void MultiClassNmsKernel::Compute(OrtKernelContext* context) {
   auto out_box = ort_context.GetOutput(0, out_box_dims);
   auto out_index = ort_context.GetOutput(1, out_index_dims);
 #else
-  Ort::Value out_box{api.KernelContext_GetOutput(
+  Ort::Unowned<Ort::Value> out_box{api.KernelContext_GetOutput(
       context, 0, out_box_dims.data(), out_box_dims.size())};
-  Ort::Value out_index{api.KernelContext_GetOutput(
+  Ort::Unowned<Ort::Value> out_index{api.KernelContext_GetOutput(
       context, 1, out_index_dims.data(), out_index_dims.size())};
 #endif
 
@@ -267,8 +267,8 @@ void MultiClassNmsKernel::GetAttribute(const OrtKernelInfo* info) {
   keep_top_k = ort_info.GetAttribute<int64_t>("keep_top_k");
   nms_eta = ort_info.GetAttribute<float>("nms_eta");
   nms_threshold = ort_info.GetAttribute<float>("nms_threshold");
-  nms_top_k = ort_info.GetAttribute<float>("nms_top_k");
-  normalized = ort_info.GetAttribute<float>("normalized");
+  nms_top_k = ort_info.GetAttribute<int64_t>("nms_top_k");
+  normalized = ort_info.GetAttribute<int64_t>("normalized");
   score_threshold = ort_info.GetAttribute<float>("score_threshold");
 #else
   Ort::CustomOpApi api{ort_};

--- a/fastdeploy/runtime/backends/ort/ops/multiclass_nms.h
+++ b/fastdeploy/runtime/backends/ort/ops/multiclass_nms.h
@@ -30,11 +30,10 @@ struct MultiClassNmsKernel {
   int64_t nms_top_k;
   bool normalized;
   float score_threshold;
-  Ort::CustomOpApi ort_;
+  OrtApi ort_;
 
  public:
-  MultiClassNmsKernel(Ort::CustomOpApi ort, const OrtKernelInfo* info)
-      : ort_(ort) {
+  MultiClassNmsKernel(OrtApi ort, const OrtKernelInfo* info) : ort_(ort) {
     GetAttribute(info);
   }
 
@@ -50,7 +49,7 @@ struct MultiClassNmsKernel {
 
 struct MultiClassNmsOp
     : Ort::CustomOpBase<MultiClassNmsOp, MultiClassNmsKernel> {
-  void* CreateKernel(Ort::CustomOpApi api, const OrtKernelInfo* info) const {
+  void* CreateKernel(OrtApi api, const OrtKernelInfo* info) const {
     return new MultiClassNmsKernel(api, info);
   }
 


### PR DESCRIPTION
`Ort::CustomOpApi` deprecated in ONNXRuntime 1.15

fix https://github.com/PaddlePaddle/FastDeploy/issues/2033

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
Backend

### Description
Upstream had `CustomOpApi` removed from its main branch (ref: https://github.com/microsoft/onnxruntime/commit/908e94066006734828e449ebd16371029ff814d1) , which breaks compilation.

