### PR TITLE
fix: config including

### DIFF
--- a/fastdeploy/runtime/enum_variables.cc
+++ b/fastdeploy/runtime/enum_variables.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "fastdeploy/runtime/enum_variables.h"
+#include "fastdeploy/core/config.h"
 
 namespace fastdeploy {
 std::ostream& operator<<(std::ostream& out, const Backend& backend) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->

Bug Fix

### Description
<!-- Describe what this PR does -->


`fastdeploy/runtime/enum_variables.cc` 这个文件的包含树中没有过 `config.h`，导致 `GetAvailableBackends` 函数中的宏都读不到，返回的是个空的 vector