### PR TITLE
[Features] support hugging face qwen3 dense and qwen2 model 

### DIFF
--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -1060,7 +1060,7 @@ class FDConfig:
         self.disable_any_whitespace = disable_any_whitespace
         self._str_to_list("innode_prefill_ports", int)
 
-        if envs.HUGGING_FACE_FORMAT:
+        if envs.FD_FOR_TORCH_MODEL_FORMAT:
             self.model_config.model_format = "torch"
 
         # TODO

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -213,7 +213,7 @@ class ModelConfig:
         config_path = os.path.join(self.model, "config.json")
         if os.path.exists(config_path):
             self.model_config = json.load(open(config_path, "r", encoding="utf-8"))
-            if "torch_dtype" and "dtype" in self.model_config:
+            if "torch_dtype" in self.model_config and "dtype" in self.model_config:
                 raise ValueError(
                     "Only one of 'torch_dtype' or 'dtype' should be present in config.json. "
                     "Found both, which indicates an ambiguous model format. "

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -128,7 +128,7 @@ class ModelConfig:
         self.quantization = None
         self.pad_token_id: int = -1
         self.eos_tokens_lens: int = 2
-        self.model_format = None
+        self.model_format = "auto"
         for key, value in args.items():
             if hasattr(self, key):
                 setattr(self, key, value)

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -1053,8 +1053,6 @@ class FDConfig:
         if self.load_config.hugging_face_format:
             self.model_config.model_format = "hugging_face"
 
-        print("self.model_config.model_format", self.model_config.model_format)
-
         # TODO
         self.max_prefill_batch = 3
         if current_platform.is_xpu():

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -209,7 +209,6 @@ class ModelConfig:
         reset_config_value("ROPE_THETA", 10000)
 
     def read_model_config(self):
-        self.model_config = {}
         config_path = os.path.join(self.model, "config.json")
         if os.path.exists(config_path):
             self.model_config = json.load(open(config_path, "r", encoding="utf-8"))

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -128,6 +128,7 @@ class ModelConfig:
         self.quantization = None
         self.pad_token_id: int = -1
         self.eos_tokens_lens: int = 2
+        self.model_format = None
         for key, value in args.items():
             if hasattr(self, key):
                 setattr(self, key, value)
@@ -165,6 +166,7 @@ class ModelConfig:
 
         self.override_name_from_config()
         self.read_from_env()
+        self.read_model_config()
 
     def override_name_from_config(self):
         """
@@ -205,6 +207,18 @@ class ModelConfig:
 
         reset_config_value("COMPRESSION_RATIO", 1.0)
         reset_config_value("ROPE_THETA", 10000)
+
+    def read_model_config(self):
+        self.model_config = {}
+        config_path = os.path.join(self.model, "config.json")
+        if os.path.exists(config_path):
+            self.model_config = json.load(open(config_path, "r", encoding="utf-8"))
+            if "torch_dtype" in self.model_config:
+                self.model_format = "hugging_face"
+                logger.info("The model format is Hugging Face")
+            else:
+                self.model_format = "paddle"
+                logger.info("The model format is Paddle")
 
     def _get_download_model(self, model_name, model_type="default"):
         # TODO: Provide dynamic graph for self-downloading and save to the specified download directory.
@@ -683,6 +697,7 @@ class LoadConfig:
             - 'ipc': Real-time IPC streaming with automatic resharding
             - 'ipc_snapshot': Load from disk snapshot of IPC weights
             - None: No dynamic loading
+        hugging_face_format: Whether to use models in Hugging Face format
     """
 
     def __init__(
@@ -690,6 +705,7 @@ class LoadConfig:
         args,
     ):
         self.load_choices: Union[str, LoadChoices] = LoadChoices.DEFAULT.value
+        self.hugging_face_format: bool = False
         self.use_fastsafetensor = int(envs.FD_USE_FASTSAFETENSOR) == 1
         self.dynamic_load_weight: bool = False
         self.load_strategy: Optional[Literal["ipc", "ipc_snapshot"]] = None
@@ -1033,6 +1049,11 @@ class FDConfig:
         self.guided_decoding_backend = guided_decoding_backend
         self.disable_any_whitespace = disable_any_whitespace
         self._str_to_list("innode_prefill_ports", int)
+
+        if self.load_config.hugging_face_format:
+            self.model_config.model_format = "hugging_face"
+
+        print("self.model_config.model_format", self.model_config.model_format)
 
         # TODO
         self.max_prefill_batch = 3

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -213,12 +213,24 @@ class ModelConfig:
         config_path = os.path.join(self.model, "config.json")
         if os.path.exists(config_path):
             self.model_config = json.load(open(config_path, "r", encoding="utf-8"))
-            if "torch_dtype" in self.model_config:
-                self.model_format = "hugging_face"
+            if "torch_dtype" and "dtype" in self.model_config:
+                raise ValueError(
+                    "Only one of 'torch_dtype' or 'dtype' should be present in config.json. "
+                    "Found both, which indicates an ambiguous model format. "
+                    "Please ensure your config.json contains only one dtype field."
+                )
+            elif "torch_dtype" in self.model_config:
+                self.model_format = "torch"
                 logger.info("The model format is Hugging Face")
-            else:
+            elif "dtype" in self.model_config:
                 self.model_format = "paddle"
                 logger.info("The model format is Paddle")
+            else:
+                raise ValueError(
+                    "Unknown model format. Please ensure your config.json contains "
+                    "either 'torch_dtype' (for Hugging Face models) or 'dtype' (for Paddle models) field. "
+                    f"Config file path: {config_path}"
+                )
 
     def _get_download_model(self, model_name, model_type="default"):
         # TODO: Provide dynamic graph for self-downloading and save to the specified download directory.
@@ -697,7 +709,6 @@ class LoadConfig:
             - 'ipc': Real-time IPC streaming with automatic resharding
             - 'ipc_snapshot': Load from disk snapshot of IPC weights
             - None: No dynamic loading
-        hugging_face_format: Whether to use models in Hugging Face format
     """
 
     def __init__(
@@ -705,7 +716,6 @@ class LoadConfig:
         args,
     ):
         self.load_choices: Union[str, LoadChoices] = LoadChoices.DEFAULT.value
-        self.hugging_face_format: bool = False
         self.use_fastsafetensor = int(envs.FD_USE_FASTSAFETENSOR) == 1
         self.dynamic_load_weight: bool = False
         self.load_strategy: Optional[Literal["ipc", "ipc_snapshot"]] = None
@@ -1050,8 +1060,8 @@ class FDConfig:
         self.disable_any_whitespace = disable_any_whitespace
         self._str_to_list("innode_prefill_ports", int)
 
-        if self.load_config.hugging_face_format:
-            self.model_config.model_format = "hugging_face"
+        if envs.HUGGING_FACE_FORMAT:
+            self.model_config.model_format = "torch"
 
         # TODO
         self.max_prefill_batch = 3

--- a/fastdeploy/engine/args_utils.py
+++ b/fastdeploy/engine/args_utils.py
@@ -357,7 +357,11 @@ class EngineArgs:
     """The format of the model weights to load.
         Options include:
         - "default": default loader.
-        - "new_loader": new  loader.
+        - "new_loader": default_v1.
+    """
+    hugging_face_format: bool = False
+    """
+    Whether to use models in Hugging Face format
     """
 
     def __post_init__(self):
@@ -622,6 +626,12 @@ class EngineArgs:
             default=EngineArgs.load_choices,
             help="The format of the model weights to load.\
                  default/new_loader.",
+        )
+        load_group.add_argument(
+            "--hugging_face_format",
+            action="store_true",
+            default=EngineArgs.hugging_face_format,
+            help="Enable when loading models in Hugging Face format",
         )
 
         # CacheConfig parameters group

--- a/fastdeploy/engine/args_utils.py
+++ b/fastdeploy/engine/args_utils.py
@@ -629,7 +629,7 @@ class EngineArgs:
         )
         load_group.add_argument(
             "--hugging_face_format",
-            action="store_true",
+            action=DeprecatedOptionWarning,
             default=EngineArgs.hugging_face_format,
             help="Enable when loading models in Hugging Face format",
         )

--- a/fastdeploy/engine/args_utils.py
+++ b/fastdeploy/engine/args_utils.py
@@ -357,7 +357,7 @@ class EngineArgs:
     """The format of the model weights to load.
         Options include:
         - "default": default loader.
-        - "new_loader": default_v1.
+        - "default_v1": default_v1 loader.
     """
     hugging_face_format: bool = False
     """

--- a/fastdeploy/engine/args_utils.py
+++ b/fastdeploy/engine/args_utils.py
@@ -359,10 +359,6 @@ class EngineArgs:
         - "default": default loader.
         - "default_v1": default_v1 loader.
     """
-    hugging_face_format: bool = False
-    """
-    Whether to use models in Hugging Face format
-    """
 
     def __post_init__(self):
         """
@@ -626,12 +622,6 @@ class EngineArgs:
             default=EngineArgs.load_choices,
             help="The format of the model weights to load.\
                  default/new_loader.",
-        )
-        load_group.add_argument(
-            "--hugging_face_format",
-            action=DeprecatedOptionWarning,
-            default=EngineArgs.hugging_face_format,
-            help="Enable when loading models in Hugging Face format",
         )
 
         # CacheConfig parameters group

