### PR TITLE
Fix inconsistency when boxes is empty by inserting full ROI

### DIFF
--- a/fastdeploy/vision/ocr/ppocr/ppocr_v2.cc
+++ b/fastdeploy/vision/ocr/ppocr/ppocr_v2.cc
@@ -129,6 +129,7 @@ bool PPOCRv2::BatchPredict(const std::vector<cv::Mat>& images,
     std::vector<cv::Mat> image_list;
     if (boxes.size() == 0) {
       image_list.emplace_back(img);
+      ocr_result.boxes.emplace_back(std::array<int, 8>{0, 0, img.cols, 0, img.cols, img.rows, 0, img.rows});
     }else{
       image_list.resize(boxes.size());
       for (size_t i_box = 0; i_box < boxes.size(); ++i_box) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types(PR类型)
<!-- One of PR types [ Model | Backend | Serving | Quantization | Doc | Bug Fix | Other] -->
Bug Fix

### Description
<!-- Describe what this PR does -->
When `boxes` is empty, the full-size image is used as the inference input. However, the corresponding full ROI was not inserted into `boxes`, leading to a mismatch where `boxes.size() == 0` but `text.size() == 1`.
This behavior is inconsistent with the design documented, which specifies that `boxes` and `text` should always have the same number of elements.
This PR fixes the issue by properly inserting the full ROI into boxes.