### PR TITLE
Specify dtype as int32 for paddle.cumsum due to API Change

### DIFF
--- a/custom_ops/xpu_ops/test/test_speculate_get_output_padding_offset.py
+++ b/custom_ops/xpu_ops/test/test_speculate_get_output_padding_offset.py
@@ -30,7 +30,7 @@ def test_speculate_get_output_padding_offset():
 
     seq_lens_output = paddle.to_tensor(seq_lens_output, dtype="int32")
     out_token_num = paddle.sum(seq_lens_output)
-    output_cum_offsets_tmp = paddle.cumsum(max_seq_len - seq_lens_output)
+    output_cum_offsets_tmp = paddle.cumsum(max_seq_len - seq_lens_output, dtype="int32")
 
     output_padding_offset_xpu, output_cum_offsets_xpu = speculate_get_output_padding_offset(
         output_cum_offsets_tmp, out_token_num, seq_lens_output, max_seq_len

--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -397,7 +397,7 @@ class EngineSevice:
             image_type_ids = paddle.to_tensor(inputs["image_type_ids"], dtype="int32")
             image_mask = input_ids == self.data_processor.image_patch_id
             image_token_sum = paddle.full(shape=[len(input_ids) + 1], fill_value=0, dtype="int32")
-            image_token_sum[1:] = paddle.cumsum(image_mask.cast("int32"))
+            image_token_sum[1:] = paddle.cumsum(image_mask.cast("int32"), dtype="int32")
             grid_thw = []
             for one in inputs["grid_thw"]:
                 if one[0] == 1:

--- a/fastdeploy/model_executor/layers/utils.py
+++ b/fastdeploy/model_executor/layers/utils.py
@@ -257,7 +257,7 @@ def remove_padding(
             - The key sequence lengths (paddle.Tensor).
     """
     if current_platform.is_cuda():
-        cum_offsets_now = paddle.cumsum(max_len - seq_lens_this_time)
+        cum_offsets_now = paddle.cumsum(max_len - seq_lens_this_time, dtype="int32")
         token_num = paddle.sum(seq_lens_this_time)
         (
             ids_remove_padding,
@@ -301,7 +301,7 @@ def speculate_remove_padding(
             - Key sequence lengths (paddle.Tensor).
     """
     if current_platform.is_cuda():
-        cum_offsets_now = paddle.cumsum(max_len - seq_lens_this_time)
+        cum_offsets_now = paddle.cumsum(max_len - seq_lens_this_time, dtype="int32")
         token_num = paddle.sum(seq_lens_this_time)
         (
             ids_remove_padding,

--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -106,7 +106,7 @@ def pre_process(
     """
     # Remove padding
     max_len = input_ids.shape[1]
-    cum_offsets_now = paddle.cumsum(max_len - seq_lens_this_time)
+    cum_offsets_now = paddle.cumsum(max_len - seq_lens_this_time, dtype="int32")
     token_num = paddle.sum(seq_lens_this_time)
     output_padding_offset = None
     output_cum_offsets = None
@@ -132,7 +132,7 @@ def pre_process(
         if isinstance(seq_lens_output, list):
             seq_lens_output = seq_lens_output[0]
         output_token_num = paddle.sum(seq_lens_output)
-        output_cum_offsets_tmp = paddle.cumsum(max_len - seq_lens_output)
+        output_cum_offsets_tmp = paddle.cumsum(max_len - seq_lens_output, dtype="int32")
         output_padding_offset, output_cum_offsets = speculate_get_output_padding_offset(
             output_cum_offsets_tmp,
             output_token_num,

--- a/fastdeploy/worker/xpu_model_runner.py
+++ b/fastdeploy/worker/xpu_model_runner.py
@@ -63,7 +63,7 @@ def xpu_pre_process(
 ) -> XPUForwardMeta:
     """ """
     max_len = input_ids.shape[1]
-    cum_offsets_now = paddle.cumsum(max_len - seq_lens_this_time)
+    cum_offsets_now = paddle.cumsum(max_len - seq_lens_this_time, dtype="int32")
     token_num = paddle.sum(seq_lens_this_time)
 
     (

--- a/tests/layers/test_append_attention.py
+++ b/tests/layers/test_append_attention.py
@@ -197,7 +197,7 @@ def naive_attention_impl(
 
 
 def get_padding_offset(bsz, max_seq_len, seq_lens_this_time):
-    cum_offsets_now = paddle.cumsum(max_seq_len - seq_lens_this_time)
+    cum_offsets_now = paddle.cumsum(max_seq_len - seq_lens_this_time, dtype="int32")
     cum_offsets = paddle.zeros(shape=(bsz + 1), dtype="int32")
     cum_offsets[1:] = cum_offsets_now
     token_num = paddle.sum(seq_lens_this_time)

--- a/tests/layers/test_append_attention_with_output.py
+++ b/tests/layers/test_append_attention_with_output.py
@@ -197,7 +197,7 @@ def naive_attention_impl(
 
 
 def get_padding_offset(bsz, max_seq_len, seq_lens_this_time):
-    cum_offsets_now = paddle.cumsum(max_seq_len - seq_lens_this_time)
+    cum_offsets_now = paddle.cumsum(max_seq_len - seq_lens_this_time, dtype="int32")
     cum_offsets = paddle.zeros(shape=(bsz + 1), dtype="int32")
     cum_offsets[1:] = cum_offsets_now
     token_num = paddle.sum(seq_lens_this_time)


### PR DESCRIPTION
[Paddle#74625](https://github.com/PaddlePaddle/Paddle/pull/74625) **(合入时间8月20号9点)** 引入后，`paddle.cumsum` 输出值 `cum_offsets` 的默认 dtype 是 `int64`，不再是 `int32`

后面自定义算子中存在按照 int32 类型解析的逻辑，存在问题


```c
cum_offsets.data<int>(),
```

本PR将必要的 `paddle.cumsum` 参数 `dtype` 指定为 `int32`

PS:
> 目前CI上 FD develop 分支是锁的 python -m pip install paddlepaddle-gpu==3.0.0.dev20250818 -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/ 这个 paddle 版本

cc @SigureMo