--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -86,6 +86,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "FD_JOB_ID": lambda: os.getenv("FD_JOB_ID"),
     # support max connections
     "FD_SUPPORT_MAX_CONNECTIONS": lambda: int(os.getenv("FD_SUPPORT_MAX_CONNECTIONS", "1024")),
+    "HUGGING_FACE_FORMAT": lambda: os.getenv("HUGGING_FACE_FORMAT", "False"),
 }
 
 

--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -86,7 +86,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "FD_JOB_ID": lambda: os.getenv("FD_JOB_ID"),
     # support max connections
     "FD_SUPPORT_MAX_CONNECTIONS": lambda: int(os.getenv("FD_SUPPORT_MAX_CONNECTIONS", "1024")),
-    "HUGGING_FACE_FORMAT": lambda: os.getenv("HUGGING_FACE_FORMAT", "False"),
+    "FD_FOR_TORCH_MODEL_FORMAT": lambda: os.getenv("FD_FOR_TORCH_MODEL_FORMAT", "False"),
 }
 
 

--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -86,7 +86,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "FD_JOB_ID": lambda: os.getenv("FD_JOB_ID"),
     # support max connections
     "FD_SUPPORT_MAX_CONNECTIONS": lambda: int(os.getenv("FD_SUPPORT_MAX_CONNECTIONS", "1024")),
-    "FD_FOR_TORCH_MODEL_FORMAT": lambda: os.getenv("FD_FOR_TORCH_MODEL_FORMAT", "False"),
+    "FD_FOR_TORCH_MODEL_FORMAT": lambda: bool(int(os.getenv("FD_FOR_TORCH_MODEL_FORMAT", "0"))),
 }
 
 

--- a/fastdeploy/model_executor/layers/linear.py
+++ b/fastdeploy/model_executor/layers/linear.py
@@ -57,6 +57,7 @@ class UnquantizedLinearMethod(QuantMethodBase):
             {
                 **extra_weight_attrs,
                 "weight_loader": extra_weight_attrs.get("weight_loader", default_weight_loader(layer.fd_config)),
+                "hugging_face_format": extra_weight_attrs.get("hugging_face_format", False),
             },
         )
 
