### PR TITLE
[Bug fix] Fixed the garbled text issues in Qwen3-8B

### DIFF
--- a/fastdeploy/model_executor/layers/lm_head.py
+++ b/fastdeploy/model_executor/layers/lm_head.py
@@ -114,7 +114,7 @@ class ParallelLMHead(nn.Layer):
         else:
             if self.tie_word_embeddings:
                 self.out_linear.weight.set_value(
-                    get_tensor(state_dict[self.linear_weight_key]).astype(
+                    get_tensor(state_dict.pop(self.linear_weight_key)).astype(
                         paddle.get_default_dtype()).transpose([1, 0]))
             else:
                 weight_tensor = get_tensor(

--- a/fastdeploy/model_executor/layers/lm_head.py
+++ b/fastdeploy/model_executor/layers/lm_head.py
@@ -114,7 +114,7 @@ class ParallelLMHead(nn.Layer):
         else:
             if self.tie_word_embeddings:
                 self.out_linear.weight.set_value(
-                    get_tensor(state_dict.pop(self.linear_weight_key)).astype(
+                    get_tensor(state_dict[self.linear_weight_key]).astype(
                         paddle.get_default_dtype()).transpose([1, 0]))
             else:
                 weight_tensor = get_tensor(

--- a/fastdeploy/model_executor/models/qwen3.py
+++ b/fastdeploy/model_executor/models/qwen3.py
@@ -245,7 +245,7 @@ class Qwen3ForCausalLM(ModelForCasualLM):
             embedding_dim=fd_config.model_config.hidden_size,
             num_embeddings=fd_config.model_config.vocab_size,
             prefix="lm_head",
-            )
+        )
 
     @classmethod
     def name(self):

--- a/fastdeploy/model_executor/models/qwen3.py
+++ b/fastdeploy/model_executor/models/qwen3.py
@@ -240,19 +240,11 @@ class Qwen3ForCausalLM(ModelForCasualLM):
 
         self.ori_vocab_size = fd_config.model_config.ori_vocab_size
         self.tie_word_embeddings = fd_config.model_config.tie_word_embeddings
-        if self.tie_word_embeddings:
-            self.lm_head = ParallelLMHead(
-                fd_config=fd_config,
-                embedding_dim=fd_config.model_config.hidden_size,
-                num_embeddings=fd_config.model_config.vocab_size,
-                prefix=(f"{fd_config.model_config.prefix_name}.embed_tokens"),
-            )
-        else:
-            self.lm_head = ParallelLMHead(
-                fd_config=fd_config,
-                embedding_dim=fd_config.model_config.hidden_size,
-                num_embeddings=fd_config.model_config.vocab_size,
-                prefix="lm_head",
+        self.lm_head = ParallelLMHead(
+            fd_config=fd_config,
+            embedding_dim=fd_config.model_config.hidden_size,
+            num_embeddings=fd_config.model_config.vocab_size,
+            prefix="lm_head",
             )
 
     @classmethod
@@ -272,9 +264,11 @@ class Qwen3ForCausalLM(ModelForCasualLM):
                 and values are NumPy arrays or PaddlePaddle tensors.
         """
         self.model.load_state_dict(state_dict)
-        self.lm_head.out_linear.weight.set_value(
-            self.model.embeddings.word_embeddings.weight.transpose([1, 0]))
-        self.lm_head.load_state_dict(state_dict)
+        if self.tie_word_embeddings:
+            self.lm_head.out_linear.weight.set_value(
+                self.model.embeddings.word_embeddings.weight.transpose([1, 0]))
+        else:
+            self.lm_head.load_state_dict(state_dict)
 
     def compute_logits(self, hidden_states: paddle.Tensor):
         """

--- a/fastdeploy/model_executor/models/qwen3.py
+++ b/fastdeploy/model_executor/models/qwen3.py
@@ -164,7 +164,6 @@ class Qwen3Model(nn.Layer):
 
         self.num_layers = fd_config.model_config.num_layers
         fd_config.model_config.prefix_name = "model"
-        fd_config.model_config.tie_word_embeddings = True
 
         self.embeddings = VocabParallelEmbedding(
             fd_config=fd_config,
@@ -240,14 +239,21 @@ class Qwen3ForCausalLM(ModelForCasualLM):
         self.model = Qwen3Model(fd_config=fd_config)
 
         self.ori_vocab_size = fd_config.model_config.ori_vocab_size
-
-        self.lm_head = ParallelLMHead(
-            fd_config=fd_config,
-            embedding_dim=fd_config.model_config.hidden_size,
-            num_embeddings=fd_config.model_config.vocab_size,
-            prefix=(f"{fd_config.model_config.prefix_name}.embed_tokens"),
-        )
         self.tie_word_embeddings = fd_config.model_config.tie_word_embeddings
+        if self.tie_word_embeddings:
+            self.lm_head = ParallelLMHead(
+                fd_config=fd_config,
+                embedding_dim=fd_config.model_config.hidden_size,
+                num_embeddings=fd_config.model_config.vocab_size,
+                prefix=(f"{fd_config.model_config.prefix_name}.embed_tokens"),
+            )
+        else:
+            self.lm_head = ParallelLMHead(
+                fd_config=fd_config,
+                embedding_dim=fd_config.model_config.hidden_size,
+                num_embeddings=fd_config.model_config.vocab_size,
+                prefix="lm_head",
+            )
 
     @classmethod
     def name(self):
@@ -266,9 +272,8 @@ class Qwen3ForCausalLM(ModelForCasualLM):
                 and values are NumPy arrays or PaddlePaddle tensors.
         """
         self.model.load_state_dict(state_dict)
-        if self.tie_word_embeddings:
-            self.lm_head.out_linear.weight.set_value(
-                self.model.embeddings.word_embeddings.weight.transpose([1, 0]))
+        self.lm_head.out_linear.weight.set_value(
+            self.model.embeddings.word_embeddings.weight.transpose([1, 0]))
         self.lm_head.load_state_dict(state_dict)
 
     def compute_logits(self, hidden_states: paddle.Tensor):
@@ -324,6 +329,7 @@ class Qwen3PretrainedModel(PretrainedModel):
 
             base_actions = {
                 # Row Linear
+                "lm_head.weight": partial(fn, is_column=True),
                 "embed_tokens.weight": partial(fn, is_column=False),
                 "layers.0.self_attn.o_proj.weight": partial(fn,
                                                             is_column=False),

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -579,7 +579,8 @@ def initialize_fd_config(args: argparse.Namespace) -> FDConfig:
     model_config = ModelConfig.from_dict(config)
     # TODO Set `head_dim` again. Because `ModelConfig` class doesn't support feeding head_dim at all!
     model_config.head_dim = config["head_dim"]
-    model_config.tie_word_embeddings = config["tie_word_embeddings"]
+    if 'tie_word_embeddings' in config:
+        model_config.tie_word_embeddings = config["tie_word_embeddings"]
     paddle.set_default_dtype(args.dtype)
 
     device_config = DeviceConfig()

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -579,6 +579,7 @@ def initialize_fd_config(args: argparse.Namespace) -> FDConfig:
     model_config = ModelConfig.from_dict(config)
     # TODO Set `head_dim` again. Because `ModelConfig` class doesn't support feeding head_dim at all!
     model_config.head_dim = config["head_dim"]
+    model_config.tie_word_embeddings = config["tie_word_embeddings"]
     paddle.set_default_dtype(args.dtype)
 
     device_config = DeviceConfig()


### PR DESCRIPTION
修复了Qwen3-8b乱码问题， tie_word_embeddings一直为True的情况，考虑了tie_word_embeddings为False的情况，并且添加了权重lm_head.weight为列切的方式加载。修复后Qwen3-8b精度正确