### PR TITLE
[BugFix]fix the bug for prefilled_step_idx signal of cache_messager in cudagraph and PD

### DIFF
--- a/fastdeploy/cache_manager/cache_messager.py
+++ b/fastdeploy/cache_manager/cache_messager.py
@@ -211,7 +211,6 @@ class CacheMessager:
                             self.cache_info[info["request_id"]] = info
                 prefilled_layer_idx = layer_shm_value.value[0]
                 prefilled_step_idx = step_shm_value.value[0]
-                logger.info(f"prefilled_layer_idx: {prefilled_layer_idx}, prefilled_step_idx: {prefilled_step_idx}")
                 if prefilled_layer_idx == self.num_layers - 1:
                     time.sleep(0.001)
                     prefilled_layer_idx = layer_shm_value.value[0]

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -429,6 +429,23 @@ class PaddleDisWorkerProc:
 
     def graph_optimize_and_warm_up_model(self) -> None:
         self.worker.graph_optimize_and_warm_up_model()
+        # reset cache_messager prefilled_step signal
+        if self.scheduler_config.splitwise_role == "prefill":
+            dp_rank_id = (
+                self.local_rank
+                + self.parallel_config.local_data_parallel_id * self.parallel_config.tensor_parallel_size
+            )
+            gpu_id = self.worker.model_runner.device_id
+            prefilled_step_name = f"splitwise_complete_prefilled_step_{dp_rank_id}"
+            prefilled_step_idx_data = np.zeros(shape=[1], dtype=np.int32)
+            step_shm_value = IPCSignal(
+                name=prefilled_step_name,
+                array=prefilled_step_idx_data,
+                dtype=np.int32,
+                suffix=gpu_id,
+                create=False,
+            )
+            step_shm_value.value[0] = -1
 
     def init_device(self) -> None:
         """Initialize device and Construct model runner"""
@@ -800,7 +817,7 @@ def run_worker_proc() -> None:
     worker_proc.initialize_kv_cache()
 
     # Trigger CUDAGraph capture
-    worker_proc.worker.graph_optimize_and_warm_up_model()
+    worker_proc.graph_optimize_and_warm_up_model()
 
     # Initialize health status
     worker_proc.init_health_status()


### PR DESCRIPTION
问题描述：
pd分离+cudagraph在压测推理时会出现部分query推理结果超长的现象，结果超长导致了使用cache的blocks数量激增，出现频繁的cache换入换出现象，导致开启cudagraph后的QPS显著低于不开启cudagraph的QPS。

产生原因：
pd分离场景下，P节点和D节点的KV Cache交互需要cache_messager进行管理，在cache_messager中，会使用prefilled_step_idx这个信号参与传输逻辑，这个信号只有在atten_backend初始化的时候会增加。在cudagraph捕获图的过程中，有多次atten_backend的初始化过程，而不开启cudagraph时，真正进行推理之前是不会有atten_backend的初始化过程的。这就导致了开启cudagraph和不开启cudagraph时，prefilled_step_idx的初始值不一致的问题，从而影响了后续KV Cache的传输，出现模型计算结果diff，导致开启cudagraph在部分query计算时出现超长的问题。

解决方案：
在cudagraph捕获图完成后，重置prefilled_step_idx信号，确保开启cudagraph和不开启cudagraph时，cache_messager的信号保持一致。

pcard-71500