### PR TITLE
[Bug Fix] fix the bug when num_key_value_heads < tensor_parallel_size in launching kv_cahce_manager

### DIFF
--- a/fastdeploy/cache_manager/prefix_cache_manager.py
+++ b/fastdeploy/cache_manager/prefix_cache_manager.py
@@ -154,7 +154,7 @@ class PrefixCacheManager:
             kv_num_head = int(cache_config.model_cfg.num_key_value_heads) // tensor_parallel_size
         else:
             kv_num_head = cache_config.model_cfg.num_attention_heads // tensor_parallel_size
-
+        kv_num_head = max(1, kv_num_head)
         cache_ready_signal_data = np.zeros(shape=[tensor_parallel_size], dtype=np.int32)
         self.cache_ready_signal = IPCSignal(
             name="cache_ready_signal",


### PR DESCRIPTION
pcard-71500

TP4启动ERNIE4.5-0.3B模型时，卡在了等待kv_cache_manager启动的阶段。

主要原因：cache_config.model_cfg.num_key_value_heads的大小为2，tensor_parallel_size为4，在进行kv_cache切分的时候导致了最后算出的切分结果为0，最后初始化kv_cache的size为[gpu_block, 0, block_size, head_dim]初始化kv_cache失败。

解决方案：初始化KV Cache时，在计算好kv_num_head之后，对其和1取最大值，即`kv_num_head = max(1, kv_num_head)`