### PR TITLE
[Fix] Ernie4_5_MLP not using `reduce_results` 

### DIFF
--- a/fastdeploy/model_executor/models/ernie4_5_moe.py
+++ b/fastdeploy/model_executor/models/ernie4_5_moe.py
@@ -71,6 +71,7 @@ class Ernie4_5_MLP(nn.Layer):
             input_size=intermediate_size,
             output_size=fd_config.model_config.hidden_size,
             with_bias=False,
+            reduce_results=reduce_results,
         )
 
         self.act_fn = SiluAndMul(

--- a/fastdeploy/model_executor/models/ernie4_5_vl/ernie4_5_vl_moe.py
+++ b/fastdeploy/model_executor/models/ernie4_5_vl/ernie4_5_vl_moe.py
@@ -219,10 +219,10 @@ class Ernie4_5_VLMoE(nn.Layer):
             )
         else:
             hidden_states = self.text_fused_moe(hidden_states)
-        if self.tp_size > 1:
-            tensor_model_parallel_all_reduce(hidden_states)
         if self.num_shared_experts > 0:
             hidden_states += share_experts_out
+        if self.tp_size > 1:
+            tensor_model_parallel_all_reduce(hidden_states)
         return hidden_states
 
 

--- a/fastdeploy/model_executor/models/ernie4_5_vl/ernie4_5_vl_moe.py
+++ b/fastdeploy/model_executor/models/ernie4_5_vl/ernie4_5_vl_moe.py
@@ -107,6 +107,7 @@ class Ernie4_5_VLMoE(nn.Layer):
             }
             self.text_fused_moe = FusedMoE(
                 fd_config=fd_config,
+                reduce_results=False,
                 moe_intermediate_size=fd_config.model_config.
                 moe_intermediate_size[0],
                 num_experts=fd_config.model_config.moe_num_experts[0],
@@ -138,6 +139,7 @@ class Ernie4_5_VLMoE(nn.Layer):
             }
             self.image_fused_moe = FusedMoE(
                 fd_config=fd_config,
+                reduce_results=False,
                 moe_intermediate_size=fd_config.model_config.
                 moe_intermediate_size[1],
                 num_experts=fd_config.model_config.moe_num_experts[1],
@@ -162,6 +164,7 @@ class Ernie4_5_VLMoE(nn.Layer):
                 intermediate_size=self.num_shared_experts *
                 fd_config.model_config.moe_intermediate_size[0],
                 prefix=f"{prefix}.shared_experts",
+                reduce_results=False,
             )
 
     def extract_gate_correction_bias_text(self, gate_correction_bias_key,
@@ -216,6 +219,8 @@ class Ernie4_5_VLMoE(nn.Layer):
             )
         else:
             hidden_states = self.text_fused_moe(hidden_states)
+        if self.tp_size > 1:
+            tensor_model_parallel_all_reduce(hidden_states)
         if self.num_shared_experts > 0:
             hidden_states += share_experts_out
         return hidden_states

--- a/fastdeploy/model_executor/models/ernie4_5_vl/ernie4_5_vl_moe.py
+++ b/fastdeploy/model_executor/models/ernie4_5_vl/ernie4_5_vl_moe.py
@@ -107,7 +107,6 @@ class Ernie4_5_VLMoE(nn.Layer):
             }
             self.text_fused_moe = FusedMoE(
                 fd_config=fd_config,
-                reduce_results=False,
                 moe_intermediate_size=fd_config.model_config.
                 moe_intermediate_size[0],
                 num_experts=fd_config.model_config.moe_num_experts[0],
@@ -139,7 +138,6 @@ class Ernie4_5_VLMoE(nn.Layer):
             }
             self.image_fused_moe = FusedMoE(
                 fd_config=fd_config,
-                reduce_results=False,
                 moe_intermediate_size=fd_config.model_config.
                 moe_intermediate_size[1],
                 num_experts=fd_config.model_config.moe_num_experts[1],
@@ -164,7 +162,6 @@ class Ernie4_5_VLMoE(nn.Layer):
                 intermediate_size=self.num_shared_experts *
                 fd_config.model_config.moe_intermediate_size[0],
                 prefix=f"{prefix}.shared_experts",
-                reduce_results=False,
             )
 
     def extract_gate_correction_bias_text(self, gate_correction_bias_key,
@@ -221,8 +218,6 @@ class Ernie4_5_VLMoE(nn.Layer):
             hidden_states = self.text_fused_moe(hidden_states)
         if self.num_shared_experts > 0:
             hidden_states += share_experts_out
-        if self.tp_size > 1:
-            tensor_model_parallel_all_reduce(hidden_states)
         return hidden_states
 
 


### PR DESCRIPTION
Ernie4_5_MLP中RowParallelLinear层未传入`reduce_results`参数，使得share_experts计算完成后执行了多余的allreduce，引起多卡推理精度不对齐。

https://github.com/PaddlePaddle/FastDeploy/blob/aa76085d1fd9bd0bac8962ad2344247500cd4de8/fastdeploy/model_executor/models/ernie4_5_moe.py#L68-L75
