### PR TITLE
[Executor] Fixed the issue of CUDA graph execution failure caused by different branches during decoding 

### DIFF
--- a/custom_ops/gpu_ops/append_attn/append_attention_c16_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_c16_impl.cuh
@@ -1065,149 +1065,201 @@ void MultiQueryAppendAttention(
     const int num_chunks = div_up(max_seq_len, chunk_size);
     dim3 grids(num_blocks_x_cpu, num_chunks, kv_num_heads);
     dim3 blocks(32, num_warps);
+    if (num_chunks <= 0) {
+      auto nosplit_kv_kernel =
+          multi_query_append_attention_warp1_4_kernel<NV_TYPE,
+                                                      false,
+                                                      GROUP_SIZE,
+                                                      CAUSAL,
+                                                      num_warps,
+                                                      NUM_WARP_Q,
+                                                      NUM_WARP_KV,
+                                                      HEAD_DIM,
+                                                      BLOCK_SIZE,
+                                                      num_frags_x,
+                                                      num_frags_z,
+                                                      num_frags_y,
+                                                      OUT_NV_TYPE,
+                                                      ENABLE_PREFILL>;
+      if (smem_size >= 48 * 1024) {
+        cudaFuncSetAttribute(nosplit_kv_kernel,
+                             cudaFuncAttributeMaxDynamicSharedMemorySize,
+                             smem_size);
+      }
 
-    phi::Allocator::AllocationPtr tmp_workspace, tmp_m, tmp_d;
-    if (is_decoder) {
-      tmp_workspace = allocator->Allocate(
-          phi::SizeOf(qkv.dtype()) *
-          static_cast<size_t>(bsz * num_chunks * num_heads * HEAD_DIM));
-      tmp_m = allocator->Allocate(
-          phi::SizeOf(paddle::DataType::FLOAT32) *
-          static_cast<size_t>(bsz * num_chunks * num_heads));
-      tmp_d = allocator->Allocate(
-          phi::SizeOf(paddle::DataType::FLOAT32) *
-          static_cast<size_t>(bsz * num_chunks * num_heads));
+      nosplit_kv_kernel<<<grids, blocks, smem_size, stream>>>(
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k.data<T>())),
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v.data<T>())),
+          shift_bias ? reinterpret_cast<NV_TYPE *>(
+                           const_cast<T *>(shift_bias.get().data<T>()))
+                     : nullptr,
+          smooth_weight ? reinterpret_cast<NV_TYPE *>(
+                              const_cast<T *>(smooth_weight.get().data<T>()))
+                        : nullptr,
+          seq_lens_q.data<int>(),
+          seq_lens_kv.data<int>(),
+          batch_ids.data<int>(),
+          tile_ids_per_batch.data<int>(),
+          cu_seqlens_q.data<int>(),
+          block_table.data<int>(),
+          max_seq_len,
+          max_dec_len,
+          max_block_num_per_seq,
+          scale,
+          quant_max_bound,
+          quant_min_bound,
+          in_scale,
+          chunk_size,
+          nullptr,
+          nullptr,
+          nullptr,
+          reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          speculate_max_draft_token_num);
     } else {
-      if (ENABLE_PREFILL) {
-        tmp_workspace =
-            allocator->Allocate(phi::SizeOf(qkv.dtype()) *
-                                static_cast<size_t>(token_num * num_chunks *
-                                                    num_heads * HEAD_DIM));
-        tmp_m = allocator->Allocate(
-            phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(token_num * num_chunks * num_heads));
-        tmp_d = allocator->Allocate(
-            phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(token_num * num_chunks * num_heads));
-      } else {
+      phi::Allocator::AllocationPtr tmp_workspace, tmp_m, tmp_d;
+      if (is_decoder) {
         tmp_workspace = allocator->Allocate(
             phi::SizeOf(qkv.dtype()) *
-            static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                num_chunks * num_heads * HEAD_DIM));
+            static_cast<size_t>(bsz * num_chunks * num_heads * HEAD_DIM));
         tmp_m = allocator->Allocate(
             phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                num_chunks * num_heads));
+            static_cast<size_t>(bsz * num_chunks * num_heads));
         tmp_d = allocator->Allocate(
             phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                num_chunks * num_heads));
+            static_cast<size_t>(bsz * num_chunks * num_heads));
+      } else {
+        if (ENABLE_PREFILL) {
+          tmp_workspace =
+              allocator->Allocate(phi::SizeOf(qkv.dtype()) *
+                                  static_cast<size_t>(token_num * num_chunks *
+                                                      num_heads * HEAD_DIM));
+          tmp_m = allocator->Allocate(
+              phi::SizeOf(paddle::DataType::FLOAT32) *
+              static_cast<size_t>(token_num * num_chunks * num_heads));
+          tmp_d = allocator->Allocate(
+              phi::SizeOf(paddle::DataType::FLOAT32) *
+              static_cast<size_t>(token_num * num_chunks * num_heads));
+        } else {
+          tmp_workspace = allocator->Allocate(
+              phi::SizeOf(qkv.dtype()) *
+              static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                  num_chunks * num_heads * HEAD_DIM));
+          tmp_m = allocator->Allocate(
+              phi::SizeOf(paddle::DataType::FLOAT32) *
+              static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                  num_chunks * num_heads));
+          tmp_d = allocator->Allocate(
+              phi::SizeOf(paddle::DataType::FLOAT32) *
+              static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                  num_chunks * num_heads));
+        }
       }
-    }
-    split_kv_kernel<<<grids, blocks, smem_size, stream>>>(
-        reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
-        reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k.data<T>())),
-        reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v.data<T>())),
-        shift_bias ? reinterpret_cast<NV_TYPE *>(
-                          const_cast<T *>(shift_bias.get().data<T>()))
-                    : nullptr,
-        smooth_weight ? reinterpret_cast<NV_TYPE *>(
-                            const_cast<T *>(smooth_weight.get().data<T>()))
+      split_kv_kernel<<<grids, blocks, smem_size, stream>>>(
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k.data<T>())),
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v.data<T>())),
+          shift_bias ? reinterpret_cast<NV_TYPE *>(
+                            const_cast<T *>(shift_bias.get().data<T>()))
                       : nullptr,
-        seq_lens_q.data<int>(),
-        seq_lens_kv.data<int>(),
-        batch_ids.data<int>(),
-        tile_ids_per_batch.data<int>(),
-        cu_seqlens_q.data<int>(),
-        block_table.data<int>(),
-        max_seq_len,
-        max_dec_len,
-        max_block_num_per_seq,
-        scale,
-        quant_max_bound,
-        quant_min_bound,
-        in_scale,
-        chunk_size,
-        reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-        static_cast<float *>(tmp_m->ptr()),
-        static_cast<float *>(tmp_d->ptr()),
-        reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-        speculate_max_draft_token_num);
+          smooth_weight ? reinterpret_cast<NV_TYPE *>(
+                              const_cast<T *>(smooth_weight.get().data<T>()))
+                        : nullptr,
+          seq_lens_q.data<int>(),
+          seq_lens_kv.data<int>(),
+          batch_ids.data<int>(),
+          tile_ids_per_batch.data<int>(),
+          cu_seqlens_q.data<int>(),
+          block_table.data<int>(),
+          max_seq_len,
+          max_dec_len,
+          max_block_num_per_seq,
+          scale,
+          quant_max_bound,
+          quant_min_bound,
+          in_scale,
+          chunk_size,
+          reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+          static_cast<float *>(tmp_m->ptr()),
+          static_cast<float *>(tmp_d->ptr()),
+          reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          speculate_max_draft_token_num);
 
-    // merge
-    constexpr int vec_size = num_elems_per_128b<NV_TYPE>();
-    if (is_decoder) {
-      constexpr int blockx = HEAD_DIM / vec_size;
-      constexpr int blocky = (128 + blockx - 1) / blockx;
-      dim3 grids_merge(bsz, num_heads);
-      dim3 blocks_merge(blockx, blocky);
-      merge_multi_chunks_decoder_kernel<NV_TYPE,
-                                        vec_size,
-                                        blocky,
-                                        HEAD_DIM,
-                                        OUT_NV_TYPE,
-                                        ENABLE_PREFILL>
-          <<<grids_merge, blocks_merge, 0, stream>>>(
-              reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-              static_cast<float *>(tmp_m->ptr()),
-              static_cast<float *>(tmp_d->ptr()),
-              seq_lens_q.data<int>(),
-              seq_lens_kv.data<int>(),
-              seq_lens_encoder.data<int>(),
-              cu_seqlens_q.data<int>(),
-              shift_bias ? reinterpret_cast<NV_TYPE *>(
-                                const_cast<T *>(shift_bias.get().data<T>()))
-                          : nullptr,
-              smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
-                                  smooth_weight.get().data<T>()))
+      // merge
+      constexpr int vec_size = num_elems_per_128b<NV_TYPE>();
+      if (is_decoder) {
+        constexpr int blockx = HEAD_DIM / vec_size;
+        constexpr int blocky = (128 + blockx - 1) / blockx;
+        dim3 grids_merge(bsz, num_heads);
+        dim3 blocks_merge(blockx, blocky);
+        merge_multi_chunks_decoder_kernel<NV_TYPE,
+                                          vec_size,
+                                          blocky,
+                                          HEAD_DIM,
+                                          OUT_NV_TYPE,
+                                          ENABLE_PREFILL>
+            <<<grids_merge, blocks_merge, 0, stream>>>(
+                reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+                static_cast<float *>(tmp_m->ptr()),
+                static_cast<float *>(tmp_d->ptr()),
+                seq_lens_q.data<int>(),
+                seq_lens_kv.data<int>(),
+                seq_lens_encoder.data<int>(),
+                cu_seqlens_q.data<int>(),
+                shift_bias ? reinterpret_cast<NV_TYPE *>(
+                                  const_cast<T *>(shift_bias.get().data<T>()))
                             : nullptr,
-              reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-              quant_max_bound,
-              quant_min_bound,
-              in_scale,
-              max_seq_len,
-              num_chunks,
-              num_heads,
-              chunk_size,
-              HEAD_DIM);
-    } else {
-      constexpr int blockx = HEAD_DIM / vec_size;
-      constexpr int blocky = (128 + blockx - 1) / blockx;
-      dim3 grids_merge(min(sm_count * 4, token_num),
-                        num_heads);
-      dim3 blocks_merge(blockx, blocky);
-      merge_multi_chunks_v2_kernel<NV_TYPE,
-                                    vec_size,
-                                    blocky,
-                                    HEAD_DIM,
-                                    OUT_NV_TYPE,
-                                    ENABLE_PREFILL>
-          <<<grids_merge, blocks_merge, 0, stream>>>(
-              reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-              static_cast<float *>(tmp_m->ptr()),
-              static_cast<float *>(tmp_d->ptr()),
-              seq_lens_q.data<int>(),
-              seq_lens_kv.data<int>(),
-              seq_lens_encoder.data<int>(),
-              batch_id_per_token.data<int>(),
-              cu_seqlens_q.data<int>(),
-              shift_bias ? reinterpret_cast<NV_TYPE *>(
-                                const_cast<T *>(shift_bias.get().data<T>()))
-                          : nullptr,
-              smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
-                                  smooth_weight.get().data<T>()))
+                smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
+                                    smooth_weight.get().data<T>()))
+                              : nullptr,
+                reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+                quant_max_bound,
+                quant_min_bound,
+                in_scale,
+                max_seq_len,
+                num_chunks,
+                num_heads,
+                chunk_size,
+                HEAD_DIM);
+      } else {
+        constexpr int blockx = HEAD_DIM / vec_size;
+        constexpr int blocky = (128 + blockx - 1) / blockx;
+        dim3 grids_merge(min(sm_count * 4, token_num),
+                          num_heads);
+        dim3 blocks_merge(blockx, blocky);
+        merge_multi_chunks_v2_kernel<NV_TYPE,
+                                      vec_size,
+                                      blocky,
+                                      HEAD_DIM,
+                                      OUT_NV_TYPE,
+                                      ENABLE_PREFILL>
+            <<<grids_merge, blocks_merge, 0, stream>>>(
+                reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+                static_cast<float *>(tmp_m->ptr()),
+                static_cast<float *>(tmp_d->ptr()),
+                seq_lens_q.data<int>(),
+                seq_lens_kv.data<int>(),
+                seq_lens_encoder.data<int>(),
+                batch_id_per_token.data<int>(),
+                cu_seqlens_q.data<int>(),
+                shift_bias ? reinterpret_cast<NV_TYPE *>(
+                                  const_cast<T *>(shift_bias.get().data<T>()))
                             : nullptr,
-              reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-              quant_max_bound,
-              quant_min_bound,
-              in_scale,
-              max_seq_len,
-              num_chunks,
-              num_heads,
-              chunk_size,
-              HEAD_DIM,
-              token_num,
-              speculate_max_draft_token_num);
+                smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
+                                    smooth_weight.get().data<T>()))
+                              : nullptr,
+                reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+                quant_max_bound,
+                quant_min_bound,
+                in_scale,
+                max_seq_len,
+                num_chunks,
+                num_heads,
+                chunk_size,
+                HEAD_DIM,
+                token_num,
+                speculate_max_draft_token_num);
+      }
     }
   }
 }

