### PR TITLE
[Model] Provide clearer error for missing KV cache quantization scales

### DIFF
--- a/fastdeploy/model_executor/models/deepseek_v3.py
+++ b/fastdeploy/model_executor/models/deepseek_v3.py
@@ -420,6 +420,7 @@ class DeepseekV3MLAAttention(nn.Layer):
         # NOTE(Ryan):Make sure kv_b_proj_bmm loaded before kv_b_proj,
         # The same weight key will be poped after kv_b_proj.
         self.o_proj.load_state_dict(state_dict)
+        self.mla_attn.load_state_dict(state_dict)
 
 
 class DeepSeekV3DecoderLayer(nn.Layer):

--- a/fastdeploy/model_executor/models/qwen2.py
+++ b/fastdeploy/model_executor/models/qwen2.py
@@ -113,6 +113,7 @@ class Qwen2Attention(nn.Layer):
         """ """
         self.qkv_proj.load_state_dict(state_dict)
         self.o_proj.load_state_dict(state_dict)
+        self.attn.load_state_dict(state_dict)
 
     def forward(
         self,

--- a/fastdeploy/model_executor/models/qwen3.py
+++ b/fastdeploy/model_executor/models/qwen3.py
@@ -95,6 +95,7 @@ class Qwen3Attention(nn.Layer):
         self.o_proj.load_state_dict(state_dict)
         self.q_norm.load_state_dict(state_dict)
         self.k_norm.load_state_dict(state_dict)
+        self.attn.load_state_dict(state_dict)
 
     def forward(
         self,


### PR DESCRIPTION
When users incorrectly modify `config.json` by adding unsupported quantization options, the underlying CUDA operators would previously throw difficult-to-understand errors. 

`RuntimeError: (InvalidArgument) The type of data we are trying to retrieve (bfloat16) does not match the type of data (uint8) currently contained in the container.
(Hint: Expected dtype() = phi::CppTypeToDataType<T>:Type(),but received dype():2 ！= phi:CpTypeToDataType<T>::Type():16.](at/paddle/paddle/phi/core/dense_tensor. c:167)`

With this change, the error now originates from the Python layer, indicating a failure to retrieve specific content from the configuration file, making it much easier for users to diagnose and resolve.
`File "/root/paddlejob/workspace/env_run/output/XXX/FastDeploy/fastdeploy/model_executor/layers/quantization/block_wise_fp8.py", line 108, in process_prequanted_weights
    quant_weight = get_tensor(state_dict.pop(layer.weight_key))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'qwen2.layers.0.self_attn.qkv_proj.quant_weight'`

This makes it easy for users to tell if the model file is unsupported some option about quantization。There are actually different KeyError types, so throwing a specific hint for each one would be cumbersome. The goal is simply to make the resulting error message easier to understand.