### PR TITLE
Modified the omissions about cum_offsets

### DIFF
--- a/test/layers/test_append_attention.py
+++ b/test/layers/test_append_attention.py
@@ -423,7 +423,6 @@ class TestAppendGroupQueryAttnWithRope(unittest.TestCase):
             self.seq_lens_encoder,
             self.seq_lens_decoder,
             self.seq_lens_this_time,
-            self.cum_offset,
             64,
             12,
             (self.q_num_head + 2 * self.kv_num_head) // self.kv_num_head,


### PR DESCRIPTION
https://github.com/PaddlePaddle/FastDeploy/pull/2913 remove cum_offsets, but test/layers/test_append_attention.py still use it