--- a/custom_ops/gpu_ops/append_attn/append_attention_c16_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_c16_impl.cuh
@@ -1061,7 +1061,7 @@ void MultiQueryAppendAttention(
     if (!is_decoder) {
       chunk_size = static_cast<uint32_t>(encoder_max_partition_size);
     }
-    
+
     const int num_chunks = div_up(max_seq_len, chunk_size);
     dim3 grids(num_blocks_x_cpu, num_chunks, kv_num_heads);
     dim3 blocks(32, num_warps);

--- a/custom_ops/gpu_ops/append_attn/append_attention_c16_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_c16_impl.cuh
@@ -1061,206 +1061,153 @@ void MultiQueryAppendAttention(
     if (!is_decoder) {
       chunk_size = static_cast<uint32_t>(encoder_max_partition_size);
     }
-    const int num_chunks = div_up(encoder_max_partition_size, chunk_size);
-
+    
+    const int num_chunks = div_up(max_seq_len, chunk_size);
     dim3 grids(num_blocks_x_cpu, num_chunks, kv_num_heads);
     dim3 blocks(32, num_warps);
 
-    if (num_chunks <= 0) {
-      auto nosplit_kv_kernel =
-          multi_query_append_attention_warp1_4_kernel<NV_TYPE,
-                                                      false,
-                                                      GROUP_SIZE,
-                                                      CAUSAL,
-                                                      num_warps,
-                                                      NUM_WARP_Q,
-                                                      NUM_WARP_KV,
-                                                      HEAD_DIM,
-                                                      BLOCK_SIZE,
-                                                      num_frags_x,
-                                                      num_frags_z,
-                                                      num_frags_y,
-                                                      OUT_NV_TYPE,
-                                                      ENABLE_PREFILL>;
-      if (smem_size >= 48 * 1024) {
-        cudaFuncSetAttribute(nosplit_kv_kernel,
-                             cudaFuncAttributeMaxDynamicSharedMemorySize,
-                             smem_size);
-      }
-
-      nosplit_kv_kernel<<<grids, blocks, smem_size, stream>>>(
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k.data<T>())),
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v.data<T>())),
-          shift_bias ? reinterpret_cast<NV_TYPE *>(
-                           const_cast<T *>(shift_bias.get().data<T>()))
-                     : nullptr,
-          smooth_weight ? reinterpret_cast<NV_TYPE *>(
-                              const_cast<T *>(smooth_weight.get().data<T>()))
-                        : nullptr,
-          seq_lens_q.data<int>(),
-          seq_lens_kv.data<int>(),
-          batch_ids.data<int>(),
-          tile_ids_per_batch.data<int>(),
-          cu_seqlens_q.data<int>(),
-          block_table.data<int>(),
-          max_seq_len,
-          max_dec_len,
-          max_block_num_per_seq,
-          scale,
-          quant_max_bound,
-          quant_min_bound,
-          in_scale,
-          chunk_size,
-          nullptr,
-          nullptr,
-          nullptr,
-          reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-          speculate_max_draft_token_num);
+    phi::Allocator::AllocationPtr tmp_workspace, tmp_m, tmp_d;
+    if (is_decoder) {
+      tmp_workspace = allocator->Allocate(
+          phi::SizeOf(qkv.dtype()) *
+          static_cast<size_t>(bsz * num_chunks * num_heads * HEAD_DIM));
+      tmp_m = allocator->Allocate(
+          phi::SizeOf(paddle::DataType::FLOAT32) *
+          static_cast<size_t>(bsz * num_chunks * num_heads));
+      tmp_d = allocator->Allocate(
+          phi::SizeOf(paddle::DataType::FLOAT32) *
+          static_cast<size_t>(bsz * num_chunks * num_heads));
     } else {
-      phi::Allocator::AllocationPtr tmp_workspace, tmp_m, tmp_d;
-      if (is_decoder) {
-        tmp_workspace = allocator->Allocate(
-            phi::SizeOf(qkv.dtype()) *
-            static_cast<size_t>(bsz * num_chunks * num_heads * HEAD_DIM));
+      if (ENABLE_PREFILL) {
+        tmp_workspace =
+            allocator->Allocate(phi::SizeOf(qkv.dtype()) *
+                                static_cast<size_t>(token_num * num_chunks *
+                                                    num_heads * HEAD_DIM));
         tmp_m = allocator->Allocate(
             phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(bsz * num_chunks * num_heads));
+            static_cast<size_t>(token_num * num_chunks * num_heads));
         tmp_d = allocator->Allocate(
             phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(bsz * num_chunks * num_heads));
+            static_cast<size_t>(token_num * num_chunks * num_heads));
       } else {
-        if (ENABLE_PREFILL) {
-          tmp_workspace =
-              allocator->Allocate(phi::SizeOf(qkv.dtype()) *
-                                  static_cast<size_t>(token_num * num_chunks *
-                                                      num_heads * HEAD_DIM));
-          tmp_m = allocator->Allocate(
-              phi::SizeOf(paddle::DataType::FLOAT32) *
-              static_cast<size_t>(token_num * num_chunks * num_heads));
-          tmp_d = allocator->Allocate(
-              phi::SizeOf(paddle::DataType::FLOAT32) *
-              static_cast<size_t>(token_num * num_chunks * num_heads));
-        } else {
-          tmp_workspace = allocator->Allocate(
-              phi::SizeOf(qkv.dtype()) *
-              static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                  num_chunks * num_heads * HEAD_DIM));
-          tmp_m = allocator->Allocate(
-              phi::SizeOf(paddle::DataType::FLOAT32) *
-              static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                  num_chunks * num_heads));
-          tmp_d = allocator->Allocate(
-              phi::SizeOf(paddle::DataType::FLOAT32) *
-              static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                  num_chunks * num_heads));
-        }
+        tmp_workspace = allocator->Allocate(
+            phi::SizeOf(qkv.dtype()) *
+            static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                num_chunks * num_heads * HEAD_DIM));
+        tmp_m = allocator->Allocate(
+            phi::SizeOf(paddle::DataType::FLOAT32) *
+            static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                num_chunks * num_heads));
+        tmp_d = allocator->Allocate(
+            phi::SizeOf(paddle::DataType::FLOAT32) *
+            static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                num_chunks * num_heads));
       }
-      split_kv_kernel<<<grids, blocks, smem_size, stream>>>(
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k.data<T>())),
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v.data<T>())),
-          shift_bias ? reinterpret_cast<NV_TYPE *>(
-                           const_cast<T *>(shift_bias.get().data<T>()))
-                     : nullptr,
-          smooth_weight ? reinterpret_cast<NV_TYPE *>(
-                              const_cast<T *>(smooth_weight.get().data<T>()))
-                        : nullptr,
-          seq_lens_q.data<int>(),
-          seq_lens_kv.data<int>(),
-          batch_ids.data<int>(),
-          tile_ids_per_batch.data<int>(),
-          cu_seqlens_q.data<int>(),
-          block_table.data<int>(),
-          max_seq_len,
-          max_dec_len,
-          max_block_num_per_seq,
-          scale,
-          quant_max_bound,
-          quant_min_bound,
-          in_scale,
-          chunk_size,
-          reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-          static_cast<float *>(tmp_m->ptr()),
-          static_cast<float *>(tmp_d->ptr()),
-          reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-          speculate_max_draft_token_num);
+    }
+    split_kv_kernel<<<grids, blocks, smem_size, stream>>>(
+        reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
+        reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k.data<T>())),
+        reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v.data<T>())),
+        shift_bias ? reinterpret_cast<NV_TYPE *>(
+                          const_cast<T *>(shift_bias.get().data<T>()))
+                    : nullptr,
+        smooth_weight ? reinterpret_cast<NV_TYPE *>(
+                            const_cast<T *>(smooth_weight.get().data<T>()))
+                      : nullptr,
+        seq_lens_q.data<int>(),
+        seq_lens_kv.data<int>(),
+        batch_ids.data<int>(),
+        tile_ids_per_batch.data<int>(),
+        cu_seqlens_q.data<int>(),
+        block_table.data<int>(),
+        max_seq_len,
+        max_dec_len,
+        max_block_num_per_seq,
+        scale,
+        quant_max_bound,
+        quant_min_bound,
+        in_scale,
+        chunk_size,
+        reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+        static_cast<float *>(tmp_m->ptr()),
+        static_cast<float *>(tmp_d->ptr()),
+        reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+        speculate_max_draft_token_num);
 
