### PR TITLE
Add custom op declaration for `all_reduce`

### DIFF
--- a/custom_ops/gpu_ops/cpp_extensions.cc
+++ b/custom_ops/gpu_ops/cpp_extensions.cc
@@ -530,7 +530,7 @@ paddle::Tensor FusedHadamardQuantFp8Func(
 int64_t init_custom_all_reduce(const std::vector<int64_t>& fake_ipc_ptrs,
                       paddle::Tensor& rank_data, int64_t rank, bool full_nvlink);
 
-void all_reduce(int64_t _fa, paddle::Tensor& inp, paddle::Tensor& out,
+void all_reduce(paddle::Tensor& inp, paddle::Tensor& out, int64_t _fa,
                 int64_t reg_buffer, int64_t reg_buffer_sz_bytes);
 
 void dispose(int64_t _fa);

--- a/custom_ops/gpu_ops/custom_all_reduce/all_reduce.cu
+++ b/custom_ops/gpu_ops/custom_all_reduce/all_reduce.cu
@@ -49,7 +49,7 @@ fptr_t init_custom_all_reduce(const std::vector<fptr_t>& fake_ipc_ptrs,
  * Otherwise, _reg_buffer is assumed to be IPC-registered and inp is first
  * copied into _reg_buffer.
  */
-void all_reduce(fptr_t _fa, paddle::Tensor& inp, paddle::Tensor& out,
+void all_reduce(paddle::Tensor& inp, paddle::Tensor& out, fptr_t _fa,
                 fptr_t _reg_buffer, int64_t reg_buffer_sz_bytes) {
   auto fa = reinterpret_cast<paddle::CustomAllreduce*>(_fa);
   auto stream = inp.stream();
@@ -163,3 +163,12 @@ fptr_t open_mem_handle(paddle::Tensor& mem_handle) {
 void free_shared_buffer(fptr_t buffer) {
   CUDACHECK(cudaFree(reinterpret_cast<void*>(buffer)));
 }
+
+
+PD_BUILD_STATIC_OP(all_reduce)
+    .Inputs({"inp",
+             "out"})
+    .Outputs({"new_out"})
+    .Attrs({"_fa: int64_t", "_reg_buffer: int64_t", "reg_buffer_sz_bytes: int64_t"})
+    .SetInplaceMap({{"out", "new_out"}})
+    .SetKernelFn(PD_KERNEL(all_reduce));

--- a/fastdeploy/distributed/communication.py
+++ b/fastdeploy/distributed/communication.py
@@ -42,17 +42,22 @@ def use_custom_allreduce(custom_all_reduce_max_bytes: int = 8192 * 1024):
     _TP_AR = CustomAllreduce(model_parallel_group, custom_all_reduce_max_bytes)
 
 
-@paddle.jit.marker.unified
-def tensor_model_parallel_all_reduce(
-    input_: paddle.Tensor,
-) -> paddle.Tensor:
-    """All-reduce the input tensor across model parallel group."""
-    global _TP_AR
-    if _TP_AR is not None and _TP_AR.should_custom_ar(input_):
-        _TP_AR.custom_all_reduce(input_)
-    elif paddle.in_dynamic_mode():
-        hcg = fleet.get_hybrid_communicate_group()
-        mp_group = hcg.get_model_parallel_group()
-        dist.all_reduce(input_, group=mp_group)
-    else:
-        dist.all_reduce(input_)
+try:
+
+    @paddle.jit.marker.unified
+    def tensor_model_parallel_all_reduce(
+        input_: paddle.Tensor,
+    ) -> paddle.Tensor:
+        """All-reduce the input tensor across model parallel group."""
+        global _TP_AR
+        if _TP_AR is not None and _TP_AR.should_custom_ar(input_):
+            _TP_AR.custom_all_reduce(input_)
+        elif paddle.in_dynamic_mode():
+            hcg = fleet.get_hybrid_communicate_group()
+            mp_group = hcg.get_model_parallel_group()
+            dist.all_reduce(input_, group=mp_group)
+        else:
+            dist.all_reduce(input_)
+
+except:
+    tensor_model_parallel_all_reduce = None

--- a/fastdeploy/distributed/communication.py
+++ b/fastdeploy/distributed/communication.py
@@ -42,22 +42,17 @@ def use_custom_allreduce(custom_all_reduce_max_bytes: int = 8192 * 1024):
     _TP_AR = CustomAllreduce(model_parallel_group, custom_all_reduce_max_bytes)
 
 
-try:
-
-    @paddle.jit.marker.unified
-    def tensor_model_parallel_all_reduce(
-        input_: paddle.Tensor,
-    ) -> paddle.Tensor:
-        """All-reduce the input tensor across model parallel group."""
-        global _TP_AR
-        if _TP_AR is not None and _TP_AR.should_custom_ar(input_):
-            _TP_AR.custom_all_reduce(input_)
-        elif paddle.in_dynamic_mode():
-            hcg = fleet.get_hybrid_communicate_group()
-            mp_group = hcg.get_model_parallel_group()
-            dist.all_reduce(input_, group=mp_group)
-        else:
-            dist.all_reduce(input_)
-
-except:
-    tensor_model_parallel_all_reduce = None
+@paddle.jit.marker.unified
+def tensor_model_parallel_all_reduce(
+    input_: paddle.Tensor,
+) -> paddle.Tensor:
+    """All-reduce the input tensor across model parallel group."""
+    global _TP_AR
+    if _TP_AR is not None and _TP_AR.should_custom_ar(input_):
+        _TP_AR.custom_all_reduce(input_)
+    elif paddle.in_dynamic_mode():
+        hcg = fleet.get_hybrid_communicate_group()
+        mp_group = hcg.get_model_parallel_group()
+        dist.all_reduce(input_, group=mp_group)
+    else:
+        dist.all_reduce(input_)

--- a/fastdeploy/distributed/custom_all_reduce/custom_all_reduce.py
+++ b/fastdeploy/distributed/custom_all_reduce/custom_all_reduce.py
@@ -158,9 +158,9 @@ class CustomAllreduce:
         if out is None:
             out = paddle.empty_like(inp)
         if registered:
-            all_reduce(self._ptr, inp, out, 0, 0)
+            all_reduce(inp, out, self._ptr, 0, 0)
         else:
-            all_reduce(self._ptr, inp, out, self.buffer_ptrs[self.rank], self.max_size)
+            all_reduce(inp, out, self._ptr, self.buffer_ptrs[self.rank], self.max_size)
         return out
 
     def start_capture(self):

--- a/fastdeploy/model_executor/layers/attention/mla_attention_backend.py
+++ b/fastdeploy/model_executor/layers/attention/mla_attention_backend.py
@@ -89,6 +89,9 @@ class MLAAttentionMetadata(AttentionMetadata):
     kv_signal_metadata: Optional[paddle.Tensor] = None
     kv_signal_data_list: List[Optional[paddle.Tensor]] = field(default_factory=list)
 
+    max_enc_len_this_time: Optional[paddle.Tensor] = None
+    max_dec_len_this_time: Optional[paddle.Tensor] = None
+
 
 class MLAAttentionBackend(AttentionBackend):
     """


### PR DESCRIPTION
Deepseek V3 开启SOT动转静推理后，存在这样一个打断：

```shell
[Translate InlineFn 3] (line 163) CALL_FUNCTION 5, stack is [BuiltinVariable(all_reduce, object_28183), 
		ConstantVariable(468079520, object_28197, _TP_AR._ptr), 
		TensorVariable([1, 7168], bfloat16, False, var_619, None, object_27861, input_), 
		TensorVariable([1, 7168], bfloat16, False, var_619, None, object_27861, input_), 
		ConstantVariable(44216352768, object_28203, _TP_AR.buffer_ptrs[2]), 
		ConstantVariable(8388608, object_28121, _TP_AR.max_size)
]
[BreakGraph] call function Break graph:
    File "/workspace/FastDeploy/fastdeploy/distributed/custom_all_reduce/custom_all_reduce.py", line 207, in custom_all_reduce encountered breakgraph error caused by
    File "/workspace/FastDeploy/fastdeploy/distributed/custom_all_reduce/custom_all_reduce.py", line 146, in all_reduce encountered breakgraph error caused by
    Not support builtin function: PyCapsule.all_reduce with args: Args(ConstantVariable, TensorVariable, TensorVariable, ConstantVariable, ConstantVariable)
start subgraph compile and execution.
```

排查后发现，目前的 `all_reduce` 只是 cpp_extensions （PyCapsule表明是C++拓展），而不是 Paddle 自定义算子，所以需要给 `all_reduce` 添加自定义算子声明：

```cpp
PD_BUILD_STATIC_OP(all_reduce)
    .Inputs({"inp",
             "out"})
    .Outputs({"new_out"})
    .Attrs({"_fa: int64_t", "_reg_buffer: int64_t", "reg_buffer_sz_bytes: int64_t"})
    .SetInplaceMap({{"out", "new_out"}})
    .SetKernelFn(PD_KERNEL(all_reduce));
```
另外，由于自定义算子要求 Tensor 参数在前，其他 attr 参数在后，所以也调整了 all_reduce 的参数顺序

----

另外由于SOT的dataclass目前存在这样的问题——直接这样设置会存在属性设置不生效的问题：

```python
        metadata.max_enc_len_this_time = forward_meta.max_len_tensor_cpu[1]
        metadata.max_dec_len_this_time = forward_meta.max_len_tensor_cpu[2]
```

```python
[Translate InlineFn 3] (line 451) LOAD_FAST    metadata, stack is [PaddleApiVariable(flash_attention_v3_varlen, object_11204, forward_meta.attn_backend.flash_attn_func), TensorVariable([1534, 16, 192], bfloat16, False, var_193, None, object_10794, q), TensorVariable([1534, 16, 192], bfloat16, False, var_194, None, object_10799, k), TensorVariable([1534, 16, 192], bfloat16, False, var_195, None, object_10804, v), TensorVariable([SymbolicInt(9)], int32, True, var_209, None, object_11189, forward_meta.cu_seqlens_q), TensorVariable([SymbolicInt(9)], int32, True, var_212, None, object_11209, forward_meta.cu_seqlens_k)]
[Translate InlineFn 3] (line 451) LOAD_ATTR    max_enc_len_this_time, stack is [PaddleApiVariable(flash_attention_v3_varlen, object_11204, forward_meta.attn_backend.flash_attn_func), TensorVariable([1534, 16, 192], bfloat16, False, var_193, None, object_10794, q), TensorVariable([1534, 16, 192], bfloat16, False, var_194, None, object_10799, k), TensorVariable([1534, 16, 192], bfloat16, False, var_195, None, object_10804, v), TensorVariable([SymbolicInt(9)], int32, True, var_209, None, object_11189, forward_meta.cu_seqlens_q), TensorVariable([SymbolicInt(9)], int32, True, var_212, None, object_11209, forward_meta.cu_seqlens_k), DataClassInstanceVariable(object_11048, forward_meta.attn_backend.attention_metadata)]
Traceback (most recent call last):
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/executor_cache.py", line 407, in start_translate
    new_custom_code, guard_fn = simulator.transform(frame)
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py", line 2125, in transform
    self.run()
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py", line 628, in run
    is_stop = self.step(cur_instr)
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py", line 674, in step
    return getattr(self, opname)(instr)  # run single step.
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py", line 312, in wrapper
    return call_fn(self, instr)
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py", line 1436, in CALL_METHOD
    self.stack.push(method(*args))
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py", line 158, in __call__
    return self.call_function(*args, **kwargs)
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py", line 334, in call_function
    raise e
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py", line 328, in call_function
    output = inline_executor.inline_call()
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py", line 100, in inline_call
    self.run()
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py", line 628, in run
    is_stop = self.step(cur_instr)
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py", line 674, in step
    return getattr(self, opname)(instr)  # run single step.
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py", line 312, in wrapper
    return call_fn(self, instr)
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py", line 1436, in CALL_METHOD
    self.stack.push(method(*args))
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py", line 158, in __call__
    return self.call_function(*args, **kwargs)
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py", line 334, in call_function
    raise e
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py", line 328, in call_function
    output = inline_executor.inline_call()
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/opcode_inline_executor.py", line 100, in inline_call
    self.run()
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py", line 628, in run
    is_stop = self.step(cur_instr)
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py", line 674, in step
    return getattr(self, opname)(instr)  # run single step.
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py", line 312, in wrapper
    return call_fn(self, instr)
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py", line 934, in LOAD_ATTR
    BuiltinVariable(
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py", line 158, in __call__
    return self.call_function(*args, **kwargs)
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py", line 968, in call_function
    return handler(*args, **kwargs)
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/variable_dispatch.py", line 604, in <lambda>
    lambda var, name, default=None: var.getattr(
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py", line 2462, in getattr
    return super().getattr(name, default)
  File "/workspace/Paddle/build/python/paddle/jit/sot/opcode_translator/executor/variables/base.py", line 545, in getattr
    raise HasNoAttributeError(
paddle.jit.sot.utils.exceptions.HasNoAttributeError: DataClassInstanceVariable DataClassInstanceVariable(object_11048, forward_meta.attn_backend.attention_metadata) has no attribute max_enc_len_this_time
```

所以提前设置一下，后续SOT会修复这个问题：

```
    max_enc_len_this_time: Optional[paddle.Tensor] = None
    max_dec_len_this_time: Optional[paddle.Tensor] = None
```

cc @SigureMo @zyfncg 