### PR TITLE
[Bug Fix] fix the bug in test_sampler

### DIFF
--- a/test/layers/test_sampler.py
+++ b/test/layers/test_sampler.py
@@ -56,6 +56,7 @@ def _create_default_sampling_metadata(
         min_dec_lens=paddle.full(shape=[batch_size, 1], fill_value=min_seq_len, dtype="int64"),
         bad_words_token_ids=paddle.full(shape=[batch_size], fill_value=-1, dtype="int64"),
         eos_token_ids=paddle.full(shape=[batch_size], fill_value=-2, dtype="int64"),
+        min_p=paddle.randn([batch_size]),
     )
     return fake_sampling_metadata
 


### PR DESCRIPTION
pcard-71500

修复`test/layers/test_sampler.py`单测执行出错的BUG。

**问题分析**：
PR https://github.com/PaddlePaddle/FastDeploy/pull/2872 向`sampling_metadata`中，新增了一个`min_p`属性默认值为None，同时在forward中添加了一个必定会执行的`probs = min_p_sampling(probs, sampling_metadata.min_p) `步骤，又因为`test/layers/test_sampler.py`中的`sampling_metadata`没有初始化`min_p`属性，导致执行到`min_p_sampling`时传入了`min_p=None`导致报错。

**解决方案**：
在`test/layers/test_sampler.py`单测中，添加`min_p`的初始化。
> ps: min_p是一个维度为[bs]的Tensor，由于只有显示实例化`sampling_metadata`时才能知道bs的大小，所以不能给他设置一个确定默认值。

修复前报错内容如下：
```shell
Traceback (most recent call last):
  File "/root/paddlejob/workspace/env_run/output/liuyuanle/llj/baidu/paddle_internal/FastDeploy/test/layers/test_sampler.py", line 77, in <module>
    test_sampler()
  File "/root/paddlejob/workspace/env_run/output/liuyuanle/llj/baidu/paddle_internal/FastDeploy/test/layers/test_sampler.py", line 72, in test_sampler
    next_tokens = sampler(logits, sampling_metadata)
  File "/root/paddlejob/workspace/env_run/output/liuyuanle/miniconda3/envs/llj_py310/lib/python3.10/site-packages/paddle/nn/layer/layers.py", line 1571, in __call__
    return self.forward(*inputs, **kwargs)
  File "/root/paddlejob/workspace/env_run/output/liuyuanle/miniconda3/envs/llj_py310/lib/python3.10/site-packages/fastdeploy/model_executor/layers/sample/sampler.py", line 284, in forward_cuda
    probs = min_p_sampling(probs, sampling_metadata.min_p)
  File "/root/paddlejob/workspace/env_run/output/liuyuanle/miniconda3/envs/llj_py310/lib/python3.10/site-packages/fastdeploy/model_executor/layers/sample/ops/top_k_top_p_sampling.py", line 171, in min_p_sampling
    if paddle.count_nonzero(min_p_arr) == 0:
  File "/root/paddlejob/workspace/env_run/output/liuyuanle/miniconda3/envs/llj_py310/lib/python3.10/site-packages/paddle/tensor/math.py", line 2096, in count_nonzero
    bool_tensor = paddle.cast(x, 'bool')
  File "/root/paddlejob/workspace/env_run/output/liuyuanle/miniconda3/envs/llj_py310/lib/python3.10/site-packages/paddle/tensor/manipulation.py", line 237, in cast
    return _C_ops.cast(x, dtype)
ValueError: (InvalidArgument) cast(): argument 'x' (position 0) must be Tensor, but got None (at /root/paddlejob/workspace/env_run/output/liuyuanle/llj/Paddle/paddle/fluid/pybind/eager_utils.cc:1330)
```