-      // merge
-      constexpr int vec_size = num_elems_per_128b<NV_TYPE>();
-      if (is_decoder) {
-        constexpr int blockx = HEAD_DIM / vec_size;
-        constexpr int blocky = (128 + blockx - 1) / blockx;
-        dim3 grids_merge(bsz, num_heads);
-        dim3 blocks_merge(blockx, blocky);
-        merge_multi_chunks_decoder_kernel<NV_TYPE,
-                                          vec_size,
-                                          blocky,
-                                          HEAD_DIM,
-                                          OUT_NV_TYPE,
-                                          ENABLE_PREFILL>
-            <<<grids_merge, blocks_merge, 0, stream>>>(
-                reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-                static_cast<float *>(tmp_m->ptr()),
-                static_cast<float *>(tmp_d->ptr()),
-                seq_lens_q.data<int>(),
-                seq_lens_kv.data<int>(),
-                seq_lens_encoder.data<int>(),
-                cu_seqlens_q.data<int>(),
-                shift_bias ? reinterpret_cast<NV_TYPE *>(
-                                 const_cast<T *>(shift_bias.get().data<T>()))
-                           : nullptr,
-                smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
-                                    smooth_weight.get().data<T>()))
-                              : nullptr,
-                reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-                quant_max_bound,
-                quant_min_bound,
-                in_scale,
-                max_seq_len,
-                num_chunks,
-                num_heads,
-                chunk_size,
-                HEAD_DIM);
-      } else {
-        constexpr int blockx = HEAD_DIM / vec_size;
-        constexpr int blocky = (128 + blockx - 1) / blockx;
-        dim3 grids_merge(min(sm_count * 4, token_num),
-                         num_heads);
-        dim3 blocks_merge(blockx, blocky);
-        merge_multi_chunks_v2_kernel<NV_TYPE,
-                                     vec_size,
-                                     blocky,
-                                     HEAD_DIM,
-                                     OUT_NV_TYPE,
-                                     ENABLE_PREFILL>
-            <<<grids_merge, blocks_merge, 0, stream>>>(
-                reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-                static_cast<float *>(tmp_m->ptr()),
-                static_cast<float *>(tmp_d->ptr()),
-                seq_lens_q.data<int>(),
-                seq_lens_kv.data<int>(),
-                seq_lens_encoder.data<int>(),
-                batch_id_per_token.data<int>(),
-                cu_seqlens_q.data<int>(),
-                shift_bias ? reinterpret_cast<NV_TYPE *>(
-                                 const_cast<T *>(shift_bias.get().data<T>()))
-                           : nullptr,
-                smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
-                                    smooth_weight.get().data<T>()))
-                              : nullptr,
-                reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-                quant_max_bound,
-                quant_min_bound,
-                in_scale,
-                max_seq_len,
-                num_chunks,
-                num_heads,
-                chunk_size,
-                HEAD_DIM,
-                token_num,
-                speculate_max_draft_token_num);
-      }
+    // merge
+    constexpr int vec_size = num_elems_per_128b<NV_TYPE>();
+    if (is_decoder) {
+      constexpr int blockx = HEAD_DIM / vec_size;
+      constexpr int blocky = (128 + blockx - 1) / blockx;
+      dim3 grids_merge(bsz, num_heads);
+      dim3 blocks_merge(blockx, blocky);
+      merge_multi_chunks_decoder_kernel<NV_TYPE,
+                                        vec_size,
+                                        blocky,
+                                        HEAD_DIM,
+                                        OUT_NV_TYPE,
+                                        ENABLE_PREFILL>
+          <<<grids_merge, blocks_merge, 0, stream>>>(
+              reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+              static_cast<float *>(tmp_m->ptr()),
+              static_cast<float *>(tmp_d->ptr()),
+              seq_lens_q.data<int>(),
+              seq_lens_kv.data<int>(),
+              seq_lens_encoder.data<int>(),
+              cu_seqlens_q.data<int>(),
+              shift_bias ? reinterpret_cast<NV_TYPE *>(
+                                const_cast<T *>(shift_bias.get().data<T>()))
+                          : nullptr,
+              smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
+                                  smooth_weight.get().data<T>()))
+                            : nullptr,
+              reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+              quant_max_bound,
+              quant_min_bound,
+              in_scale,
+              max_seq_len,
+              num_chunks,
+              num_heads,
+              chunk_size,
+              HEAD_DIM);
+    } else {
+      constexpr int blockx = HEAD_DIM / vec_size;
+      constexpr int blocky = (128 + blockx - 1) / blockx;
+      dim3 grids_merge(min(sm_count * 4, token_num),
+                        num_heads);
+      dim3 blocks_merge(blockx, blocky);
+      merge_multi_chunks_v2_kernel<NV_TYPE,
+                                    vec_size,
+                                    blocky,
+                                    HEAD_DIM,
+                                    OUT_NV_TYPE,
+                                    ENABLE_PREFILL>
+          <<<grids_merge, blocks_merge, 0, stream>>>(
+              reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+              static_cast<float *>(tmp_m->ptr()),
+              static_cast<float *>(tmp_d->ptr()),
+              seq_lens_q.data<int>(),
+              seq_lens_kv.data<int>(),
+              seq_lens_encoder.data<int>(),
+              batch_id_per_token.data<int>(),
+              cu_seqlens_q.data<int>(),
+              shift_bias ? reinterpret_cast<NV_TYPE *>(
+                                const_cast<T *>(shift_bias.get().data<T>()))
+                          : nullptr,
+              smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
+                                  smooth_weight.get().data<T>()))
+                            : nullptr,
+              reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+              quant_max_bound,
+              quant_min_bound,
+              in_scale,
+              max_seq_len,
+              num_chunks,
+              num_heads,
+              chunk_size,
+              HEAD_DIM,
+              token_num,
+              speculate_max_draft_token_num);
     }
   }
 }

--- a/custom_ops/gpu_ops/append_attn/append_attention_c16_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_c16_impl.cuh
@@ -1061,12 +1061,12 @@ void MultiQueryAppendAttention(
     if (!is_decoder) {
       chunk_size = static_cast<uint32_t>(encoder_max_partition_size);
     }
-    const int num_chunks = div_up(max_dec_len, chunk_size);
+    const int num_chunks = div_up(encoder_max_partition_size, chunk_size);
 
     dim3 grids(num_blocks_x_cpu, num_chunks, kv_num_heads);
     dim3 blocks(32, num_warps);
 
-    if (num_chunks <= 1) {
+    if (num_chunks <= 0) {
       auto nosplit_kv_kernel =
           multi_query_append_attention_warp1_4_kernel<NV_TYPE,
                                                       false,

--- a/custom_ops/gpu_ops/append_attn/append_attention_c4_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_c4_impl.cuh
@@ -1285,10 +1285,10 @@ void MultiQueryAppendC4Attention(
     if (!is_decoder) {
       chunk_size = static_cast<uint32_t>(encoder_max_partition_size);
     }
-    const int num_chunks = div_up(max_dec_len, chunk_size);
+    const int num_chunks = div_up(encoder_max_partition_size, chunk_size);
     dim3 grids(num_blocks_x_cpu, num_chunks, kv_num_heads);
     dim3 blocks(32, num_warps);
-    if (num_chunks <= 1) {
+    if (num_chunks <= 0) {
       auto nosplit_kv_kernel =
           multi_query_append_attention_c4_warp1_4_kernel<NV_TYPE,
                                                          uint8_t,

--- a/custom_ops/gpu_ops/append_attn/append_attention_c4_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_c4_impl.cuh
@@ -1285,219 +1285,160 @@ void MultiQueryAppendC4Attention(
     if (!is_decoder) {
       chunk_size = static_cast<uint32_t>(encoder_max_partition_size);
     }
-    const int num_chunks = div_up(encoder_max_partition_size, chunk_size);
+    
+    const int num_chunks = div_up(max_seq_len, chunk_size);
     dim3 grids(num_blocks_x_cpu, num_chunks, kv_num_heads);
     dim3 blocks(32, num_warps);
-    if (num_chunks <= 0) {
-      auto nosplit_kv_kernel =
-          multi_query_append_attention_c4_warp1_4_kernel<NV_TYPE,
-                                                         uint8_t,
-                                                         false,
-                                                         GROUP_SIZE,
-                                                         CAUSAL,
-                                                         num_warps,
-                                                         NUM_WARP_Q,
-                                                         NUM_WARP_KV,
-                                                         HEAD_DIM,
-                                                         BLOCK_SIZE,
-                                                         num_frags_x,
-                                                         num_frags_z,
-                                                         num_frags_y,
-                                                         OUT_NV_TYPE,
-                                                         ENABLE_PREFILL>;
-      if (smem_size >= 48 * 1024) {
-        cudaFuncSetAttribute(nosplit_kv_kernel,
-                             cudaFuncAttributeMaxDynamicSharedMemorySize,
-                             smem_size);
-      }
-      nosplit_kv_kernel<<<grids, blocks, smem_size, stream>>>(
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
-          const_cast<uint8_t *>(cache_k.data<uint8_t>()),
-          const_cast<uint8_t *>(cache_v.data<uint8_t>()),
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k_scale.data<T>())),
-          cache_k_zp ? reinterpret_cast<NV_TYPE *>(
-                           const_cast<T *>(cache_k_zp.get().data<T>()))
-                     : nullptr,
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v_scale.data<T>())),
-          cache_v_zp ? reinterpret_cast<NV_TYPE *>(
-                           const_cast<T *>(cache_v_zp.get().data<T>()))
-                     : nullptr,
-          shift_bias ? reinterpret_cast<NV_TYPE *>(
-                           const_cast<T *>(shift_bias.get().data<T>()))
-                     : nullptr,
-          smooth_weight ? reinterpret_cast<NV_TYPE *>(
-                              const_cast<T *>(smooth_weight.get().data<T>()))
-                        : nullptr,
-          seq_lens_q.data<int>(),
-          seq_lens_kv.data<int>(),
-          batch_ids.data<int>(),
-          tile_ids_per_batch.data<int>(),
-          cu_seqlens_q.data<int>(),
-          block_table.data<int>(),
-          max_seq_len,
-          max_dec_len,
-          max_block_num_per_seq,
-          scale,
-          quant_max_bound,
-          quant_min_bound,
-          in_scale,
-          chunk_size,
-          nullptr,
-          nullptr,
-          nullptr,
-          reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-          speculate_max_draft_token_num);
+
+    phi::Allocator::AllocationPtr tmp_workspace, tmp_m, tmp_d;
+    if (is_decoder) {
+      tmp_workspace = allocator->Allocate(
+          phi::SizeOf(qkv.dtype()) *
+          static_cast<size_t>(bsz * num_chunks * num_heads * HEAD_DIM));
+      tmp_m = allocator->Allocate(
+          phi::SizeOf(paddle::DataType::FLOAT32) *
+          static_cast<size_t>(bsz * num_chunks * num_heads));
+      tmp_d = allocator->Allocate(
+          phi::SizeOf(paddle::DataType::FLOAT32) *
+          static_cast<size_t>(bsz * num_chunks * num_heads));
     } else {
-      phi::Allocator::AllocationPtr tmp_workspace, tmp_m, tmp_d;
-      if (is_decoder) {
-        tmp_workspace = allocator->Allocate(
-            phi::SizeOf(qkv.dtype()) *
-            static_cast<size_t>(bsz * num_chunks * num_heads * HEAD_DIM));
+      if (ENABLE_PREFILL) {
+        tmp_workspace =
+            allocator->Allocate(phi::SizeOf(qkv.dtype()) *
+                                static_cast<size_t>(token_num * num_chunks *
+                                                    num_heads * HEAD_DIM));
         tmp_m = allocator->Allocate(
             phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(bsz * num_chunks * num_heads));
+            static_cast<size_t>(token_num * num_chunks * num_heads));
         tmp_d = allocator->Allocate(
             phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(bsz * num_chunks * num_heads));
+            static_cast<size_t>(token_num * num_chunks * num_heads));
       } else {
-        if (ENABLE_PREFILL) {
-          tmp_workspace =
-              allocator->Allocate(phi::SizeOf(qkv.dtype()) *
-                                  static_cast<size_t>(token_num * num_chunks *
-                                                      num_heads * HEAD_DIM));
-          tmp_m = allocator->Allocate(
-              phi::SizeOf(paddle::DataType::FLOAT32) *
-              static_cast<size_t>(token_num * num_chunks * num_heads));
-          tmp_d = allocator->Allocate(
-              phi::SizeOf(paddle::DataType::FLOAT32) *
-              static_cast<size_t>(token_num * num_chunks * num_heads));
-        } else {
-          tmp_workspace = allocator->Allocate(
-              phi::SizeOf(qkv.dtype()) *
-              static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                  num_chunks * num_heads * HEAD_DIM));
-          tmp_m = allocator->Allocate(
-              phi::SizeOf(paddle::DataType::FLOAT32) *
-              static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                  num_chunks * num_heads));
-          tmp_d = allocator->Allocate(
-              phi::SizeOf(paddle::DataType::FLOAT32) *
-              static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                  num_chunks * num_heads));
-        }
+        tmp_workspace = allocator->Allocate(
+            phi::SizeOf(qkv.dtype()) *
+            static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                num_chunks * num_heads * HEAD_DIM));
+        tmp_m = allocator->Allocate(
+            phi::SizeOf(paddle::DataType::FLOAT32) *
+            static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                num_chunks * num_heads));
+        tmp_d = allocator->Allocate(
+            phi::SizeOf(paddle::DataType::FLOAT32) *
+            static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                num_chunks * num_heads));
       }