@@ -343,11 +344,13 @@ class ColumnParallelLinear(LinearBase):
             weight_loader=(
                 self.weight_loader if hasattr(self, "weight_loader") else default_weight_loader(self.fd_config)
             ),
+            hugging_face_format=fd_config.model_config.model_format == "hugging_face",
         )
         if self.nranks > 0:
             if self.with_bias:
                 # col parallel
                 _set_var_distributed(self.bias, split_axis=1)
+                set_weight_attrs(self.bias, {"output_dim": True})
                 if self.nranks > 1:
                     set_weight_attrs(self.bias, {"output_dim": True})
 
@@ -403,7 +406,11 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         )
 
     def weight_loader(self, param, loaded_weight, loaded_shard_id: Optional[str] = None):
+        hugging_face_format = getattr(param, "hugging_face_format", None)
+        if hugging_face_format:
+            loaded_weight = loaded_weight.transpose([1, 0])
         output_dim = getattr(param, "output_dim", None)
+        assert output_dim is not None
         shard_dim = -1 if output_dim else 0
         output_size = param.shape[shard_dim]
         if loaded_shard_id is None:
@@ -424,7 +431,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             # Tensor parallelism splits the weight along the output_dim
             if self.nranks != 1:
                 dim = -1 if output_dim else 0
-                if isinstance(loaded_weight, np.ndarray):
+                if isinstance(loaded_weight, (np.ndarray, paddle.Tensor)):
                     size = loaded_weight.shape[dim]
                 else:
                     size = loaded_weight.get_shape()[dim]
@@ -521,7 +528,12 @@ class QKVParallelLinear(ColumnParallelLinear):
 
     def weight_loader(self, param, loaded_weight, loaded_shard_id: Optional[str] = None):
         output_dim = getattr(param, "output_dim", None)
-        head_dim = param.shape[output_dim] // (self.num_heads_per_rank + 2 * self.kv_num_heads_per_rank)
+        assert output_dim is not None
+        dim = -1 if output_dim else 0
+        head_dim = param.shape[dim] // (self.num_heads_per_rank + 2 * self.kv_num_heads_per_rank)
+        hugging_face_format = getattr(param, "hugging_face_format", False)
+        if hugging_face_format:
+            loaded_weight = loaded_weight.transpose([1, 0])
         if loaded_shard_id is None:
             # Loaded weight is already fused on disk
             shard_offsets = [
@@ -541,7 +553,7 @@ class QKVParallelLinear(ColumnParallelLinear):
             # Tensor parallelism splits the weight along the output_dim
             if self.nranks != 1:
                 dim = -1 if output_dim else 0
-                if isinstance(loaded_weight, np.ndarray):
+                if isinstance(loaded_weight, (np.ndarray, paddle.Tensor)):
                     size = loaded_weight.shape[dim]
                 else:
                     size = loaded_weight.get_shape()[dim]
@@ -712,18 +724,18 @@ class RowParallelLinear(LinearBase):
             weight_loader=(
                 self.weight_loader if hasattr(self, "weight_loader") else default_weight_loader(self.fd_config)
             ),
+            hugging_face_format=fd_config.model_config.model_format == "hugging_face",
         )
         if self.nranks > 0:
             if self.with_bias:
                 # col parallel
                 _set_var_distributed(self.bias, split_axis=0)
-                if self.nranks > 1:
-                    set_weight_attrs(
-                        self.bias,
-                        {
-                            "output_dim": False,
-                        },
-                    )
+                set_weight_attrs(
+                    self.bias,
+                    {
+                        "output_dim": False,
+                    },
+                )
 
         self.reduce_results = reduce_results
 

--- a/fastdeploy/model_executor/layers/linear.py
+++ b/fastdeploy/model_executor/layers/linear.py
@@ -57,7 +57,7 @@ class UnquantizedLinearMethod(QuantMethodBase):
             {
                 **extra_weight_attrs,
                 "weight_loader": extra_weight_attrs.get("weight_loader", default_weight_loader(layer.fd_config)),
-                "model_format": extra_weight_attrs.get("model_format", None),
+                "model_format": extra_weight_attrs.get("model_format", ""),
             },
         )
 
@@ -405,7 +405,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         )
 
     def weight_loader(self, param, loaded_weight, loaded_shard_id: Optional[str] = None):
-        model_format = getattr(param, "model_format", None)
+        model_format = getattr(param, "model_format", "")
         if model_format == "torch":
             loaded_weight = loaded_weight.transpose([1, 0])
         output_dim = getattr(param, "output_dim", None)
@@ -529,7 +529,7 @@ class QKVParallelLinear(ColumnParallelLinear):
         assert output_dim is not None
         dim = -1 if output_dim else 0
         head_dim = param.shape[dim] // (self.num_heads_per_rank + 2 * self.kv_num_heads_per_rank)
-        model_format = getattr(param, "model_format", None)
+        model_format = getattr(param, "model_format", "")
         if model_format == "torch":
             loaded_weight = loaded_weight.transpose([1, 0])
         if loaded_shard_id is None:

--- a/fastdeploy/model_executor/layers/linear.py
+++ b/fastdeploy/model_executor/layers/linear.py
@@ -57,7 +57,7 @@ class UnquantizedLinearMethod(QuantMethodBase):
             {
                 **extra_weight_attrs,
                 "weight_loader": extra_weight_attrs.get("weight_loader", default_weight_loader(layer.fd_config)),
-                "model_format": extra_weight_attrs.get("model_format", False),
+                "model_format": extra_weight_attrs.get("model_format", None),
             },
         )
 
