### PR TITLE
[fix] fix completion stream api output_tokens not in usage

### DIFF
--- a/fastdeploy/entrypoints/openai/serving_completion.py
+++ b/fastdeploy/entrypoints/openai/serving_completion.py
@@ -358,6 +358,7 @@ class OpenAIServingCompletion:
                                 usage=UsageInfo(
                                     prompt_tokens=len(prompt_batched_token_ids[idx]),
                                     completion_tokens=output_tokens[idx],
+                                    total_tokens=len(prompt_batched_token_ids[idx]) + output_tokens[idx],
                                 ),
                             )
                             yield f"data: {usage_chunk.model_dump_json(exclude_unset=True)}\n\n"


### PR DESCRIPTION
修复流式 completion 接口最后一个chunk 返回的 usage 信息缺失 total_tokens 的问题