-      split_kv_kernel<<<grids, blocks, smem_size, stream>>>(
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
-          const_cast<uint8_t *>(cache_k.data<uint8_t>()),
-          const_cast<uint8_t *>(cache_v.data<uint8_t>()),
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k_scale.data<T>())),
-          cache_k_zp ? reinterpret_cast<NV_TYPE *>(
-                           const_cast<T *>(cache_k_zp.get().data<T>()))
-                     : nullptr,
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v_scale.data<T>())),
-          cache_v_zp ? reinterpret_cast<NV_TYPE *>(
-                           const_cast<T *>(cache_v_zp.get().data<T>()))
-                     : nullptr,
-          shift_bias ? reinterpret_cast<NV_TYPE *>(
-                           const_cast<T *>(shift_bias.get().data<T>()))
-                     : nullptr,
-          smooth_weight ? reinterpret_cast<NV_TYPE *>(
-                              const_cast<T *>(smooth_weight.get().data<T>()))
-                        : nullptr,
-          seq_lens_q.data<int>(),
-          seq_lens_kv.data<int>(),
-          batch_ids.data<int>(),
-          tile_ids_per_batch.data<int>(),
-          cu_seqlens_q.data<int>(),
-          block_table.data<int>(),
-          max_seq_len,
-          max_dec_len,
-          max_block_num_per_seq,
-          scale,
-          quant_max_bound,
-          quant_min_bound,
-          in_scale,
-          chunk_size,
-          reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-          static_cast<float *>(tmp_m->ptr()),
-          static_cast<float *>(tmp_d->ptr()),
-          reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-          speculate_max_draft_token_num);
-      // merge
-      constexpr int vec_size = num_elems_per_128b<NV_TYPE>();
-      if (is_decoder) {
-        constexpr int blockx = HEAD_DIM / vec_size;
-        constexpr int blocky = (128 + blockx - 1) / blockx;
-        dim3 grids_merge(bsz, num_heads);
-        dim3 blocks_merge(blockx, blocky);
-        merge_multi_chunks_decoder_kernel<NV_TYPE,
-                                          vec_size,
-                                          blocky,
-                                          HEAD_DIM,
-                                          OUT_NV_TYPE,
-                                          ENABLE_PREFILL>
-            <<<grids_merge, blocks_merge, 0, stream>>>(
-                reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-                static_cast<float *>(tmp_m->ptr()),
-                static_cast<float *>(tmp_d->ptr()),
-                seq_lens_q.data<int>(),
-                seq_lens_kv.data<int>(),
-                seq_lens_encoder.data<int>(),
-                cu_seqlens_q.data<int>(),
-                shift_bias ? reinterpret_cast<NV_TYPE *>(
-                                 const_cast<T *>(shift_bias.get().data<T>()))
-                           : nullptr,
-                smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
-                                    smooth_weight.get().data<T>()))
-                              : nullptr,
-                reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-                quant_max_bound,
-                quant_min_bound,
-                in_scale,
-                max_seq_len,
-                num_chunks,
-                num_heads,
-                chunk_size,
-                HEAD_DIM);
-      } else {
-        constexpr int blockx = HEAD_DIM / vec_size;
-        constexpr int blocky = (128 + blockx - 1) / blockx;
-        dim3 grids_merge(min(sm_count * 4, token_num),
-                         num_heads);
-        dim3 blocks_merge(blockx, blocky);
-        merge_multi_chunks_v2_kernel<NV_TYPE,
-                                     vec_size,
-                                     blocky,
-                                     HEAD_DIM,
-                                     OUT_NV_TYPE,
-                                     ENABLE_PREFILL>
-            <<<grids_merge, blocks_merge, 0, stream>>>(
-                reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-                static_cast<float *>(tmp_m->ptr()),
-                static_cast<float *>(tmp_d->ptr()),
-                seq_lens_q.data<int>(),
-                seq_lens_kv.data<int>(),
-                seq_lens_encoder.data<int>(),
-                batch_id_per_token.data<int>(),
-                cu_seqlens_q.data<int>(),
-                shift_bias ? reinterpret_cast<NV_TYPE *>(
-                                 const_cast<T *>(shift_bias.get().data<T>()))
-                           : nullptr,
-                smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
-                                    smooth_weight.get().data<T>()))
-                              : nullptr,
-                reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-                quant_max_bound,
-                quant_min_bound,
-                in_scale,
-                max_seq_len,
-                num_chunks,
-                num_heads,
-                chunk_size,
-                HEAD_DIM,
-                token_num,
-                speculate_max_draft_token_num);
-      }
+    }
+    split_kv_kernel<<<grids, blocks, smem_size, stream>>>(
+        reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
+        const_cast<uint8_t *>(cache_k.data<uint8_t>()),
+        const_cast<uint8_t *>(cache_v.data<uint8_t>()),
+        reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k_scale.data<T>())),
+        cache_k_zp ? reinterpret_cast<NV_TYPE *>(
+                          const_cast<T *>(cache_k_zp.get().data<T>()))
+                    : nullptr,
+        reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v_scale.data<T>())),
+        cache_v_zp ? reinterpret_cast<NV_TYPE *>(
+                          const_cast<T *>(cache_v_zp.get().data<T>()))
+                    : nullptr,
+        shift_bias ? reinterpret_cast<NV_TYPE *>(
+                          const_cast<T *>(shift_bias.get().data<T>()))
+                    : nullptr,
+        smooth_weight ? reinterpret_cast<NV_TYPE *>(
+                            const_cast<T *>(smooth_weight.get().data<T>()))
+                      : nullptr,
+        seq_lens_q.data<int>(),
+        seq_lens_kv.data<int>(),
+        batch_ids.data<int>(),
+        tile_ids_per_batch.data<int>(),
+        cu_seqlens_q.data<int>(),
+        block_table.data<int>(),
+        max_seq_len,
+        max_dec_len,
+        max_block_num_per_seq,
+        scale,
+        quant_max_bound,
+        quant_min_bound,
+        in_scale,
+        chunk_size,
+        reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+        static_cast<float *>(tmp_m->ptr()),
+        static_cast<float *>(tmp_d->ptr()),
+        reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+        speculate_max_draft_token_num);
+    // merge
+    constexpr int vec_size = num_elems_per_128b<NV_TYPE>();
+    if (is_decoder) {
+      constexpr int blockx = HEAD_DIM / vec_size;
+      constexpr int blocky = (128 + blockx - 1) / blockx;
+      dim3 grids_merge(bsz, num_heads);
+      dim3 blocks_merge(blockx, blocky);
+      merge_multi_chunks_decoder_kernel<NV_TYPE,
+                                        vec_size,
+                                        blocky,
+                                        HEAD_DIM,
+                                        OUT_NV_TYPE,
+                                        ENABLE_PREFILL>
+          <<<grids_merge, blocks_merge, 0, stream>>>(
+              reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+              static_cast<float *>(tmp_m->ptr()),
+              static_cast<float *>(tmp_d->ptr()),
+              seq_lens_q.data<int>(),
+              seq_lens_kv.data<int>(),
+              seq_lens_encoder.data<int>(),
+              cu_seqlens_q.data<int>(),
+              shift_bias ? reinterpret_cast<NV_TYPE *>(
+                                const_cast<T *>(shift_bias.get().data<T>()))
+                          : nullptr,
+              smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
+                                  smooth_weight.get().data<T>()))
+                            : nullptr,
+              reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+              quant_max_bound,
+              quant_min_bound,
+              in_scale,
+              max_seq_len,
+              num_chunks,
+              num_heads,
+              chunk_size,
+              HEAD_DIM);
+    } else {
+      constexpr int blockx = HEAD_DIM / vec_size;
+      constexpr int blocky = (128 + blockx - 1) / blockx;
+      dim3 grids_merge(min(sm_count * 4, token_num),
+                        num_heads);
+      dim3 blocks_merge(blockx, blocky);
+      merge_multi_chunks_v2_kernel<NV_TYPE,
+                                    vec_size,
+                                    blocky,
+                                    HEAD_DIM,
+                                    OUT_NV_TYPE,
+                                    ENABLE_PREFILL>
+          <<<grids_merge, blocks_merge, 0, stream>>>(
+              reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+              static_cast<float *>(tmp_m->ptr()),
+              static_cast<float *>(tmp_d->ptr()),
+              seq_lens_q.data<int>(),
+              seq_lens_kv.data<int>(),
+              seq_lens_encoder.data<int>(),
+              batch_id_per_token.data<int>(),
+              cu_seqlens_q.data<int>(),
+              shift_bias ? reinterpret_cast<NV_TYPE *>(
+                                const_cast<T *>(shift_bias.get().data<T>()))
+                          : nullptr,
+              smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
+                                  smooth_weight.get().data<T>()))
+                            : nullptr,
+              reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+              quant_max_bound,
+              quant_min_bound,
+              in_scale,
+              max_seq_len,
+              num_chunks,
+              num_heads,
+              chunk_size,
+              HEAD_DIM,
+              token_num,
+              speculate_max_draft_token_num);
     }
   }
 }

