### PR TITLE
修复insightface python案例在rknpu2 npu上运行报错

### DIFF
--- a/examples/vision/faceid/insightface/rknpu2/python/infer_arcface.py
+++ b/examples/vision/faceid/insightface/rknpu2/python/infer_arcface.py
@@ -46,10 +46,9 @@ def build_option(args):
 
 args = parse_arguments()
 
-runtime_option = fd.RuntimeOption()
-model = fd.vision.faceid.ArcFace(args.model, runtime_option=runtime_option)
+runtime_option = build_option(args)
+model = fd.vision.faceid.ArcFace(args.model, runtime_option=runtime_option, model_format=fd.ModelFormat.RKNN if args.device.lower() == "npu" else fd.ModelFormat.ONNX)
 if args.device.lower() == "npu":
-    runtime_option.use_rknpu2()
     model.preprocessor.disable_normalize()
     model.preprocessor.disable_permute()
 


### PR DESCRIPTION



### PR types(PR类型)
Bug Fix

### Description

runtime_option.use_rknpu2() 调用时机有误，且未指定模型类型

