### PR TITLE
fix Windows text encoding issue causing infinite loop

### DIFF
--- a/examples/text/uie/cpp/CMakeLists.txt
+++ b/examples/text/uie/cpp/CMakeLists.txt
@@ -14,6 +14,9 @@
 
 PROJECT(infer_demo C CXX)
 CMAKE_MINIMUM_REQUIRED (VERSION 3.10)
+if(MSVC)
+  add_definitions(/utf-8)
+endif()
 
 option(FASTDEPLOY_INSTALL_DIR "Path of downloaded fastdeploy sdk.")
 

--- a/examples/text/uie/cpp/infer.cc
+++ b/examples/text/uie/cpp/infer.cc
@@ -17,6 +17,10 @@
 
 #include "fastdeploy/text.h"
 
+#ifdef WIN32
+#include <windows.h>
+#endif
+
 using namespace paddlenlp;
 
 #ifdef WIN32
@@ -77,6 +81,9 @@ int main(int argc, char* argv[]) {
   predictor.Predict({"2月8日上午北京冬奥会自由式滑雪女子大跳台决赛中中国选手谷"
                      "爱凌以188.25分获得金牌！"},
                     &results);
+#ifdef WIN32
+  SetConsoleOutputCP(CP_UTF8);
+#endif
   std::cout << results << std::endl;
   results.clear();
 


### PR DESCRIPTION
This PR solve infinite loop bug of UIE example due to encoding reason on Windows.

### PR types(PR类型)
Bug Fix

### Description
- add utf-8 compile definition
- add utf-8 output setting code