--- a/custom_ops/gpu_ops/append_attn/append_attention_c4_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_c4_impl.cuh
@@ -1289,156 +1289,216 @@ void MultiQueryAppendC4Attention(
     const int num_chunks = div_up(max_seq_len, chunk_size);
     dim3 grids(num_blocks_x_cpu, num_chunks, kv_num_heads);
     dim3 blocks(32, num_warps);
-
-    phi::Allocator::AllocationPtr tmp_workspace, tmp_m, tmp_d;
-    if (is_decoder) {
-      tmp_workspace = allocator->Allocate(
-          phi::SizeOf(qkv.dtype()) *
-          static_cast<size_t>(bsz * num_chunks * num_heads * HEAD_DIM));
-      tmp_m = allocator->Allocate(
-          phi::SizeOf(paddle::DataType::FLOAT32) *
-          static_cast<size_t>(bsz * num_chunks * num_heads));
-      tmp_d = allocator->Allocate(
-          phi::SizeOf(paddle::DataType::FLOAT32) *
-          static_cast<size_t>(bsz * num_chunks * num_heads));
+    if (num_chunks <= 0) {
+      auto nosplit_kv_kernel =
+          multi_query_append_attention_c4_warp1_4_kernel<NV_TYPE,
+                                                         uint8_t,
+                                                         false,
+                                                         GROUP_SIZE,
+                                                         CAUSAL,
+                                                         num_warps,
+                                                         NUM_WARP_Q,
+                                                         NUM_WARP_KV,
+                                                         HEAD_DIM,
+                                                         BLOCK_SIZE,
+                                                         num_frags_x,
+                                                         num_frags_z,
+                                                         num_frags_y,
+                                                         OUT_NV_TYPE,
+                                                         ENABLE_PREFILL>;
+      if (smem_size >= 48 * 1024) {
+        cudaFuncSetAttribute(nosplit_kv_kernel,
+                             cudaFuncAttributeMaxDynamicSharedMemorySize,
+                             smem_size);
+      }
+      nosplit_kv_kernel<<<grids, blocks, smem_size, stream>>>(
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
+          const_cast<uint8_t *>(cache_k.data<uint8_t>()),
+          const_cast<uint8_t *>(cache_v.data<uint8_t>()),
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k_scale.data<T>())),
+          cache_k_zp ? reinterpret_cast<NV_TYPE *>(
+                           const_cast<T *>(cache_k_zp.get().data<T>()))
+                     : nullptr,
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v_scale.data<T>())),
+          cache_v_zp ? reinterpret_cast<NV_TYPE *>(
+                           const_cast<T *>(cache_v_zp.get().data<T>()))
+                     : nullptr,
+          shift_bias ? reinterpret_cast<NV_TYPE *>(
+                           const_cast<T *>(shift_bias.get().data<T>()))
+                     : nullptr,
+          smooth_weight ? reinterpret_cast<NV_TYPE *>(
+                              const_cast<T *>(smooth_weight.get().data<T>()))
+                        : nullptr,
+          seq_lens_q.data<int>(),
+          seq_lens_kv.data<int>(),
+          batch_ids.data<int>(),
+          tile_ids_per_batch.data<int>(),
+          cu_seqlens_q.data<int>(),
+          block_table.data<int>(),
+          max_seq_len,
+          max_dec_len,
+          max_block_num_per_seq,
+          scale,
+          quant_max_bound,
+          quant_min_bound,
+          in_scale,
+          chunk_size,
+          nullptr,
+          nullptr,
+          nullptr,
+          reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          speculate_max_draft_token_num);
     } else {
-      if (ENABLE_PREFILL) {
-        tmp_workspace =
-            allocator->Allocate(phi::SizeOf(qkv.dtype()) *
-                                static_cast<size_t>(token_num * num_chunks *
-                                                    num_heads * HEAD_DIM));
-        tmp_m = allocator->Allocate(
-            phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(token_num * num_chunks * num_heads));
-        tmp_d = allocator->Allocate(
-            phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(token_num * num_chunks * num_heads));
-      } else {
+      phi::Allocator::AllocationPtr tmp_workspace, tmp_m, tmp_d;
+      if (is_decoder) {
         tmp_workspace = allocator->Allocate(
             phi::SizeOf(qkv.dtype()) *
-            static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                num_chunks * num_heads * HEAD_DIM));
+            static_cast<size_t>(bsz * num_chunks * num_heads * HEAD_DIM));
         tmp_m = allocator->Allocate(
             phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                num_chunks * num_heads));
+            static_cast<size_t>(bsz * num_chunks * num_heads));
         tmp_d = allocator->Allocate(
             phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                num_chunks * num_heads));
+            static_cast<size_t>(bsz * num_chunks * num_heads));
+      } else {
+        if (ENABLE_PREFILL) {
+          tmp_workspace =
+              allocator->Allocate(phi::SizeOf(qkv.dtype()) *
+                                  static_cast<size_t>(token_num * num_chunks *
+                                                      num_heads * HEAD_DIM));
+          tmp_m = allocator->Allocate(
+              phi::SizeOf(paddle::DataType::FLOAT32) *
+              static_cast<size_t>(token_num * num_chunks * num_heads));
+          tmp_d = allocator->Allocate(
+              phi::SizeOf(paddle::DataType::FLOAT32) *
+              static_cast<size_t>(token_num * num_chunks * num_heads));
+        } else {
+          tmp_workspace = allocator->Allocate(
+              phi::SizeOf(qkv.dtype()) *
+              static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                  num_chunks * num_heads * HEAD_DIM));
+          tmp_m = allocator->Allocate(
+              phi::SizeOf(paddle::DataType::FLOAT32) *
+              static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                  num_chunks * num_heads));
+          tmp_d = allocator->Allocate(
+              phi::SizeOf(paddle::DataType::FLOAT32) *
+              static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                  num_chunks * num_heads));
+        }
       }
-    }
-    split_kv_kernel<<<grids, blocks, smem_size, stream>>>(
-        reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
-        const_cast<uint8_t *>(cache_k.data<uint8_t>()),
-        const_cast<uint8_t *>(cache_v.data<uint8_t>()),
-        reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k_scale.data<T>())),
-        cache_k_zp ? reinterpret_cast<NV_TYPE *>(
-                          const_cast<T *>(cache_k_zp.get().data<T>()))
-                    : nullptr,
-        reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v_scale.data<T>())),
-        cache_v_zp ? reinterpret_cast<NV_TYPE *>(
-                          const_cast<T *>(cache_v_zp.get().data<T>()))
-                    : nullptr,
-        shift_bias ? reinterpret_cast<NV_TYPE *>(
-                          const_cast<T *>(shift_bias.get().data<T>()))
-                    : nullptr,
-        smooth_weight ? reinterpret_cast<NV_TYPE *>(
-                            const_cast<T *>(smooth_weight.get().data<T>()))
+      split_kv_kernel<<<grids, blocks, smem_size, stream>>>(
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
+          const_cast<uint8_t *>(cache_k.data<uint8_t>()),
+          const_cast<uint8_t *>(cache_v.data<uint8_t>()),
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k_scale.data<T>())),
+          cache_k_zp ? reinterpret_cast<NV_TYPE *>(
+                            const_cast<T *>(cache_k_zp.get().data<T>()))
                       : nullptr,
-        seq_lens_q.data<int>(),
-        seq_lens_kv.data<int>(),
-        batch_ids.data<int>(),
-        tile_ids_per_batch.data<int>(),
-        cu_seqlens_q.data<int>(),
-        block_table.data<int>(),
-        max_seq_len,
-        max_dec_len,
-        max_block_num_per_seq,
-        scale,
-        quant_max_bound,
-        quant_min_bound,
-        in_scale,
-        chunk_size,
-        reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-        static_cast<float *>(tmp_m->ptr()),
-        static_cast<float *>(tmp_d->ptr()),
-        reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-        speculate_max_draft_token_num);
-    // merge
-    constexpr int vec_size = num_elems_per_128b<NV_TYPE>();
-    if (is_decoder) {
-      constexpr int blockx = HEAD_DIM / vec_size;
-      constexpr int blocky = (128 + blockx - 1) / blockx;
-      dim3 grids_merge(bsz, num_heads);
-      dim3 blocks_merge(blockx, blocky);
-      merge_multi_chunks_decoder_kernel<NV_TYPE,
-                                        vec_size,
-                                        blocky,
-                                        HEAD_DIM,
-                                        OUT_NV_TYPE,
-                                        ENABLE_PREFILL>
-          <<<grids_merge, blocks_merge, 0, stream>>>(
-              reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-              static_cast<float *>(tmp_m->ptr()),
-              static_cast<float *>(tmp_d->ptr()),
-              seq_lens_q.data<int>(),
-              seq_lens_kv.data<int>(),
-              seq_lens_encoder.data<int>(),
-              cu_seqlens_q.data<int>(),
-              shift_bias ? reinterpret_cast<NV_TYPE *>(
-                                const_cast<T *>(shift_bias.get().data<T>()))
-                          : nullptr,
-              smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
-                                  smooth_weight.get().data<T>()))
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v_scale.data<T>())),
+          cache_v_zp ? reinterpret_cast<NV_TYPE *>(
+                            const_cast<T *>(cache_v_zp.get().data<T>()))
+                      : nullptr,
+          shift_bias ? reinterpret_cast<NV_TYPE *>(
+                            const_cast<T *>(shift_bias.get().data<T>()))
+                      : nullptr,
+          smooth_weight ? reinterpret_cast<NV_TYPE *>(
+                              const_cast<T *>(smooth_weight.get().data<T>()))
+                        : nullptr,
+          seq_lens_q.data<int>(),
+          seq_lens_kv.data<int>(),
+          batch_ids.data<int>(),
+          tile_ids_per_batch.data<int>(),
+          cu_seqlens_q.data<int>(),
+          block_table.data<int>(),
+          max_seq_len,
+          max_dec_len,
+          max_block_num_per_seq,
+          scale,
+          quant_max_bound,
+          quant_min_bound,
+          in_scale,
+          chunk_size,
+          reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+          static_cast<float *>(tmp_m->ptr()),
+          static_cast<float *>(tmp_d->ptr()),
+          reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          speculate_max_draft_token_num);
+      // merge
+      constexpr int vec_size = num_elems_per_128b<NV_TYPE>();
+      if (is_decoder) {
+        constexpr int blockx = HEAD_DIM / vec_size;
+        constexpr int blocky = (128 + blockx - 1) / blockx;
+        dim3 grids_merge(bsz, num_heads);
+        dim3 blocks_merge(blockx, blocky);
+        merge_multi_chunks_decoder_kernel<NV_TYPE,
+                                          vec_size,
+                                          blocky,
+                                          HEAD_DIM,
+                                          OUT_NV_TYPE,
+                                          ENABLE_PREFILL>
+            <<<grids_merge, blocks_merge, 0, stream>>>(
+                reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+                static_cast<float *>(tmp_m->ptr()),
+                static_cast<float *>(tmp_d->ptr()),
+                seq_lens_q.data<int>(),
+                seq_lens_kv.data<int>(),
+                seq_lens_encoder.data<int>(),
+                cu_seqlens_q.data<int>(),
+                shift_bias ? reinterpret_cast<NV_TYPE *>(
+                                  const_cast<T *>(shift_bias.get().data<T>()))
                             : nullptr,
-              reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-              quant_max_bound,
-              quant_min_bound,
-              in_scale,
-              max_seq_len,
-              num_chunks,
-              num_heads,
-              chunk_size,
-              HEAD_DIM);
-    } else {
-      constexpr int blockx = HEAD_DIM / vec_size;
-      constexpr int blocky = (128 + blockx - 1) / blockx;
-      dim3 grids_merge(min(sm_count * 4, token_num),
-                        num_heads);
-      dim3 blocks_merge(blockx, blocky);
-      merge_multi_chunks_v2_kernel<NV_TYPE,
-                                    vec_size,
-                                    blocky,
-                                    HEAD_DIM,
-                                    OUT_NV_TYPE,
-                                    ENABLE_PREFILL>
-          <<<grids_merge, blocks_merge, 0, stream>>>(
-              reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-              static_cast<float *>(tmp_m->ptr()),
-              static_cast<float *>(tmp_d->ptr()),
-              seq_lens_q.data<int>(),
-              seq_lens_kv.data<int>(),
-              seq_lens_encoder.data<int>(),
-              batch_id_per_token.data<int>(),
-              cu_seqlens_q.data<int>(),
-              shift_bias ? reinterpret_cast<NV_TYPE *>(
-                                const_cast<T *>(shift_bias.get().data<T>()))
-                          : nullptr,
-              smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
-                                  smooth_weight.get().data<T>()))
+                smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
+                                    smooth_weight.get().data<T>()))
+                              : nullptr,
+                reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+                quant_max_bound,
+                quant_min_bound,
+                in_scale,
+                max_seq_len,
+                num_chunks,
+                num_heads,
+                chunk_size,
+                HEAD_DIM);
+      } else {
+        constexpr int blockx = HEAD_DIM / vec_size;
+        constexpr int blocky = (128 + blockx - 1) / blockx;
+        dim3 grids_merge(min(sm_count * 4, token_num),
+                          num_heads);
+        dim3 blocks_merge(blockx, blocky);
+        merge_multi_chunks_v2_kernel<NV_TYPE,
+                                      vec_size,
+                                      blocky,
+                                      HEAD_DIM,
+                                      OUT_NV_TYPE,
+                                      ENABLE_PREFILL>
+            <<<grids_merge, blocks_merge, 0, stream>>>(
+                reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+                static_cast<float *>(tmp_m->ptr()),
+                static_cast<float *>(tmp_d->ptr()),
+                seq_lens_q.data<int>(),
+                seq_lens_kv.data<int>(),
+                seq_lens_encoder.data<int>(),
+                batch_id_per_token.data<int>(),
+                cu_seqlens_q.data<int>(),
+                shift_bias ? reinterpret_cast<NV_TYPE *>(
+                                  const_cast<T *>(shift_bias.get().data<T>()))
                             : nullptr,
-              reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-              quant_max_bound,
-              quant_min_bound,
-              in_scale,
-              max_seq_len,
-              num_chunks,
-              num_heads,
-              chunk_size,
-              HEAD_DIM,
-              token_num,
-              speculate_max_draft_token_num);
+                smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
+                                    smooth_weight.get().data<T>()))
+                              : nullptr,
+                reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+                quant_max_bound,
+                quant_min_bound,
+                in_scale,
+                max_seq_len,
+                num_chunks,
+                num_heads,
+                chunk_size,
+                HEAD_DIM,
+                token_num,
+                speculate_max_draft_token_num);
+      }
     }
   }
 }

