### PR TITLE
[CUDAGraph]CUDA Graph support unique memory pool

### DIFF
--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -841,8 +841,13 @@ class GraphOptimizationConfig:
         Now don't support capture both decode-only and prefill-only"""
         self.full_cuda_graph: bool = True
 
+        """ Maximum CUDA Graph capture size """
         self.max_capture_size: int = None
+        """ Record maps mapped from real shape to captured size to reduce runtime overhead """
         self.real_shape_to_captured_size: dict[int, int] = None
+        """ Whether to use shared memory pool for multi capture_size """
+        self.use_unique_memory_pool: bool = False
+
         # CINN Config ...
         if args is not None:
             for key, value in args.items():

--- a/fastdeploy/model_executor/graph_optimization/cudagraph_piecewise_backend.py
+++ b/fastdeploy/model_executor/graph_optimization/cudagraph_piecewise_backend.py
@@ -23,9 +23,6 @@ import paddle.jit.dy2static.utils as jit_utils
 import paddle.nn.layer
 from paddle.device.cuda import graphs
 
-if paddle.is_compiled_with_cuda():
-    from paddle.base.core import CUDAGraph
-
 from fastdeploy import envs
 from fastdeploy.config import FDConfig
 from fastdeploy.distributed.communication import capture_custom_allreduce
@@ -101,7 +98,11 @@ class CudaGraphPiecewiseBackend:
         self.real_shape_to_captured_size = fd_config.graph_opt_config.real_shape_to_captured_size
         self.unique_memory_pool_id = None
         if self.fd_config.graph_opt_config.use_unique_memory_pool:
-            self.unique_memory_pool_id = CUDAGraph.gen_new_memory_pool_id()
+            # TODO(gongshaotian): Optimize code
+            if paddle.is_compiled_with_cuda():
+                from paddle.base.core import CUDAGraph
+
+                self.unique_memory_pool_id = CUDAGraph.gen_new_memory_pool_id()
 
         self._create_entry_dict()
 

--- a/fastdeploy/model_executor/graph_optimization/cudagraph_piecewise_backend.py
+++ b/fastdeploy/model_executor/graph_optimization/cudagraph_piecewise_backend.py
@@ -21,6 +21,7 @@ from typing import Callable, Dict, List, Optional
 
 import paddle.jit.dy2static.utils as jit_utils
 import paddle.nn.layer
+from paddle.base.core import CUDAGraph
 from paddle.device.cuda import graphs
 
 from fastdeploy import envs
@@ -96,6 +97,9 @@ class CudaGraphPiecewiseBackend:
         self.cudagraph_capture_sizes = fd_config.graph_opt_config.cudagraph_capture_sizes
         self.warm_up_size = fd_config.graph_opt_config.cudagraph_num_of_warmups
         self.real_shape_to_captured_size = fd_config.graph_opt_config.real_shape_to_captured_size
+        self.unique_memory_pool_id = None
+        if self.fd_config.graph_opt_config.use_unique_memory_pool:
+            self.unique_memory_pool_id = CUDAGraph.gen_new_memory_pool_id()
 
         self._create_entry_dict()
 
@@ -169,7 +173,11 @@ class CudaGraphPiecewiseBackend:
             input_addresses = [x.data_ptr() for (_, x) in kwargs.items() if isinstance(x, paddle.Tensor)]
             entry.input_addresses = input_addresses
 
-            new_grpah = graphs.CUDAGraph()
+            new_grpah = (
+                graphs.CUDAGraph(pool_id=self.unique_memory_pool_id)
+                if self.fd_config.graph_opt_config.use_unique_memory_pool
+                else graphs.CUDAGraph()
+            )
             paddle.device.synchronize()
 
             # Capture

--- a/fastdeploy/model_executor/graph_optimization/cudagraph_piecewise_backend.py
+++ b/fastdeploy/model_executor/graph_optimization/cudagraph_piecewise_backend.py
@@ -176,11 +176,7 @@ class CudaGraphPiecewiseBackend:
             input_addresses = [x.data_ptr() for (_, x) in kwargs.items() if isinstance(x, paddle.Tensor)]
             entry.input_addresses = input_addresses
 
-            new_grpah = (
-                graphs.CUDAGraph(pool_id=self.unique_memory_pool_id)
-                if self.fd_config.graph_opt_config.use_unique_memory_pool
-                else graphs.CUDAGraph()
-            )
+            new_grpah = graphs.CUDAGraph(pool_id=self.unique_memory_pool_id)
             paddle.device.synchronize()
 
             # Capture

--- a/fastdeploy/model_executor/graph_optimization/cudagraph_piecewise_backend.py
+++ b/fastdeploy/model_executor/graph_optimization/cudagraph_piecewise_backend.py
@@ -23,6 +23,9 @@ import paddle.jit.dy2static.utils as jit_utils
 import paddle.nn.layer
 from paddle.device.cuda import graphs
 
+if paddle.is_compiled_with_cuda():
+    from paddle.base.core import CUDAGraph
+
 from fastdeploy import envs
 from fastdeploy.config import FDConfig
 from fastdeploy.distributed.communication import capture_custom_allreduce
@@ -98,9 +101,7 @@ class CudaGraphPiecewiseBackend:
         self.real_shape_to_captured_size = fd_config.graph_opt_config.real_shape_to_captured_size
         self.unique_memory_pool_id = None
         if self.fd_config.graph_opt_config.use_unique_memory_pool:
-            if paddle.is_compiled_with_cuda():
-                from paddle.base.core import CUDAGraph
-                self.unique_memory_pool_id = CUDAGraph.gen_new_memory_pool_id()
+            self.unique_memory_pool_id = CUDAGraph.gen_new_memory_pool_id()
 
         self._create_entry_dict()
 

--- a/fastdeploy/model_executor/graph_optimization/cudagraph_piecewise_backend.py
+++ b/fastdeploy/model_executor/graph_optimization/cudagraph_piecewise_backend.py
@@ -21,7 +21,6 @@ from typing import Callable, Dict, List, Optional
 
 import paddle.jit.dy2static.utils as jit_utils
 import paddle.nn.layer
-from paddle.base.core import CUDAGraph
 from paddle.device.cuda import graphs
 
 from fastdeploy import envs
@@ -99,7 +98,9 @@ class CudaGraphPiecewiseBackend:
         self.real_shape_to_captured_size = fd_config.graph_opt_config.real_shape_to_captured_size
         self.unique_memory_pool_id = None
         if self.fd_config.graph_opt_config.use_unique_memory_pool:
-            self.unique_memory_pool_id = CUDAGraph.gen_new_memory_pool_id()
+            if paddle.is_compiled_with_cuda():
+                from paddle.base.core import CUDAGraph
+                self.unique_memory_pool_id = CUDAGraph.gen_new_memory_pool_id()
 
         self._create_entry_dict()
 


### PR DESCRIPTION
Using a unified memory pool during CUDA Graph capture can reduce the video memory overhead of CUDA Graph. In earlier versions, CUDA Graph used the unified memory pool to generate bugs. This risk has not been completely eliminated, so it is not enabled by default.

Related PR: https://github.com/PaddlePaddle/FastDeploy/pull/4199