### PR TITLE
[Bug Fix] fix trt backend page-locked error

### DIFF
--- a/fastdeploy/runtime/backends/tensorrt/trt_backend.cc
+++ b/fastdeploy/runtime/backends/tensorrt/trt_backend.cc
@@ -475,11 +475,10 @@ void TrtBackend::SetInputs(const std::vector<FDTensor>& inputs) {
         //                          item.Nbytes() / 2, cudaMemcpyHostToDevice,
         //                          stream_) == 0,
         //          "Error occurs while copy memory from CPU to GPU.");
-        // WARN: For cudaMemcpyHostToDevice direction, cudaMemcpyAsync need 
-        // page-locked host memory to avoid any overlap to occur. The page-locked 
-        // feature may not guarentee for FDTensor now. Reference: 
-        // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html
-        // #creation-and-destruction
+        // WARN: For cudaMemcpyHostToDevice direction, cudaMemcpyAsync need page-locked host 
+        // memory to avoid any overlap to occur. The page-locked feature need by cudaMemcpyAsync 
+        // may not guarantee by FDTensor now. Reference: 
+        // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#creation-and-destruction  
         FDASSERT(cudaMemcpy(inputs_device_buffer_[item.name].data(),
                             static_cast<void*>(casted_data.data()),
                             item.Nbytes() / 2, cudaMemcpyHostToDevice) == 0,
@@ -489,11 +488,10 @@ void TrtBackend::SetInputs(const std::vector<FDTensor>& inputs) {
         //                          item.Data(), item.Nbytes(),
         //                          cudaMemcpyHostToDevice, stream_) == 0,
         //          "Error occurs while copy memory from CPU to GPU.");
-        // WARN: For cudaMemcpyHostToDevice direction, cudaMemcpyAsync need 
-        // page-locked host memory to avoid any overlap to occur. The page-locked 
-        // feature may not guarentee for FDTensor now. Reference: 
-        // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html
-        // #creation-and-destruction
+        // WARN: For cudaMemcpyHostToDevice direction, cudaMemcpyAsync need page-locked host 
+        // memory to avoid any overlap to occur. The page-locked feature need by cudaMemcpyAsync 
+        // may not guarantee by FDTensor now. Reference: 
+        // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#creation-and-destruction 
         FDASSERT(cudaMemcpy(inputs_device_buffer_[item.name].data(),
                             item.Data(), item.Nbytes(),
                             cudaMemcpyHostToDevice) == 0,

--- a/fastdeploy/runtime/backends/tensorrt/trt_backend.cc
+++ b/fastdeploy/runtime/backends/tensorrt/trt_backend.cc
@@ -470,16 +470,34 @@ void TrtBackend::SetInputs(const std::vector<FDTensor>& inputs) {
       if (item.dtype == FDDataType::INT64) {
         int64_t* data = static_cast<int64_t*>(const_cast<void*>(item.Data()));
         std::vector<int32_t> casted_data(data, data + item.Numel());
-        FDASSERT(cudaMemcpyAsync(inputs_device_buffer_[item.name].data(),
-                                 static_cast<void*>(casted_data.data()),
-                                 item.Nbytes() / 2, cudaMemcpyHostToDevice,
-                                 stream_) == 0,
-                 "Error occurs while copy memory from CPU to GPU.");
+        // FDASSERT(cudaMemcpyAsync(inputs_device_buffer_[item.name].data(),
+        //                          static_cast<void*>(casted_data.data()),
+        //                          item.Nbytes() / 2, cudaMemcpyHostToDevice,
+        //                          stream_) == 0,
+        //          "Error occurs while copy memory from CPU to GPU.");
+        // WARN: For cudaMemcpyHostToDevice direction, cudaMemcpyAsync need 
+        // page-locked host memory to avoid any overlap to occur. The page-locked 
+        // feature may not guarentee for FDTensor now. Reference: 
+        // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html
+        // #creation-and-destruction
+        FDASSERT(cudaMemcpy(inputs_device_buffer_[item.name].data(),
+                            static_cast<void*>(casted_data.data()),
+                            item.Nbytes() / 2, cudaMemcpyHostToDevice) == 0,
+                 "Error occurs while copy memory from CPU to GPU.");         
       } else {
-        FDASSERT(cudaMemcpyAsync(inputs_device_buffer_[item.name].data(),
-                                 item.Data(), item.Nbytes(),
-                                 cudaMemcpyHostToDevice, stream_) == 0,
-                 "Error occurs while copy memory from CPU to GPU.");
+        // FDASSERT(cudaMemcpyAsync(inputs_device_buffer_[item.name].data(),
+        //                          item.Data(), item.Nbytes(),
+        //                          cudaMemcpyHostToDevice, stream_) == 0,
+        //          "Error occurs while copy memory from CPU to GPU.");
+        // WARN: For cudaMemcpyHostToDevice direction, cudaMemcpyAsync need 
+        // page-locked host memory to avoid any overlap to occur. The page-locked 
+        // feature may not guarentee for FDTensor now. Reference: 
+        // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html
+        // #creation-and-destruction
+        FDASSERT(cudaMemcpy(inputs_device_buffer_[item.name].data(),
+                            item.Data(), item.Nbytes(),
+                            cudaMemcpyHostToDevice) == 0,
+                 "Error occurs while copy memory from CPU to GPU.");         
       }
     }
     // binding input buffer


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->

### Description
<!-- Describe what this PR does -->

- For cudaMemcpyHostToDevice direction, cudaMemcpyAsync need page-locked host memory to avoid any overlap to occur. The page-locked feature may not guarantee by FDTensor now. Reference: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#creation-and-destruction