--- a/custom_ops/gpu_ops/append_attn/append_attention_c4_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_c4_impl.cuh
@@ -1285,7 +1285,7 @@ void MultiQueryAppendC4Attention(
     if (!is_decoder) {
       chunk_size = static_cast<uint32_t>(encoder_max_partition_size);
     }
-    
+
     const int num_chunks = div_up(max_seq_len, chunk_size);
     dim3 grids(num_blocks_x_cpu, num_chunks, kv_num_heads);
     dim3 blocks(32, num_warps);

--- a/custom_ops/gpu_ops/append_attn/append_attention_c8_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_c8_impl.cuh
@@ -1254,10 +1254,10 @@ void MultiQueryAppendC8Attention(
       chunk_size = static_cast<uint32_t>(encoder_max_partition_size);
     }
 
-    const int num_chunks = div_up(max_dec_len, chunk_size);
+    const int num_chunks = div_up(encoder_max_partition_size, chunk_size);
     dim3 grids(num_blocks_x_cpu, num_chunks, kv_num_heads);
     dim3 blocks(32, num_warps);
-    if (num_chunks <= 1) {
+    if (num_chunks <= 0) {
       auto nosplit_kv_kernel =
           multi_query_append_attention_c8_warp1_4_kernel<NV_TYPE,
                                                          uint8_t,

--- a/custom_ops/gpu_ops/append_attn/append_attention_c8_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_c8_impl.cuh
@@ -1257,145 +1257,220 @@ void MultiQueryAppendC8Attention(
     const int num_chunks = div_up(max_seq_len, chunk_size);
     dim3 grids(num_blocks_x_cpu, num_chunks, kv_num_heads);
     dim3 blocks(32, num_warps);
+    if (num_chunks <= 0) {
+      auto nosplit_kv_kernel =
+          multi_query_append_attention_c8_warp1_4_kernel<NV_TYPE,
+                                                         uint8_t,
+                                                         false,
+                                                         GROUP_SIZE,
+                                                         CAUSAL,
+                                                         num_warps,
+                                                         NUM_WARP_Q,
+                                                         NUM_WARP_KV,
+                                                         HEAD_DIM,
+                                                         BLOCK_SIZE,
+                                                         num_frags_x,
+                                                         num_frags_z,
+                                                         num_frags_y,
+                                                         OUT_NV_TYPE,
+                                                         ENABLE_PREFILL,
+                                                         false, IsFP8>;
+      if (is_scale_channel_wise) {
+        nosplit_kv_kernel =
+          multi_query_append_attention_c8_warp1_4_kernel<NV_TYPE,
+                                                         uint8_t,
+                                                         false,
+                                                         GROUP_SIZE,
+                                                         CAUSAL,
+                                                         num_warps,
+                                                         NUM_WARP_Q,
+                                                         NUM_WARP_KV,
+                                                         HEAD_DIM,
+                                                         BLOCK_SIZE,
+                                                         num_frags_x,
+                                                         num_frags_z,
+                                                         num_frags_y,
+                                                         OUT_NV_TYPE,
+                                                         ENABLE_PREFILL,
+                                                         true, IsFP8>;
+      }
+      if (smem_size >= 48 * 1024) {
+        cudaFuncSetAttribute(nosplit_kv_kernel,
+                             cudaFuncAttributeMaxDynamicSharedMemorySize,
+                             smem_size);
+      }
 
-    phi::Allocator::AllocationPtr tmp_workspace, tmp_m, tmp_d;
-    if (is_decoder) {
-      tmp_workspace = allocator->Allocate(
-          phi::SizeOf(qkv.dtype()) *
-          static_cast<size_t>(bsz * num_chunks * num_heads * HEAD_DIM));
-      tmp_m = allocator->Allocate(
-          phi::SizeOf(paddle::DataType::FLOAT32) *
-          static_cast<size_t>(bsz * num_chunks * num_heads));
-      tmp_d = allocator->Allocate(
-          phi::SizeOf(paddle::DataType::FLOAT32) *
-          static_cast<size_t>(bsz * num_chunks * num_heads));
+      nosplit_kv_kernel<<<grids, blocks, smem_size, stream>>>(
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
+          const_cast<uint8_t *>(cache_k.data<uint8_t>()),
+          const_cast<uint8_t *>(cache_v.data<uint8_t>()),
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k_scale.data<T>())),
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v_scale.data<T>())),
+          shift_bias ? reinterpret_cast<NV_TYPE *>(
+                           const_cast<T *>(shift_bias.get().data<T>()))
+                     : nullptr,
+          smooth_weight ? reinterpret_cast<NV_TYPE *>(
+                              const_cast<T *>(smooth_weight.get().data<T>()))
+                        : nullptr,
+          seq_lens_q.data<int>(),
+          seq_lens_kv.data<int>(),
+          batch_ids.data<int>(),
+          tile_ids_per_batch.data<int>(),
+          cu_seqlens_q.data<int>(),
+          block_table.data<int>(),
+          max_seq_len,
+          max_dec_len,
+          max_block_num_per_seq,
+          scale,
+          quant_max_bound,
+          quant_min_bound,
+          in_scale,
+          chunk_size,
+          nullptr,
+          nullptr,
+          nullptr,
+          reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          speculate_max_draft_token_num);
     } else {
-      if (ENABLE_PREFILL) {
-        tmp_workspace =
-            allocator->Allocate(phi::SizeOf(qkv.dtype()) *
-                                static_cast<size_t>(token_num * num_chunks *
-                                                    num_heads * HEAD_DIM));
-        tmp_m = allocator->Allocate(
-            phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(token_num * num_chunks * num_heads));
-        tmp_d = allocator->Allocate(
-            phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(token_num * num_chunks * num_heads));
-      } else {
+      phi::Allocator::AllocationPtr tmp_workspace, tmp_m, tmp_d;
+      if (is_decoder) {
         tmp_workspace = allocator->Allocate(
             phi::SizeOf(qkv.dtype()) *
-            static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                num_chunks * num_heads * HEAD_DIM));
+            static_cast<size_t>(bsz * num_chunks * num_heads * HEAD_DIM));
         tmp_m = allocator->Allocate(
             phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                num_chunks * num_heads));
+            static_cast<size_t>(bsz * num_chunks * num_heads));
         tmp_d = allocator->Allocate(
             phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                num_chunks * num_heads));
+            static_cast<size_t>(bsz * num_chunks * num_heads));
+      } else {
+        if (ENABLE_PREFILL) {
+          tmp_workspace =
+              allocator->Allocate(phi::SizeOf(qkv.dtype()) *
+                                  static_cast<size_t>(token_num * num_chunks *
+                                                      num_heads * HEAD_DIM));
+          tmp_m = allocator->Allocate(
+              phi::SizeOf(paddle::DataType::FLOAT32) *
+              static_cast<size_t>(token_num * num_chunks * num_heads));
+          tmp_d = allocator->Allocate(
+              phi::SizeOf(paddle::DataType::FLOAT32) *
+              static_cast<size_t>(token_num * num_chunks * num_heads));
+        } else {
+          tmp_workspace = allocator->Allocate(
+              phi::SizeOf(qkv.dtype()) *
+              static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                  num_chunks * num_heads * HEAD_DIM));
+          tmp_m = allocator->Allocate(
+              phi::SizeOf(paddle::DataType::FLOAT32) *
+              static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                  num_chunks * num_heads));
+          tmp_d = allocator->Allocate(
+              phi::SizeOf(paddle::DataType::FLOAT32) *
+              static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                  num_chunks * num_heads));
+        }
       }
-    }
-    split_kv_kernel<<<grids, blocks, smem_size, stream>>>(
-        reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
-        const_cast<uint8_t *>(cache_k.data<uint8_t>()),
-        const_cast<uint8_t *>(cache_v.data<uint8_t>()),
-        reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k_scale.data<T>())),
-        reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v_scale.data<T>())),
-        shift_bias ? reinterpret_cast<NV_TYPE *>(
-                          const_cast<T *>(shift_bias.get().data<T>()))
-                    : nullptr,
-        smooth_weight ? reinterpret_cast<NV_TYPE *>(
-                            const_cast<T *>(smooth_weight.get().data<T>()))
+      split_kv_kernel<<<grids, blocks, smem_size, stream>>>(
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
+          const_cast<uint8_t *>(cache_k.data<uint8_t>()),
+          const_cast<uint8_t *>(cache_v.data<uint8_t>()),
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k_scale.data<T>())),
+          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v_scale.data<T>())),
+          shift_bias ? reinterpret_cast<NV_TYPE *>(
+                            const_cast<T *>(shift_bias.get().data<T>()))
                       : nullptr,
