### PR TITLE
fix: build error without ENABLE_PADDLE2ONNX

### DIFF
--- a/fastdeploy/runtime/backends/ort/ort_backend.cc
+++ b/fastdeploy/runtime/backends/ort/ort_backend.cc
@@ -260,8 +260,13 @@ bool OrtBackend::InitFromOnnx(const std::string& model_file,
     }
     char* model_content_ptr;
     int model_content_size = 0;
+#ifdef ENABLE_PADDLE2ONNX
     paddle2onnx::ConvertFP32ToFP16(model_file.c_str(), model_file.size(),
                                    &model_content_ptr, &model_content_size);
+#else
+    FDERROR << "Didn't compile with PaddlePaddle Frontend, FP16 is not supported" << std::endl;
+    return false;
+#endif
     std::string onnx_model_proto(model_content_ptr,
                                  model_content_ptr + model_content_size);
     delete[] model_content_ptr;

--- a/fastdeploy/runtime/backends/ort/ort_backend.cc
+++ b/fastdeploy/runtime/backends/ort/ort_backend.cc
@@ -264,7 +264,7 @@ bool OrtBackend::InitFromOnnx(const std::string& model_file,
     paddle2onnx::ConvertFP32ToFP16(model_file.c_str(), model_file.size(),
                                    &model_content_ptr, &model_content_size);
 #else
-    FDERROR << "Didn't compile with PaddlePaddle Frontend, FP16 is not supported" << std::endl;
+    FDERROR << "Didn't compile with ENABLE_PADDLE2ONNX, FP16 is not supported" << std::endl;
     return false;
 #endif
     std::string onnx_model_proto(model_content_ptr,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->

Bug Fix

### Description
<!-- Describe what this PR does -->

其他用到 `paddle2onnx` 的地方都加了宏，这里漏了，导致 build error
