### PR TITLE
[Bug fix] Fix cudagraph when use ep.

### DIFF
--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -525,6 +525,12 @@ class GPUModelRunner(ModelRunnerBase):
             num_tokens // batch_size,
             self.parallel_config.max_model_len - max_dec_len,
         )
+
+        # NOTE(wanglongzhi): When the full length is too large, DeepEP's buffer size will not be enough to cause the result to appear nan.
+        # TODO(wanglongzhi): Figure out the accurate buffer size of DeepEP.
+        if self.fd_config.parallel_config.enable_expert_parallel > 1:
+            full_length = min(full_length, 2048)
+
         input_length = int(full_length * self.cache_config.kv_cache_ratio)
         block_num = (
             input_length + self.cache_config.block_size - 1

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -528,7 +528,7 @@ class GPUModelRunner(ModelRunnerBase):
 
         # NOTE(wanglongzhi): When the full length is too large, DeepEP's buffer size will not be enough to cause the result to appear nan.
         # TODO(wanglongzhi): Figure out the accurate buffer size of DeepEP.
-        if self.fd_config.parallel_config.enable_expert_parallel > 1:
+        if self.fd_config.parallel_config.enable_expert_parallel:
             full_length = min(full_length, 2048)
 
         input_length = int(full_length * self.cache_config.kv_cache_ratio)

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -529,7 +529,7 @@ class GPUModelRunner(ModelRunnerBase):
         # NOTE(wanglongzhi): When the full length is too large, DeepEP's buffer size will not be enough to cause the result to appear nan.
         # TODO(wanglongzhi): Figure out the accurate buffer size of DeepEP.
         if self.fd_config.parallel_config.enable_expert_parallel:
-            full_length = min(full_length, 2048)
+            full_length = min(full_length, 32)
 
         input_length = int(full_length * self.cache_config.kv_cache_ratio)
         block_num = (


### PR DESCRIPTION
Fix cudagraph when use ep.

- Dataset: 200 prompts 
- model: ERNIE-4_5-300B-A47B-FP8-Paddle
- Version of paddle: 3.0.1
- max_model_len：32768

- content of pr
When `max_model_len` is large such as 32k, the `full_length` of `_dummy_prefill_inputs` function will be 4k，and the received token num of EP will be very large such as 19w, then the buffer size of DeepEP maybe not enough and then cause `nan` problem. So I reduce the full length when use EP.

- comparison result
<img width="1500" height="636" alt="image" src="https://github.com/user-attachments/assets/4cbfeb7c-76a1-4858-bfd7-988a9766ddac" />