@@ -344,8 +344,9 @@ class ColumnParallelLinear(LinearBase):
             weight_loader=(
                 self.weight_loader if hasattr(self, "weight_loader") else default_weight_loader(self.fd_config)
             ),
-            model_format=fd_config.model_config.model_format == "torch",
+            model_format=fd_config.model_config.model_format,
         )
+
         if self.nranks > 0:
             if self.with_bias:
                 # col parallel
@@ -405,7 +406,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
 
     def weight_loader(self, param, loaded_weight, loaded_shard_id: Optional[str] = None):
         model_format = getattr(param, "model_format", None)
-        if model_format:
+        if model_format == "torch":
             loaded_weight = loaded_weight.transpose([1, 0])
         output_dim = getattr(param, "output_dim", None)
         assert output_dim is not None
@@ -528,8 +529,8 @@ class QKVParallelLinear(ColumnParallelLinear):
         assert output_dim is not None
         dim = -1 if output_dim else 0
         head_dim = param.shape[dim] // (self.num_heads_per_rank + 2 * self.kv_num_heads_per_rank)
-        model_format = getattr(param, "model_format", False)
-        if model_format:
+        model_format = getattr(param, "model_format", None)
+        if model_format == "torch":
             loaded_weight = loaded_weight.transpose([1, 0])
         if loaded_shard_id is None:
             # Loaded weight is already fused on disk
@@ -721,7 +722,7 @@ class RowParallelLinear(LinearBase):
             weight_loader=(
                 self.weight_loader if hasattr(self, "weight_loader") else default_weight_loader(self.fd_config)
             ),
-            model_format=fd_config.model_config.model_format == "torch",
+            model_format=fd_config.model_config.model_format,
         )
         if self.nranks > 0:
             if self.with_bias:

--- a/fastdeploy/model_executor/layers/linear.py
+++ b/fastdeploy/model_executor/layers/linear.py
@@ -57,7 +57,7 @@ class UnquantizedLinearMethod(QuantMethodBase):
             {
                 **extra_weight_attrs,
                 "weight_loader": extra_weight_attrs.get("weight_loader", default_weight_loader(layer.fd_config)),
-                "hugging_face_format": extra_weight_attrs.get("hugging_face_format", False),
+                "model_format": extra_weight_attrs.get("model_format", False),
             },
         )
 
@@ -344,7 +344,7 @@ class ColumnParallelLinear(LinearBase):
             weight_loader=(
                 self.weight_loader if hasattr(self, "weight_loader") else default_weight_loader(self.fd_config)
             ),
-            hugging_face_format=fd_config.model_config.model_format == "hugging_face",
+            model_format=fd_config.model_config.model_format == "torch",
         )
         if self.nranks > 0:
             if self.with_bias:
@@ -404,8 +404,8 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         )
 
     def weight_loader(self, param, loaded_weight, loaded_shard_id: Optional[str] = None):
-        hugging_face_format = getattr(param, "hugging_face_format", None)
-        if hugging_face_format:
+        model_format = getattr(param, "model_format", None)
+        if model_format:
             loaded_weight = loaded_weight.transpose([1, 0])
         output_dim = getattr(param, "output_dim", None)
         assert output_dim is not None
@@ -528,8 +528,8 @@ class QKVParallelLinear(ColumnParallelLinear):
         assert output_dim is not None
         dim = -1 if output_dim else 0
         head_dim = param.shape[dim] // (self.num_heads_per_rank + 2 * self.kv_num_heads_per_rank)
-        hugging_face_format = getattr(param, "hugging_face_format", False)
-        if hugging_face_format:
+        model_format = getattr(param, "model_format", False)
+        if model_format:
             loaded_weight = loaded_weight.transpose([1, 0])
         if loaded_shard_id is None:
             # Loaded weight is already fused on disk
@@ -721,7 +721,7 @@ class RowParallelLinear(LinearBase):
             weight_loader=(
                 self.weight_loader if hasattr(self, "weight_loader") else default_weight_loader(self.fd_config)
             ),
-            hugging_face_format=fd_config.model_config.model_format == "hugging_face",
+            model_format=fd_config.model_config.model_format == "torch",
         )
         if self.nranks > 0:
             if self.with_bias:

--- a/fastdeploy/model_executor/layers/lm_head.py
+++ b/fastdeploy/model_executor/layers/lm_head.py
@@ -97,7 +97,7 @@ class ParallelLMHead(nn.Layer):
                     self.linear.weight,
                     {
                         "weight_loader": default_weight_loader(self.fd_config),
-                        "model_format": self.fd_config.model_config.model_format == "torch",
+                        "model_format": self.fd_config.model_config.model_format,
                     },
                 )
                 if self.nranks > 1:
@@ -116,7 +116,7 @@ class ParallelLMHead(nn.Layer):
                     self.linear.weight,
                     {
                         "weight_loader": default_weight_loader(self.fd_config),
-                        "model_format": self.fd_config.model_config.model_format == "torch",
+                        "model_format": self.fd_config.model_config.model_format,
                     },
                 )
 

--- a/fastdeploy/model_executor/layers/lm_head.py
+++ b/fastdeploy/model_executor/layers/lm_head.py
@@ -22,7 +22,7 @@ from paddle import nn
 from paddle.distributed import fleet
 
 from fastdeploy.config import FDConfig
-from fastdeploy.model_executor.utils import set_weight_attrs
+from fastdeploy.model_executor.utils import default_weight_loader, set_weight_attrs
 
 from .utils import get_tensor
 
