### PR TITLE
Ernie support wint8+wint4 when quantization is wint4

### DIFF
--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -689,9 +689,14 @@ def initialize_fd_config(args) -> FDConfig:
     elif args.quantization != "None":
         quantization_config = {}
         quant_config_name = args.quantization
-        if use_moe and quant_config_name == "wint4":
+        quantization_config["quantization"] = quant_config_name
+        # use some trick code for ernie model and will unify it in future.
+        is_ernie = "Ernie4_5_ForCausalLM" in config.get("architectures") or \
+                    "Ernie4_5_MoeForCausalLM" in config.get("architectures")
+        if use_moe and quant_config_name == "wint4" and is_ernie:
             quantization_config["dense_quant_type"] = "wint8"
             quantization_config["moe_quant_type"] = "wint4"
+            quantization_config["quantization"] = "mix_quant"
             quant_config_name = "mix_quant"
     else:
         quant_config_name = None


### PR DESCRIPTION
本PR实现功能：

- 命令行参数指定wint4时，仅将ernie模型的dense部分转为wint8运行