### PR TITLE
[CI] Ignore execution of test_common_model.py in CI

### DIFF
--- a/tests/cov_pytest.ini
+++ b/tests/cov_pytest.ini
@@ -22,3 +22,4 @@ addopts =
     --ignore=tests/operators/test_flash_mask_attn.py
     --ignore=tests/operators/test_w4afp8_gemm.py
     --ignore=tests/operators/test_tree_mask.py
+    --ignore=tests/model_loader/test_common_model.py


### PR DESCRIPTION
Ignore execution of `tests/model_loader/test_common_model.py` due to instability in feature/experimental_feature_20250908