-        seq_lens_q.data<int>(),
-        seq_lens_kv.data<int>(),
-        batch_ids.data<int>(),
-        tile_ids_per_batch.data<int>(),
-        cu_seqlens_q.data<int>(),
-        block_table.data<int>(),
-        max_seq_len,
-        max_dec_len,
-        max_block_num_per_seq,
-        scale,
-        quant_max_bound,
-        quant_min_bound,
-        in_scale,
-        chunk_size,
-        reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-        static_cast<float *>(tmp_m->ptr()),
-        static_cast<float *>(tmp_d->ptr()),
-        reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-        speculate_max_draft_token_num);
-    // merge
-    constexpr int vec_size = num_elems_per_128b<NV_TYPE>();
-    if (is_decoder) {
-      constexpr int blockx = HEAD_DIM / vec_size;
-      constexpr int blocky = (128 + blockx - 1) / blockx;
-      dim3 grids_merge(bsz, num_heads);
-      dim3 blocks_merge(blockx, blocky);
-      merge_multi_chunks_decoder_kernel<NV_TYPE, vec_size, blocky, HEAD_DIM>
-          <<<grids_merge, blocks_merge, 0, stream>>>(
-              reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-              static_cast<float *>(tmp_m->ptr()),
-              static_cast<float *>(tmp_d->ptr()),
-              seq_lens_q.data<int>(),
-              seq_lens_kv.data<int>(),
-              seq_lens_encoder.data<int>(),
-              cu_seqlens_q.data<int>(),
-              shift_bias ? reinterpret_cast<NV_TYPE *>(
-                                const_cast<T *>(shift_bias.get().data<T>()))
-                          : nullptr,
-              smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
-                                  smooth_weight.get().data<T>()))
+          smooth_weight ? reinterpret_cast<NV_TYPE *>(
+                              const_cast<T *>(smooth_weight.get().data<T>()))
+                        : nullptr,
+          seq_lens_q.data<int>(),
+          seq_lens_kv.data<int>(),
+          batch_ids.data<int>(),
+          tile_ids_per_batch.data<int>(),
+          cu_seqlens_q.data<int>(),
+          block_table.data<int>(),
+          max_seq_len,
+          max_dec_len,
+          max_block_num_per_seq,
+          scale,
+          quant_max_bound,
+          quant_min_bound,
+          in_scale,
+          chunk_size,
+          reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+          static_cast<float *>(tmp_m->ptr()),
+          static_cast<float *>(tmp_d->ptr()),
+          reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          speculate_max_draft_token_num);
+      // merge
+      constexpr int vec_size = num_elems_per_128b<NV_TYPE>();
+      if (is_decoder) {
+        constexpr int blockx = HEAD_DIM / vec_size;
+        constexpr int blocky = (128 + blockx - 1) / blockx;
+        dim3 grids_merge(bsz, num_heads);
+        dim3 blocks_merge(blockx, blocky);
+        merge_multi_chunks_decoder_kernel<NV_TYPE, vec_size, blocky, HEAD_DIM>
+            <<<grids_merge, blocks_merge, 0, stream>>>(
+                reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+                static_cast<float *>(tmp_m->ptr()),
+                static_cast<float *>(tmp_d->ptr()),
+                seq_lens_q.data<int>(),
+                seq_lens_kv.data<int>(),
+                seq_lens_encoder.data<int>(),
+                cu_seqlens_q.data<int>(),
+                shift_bias ? reinterpret_cast<NV_TYPE *>(
+                                  const_cast<T *>(shift_bias.get().data<T>()))
                             : nullptr,
-              reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-              quant_max_bound,
-              quant_min_bound,
-              in_scale,
-              max_seq_len,
-              num_chunks,
-              num_heads,
-              chunk_size,
-              HEAD_DIM);
-    } else {
-      constexpr int blockx = HEAD_DIM / vec_size;
-      constexpr int blocky = (128 + blockx - 1) / blockx;
-      dim3 grids_merge(min(sm_count * 4, token_num),
-                        num_heads);
-      dim3 blocks_merge(blockx, blocky);
-      merge_multi_chunks_v2_kernel<NV_TYPE,
-                                    vec_size,
-                                    blocky,
-                                    HEAD_DIM,
-                                    OUT_NV_TYPE,
-                                    ENABLE_PREFILL>
-          <<<grids_merge, blocks_merge, 0, stream>>>(
-              reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-              static_cast<float *>(tmp_m->ptr()),
-              static_cast<float *>(tmp_d->ptr()),
-              seq_lens_q.data<int>(),
-              seq_lens_kv.data<int>(),
-              seq_lens_encoder.data<int>(),
-              batch_id_per_token.data<int>(),
-              cu_seqlens_q.data<int>(),
-              shift_bias ? reinterpret_cast<NV_TYPE *>(
-                                const_cast<T *>(shift_bias.get().data<T>()))
-                          : nullptr,
-              smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
-                                  smooth_weight.get().data<T>()))
+                smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
+                                    smooth_weight.get().data<T>()))
+                              : nullptr,
+                reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+                quant_max_bound,
+                quant_min_bound,
+                in_scale,
+                max_seq_len,
+                num_chunks,
+                num_heads,
+                chunk_size,
+                HEAD_DIM);
+      } else {
+        constexpr int blockx = HEAD_DIM / vec_size;
+        constexpr int blocky = (128 + blockx - 1) / blockx;
+        dim3 grids_merge(min(sm_count * 4, token_num),
+                          num_heads);
+        dim3 blocks_merge(blockx, blocky);
+        merge_multi_chunks_v2_kernel<NV_TYPE,
+                                      vec_size,
+                                      blocky,
+                                      HEAD_DIM,
+                                      OUT_NV_TYPE,
+                                      ENABLE_PREFILL>
+            <<<grids_merge, blocks_merge, 0, stream>>>(
+                reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+                static_cast<float *>(tmp_m->ptr()),
+                static_cast<float *>(tmp_d->ptr()),
+                seq_lens_q.data<int>(),
+                seq_lens_kv.data<int>(),
+                seq_lens_encoder.data<int>(),
+                batch_id_per_token.data<int>(),
+                cu_seqlens_q.data<int>(),
+                shift_bias ? reinterpret_cast<NV_TYPE *>(
+                                  const_cast<T *>(shift_bias.get().data<T>()))
                             : nullptr,
-              reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-              quant_max_bound,
-              quant_min_bound,
-              in_scale,
-              max_seq_len,
-              num_chunks,
-              num_heads,
-              chunk_size,
-              HEAD_DIM,
-              token_num,
-              speculate_max_draft_token_num);
+                smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
+                                    smooth_weight.get().data<T>()))
+                              : nullptr,
+                reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+                quant_max_bound,
+                quant_min_bound,
+                in_scale,
+                max_seq_len,
+                num_chunks,
+                num_heads,
+                chunk_size,
+                HEAD_DIM,
+                token_num,
+                speculate_max_draft_token_num);
+      }
     }
   }
 }

--- a/custom_ops/gpu_ops/append_attn/append_attention_c8_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_c8_impl.cuh
@@ -1254,223 +1254,148 @@ void MultiQueryAppendC8Attention(
       chunk_size = static_cast<uint32_t>(encoder_max_partition_size);
     }
 
-    const int num_chunks = div_up(encoder_max_partition_size, chunk_size);
+    const int num_chunks = div_up(max_seq_len, chunk_size);
     dim3 grids(num_blocks_x_cpu, num_chunks, kv_num_heads);
     dim3 blocks(32, num_warps);
-    if (num_chunks <= 0) {
-      auto nosplit_kv_kernel =
-          multi_query_append_attention_c8_warp1_4_kernel<NV_TYPE,
-                                                         uint8_t,
-                                                         false,
-                                                         GROUP_SIZE,
-                                                         CAUSAL,
-                                                         num_warps,
-                                                         NUM_WARP_Q,
-                                                         NUM_WARP_KV,
-                                                         HEAD_DIM,
-                                                         BLOCK_SIZE,
-                                                         num_frags_x,
-                                                         num_frags_z,
-                                                         num_frags_y,
-                                                         OUT_NV_TYPE,
-                                                         ENABLE_PREFILL,
-                                                         false, IsFP8>;
-      if (is_scale_channel_wise) {
-        nosplit_kv_kernel =
-          multi_query_append_attention_c8_warp1_4_kernel<NV_TYPE,
-                                                         uint8_t,
-                                                         false,
-                                                         GROUP_SIZE,
-                                                         CAUSAL,
-                                                         num_warps,
-                                                         NUM_WARP_Q,
-                                                         NUM_WARP_KV,
-                                                         HEAD_DIM,
-                                                         BLOCK_SIZE,
-                                                         num_frags_x,
-                                                         num_frags_z,
-                                                         num_frags_y,
-                                                         OUT_NV_TYPE,
-                                                         ENABLE_PREFILL,
-                                                         true, IsFP8>;
-      }
-      if (smem_size >= 48 * 1024) {
-        cudaFuncSetAttribute(nosplit_kv_kernel,
-                             cudaFuncAttributeMaxDynamicSharedMemorySize,
-                             smem_size);
-      }
 
-      nosplit_kv_kernel<<<grids, blocks, smem_size, stream>>>(
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
-          const_cast<uint8_t *>(cache_k.data<uint8_t>()),
-          const_cast<uint8_t *>(cache_v.data<uint8_t>()),
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k_scale.data<T>())),
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v_scale.data<T>())),
-          shift_bias ? reinterpret_cast<NV_TYPE *>(
-                           const_cast<T *>(shift_bias.get().data<T>()))
-                     : nullptr,
-          smooth_weight ? reinterpret_cast<NV_TYPE *>(
-                              const_cast<T *>(smooth_weight.get().data<T>()))
-                        : nullptr,
-          seq_lens_q.data<int>(),
-          seq_lens_kv.data<int>(),
-          batch_ids.data<int>(),
-          tile_ids_per_batch.data<int>(),
-          cu_seqlens_q.data<int>(),
-          block_table.data<int>(),
-          max_seq_len,
-          max_dec_len,
-          max_block_num_per_seq,
-          scale,
-          quant_max_bound,
-          quant_min_bound,
-          in_scale,
-          chunk_size,
-          nullptr,
-          nullptr,
-          nullptr,
-          reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-          speculate_max_draft_token_num);
+    phi::Allocator::AllocationPtr tmp_workspace, tmp_m, tmp_d;
+    if (is_decoder) {
+      tmp_workspace = allocator->Allocate(
+          phi::SizeOf(qkv.dtype()) *
+          static_cast<size_t>(bsz * num_chunks * num_heads * HEAD_DIM));
+      tmp_m = allocator->Allocate(
+          phi::SizeOf(paddle::DataType::FLOAT32) *
+          static_cast<size_t>(bsz * num_chunks * num_heads));
+      tmp_d = allocator->Allocate(
+          phi::SizeOf(paddle::DataType::FLOAT32) *
+          static_cast<size_t>(bsz * num_chunks * num_heads));
     } else {
-      phi::Allocator::AllocationPtr tmp_workspace, tmp_m, tmp_d;
-      if (is_decoder) {
-        tmp_workspace = allocator->Allocate(
-            phi::SizeOf(qkv.dtype()) *
-            static_cast<size_t>(bsz * num_chunks * num_heads * HEAD_DIM));
+      if (ENABLE_PREFILL) {
+        tmp_workspace =
+            allocator->Allocate(phi::SizeOf(qkv.dtype()) *
+                                static_cast<size_t>(token_num * num_chunks *
+                                                    num_heads * HEAD_DIM));
         tmp_m = allocator->Allocate(
             phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(bsz * num_chunks * num_heads));
+            static_cast<size_t>(token_num * num_chunks * num_heads));
         tmp_d = allocator->Allocate(
             phi::SizeOf(paddle::DataType::FLOAT32) *
-            static_cast<size_t>(bsz * num_chunks * num_heads));
+            static_cast<size_t>(token_num * num_chunks * num_heads));
       } else {
-        if (ENABLE_PREFILL) {
-          tmp_workspace =
-              allocator->Allocate(phi::SizeOf(qkv.dtype()) *
-                                  static_cast<size_t>(token_num * num_chunks *
-                                                      num_heads * HEAD_DIM));
-          tmp_m = allocator->Allocate(
-              phi::SizeOf(paddle::DataType::FLOAT32) *
-              static_cast<size_t>(token_num * num_chunks * num_heads));
-          tmp_d = allocator->Allocate(
-              phi::SizeOf(paddle::DataType::FLOAT32) *
-              static_cast<size_t>(token_num * num_chunks * num_heads));
-        } else {
-          tmp_workspace = allocator->Allocate(
-              phi::SizeOf(qkv.dtype()) *
-              static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                  num_chunks * num_heads * HEAD_DIM));
-          tmp_m = allocator->Allocate(
-              phi::SizeOf(paddle::DataType::FLOAT32) *
-              static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                  num_chunks * num_heads));
-          tmp_d = allocator->Allocate(
-              phi::SizeOf(paddle::DataType::FLOAT32) *
-              static_cast<size_t>(speculate_max_draft_token_num * bsz *
-                                  num_chunks * num_heads));
-        }
+        tmp_workspace = allocator->Allocate(
+            phi::SizeOf(qkv.dtype()) *
+            static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                num_chunks * num_heads * HEAD_DIM));
+        tmp_m = allocator->Allocate(
+            phi::SizeOf(paddle::DataType::FLOAT32) *
+            static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                num_chunks * num_heads));
+        tmp_d = allocator->Allocate(
+            phi::SizeOf(paddle::DataType::FLOAT32) *
+            static_cast<size_t>(speculate_max_draft_token_num * bsz *
+                                num_chunks * num_heads));
       }
