### PR TITLE
[Cherry-Pick] get org_vocab_size from args

### DIFF
--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -133,9 +133,7 @@ class ModelConfig:
         if hasattr(self, "vision_config"):
             self.vision_config = PretrainedConfig.from_dict(self.vision_config)
 
-        self.ori_vocab_size = self.vocab_size
-        if ErnieArchitectures.contains_ernie_arch(self.architectures):
-            self.ori_vocab_size = args.get("ori_vocab_size", self.ori_vocab_size)
+        self.ori_vocab_size = args.get("ori_vocab_size", self.vocab_size)
 
 
 class ParallelConfig:


### PR DESCRIPTION
pcard-71500

所有的模型都会有`ori_vocab_size`属性，直接获取就可以了，如果没有再用self.vocab_size替换，并不需要区分是否为Ernie。