### PR TITLE
[SOT] Remove BreakGraph with `paddle.maximum`

### DIFF
--- a/fastdeploy/model_executor/models/ernie4_5_vl/ernie4_5_vl_moe.py
+++ b/fastdeploy/model_executor/models/ernie4_5_vl/ernie4_5_vl_moe.py
@@ -393,8 +393,7 @@ class Ernie4_5_VLModel(nn.Layer):
         token_type_ids = image_mask.cast("int32")
         token_num = hidden_states.shape[0]
         image_token_num = paddle.count_nonzero(token_type_ids).cast("int32")
-        text_token_num = ((token_num - image_token_num) if
-                          (token_num - image_token_num) > 0 else 1)
+        text_token_num = paddle.clip(token_num - image_token_num, min=1)
         if image_mask.any():
             hidden_states[image_mask] = image_features.cast(self._dtype)
             text_input = paddle.full(

--- a/fastdeploy/model_executor/models/ernie4_5_vl/ernie4_5_vl_moe.py
+++ b/fastdeploy/model_executor/models/ernie4_5_vl/ernie4_5_vl_moe.py
@@ -393,7 +393,7 @@ class Ernie4_5_VLModel(nn.Layer):
         token_type_ids = image_mask.cast("int32")
         token_num = hidden_states.shape[0]
         image_token_num = paddle.count_nonzero(token_type_ids).cast("int32")
-        text_token_num = paddle.clip(token_num - image_token_num, min=1)
+        text_token_num = paddle.maximum(token_num - image_token_num, paddle.ones([],dtype="int64"))
         if image_mask.any():
             hidden_states[image_mask] = image_features.cast(self._dtype)
             text_input = paddle.full(

--- a/fastdeploy/model_executor/models/ernie4_5_vl/ernie4_5_vl_moe.py
+++ b/fastdeploy/model_executor/models/ernie4_5_vl/ernie4_5_vl_moe.py
@@ -393,7 +393,7 @@ class Ernie4_5_VLModel(nn.Layer):
         token_type_ids = image_mask.cast("int32")
         token_num = hidden_states.shape[0]
         image_token_num = paddle.count_nonzero(token_type_ids).cast("int32")
-        text_token_num = paddle.maximum(token_num - image_token_num, paddle.ones([],dtype="int64"))
+        text_token_num = paddle.maximum(token_num - image_token_num, paddle.ones([], dtype="int32"))
         if image_mask.any():
             hidden_states[image_mask] = image_features.cast(self._dtype)
             text_input = paddle.full(


### PR DESCRIPTION
```python
        text_token_num = ((token_num - image_token_num) if
                          (token_num - image_token_num) > 0 else 1)
```
这部分的 if 语句导致的打断可以用 `paddle.clip` / `paddle.maximum`消除， `token_num` 和 `image_token_num` 都是整数

cc @SigureMo 