### PR TITLE
fix a bug of comments which may misguide users

### DIFF
--- a/fastdeploy/vision/visualize/detection.cc
+++ b/fastdeploy/vision/visualize/detection.cc
@@ -292,7 +292,7 @@ cv::Mat Visualize::VisDetection(const cv::Mat& im,
     return im;
   }
   FDWARNING << "DEPRECATED: fastdeploy::vision::Visualize::VisDetection is "
-               "deprecated, please use fastdeploy::vision:VisDetection "
+               "deprecated, please use fastdeploy::vision::VisDetection "
                "function instead."
             << std::endl;
   if (result.contain_masks) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->
Doc

### Description
<!-- Describe what this PR does -->
`VisDetection`has been changed from `fastdeploy::vision::Visualize::VisDetection` to `fastdeploy::vision::VisDetection`, but when using
```C++
fastdeploy::vision::Visualize::VisDetection(Img, result_left, 0.5);
```
The terminal will show:
```bash
[WARNING] fastdeploy/vision/visualize/detection.cc(294)::VisDetection	DEPRECATED: fastdeploy::vision::Visualize::VisDetection is deprecated, please use fastdeploy::vision:VisDetection function instead.
```
Which `fastdeploy::vision:VisDetection` should be `fastdeploy::vision::VisDetection`.
There is a ':' mark missing.


