### PR TITLE
[Bug Fix] Fix bug for offline inference in scheduler v1

### DIFF
--- a/fastdeploy/engine/engine.py
+++ b/fastdeploy/engine/engine.py
@@ -500,6 +500,7 @@ class LLMEngine:
             enable_thinking = kwargs.get("enable_thinking", None)
         request = self.data_processor.process_request(request, self.cfg.max_model_len, enable_thinking=enable_thinking)
         request.prompt_token_ids_len = len(request.prompt_token_ids)
+        request.need_prefill_tokens = request.prompt_token_ids_len
         input_ids_len = request.prompt_token_ids_len
         request.set(
             "max_tokens",


### PR DESCRIPTION
Request. need_prefill_tokens should be set when Request instance is initialized. 
Because prompt_token_ids_len is not set when initilized in offline mode, need_prefill_tokens will be set None by default.