@@ -61,6 +61,7 @@ class ParallelLMHead(nn.Layer):
         self.use_ep: bool = fd_config.parallel_config.use_ep
         self.column_cut = True
         self.nranks = fd_config.parallel_config.tensor_parallel_size
+        self.fd_config = fd_config
 
         ColumnParallelLinear = fleet.meta_parallel.ColumnParallelLinear
         RowParallelLinear = fleet.meta_parallel.RowParallelLinear
@@ -90,7 +91,14 @@ class ParallelLMHead(nn.Layer):
                     weight_attr=None,
                     has_bias=True if self.bias_key is not None else False,
                     gather_output=need_gather,
-                    fuse_matmul_bias=False,  # False diff更小
+                    fuse_matmul_bias=False,
+                )
+                set_weight_attrs(
+                    self.linear.weight,
+                    {
+                        "weight_loader": default_weight_loader(self.fd_config),
+                        "hugging_face_format": self.fd_config.model_config.model_format == "hugging_face",
+                    },
                 )
                 if self.nranks > 1:
                     set_weight_attrs(self.linear.weight, {"output_dim": True})
@@ -102,8 +110,16 @@ class ParallelLMHead(nn.Layer):
                     weight_attr=None,
                     has_bias=True if self.bias_key is not None else False,
                     input_is_parallel=False,
-                    fuse_matmul_bias=False,  # False diff更小
+                    fuse_matmul_bias=False,
                 )
+                set_weight_attrs(
+                    self.linear.weight,
+                    {
+                        "weight_loader": default_weight_loader(self.fd_config),
+                        "hugging_face_format": self.fd_config.model_config.model_format == "hugging_face",
+                    },
+                )
+
                 if self.nranks > 1:
                     set_weight_attrs(self.linear.weight, {"output_dim": False})
 

--- a/fastdeploy/model_executor/layers/lm_head.py
+++ b/fastdeploy/model_executor/layers/lm_head.py
@@ -97,7 +97,7 @@ class ParallelLMHead(nn.Layer):
                     self.linear.weight,
                     {
                         "weight_loader": default_weight_loader(self.fd_config),
-                        "hugging_face_format": self.fd_config.model_config.model_format == "hugging_face",
+                        "model_format": self.fd_config.model_config.model_format == "torch",
                     },
                 )
                 if self.nranks > 1:
@@ -116,7 +116,7 @@ class ParallelLMHead(nn.Layer):
                     self.linear.weight,
                     {
                         "weight_loader": default_weight_loader(self.fd_config),
-                        "hugging_face_format": self.fd_config.model_config.model_format == "hugging_face",
+                        "model_format": self.fd_config.model_config.model_format == "torch",
                     },
                 )
 

--- a/fastdeploy/model_executor/layers/moe/moe.py
+++ b/fastdeploy/model_executor/layers/moe/moe.py
@@ -219,7 +219,7 @@ class FusedMoE(nn.Layer):
     def _load_gate_up_weight(self, param, expert_id, loaded_weight, shard_id, shard_dim=None):
         dim = -1 if shard_dim else 0
         if self.tp_size > 1:
-            if isinstance(loaded_weight, np.ndarray):
+            if isinstance(loaded_weight, (np.ndarray, paddle.Tensor)):
                 size = loaded_weight.shape[dim]
             else:
                 size = loaded_weight.get_shape()[dim]
@@ -259,7 +259,7 @@ class FusedMoE(nn.Layer):
     def _load_down_weight(self, param, expert_id, loaded_weight, shard_id, shard_dim=None):
         if self.tp_size > 1 and shard_dim is not None:
             dim = -1 if shard_dim else 0
-            if isinstance(loaded_weight, np.ndarray):
+            if isinstance(loaded_weight, (np.ndarray, paddle.Tensor)):
                 size = loaded_weight.shape[dim]
             else:
                 size = loaded_weight.get_shape()[dim]

--- a/fastdeploy/model_executor/load_weight_utils.py
+++ b/fastdeploy/model_executor/load_weight_utils.py
@@ -29,6 +29,7 @@ from safetensors import safe_open
 from tqdm import tqdm
 
 from fastdeploy.config import FDConfig
+from fastdeploy.model_executor.layers.utils import get_tensor
 from fastdeploy.model_executor.models.tp_utils import (
     check_tensor_parallel_prerequisites,
 )
@@ -180,8 +181,9 @@ def fast_weights_iterator(safe_tensor_list: list[str]):
     ):
         with fast_safe_open(st_file, framework="np") as f:
             for name in f.keys():
