### PR TITLE
[XPU] fix VL thinking mode

### DIFF
--- a/fastdeploy/worker/xpu_model_runner.py
+++ b/fastdeploy/worker/xpu_model_runner.py
@@ -1161,8 +1161,8 @@ class XPUModelRunner(ModelRunnerBase):
             accept_num=None,
             enable_thinking=(self.share_inputs["enable_thinking"] if self.enable_mm else None),
             think_end_id=(self.model_config.think_end_id if self.enable_mm else -1),
-            need_think_end=(self.share_inputs["need_think_end"][:num_running_requests] if self.enable_mm else None),
-            reasoning_index=(self.share_inputs["reasoning_index"][:num_running_requests] if self.enable_mm else None),
+            need_think_end=(self.share_inputs["need_think_end"] if self.enable_mm else None),
+            reasoning_index=(self.share_inputs["reasoning_index"] if self.enable_mm else None),
             stop_token_ids=self.share_inputs["stop_seqs"],
             stop_seqs_len=self.share_inputs["stop_seqs_len"],
         )


### PR DESCRIPTION
由于XPU的PD集中式方案中输入、输出token有重排操作，导致模型输出的维度为[max_batch_size, *]，与GPU的[num_running_requests, *]不同，因此need_think_end和reasoning_index变量维度设置为[max_batch_size]。