-      split_kv_kernel<<<grids, blocks, smem_size, stream>>>(
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
-          const_cast<uint8_t *>(cache_k.data<uint8_t>()),
-          const_cast<uint8_t *>(cache_v.data<uint8_t>()),
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k_scale.data<T>())),
-          reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v_scale.data<T>())),
-          shift_bias ? reinterpret_cast<NV_TYPE *>(
-                           const_cast<T *>(shift_bias.get().data<T>()))
-                     : nullptr,
-          smooth_weight ? reinterpret_cast<NV_TYPE *>(
-                              const_cast<T *>(smooth_weight.get().data<T>()))
-                        : nullptr,
-          seq_lens_q.data<int>(),
-          seq_lens_kv.data<int>(),
-          batch_ids.data<int>(),
-          tile_ids_per_batch.data<int>(),
-          cu_seqlens_q.data<int>(),
-          block_table.data<int>(),
-          max_seq_len,
-          max_dec_len,
-          max_block_num_per_seq,
-          scale,
-          quant_max_bound,
-          quant_min_bound,
-          in_scale,
-          chunk_size,
-          reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-          static_cast<float *>(tmp_m->ptr()),
-          static_cast<float *>(tmp_d->ptr()),
-          reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-          speculate_max_draft_token_num);
-      // merge
-      constexpr int vec_size = num_elems_per_128b<NV_TYPE>();
-      if (is_decoder) {
-        constexpr int blockx = HEAD_DIM / vec_size;
-        constexpr int blocky = (128 + blockx - 1) / blockx;
-        dim3 grids_merge(bsz, num_heads);
-        dim3 blocks_merge(blockx, blocky);
-        merge_multi_chunks_decoder_kernel<NV_TYPE, vec_size, blocky, HEAD_DIM>
-            <<<grids_merge, blocks_merge, 0, stream>>>(
-                reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-                static_cast<float *>(tmp_m->ptr()),
-                static_cast<float *>(tmp_d->ptr()),
-                seq_lens_q.data<int>(),
-                seq_lens_kv.data<int>(),
-                seq_lens_encoder.data<int>(),
-                cu_seqlens_q.data<int>(),
-                shift_bias ? reinterpret_cast<NV_TYPE *>(
-                                 const_cast<T *>(shift_bias.get().data<T>()))
-                           : nullptr,
-                smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
-                                    smooth_weight.get().data<T>()))
-                              : nullptr,
-                reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-                quant_max_bound,
-                quant_min_bound,
-                in_scale,
-                max_seq_len,
-                num_chunks,
-                num_heads,
-                chunk_size,
-                HEAD_DIM);
-      } else {
-        constexpr int blockx = HEAD_DIM / vec_size;
-        constexpr int blocky = (128 + blockx - 1) / blockx;
-        dim3 grids_merge(min(sm_count * 4, token_num),
-                         num_heads);
-        dim3 blocks_merge(blockx, blocky);
-        merge_multi_chunks_v2_kernel<NV_TYPE,
-                                     vec_size,
-                                     blocky,
-                                     HEAD_DIM,
-                                     OUT_NV_TYPE,
-                                     ENABLE_PREFILL>
-            <<<grids_merge, blocks_merge, 0, stream>>>(
-                reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
-                static_cast<float *>(tmp_m->ptr()),
-                static_cast<float *>(tmp_d->ptr()),
-                seq_lens_q.data<int>(),
-                seq_lens_kv.data<int>(),
-                seq_lens_encoder.data<int>(),
-                batch_id_per_token.data<int>(),
-                cu_seqlens_q.data<int>(),
-                shift_bias ? reinterpret_cast<NV_TYPE *>(
-                                 const_cast<T *>(shift_bias.get().data<T>()))
-                           : nullptr,
-                smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
-                                    smooth_weight.get().data<T>()))
-                              : nullptr,
-                reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-                quant_max_bound,
-                quant_min_bound,
-                in_scale,
-                max_seq_len,
-                num_chunks,
-                num_heads,
-                chunk_size,
-                HEAD_DIM,
-                token_num,
-                speculate_max_draft_token_num);
-      }
+    }
+    split_kv_kernel<<<grids, blocks, smem_size, stream>>>(
+        reinterpret_cast<NV_TYPE *>(const_cast<T *>(qkv.data<T>())),
+        const_cast<uint8_t *>(cache_k.data<uint8_t>()),
+        const_cast<uint8_t *>(cache_v.data<uint8_t>()),
+        reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_k_scale.data<T>())),
+        reinterpret_cast<NV_TYPE *>(const_cast<T *>(cache_v_scale.data<T>())),
+        shift_bias ? reinterpret_cast<NV_TYPE *>(
+                          const_cast<T *>(shift_bias.get().data<T>()))
+                    : nullptr,
+        smooth_weight ? reinterpret_cast<NV_TYPE *>(
+                            const_cast<T *>(smooth_weight.get().data<T>()))
+                      : nullptr,
+        seq_lens_q.data<int>(),
+        seq_lens_kv.data<int>(),
+        batch_ids.data<int>(),
+        tile_ids_per_batch.data<int>(),
+        cu_seqlens_q.data<int>(),
+        block_table.data<int>(),
+        max_seq_len,
+        max_dec_len,
+        max_block_num_per_seq,
+        scale,
+        quant_max_bound,
+        quant_min_bound,
+        in_scale,
+        chunk_size,
+        reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+        static_cast<float *>(tmp_m->ptr()),
+        static_cast<float *>(tmp_d->ptr()),
+        reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+        speculate_max_draft_token_num);
+    // merge
+    constexpr int vec_size = num_elems_per_128b<NV_TYPE>();
+    if (is_decoder) {
+      constexpr int blockx = HEAD_DIM / vec_size;
+      constexpr int blocky = (128 + blockx - 1) / blockx;
+      dim3 grids_merge(bsz, num_heads);
+      dim3 blocks_merge(blockx, blocky);
+      merge_multi_chunks_decoder_kernel<NV_TYPE, vec_size, blocky, HEAD_DIM>
+          <<<grids_merge, blocks_merge, 0, stream>>>(
+              reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+              static_cast<float *>(tmp_m->ptr()),
+              static_cast<float *>(tmp_d->ptr()),
+              seq_lens_q.data<int>(),
+              seq_lens_kv.data<int>(),
+              seq_lens_encoder.data<int>(),
+              cu_seqlens_q.data<int>(),
+              shift_bias ? reinterpret_cast<NV_TYPE *>(
+                                const_cast<T *>(shift_bias.get().data<T>()))
+                          : nullptr,
+              smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
+                                  smooth_weight.get().data<T>()))
+                            : nullptr,
+              reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+              quant_max_bound,
+              quant_min_bound,
+              in_scale,
+              max_seq_len,
+              num_chunks,
+              num_heads,
+              chunk_size,
+              HEAD_DIM);
+    } else {
+      constexpr int blockx = HEAD_DIM / vec_size;
+      constexpr int blocky = (128 + blockx - 1) / blockx;
+      dim3 grids_merge(min(sm_count * 4, token_num),
+                        num_heads);
+      dim3 blocks_merge(blockx, blocky);
+      merge_multi_chunks_v2_kernel<NV_TYPE,
+                                    vec_size,
+                                    blocky,
+                                    HEAD_DIM,
+                                    OUT_NV_TYPE,
+                                    ENABLE_PREFILL>
+          <<<grids_merge, blocks_merge, 0, stream>>>(
+              reinterpret_cast<NV_TYPE *>(tmp_workspace->ptr()),
+              static_cast<float *>(tmp_m->ptr()),
+              static_cast<float *>(tmp_d->ptr()),
+              seq_lens_q.data<int>(),
+              seq_lens_kv.data<int>(),
+              seq_lens_encoder.data<int>(),
+              batch_id_per_token.data<int>(),
+              cu_seqlens_q.data<int>(),
+              shift_bias ? reinterpret_cast<NV_TYPE *>(
+                                const_cast<T *>(shift_bias.get().data<T>()))
+                          : nullptr,
+              smooth_weight ? reinterpret_cast<NV_TYPE *>(const_cast<T *>(
+                                  smooth_weight.get().data<T>()))
+                            : nullptr,
+              reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+              quant_max_bound,
+              quant_min_bound,
+              in_scale,
+              max_seq_len,
+              num_chunks,
+              num_heads,
+              chunk_size,
+              HEAD_DIM,
+              token_num,
+              speculate_max_draft_token_num);
     }
   }
 }


### PR DESCRIPTION
本质原因是当前append attention在长文本时的设计（大于max_partition_size）与cuda graph不兼容，之前问题未暴露应该是没有用cuda graph去处理长文本场景。
第一个问题，使用nosplit_kv_kernel分支只会调用multi_query_append_attention_warp1_4_kernel，而split_kv_kernel分支会调用multi_query_append_attention_warp1_4_kernel与merge_multi_chunks_decoder_kernel。由于capture和replay走不同的分支会导致cuda error 700。
解决方法：num_chunks一定大于等于1，将加入nosplit_kv_kernel分支的条件改为num_chunks<=0即可避免进入该分支，之后会将这个分支删除，目前的写法只是最小改动下方便理解的写法。
第二个问题，原本split_kv_kernel分支中，启动multi_query_append_attention_warp1_4_kernel的参数与num_chunks有关，同时临时空间申请（tmp_workspace，temp_p，temp_d）的大小也与num_chunks有关。由于kernel的启动参数与空间申请大小在cuda graph中被捕获时就是固定的，这导致在解决第一个问题后，捕获num_chunks数小的graph去replay num_chunks数大的请求时会出现解码得到<unk>的情况。
解决方法：不使用当前batch中seq_len最长的去计算num_chunks，而是直接使用理论上能得到的最大num_chunks数目（div_up(encoder_max_partition_size, chunk_size)，encoder_max_partition_sizes实际是启动服务时的参数max_model_len）去启动kernel，去申请空间。当之后如果encoder_max_partition_size意义更改时，这里也要更换。
后续：为了代码简洁性，需要删除一些分支，同时c8与c4的算子也需要更改。