### PR TITLE
[BugFix] Fix default log level of paddleformers

### DIFF
--- a/fastdeploy/__init__.py
+++ b/fastdeploy/__init__.py
@@ -24,11 +24,15 @@ os.environ["GLOG_minloglevel"] = "2"
 os.environ["AISTUDIO_LOG"] = "critical"
 import typing
 
+from paddleformers.utils.log import logger as pf_logger
+
 from fastdeploy.engine.sampling_params import SamplingParams
 from fastdeploy.entrypoints.llm import LLM
-from paddleformers.utils.log import logger as pf_logger
+from fastdeploy.utils import envs
+
 if envs.FD_DEBUG != "1":
     import logging
+
     pf_logger.logger.setLevel(logging.INFO)
 
 try:

--- a/fastdeploy/__init__.py
+++ b/fastdeploy/__init__.py
@@ -26,6 +26,10 @@ import typing
 
 from fastdeploy.engine.sampling_params import SamplingParams
 from fastdeploy.entrypoints.llm import LLM
+from paddleformers.utils.log import logger as pf_logger
+if envs.FD_DEBUG != "1":
+    import logging
+    pf_logger.logger.setLevel(logging.INFO)
 
 try:
     import use_triton_in_paddle


### PR DESCRIPTION
PaddleFormers Log日志默认等级为Debug，与FD不同。此PR改为对齐