-                param = f.get_slice(name)
-                yield name, param
+                param_slice = f.get_slice(name)
+                paddle_tensor = get_tensor(param_slice)
+                yield name, paddle_tensor
 
 
 def fastsafetensors_weights_iterator(

--- a/fastdeploy/model_executor/models/qwen2.py
+++ b/fastdeploy/model_executor/models/qwen2.py
@@ -219,11 +219,7 @@ class Qwen2Model(nn.Layer):
         super().__init__()
 
         self.num_layers = fd_config.model_config.num_hidden_layers
-        hugging_face_format = fd_config.model_config.model_format == "hugging_face"
-        if hugging_face_format:
-            fd_config.model_config.pretrained_config.prefix_name = "model"
-        else:
-            fd_config.model_config.pretrained_config.prefix_name = "qwen2"
+        fd_config.model_config.pretrained_config.prefix_name = "qwen2"
 
         self.embed_tokens = VocabParallelEmbedding(
             fd_config=fd_config,

--- a/fastdeploy/model_executor/models/qwen2.py
+++ b/fastdeploy/model_executor/models/qwen2.py
@@ -52,6 +52,7 @@ class Qwen2MLP(nn.Layer):
     ) -> None:
         super().__init__()
         self.nranks = fd_config.parallel_config.tensor_parallel_size
+        print("qwen2的fd_config_format", fd_config.model_config.model_format)
         self.up_gate_proj = MergedColumnParallelLinear(
             fd_config=fd_config,
             prefix=f"{prefix}.up_gate_proj",
@@ -334,9 +335,9 @@ class Qwen2ForCausalLM(ModelForCasualLM):
         params_dict = dict(self.named_parameters())
         process_weights_after_loading_fn = process_weights_after_loading(dict(self.named_sublayers()))
         for loaded_weight_name, loaded_weight in weights_iterator:
-            model_format = self.fd_config.model_config.model_format == "torch"
+            model_format = self.fd_config.model_config.model_format
             # Because the prefix for Paddle is qwen2, and for Hugging Face it is model.
-            if model_format:
+            if model_format == "torch":
                 loaded_weight_name = loaded_weight_name.replace("model", "qwen2")
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in loaded_weight_name:

--- a/fastdeploy/model_executor/models/qwen2.py
+++ b/fastdeploy/model_executor/models/qwen2.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import re
 from functools import partial
 
 import paddle
@@ -218,7 +219,11 @@ class Qwen2Model(nn.Layer):
         super().__init__()
 
         self.num_layers = fd_config.model_config.num_hidden_layers
-        fd_config.model_config.pretrained_config.prefix_name = "qwen2"
+        hugging_face_format = fd_config.model_config.model_format == "hugging_face"
+        if hugging_face_format:
+            fd_config.model_config.pretrained_config.prefix_name = "model"
+        else:
+            fd_config.model_config.pretrained_config.prefix_name = "qwen2"
 
         self.embed_tokens = VocabParallelEmbedding(
             fd_config=fd_config,
@@ -314,7 +319,10 @@ class Qwen2ForCausalLM(ModelForCasualLM):
             weights_iterator (Iterator): An iterator yielding (name, weight) pairs.
         """
 
-        from fastdeploy.model_executor.models.utils import default_weight_loader
+        from fastdeploy.model_executor.utils import (
+            default_weight_loader,
+            process_weights_after_loading,
+        )
 
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
@@ -328,7 +336,12 @@ class Qwen2ForCausalLM(ModelForCasualLM):
         ]
 
         params_dict = dict(self.named_parameters())
+        process_weights_after_loading_fn = process_weights_after_loading(dict(self.named_sublayers()))
         for loaded_weight_name, loaded_weight in weights_iterator:
+            hugging_face_format = self.fd_config.model_config.model_format == "hugging_face"
+            # Because the prefix for Paddle is qwen2, and for Hugging Face it is model.
+            if hugging_face_format:
+                loaded_weight_name = loaded_weight_name.replace("model", "qwen2")
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in loaded_weight_name:
                     continue
@@ -340,11 +353,14 @@ class Qwen2ForCausalLM(ModelForCasualLM):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                if loaded_weight_name not in params_dict:
+                model_param_name = loaded_weight_name
+                if model_param_name not in params_dict:
                     continue
-                param = params_dict[loaded_weight_name]
+                param = params_dict[model_param_name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader(self.fd_config))
                 weight_loader(param, loaded_weight)
+            model_sublayer_name = re.sub(r"\.(weight)$", "", model_param_name)
+            process_weights_after_loading_fn(model_sublayer_name, param)
 
     @classmethod
     def name(self):

--- a/fastdeploy/model_executor/models/qwen2.py
+++ b/fastdeploy/model_executor/models/qwen2.py
@@ -52,7 +52,6 @@ class Qwen2MLP(nn.Layer):
     ) -> None:
         super().__init__()
         self.nranks = fd_config.parallel_config.tensor_parallel_size
-        print("qwen2的fd_config_format", fd_config.model_config.model_format)
         self.up_gate_proj = MergedColumnParallelLinear(
             fd_config=fd_config,
             prefix=f"{prefix}.up_gate_proj",

--- a/fastdeploy/model_executor/models/qwen2.py
+++ b/fastdeploy/model_executor/models/qwen2.py
@@ -334,9 +334,9 @@ class Qwen2ForCausalLM(ModelForCasualLM):
         params_dict = dict(self.named_parameters())
         process_weights_after_loading_fn = process_weights_after_loading(dict(self.named_sublayers()))
         for loaded_weight_name, loaded_weight in weights_iterator:
-            hugging_face_format = self.fd_config.model_config.model_format == "hugging_face"
+            model_format = self.fd_config.model_config.model_format == "torch"
             # Because the prefix for Paddle is qwen2, and for Hugging Face it is model.
-            if hugging_face_format:
+            if model_format:
                 loaded_weight_name = loaded_weight_name.replace("model", "qwen2")
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in loaded_weight_name:

--- a/fastdeploy/model_executor/utils.py
+++ b/fastdeploy/model_executor/utils.py
@@ -16,6 +16,8 @@
 
 from typing import Any, Optional, Union
 
+import paddle
+
 from fastdeploy.config import FDConfig
 from fastdeploy.model_executor.layers.utils import get_tensor
 
@@ -155,10 +157,16 @@ def default_weight_loader(fd_config: FDConfig) -> None:
     def fn(param, loaded_weight, shard_id: Optional[Union[int, str]] = None):
         """fn"""
         output_dim = getattr(param, "output_dim", None)
+        hugging_face_format = getattr(param, "hugging_face_format", None)
+        if hugging_face_format:
+            loaded_weight = loaded_weight.transpose([1, 0])
         # Tensor parallelism splits the weight along the output_dim
         if output_dim is not None and fd_config.parallel_config.tensor_parallel_size > 1:
             dim = -1 if output_dim else 0
-            size = loaded_weight.get_shape()[dim]
+            if isinstance(loaded_weight, paddle.Tensor):
+                size = loaded_weight.shape[dim]
+            else:
+                size = loaded_weight.get_shape()[dim]
             block_size = size // fd_config.parallel_config.tensor_parallel_size
             shard_offset = fd_config.parallel_config.tensor_parallel_rank * block_size
             shard_size = (fd_config.parallel_config.tensor_parallel_rank + 1) * block_size

--- a/fastdeploy/model_executor/utils.py
+++ b/fastdeploy/model_executor/utils.py
@@ -158,7 +158,7 @@ def default_weight_loader(fd_config: FDConfig) -> None:
         """fn"""
         output_dim = getattr(param, "output_dim", None)
         model_format = getattr(param, "model_format", None)
-        if model_format:
+        if model_format == "torch":
             loaded_weight = loaded_weight.transpose([1, 0])
         # Tensor parallelism splits the weight along the output_dim
         if output_dim is not None and fd_config.parallel_config.tensor_parallel_size > 1:

--- a/fastdeploy/model_executor/utils.py
+++ b/fastdeploy/model_executor/utils.py
@@ -157,8 +157,8 @@ def default_weight_loader(fd_config: FDConfig) -> None:
     def fn(param, loaded_weight, shard_id: Optional[Union[int, str]] = None):
         """fn"""
         output_dim = getattr(param, "output_dim", None)
-        hugging_face_format = getattr(param, "hugging_face_format", None)
-        if hugging_face_format:
+        model_format = getattr(param, "model_format", None)
+        if model_format:
             loaded_weight = loaded_weight.transpose([1, 0])
         # Tensor parallelism splits the weight along the output_dim
         if output_dim is not None and fd_config.parallel_config.tensor_parallel_size > 1:

--- a/fastdeploy/model_executor/utils.py
+++ b/fastdeploy/model_executor/utils.py
@@ -157,7 +157,7 @@ def default_weight_loader(fd_config: FDConfig) -> None:
     def fn(param, loaded_weight, shard_id: Optional[Union[int, str]] = None):
         """fn"""
         output_dim = getattr(param, "output_dim", None)
-        model_format = getattr(param, "model_format", None)
+        model_format = getattr(param, "model_format", "")
         if model_format == "torch":
             loaded_weight = loaded_weight.transpose([1, 0])
         # Tensor parallelism splits the weight along the output_dim

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -605,9 +605,6 @@ def parse_args():
         default="default",
         help="The format of the model weights to load. default/new_loader.",
     )
-    parser.add_argument(
-        "--hugging_face_format", action="store_true", help="Whether to use models in Hugging Face format"
-    )
 
     parser.add_argument(
         "--ips",

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -605,6 +605,9 @@ def parse_args():
         default="default",
         help="The format of the model weights to load. default/new_loader.",
     )
+    parser.add_argument(
+        "--hugging_face_format", action="store_true", help="Whether to use models in Hugging Face format"
+    )
 
     parser.add_argument(
         "--ips",

--- a/tests/model_loader/test_common_model.py
+++ b/tests/model_loader/test_common_model.py
@@ -30,20 +30,20 @@ TokensIdText = list[tuple[list[int], str]]
 def get_model_paths(base_model_name: str) -> tuple[str, str]:
     """return (fastdeploy_path, huggingface_path)"""
     # FastDeploy model path
-    fd_base_path = os.getenv("FD_MODEL_PATH")
+    fd_base_path = os.getenv("MODEL_PATH")
     if fd_base_path:
         fd_model_path = os.path.join(fd_base_path, base_model_name)
     else:
         fd_model_path = base_model_name
 
     # HuggingFace model path
-    hf_base_path = os.getenv("HF_MODEL_PATH")
-    if hf_base_path:
-        hf_model_path = os.path.join(hf_base_path, base_model_name)
-    else:
-        hf_model_path = base_model_name
+    torch_model_path = os.path.join(
+        fd_base_path,
+        "torch",
+        base_model_name,
+    )
 
-    return fd_model_path, hf_model_path
+    return fd_model_path, torch_model_path
 
 
 def check_tokens_id_and_text_close(
@@ -224,7 +224,7 @@ for model, cfg in hugging_face_model_param_map.items():
     "model_name_or_path,tensor_parallel_size,max_model_len,quantization,max_tokens",
     hf_params,
 )
-def test_paddle_vs_huggingface_model(
+def test_paddle_vs_torch_model(
     fd_runner,
     model_name_or_path: str,
     tensor_parallel_size: int,
@@ -232,9 +232,8 @@ def test_paddle_vs_huggingface_model(
     max_tokens: int,
     quantization: str,
 ) -> None:
-    """测试 Paddle 模型（default loader）和 HuggingFace 模型（default_v1 loader）"""
 
-    fd_model_path, hf_model_path = get_model_paths(model_name_or_path)
+    fd_model_path, torch_model_path = get_model_paths(model_name_or_path)
 
     result_queue = Queue()
 
@@ -255,12 +254,11 @@ def test_paddle_vs_huggingface_model(
     p_paddle.join()
     paddle_outputs = result_queue.get(timeout=60)
 
-    print(f"Testing HuggingFace model with default_v1 loader: {hf_model_path}")
     p_hf = Process(
         target=form_model_get_output,
         args=(
             fd_runner,
-            hf_model_path,
+            torch_model_path,
             tensor_parallel_size,
             max_model_len,
             max_tokens,

--- a/tests/model_loader/test_common_model.py
+++ b/tests/model_loader/test_common_model.py
@@ -27,6 +27,25 @@ TokensIdText = list[tuple[list[int], str]]
 # (token_ids, text)
 
 
+def get_model_paths(base_model_name: str) -> tuple[str, str]:
+    """return (fastdeploy_path, huggingface_path)"""
+    # FastDeploy model path
+    fd_base_path = os.getenv("FD_MODEL_PATH")
+    if fd_base_path:
+        fd_model_path = os.path.join(fd_base_path, base_model_name)
+    else:
+        fd_model_path = base_model_name
+
+    # HuggingFace model path
+    hf_base_path = os.getenv("HF_MODEL_PATH")
+    if hf_base_path:
+        hf_model_path = os.path.join(hf_base_path, base_model_name)
+    else:
+        hf_model_path = base_model_name
+
+    return fd_model_path, hf_model_path
+
+
 def check_tokens_id_and_text_close(
     *,
     outputs_0_lst: TokensIdText,
@@ -99,7 +118,11 @@ model_param_map = {
         "tensor_parallel_size": 2,
         "quantizations": ["wint8"],
     },
+    "Qwen2-7B-Instruct": {
+        "quantizations": ["None", "wint8"],
+    },
 }
+
 
 params = []
 for model, cfg in model_param_map.items():
@@ -172,4 +195,87 @@ def test_common_model(
         outputs_1_lst=fd_outputs_v1,
         name_0="default loader",
         name_1="default_v1 loader",
+    )
+
+
+hugging_face_model_param_map = {
+    "Qwen2.5-7B-Instruct": {
+        "tensor_parallel_size": 2,
+        "quantizations": ["None"],
+    },
+}
+
+hf_params = []
+for model, cfg in hugging_face_model_param_map.items():
+    for q in cfg["quantizations"]:
+        hf_params.append(
+            pytest.param(
+                model,
+                cfg.get("tensor_parallel_size", 1),
+                cfg.get("max_model_len", 1024),
+                q,
+                cfg.get("max_tokens", 32),
+                marks=[pytest.mark.core_model],
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "model_name_or_path,tensor_parallel_size,max_model_len,quantization,max_tokens",
+    hf_params,
+)
+def test_paddle_vs_huggingface_model(
+    fd_runner,
+    model_name_or_path: str,
+    tensor_parallel_size: int,
+    max_model_len: int,
+    max_tokens: int,
+    quantization: str,
+) -> None:
+    """测试 Paddle 模型（default loader）和 HuggingFace 模型（default_v1 loader）"""
+
+    fd_model_path, hf_model_path = get_model_paths(model_name_or_path)
+
+    result_queue = Queue()
+
+    p_paddle = Process(
+        target=form_model_get_output,
+        args=(
+            fd_runner,
+            fd_model_path,
+            tensor_parallel_size,
+            max_model_len,
+            max_tokens,
+            quantization,
+            "default",
+            result_queue,
+        ),
+    )
+    p_paddle.start()
+    p_paddle.join()
+    paddle_outputs = result_queue.get(timeout=60)
+
+    print(f"Testing HuggingFace model with default_v1 loader: {hf_model_path}")
+    p_hf = Process(
+        target=form_model_get_output,
+        args=(
+            fd_runner,
+            hf_model_path,
+            tensor_parallel_size,
+            max_model_len,
+            max_tokens,
+            quantization,
+            "default_v1",
+            result_queue,
+        ),
+    )
+    p_hf.start()
+    p_hf.join()
+    hf_outputs = result_queue.get(timeout=60)
+
+    check_tokens_id_and_text_close(
+        outputs_0_lst=paddle_outputs,
+        outputs_1_lst=hf_outputs,
+        name_0="Paddle model (default loader)",
+        name_1="HuggingFace model (default_v1 loader)",
     )


### PR DESCRIPTION
Fastdeploy支持**hugging face** qwen2系列，qwen3 dense模型模型

使用示例:
目前仅在load_choices为default_v1时，才支持加载hugging face模型，我们根据模型config.json中是否有torch_dtype来判断是加载的hugging face模型还是paddle模型,同时我们也支持指定环境变量来加载hugging face的模型，设置export HUGGING_FACE_FORMAT=True
服务方式:
```python
启动服务方式:
python -m fastdeploy.entrypoints.openai.api_server --model ${model_path} \
    --max-num-seqs 256 --max-model-len 32768 \
    --port 9032 --engine-worker-queue-port 7102 \
    --metrics-port 7203 --tensor-parallel-size 2 \
    --gpu-memory-utilization 0.9 \
    --load_choices "default_v1" \

请求:
import openai

ip = "0.0.0.0"
service_http_port = "9032"  # 服务配置的

client = openai.Client(base_url=f"http://{ip}:{service_http_port}/v1", api_key="EMPTY_API_KEY")
response = client.chat.completions.create(
    model="default",
    messages=[
        {"role": "user", "content": "北京天安门在哪里?"},
    ],
    temperature=1,
    seed=1,
    stream=False,
    max_tokens=30,
)

print(response.choices[0].message.content)
print("\n")


```


离线方式:
```python
offline_demo.py
from fastdeploy.engine.sampling_params import SamplingParams
from fastdeploy.entrypoints.llm import LLM

model_name_or_path = "/workspace/Models/Qwen2.5-7B-Instruct"
sampling_params = SamplingParams(temperature=0.1, max_tokens=30, top_p=0)
# load_choices取值"default_v1"是新版Loader，"default"是旧版
llm = LLM(model=model_name_or_path,num_gpu_blocks_override=1024, tensor_parallel_size=2, load_choices="default_v1")
output = llm.generate(prompts="who are you",
                      use_tqdm=True,
                      sampling_params=sampling_params)
print(output)
```
