### PR TITLE
Fix the confused enable_early_stop when only set early_stop_config

### DIFF
--- a/fastdeploy/utils.py
+++ b/fastdeploy/utils.py
@@ -362,7 +362,11 @@ class FlexibleArgumentParser(argparse.ArgumentParser):
         for key, value in filtered_config.items():
             setattr(namespace, key, value)
         args = super().parse_args(args=remaining_args, namespace=namespace)
-        if hasattr(args, "early_stop_config") and args.early_stop_config and args.early_stop_config["enable_early_stop"]:
+        if (
+            hasattr(args, "early_stop_config")
+            and args.early_stop_config
+            and args.early_stop_config["enable_early_stop"]
+        ):
             setattr(args, "enable_early_stop", True)
         return args
 

--- a/fastdeploy/utils.py
+++ b/fastdeploy/utils.py
@@ -39,6 +39,10 @@ from fastdeploy import envs
 
 T = TypeVar("T")
 
+# [N,2] -> every line is [config_name, enable_xxx_name]
+# Make sure enable_xxx equal to config.enable_xxx
+ARGS_CORRECTION_LIST = [["early_stop_config", "enable_early_stop"], ["graph_optimization_config", "use_cudagraph"]]
+
 
 class EngineError(Exception):
     """Base exception class for engine errors"""
@@ -362,12 +366,14 @@ class FlexibleArgumentParser(argparse.ArgumentParser):
         for key, value in filtered_config.items():
             setattr(namespace, key, value)
         args = super().parse_args(args=remaining_args, namespace=namespace)
-        if (
-            hasattr(args, "early_stop_config")
-            and args.early_stop_config
-            and args.early_stop_config["enable_early_stop"]
-        ):
-            setattr(args, "enable_early_stop", True)
+
+        # Args correction
+        for config_name, flag_name in ARGS_CORRECTION_LIST:
+            if hasattr(args, config_name) and hasattr(args, flag_name):
+                # config is a dict
+                config = getattr(args, config_name, None)
+                if config is not None and flag_name in config.keys():
+                    setattr(args, flag_name, config[flag_name])
         return args
 
 

--- a/fastdeploy/utils.py
+++ b/fastdeploy/utils.py
@@ -361,8 +361,10 @@ class FlexibleArgumentParser(argparse.ArgumentParser):
             namespace = argparse.Namespace()
         for key, value in filtered_config.items():
             setattr(namespace, key, value)
-
-        return super().parse_args(args=remaining_args, namespace=namespace)
+        args = super().parse_args(args=remaining_args, namespace=namespace)
+        if hasattr(args, "early_stop_config") and args.early_stop_config and args.early_stop_config["enable_early_stop"]:
+            setattr(args, "enable_early_stop", True)
+        return args
 
 
 def resolve_obj_from_strname(strname: str):


### PR DESCRIPTION
pcard-71500

修复enable_early_stop在api_server.log中同时显示True和False的迷惑日志。

问题分析：

启动在线服务时，如果只设置了early_stop_config的参数，没有设置enable_early_stop时，api_server.log在启动好服务后会打印启动参数信息（见下图），这时候enable_early_stop会使用默认值False，但是由于设置了early_stop_config，这个config里面的enable_early_config会显示为True，导致无法确认是否启用early_stop功能。
![image](https://github.com/user-attachments/assets/9d2fc204-abcb-4782-adcc-879c9cc81fb5)

early_stop只要设置了early_stop_config就一定会根据config内的参数决定是否启动early_stop功能，这时候enable_early_stop的值就不重要了。所以本PR在处理启动参数时新增了对early_stop_config和enable_early_stop的对齐，消除迷惑日志。最终日志如下图。
![image](https://github.com/user-attachments/assets/3ccb326d-fa33-4412-864a-1a3748c88320)

