### PR TITLE
[fix] setting disable_chat_template while passing prompt_token_ids led to response error

### DIFF
--- a/fastdeploy/entrypoints/openai/protocol.py
+++ b/fastdeploy/entrypoints/openai/protocol.py
@@ -563,12 +563,11 @@ class ChatCompletionRequest(BaseModel):
             if "messages" in req_dict:
                 del req_dict["messages"]
         else:
-            assert len(self.messages) > 0
-
-        # If disable_chat_template is set, then the first message in messages will be used as the prompt.
-        if self.disable_chat_template:
-            req_dict["prompt"] = req_dict["messages"][0]["content"]
-            del req_dict["messages"]
+            # If disable_chat_template is set, then the first message in messages will be used as the prompt.
+            assert len(req_dict["messages"]) > 0, "messages can not be an empty list, unless prompt_token_ids is passed"
+            if self.disable_chat_template:
+                req_dict["prompt"] = req_dict["messages"][0]["content"]
+                del req_dict["messages"]
 
         guided_json_object = None
         if self.response_format is not None:

--- a/fastdeploy/entrypoints/openai/protocol.py
+++ b/fastdeploy/entrypoints/openai/protocol.py
@@ -564,7 +564,9 @@ class ChatCompletionRequest(BaseModel):
                 del req_dict["messages"]
         else:
             # If disable_chat_template is set, then the first message in messages will be used as the prompt.
-            assert len(req_dict["messages"]) > 0, "messages can not be an empty list, unless prompt_token_ids is passed"
+            assert (
+                len(req_dict["messages"]) > 0
+            ), "messages can not be an empty list, unless prompt_token_ids is passed"
             if self.disable_chat_template:
                 req_dict["prompt"] = req_dict["messages"][0]["content"]
                 del req_dict["messages"]

--- a/test/ci_use/EB_Lite/test_EB_Lite_serving.py
+++ b/test/ci_use/EB_Lite/test_EB_Lite_serving.py
@@ -954,3 +954,13 @@ def test_streaming_completion_with_bad_words(openai_client, capsys):
         assert hasattr(chunk.choices[0], "text")
         output_1.append(chunk.choices[0].text)
     assert output_0 not in output_1
+
+
+def test_chat_with_empty_message_list(openai_client, capsys):
+    for is_stream in [True, False]:
+        response = openai_client.chat.completions.create(
+            model="default",
+            messages=[],
+            stream=is_stream,
+        )
+        assert response.status_code == 400

--- a/test/ci_use/EB_Lite/test_EB_Lite_serving.py
+++ b/test/ci_use/EB_Lite/test_EB_Lite_serving.py
@@ -706,10 +706,25 @@ def test_streaming_completion_with_prompt_token_ids(openai_client, capsys):
             assert chunk.usage.prompt_tokens == 9
 
 
-def test_non_streaming_chat_completion_disable_chat_template(openai_client, capsys):
+def test_non_streaming_chat_with_disable_chat_template(openai_client, capsys):
     """
     Test disable_chat_template option in chat functionality with the local service.
     """
+    enabled_response = openai_client.chat.completions.create(
+        model="default",
+        messages=[],
+        max_tokens=10,
+        temperature=0.0,
+        top_p=0,
+        extra_body={
+            "disable_chat_template": True,
+            "prompt_token_ids": [5209, 626, 274, 45954, 1071, 3265, 3934, 1869, 93937],
+        },
+        stream=False,
+    )
+    assert hasattr(enabled_response, "choices")
+    assert len(enabled_response.choices) > 0
+
     enabled_response = openai_client.chat.completions.create(
         model="default",
         messages=[{"role": "user", "content": "Hello, how are you?"}],

--- a/test/ci_use/EB_Lite/test_EB_Lite_serving.py
+++ b/test/ci_use/EB_Lite/test_EB_Lite_serving.py
@@ -956,11 +956,8 @@ def test_streaming_completion_with_bad_words(openai_client, capsys):
     assert output_0 not in output_1
 
 
-def test_chat_with_empty_message_list(openai_client, capsys):
+def test_chat_with_empty_message_list(api_url, headers):
     for is_stream in [True, False]:
-        response = openai_client.chat.completions.create(
-            model="default",
-            messages=[],
-            stream=is_stream,
-        )
+        payload = {"messages": [], "stream": is_stream}
+        response = requests.post(api_url, headers=headers, json=payload)
         assert response.status_code == 400


### PR DESCRIPTION
**问题描述**：
修复在传入 prompt_token_ids 且 messages 设为空列表时，设置 disable_chat_template 为 true 将导致 400 Bad Request 的问题

**原因排查**：
当设置 disable_chat_template 为 true 时，会取出 messages 的第一条消息作为 prompt；但在传入 prompt_token_ids 时，messages 可能是空列表，导致列表索引越界。

**解决方法**：
将 disable_chat_template 取首条 messages 的逻辑移到 prompt_token_ids 为空的分支，避免冲突