### PR TITLE
[BugFix] The last pack of the v1/completion stream output needs to include total_tokens

### DIFF
--- a/fastdeploy/entrypoints/openai/serving_completion.py
+++ b/fastdeploy/entrypoints/openai/serving_completion.py
@@ -350,14 +350,17 @@ class OpenAIServingCompletion:
                     if res["finished"]:
                         num_choices -= 1
                         if getattr(request, "stream_options", None) and request.stream_options.include_usage:
+                            total_prompt_toknes = len(prompt_batched_token_ids[idx])
+                            total_completion_tokens = output_tokens[idx]
                             usage_chunk = CompletionStreamResponse(
                                 id=request_id,
                                 created=created_time,
                                 model=model_name,
                                 choices=[],
                                 usage=UsageInfo(
-                                    prompt_tokens=len(prompt_batched_token_ids[idx]),
-                                    completion_tokens=output_tokens[idx],
+                                    prompt_tokens=total_prompt_toknes,
+                                    completion_tokens=total_completion_tokens,
+                                    total_tokens=total_prompt_toknes + total_completion_tokens,
                                 ),
                             )
                             yield f"data: {usage_chunk.model_dump_json(exclude_unset=True)}\n\n"


### PR DESCRIPTION
对v1/completion接口流式输出最后一包total_tokens为空的问题进行了修复。

- 目前v1/completion接口流式输出的最后一包中total_tokens字段为空
- 经过修改，目前每个流式输出的最后一包中包含total_tokens信息，total_tokens为一问一答的总token值，取值为prompt_tokens与total_tokens之和，这两个值分别表示输入提示的Token总数(针对单个问题)和生成结果的Token总数(针对单个答案)。