### PR TITLE
[BugFix] Add prefill restrictions for chunked_prefill+VL

### DIFF
--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -150,10 +150,17 @@ class GPUModelRunner(ModelRunnerBase):
         """
         Check whether prefill stage finished
         """
-        if int(paddle.max(self.share_inputs["seq_lens_encoder"])) != 0:
-            return 1
+        if self.enable_mm:
+            # VL only support 1 batch to prefill
+            prefill_statue = (self.share_inputs["seq_lens_this_time"] != 0) & (
+                self.share_inputs["seq_lens_this_time"] != 1
+            )
+            return not paddle.any(prefill_statue).numpy()
         else:
-            return 0
+            if int(paddle.max(self.share_inputs["seq_lens_encoder"])) != 0:
+                return 1
+            else:
+                return 0
 
     def _init_speculative_proposer(self):
         """

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -285,10 +285,12 @@ class PaddleDisWorkerProc:
             # The first worker detects whether there are tasks in the task queue
             if self.local_rank % mp_num_per_node == 0:
                 if self.task_queue.num_tasks() > 0:
-                    if self.nnode > 1:
-                        self.task_queue.read_finish_flag.set(1)
-                    else:
-                        self.exist_task_signal.value[self.fd_config.parallel_config.expert_parallel_rank] = 1
+                    # VL only support 1 batch to prefill
+                    if not self.fd_config.model_config.enable_mm or self.worker.prefill_finished():
+                        if self.nnode > 1:
+                            self.task_queue.read_finish_flag.set(1)
+                        else:
+                            self.exist_task_signal.value[self.fd_config.parallel_config.expert_parallel_rank] = 1
 
             if self.parallel_config.tensor_parallel_size > 1:
                 # Synchronize the signal for other workers
@@ -344,8 +346,8 @@ class PaddleDisWorkerProc:
             # Execute model to generate token. The generated token will be written to the buffer.
             # These generated tokens can be obtained through get_output op.
             self.worker.execute_model(req_dicts)
-
-            self.exist_prefill_task_signal.value[0] = self.worker.prefill_finished()
+            if not self.fd_config.model_config.enable_mm:
+                self.exist_prefill_task_signal.value[0] = self.worker.prefill_finished()
 
     def initialize_kv_cache(self) -> None:
         """Profiles the peak memory usage of the model to determine how many


### PR DESCRIPTION
pcard-71500

当前VL和纯文本的执行流程已经合并到worker_process中，但合入时忽略了chunked_prefill场景下，纯文本与VL执行prefill的差异（VL每次只能有一个batch在做prefill，但纯文本可以有多个）。

本PR为执行流程添加了VL的限制，经过1000条数据的100并发测试，无报错内容且精度没问题。