### PR TITLE
add_cli_tokenizer

### DIFF
--- a/fastdeploy/entrypoints/cli/main.py
+++ b/fastdeploy/entrypoints/cli/main.py
@@ -25,10 +25,12 @@ def main():
     import fastdeploy.entrypoints.cli.openai
     import fastdeploy.entrypoints.cli.run_batch
     import fastdeploy.entrypoints.cli.serve
+    import fastdeploy.entrypoints.cli.tokenizer
     from fastdeploy.utils import FlexibleArgumentParser
 
     CMD_MODULES = [
         fastdeploy.entrypoints.cli.run_batch,
+        fastdeploy.entrypoints.cli.tokenizer,
         fastdeploy.entrypoints.cli.openai,
         fastdeploy.entrypoints.cli.benchmark.main,
         fastdeploy.entrypoints.cli.serve,

--- a/fastdeploy/entrypoints/cli/tokenizer.py
+++ b/fastdeploy/entrypoints/cli/tokenizer.py
@@ -1,0 +1,249 @@
+"""
+# Copyright (c) 2025  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import typing
+from pathlib import Path
+
+from fastdeploy.entrypoints.cli.types import CLISubcommand
+from fastdeploy.input.preprocess import InputPreprocessor
+
+if typing.TYPE_CHECKING:
+    from fastdeploy.utils import FlexibleArgumentParser
+
+
+class TokenizerSubcommand(CLISubcommand):
+    """The `tokenizer` subcommand for the FastDeploy CLI."""
+
+    name = "tokenizer"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        main(args)
+
+    def subparser_init(self, subparsers: argparse._SubParsersAction) -> FlexibleArgumentParser:
+        tokenizer_parser = subparsers.add_parser(
+            name=self.name,
+            help="Start the FastDeploy Tokenizer Server.",
+            description="Start the FastDeploy Tokenizer Server.",
+            usage="fastdeploy tokenizer [--encode/-e TEXT] [--decode/-d TEXT]",
+        )
+
+        # 添加通用参数
+        tokenizer_parser.add_argument(
+            "--model_name_or_path",
+            "--model",
+            "-m",
+            type=str,
+            default="baidu/ERNIE-4.5-0.3B-PT",
+            help="Path to model or model identifier",
+        )
+        tokenizer_parser.add_argument("--enable-mm", "-mm", action="store_true", help="Enable multi-modal support")
+        tokenizer_parser.add_argument("--vocab-size", "-vs", action="store_true", help="Show vocabulary size")
+        tokenizer_parser.add_argument("--info", "-i", action="store_true", help="Show tokenizer information")
+        tokenizer_parser.add_argument(
+            "--vocab-export", "-ve", type=str, metavar="FILE", help="Export vocabulary to file"
+        )
+        tokenizer_parser.add_argument("--encode", "-e", default=None, help="Encode text to tokens")
+        tokenizer_parser.add_argument("--decode", "-d", default=None, help="Decode tokens to text")
+
+        return tokenizer_parser
+
+
+def cmd_init() -> list[CLISubcommand]:
+    return [TokenizerSubcommand()]
+
+
+def get_vocab_size(tokenizer) -> int:
+    """获取词表大小"""
+    try:
+        if hasattr(tokenizer, "vocab_size"):
+            return tokenizer.vocab_size
+        elif hasattr(tokenizer, "get_vocab_size"):
+            return tokenizer.get_vocab_size()
+        else:
+            return 100295  # Ernie4_5Tokenizer的固定词表大小
+    except Exception:
+        return 0
+
+
+def get_tokenizer_info(tokenizer) -> dict:
+    """获取tokenizer的元信息"""
+    info = {}
+
+    try:
+        # 基本属性
+        info["vocab_size"] = get_vocab_size(tokenizer)
+
+        # 模型类型和路径
+        if hasattr(tokenizer, "name_or_path"):
+            info["model_name"] = tokenizer.name_or_path
+
+        # tokenizer类型
+        info["tokenizer_type"] = type(tokenizer).__name__
+
+        # 特殊符号
+        special_tokens = {}
+        for attr in ["bos_token", "eos_token", "unk_token", "sep_token", "pad_token", "cls_token", "mask_token"]:
+            if hasattr(tokenizer, attr):
+                token = getattr(tokenizer, attr)
+                if token:
+                    special_tokens[attr] = token
+        info["special_tokens"] = special_tokens
+
+        # 特殊token IDs
+        special_token_ids = {}
+        for attr in [
+            "bos_token_id",
+            "eos_token_id",
+            "unk_token_id",
+            "sep_token_id",
+            "pad_token_id",
+            "cls_token_id",
+            "mask_token_id",
+        ]:
+            if hasattr(tokenizer, attr):
+                token_id = getattr(tokenizer, attr)
+                if token_id is not None:
+                    special_token_ids[attr] = token_id
+        info["special_token_ids"] = special_token_ids
+
+        # 模型最大长度
+        if hasattr(tokenizer, "model_max_length"):
+            info["model_max_length"] = tokenizer.model_max_length
+
+    except Exception as e:
+        info["error"] = f"Failed to get tokenizer info: {e}"
+
+    return info
+
+
+def get_vocab_dict(tokenizer) -> dict:
+    """获取词表字典"""
+    try:
+        if hasattr(tokenizer, "vocab"):
+            return tokenizer.vocab
+        elif hasattr(tokenizer, "get_vocab"):
+            return tokenizer.get_vocab()
+        elif hasattr(tokenizer, "tokenizer") and hasattr(tokenizer.tokenizer, "vocab"):
+            return tokenizer.tokenizer.vocab
+        elif hasattr(tokenizer, "encoder"):
+            return tokenizer.encoder
+        else:
+            return {}
+    except Exception:
+        return {}
+
+
+def export_vocabulary(tokenizer, file_path: str) -> None:
+    """导出词表到文件"""
+    try:
+        vocab = get_vocab_dict(tokenizer)
+        if not vocab:
+            print("Warning: Could not retrieve vocabulary from tokenizer")
+            return
+
+        path = Path(file_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        # 根据文件扩展名选择格式
+        if path.suffix.lower() == ".json":
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(vocab, f, ensure_ascii=False, indent=2)
+        else:
+            # 默认格式：每行一个token
+            with open(path, "w", encoding="utf-8") as f:
+                for token, token_id in sorted(vocab.items(), key=lambda x: x[1]):
+                    # 处理不可打印字符
+                    try:
+                        f.write(f"{token_id}\t{repr(token)}\n")
+                    except:
+                        f.write(f"{token_id}\t<unprintable>\n")
+
+        print(f"Vocabulary exported to: {file_path}")
+        print(f"Total tokens: {len(vocab)}")
+
+    except Exception as e:
+        print(f"Error exporting vocabulary: {e}")
+
+
+def main(args: argparse.Namespace) -> None:
+
+    def print_separator(title=""):
+        if title:
+            print(f"\n{'='*50}")
+            print(f" {title}")
+            print(f"{'='*50}")
+        else:
+            print(f"\n{'='*50}")
+
+    # 检查参数
+    if not any([args.encode, args.decode, args.vocab_size, args.info, args.vocab_export]):
+        print("请至少指定一个参数：--encode, --decode, --vocab-size, --info, --export-vocab")
+        return
+
+    # 初始化tokenizer
+    preprocessor = InputPreprocessor(model_name_or_path=args.model_name_or_path, enable_mm=args.enable_mm)
+    tokenizer = preprocessor.create_processor().tokenizer
+
+    # 执行操作
+    operations_count = 0
+
+    if args.encode:
+        print_separator("ENCODING")
+        print(f"Input text: {args.encode}")
+        encoded_text = tokenizer.encode(args.encode)
+        print(f"Encoded tokens: {encoded_text}")
+        operations_count += 1
+
+    if args.decode:
+        print_separator("DECODING")
+        print(f"Input tokens: {args.decode}")
+        try:
+            if isinstance(args.decode, str):
+                if args.decode.startswith("[") and args.decode.endswith("]"):
+                    tokens = eval(args.decode)
+                else:
+                    tokens = [int(x.strip()) for x in args.decode.split(",")]
+            else:
+                tokens = args.decode
+
+            decoded_text = tokenizer.decode(tokens)
+            print(f"Decoded text: {decoded_text}")
+        except Exception as e:
+            print(f"Error decoding tokens: {e}")
+        operations_count += 1
+
+    if args.vocab_size:
+        print_separator("VOCABULARY SIZE")
+        print(f"Vocabulary size: {get_vocab_size(tokenizer)}")
+        operations_count += 1
+
+    if args.info:
+        print_separator("TOKENIZER INFO")
+        print(json.dumps(get_tokenizer_info(tokenizer), indent=2))
+        operations_count += 1
+
+    if args.vocab_export:
+        print_separator("EXPORT VOCABULARY")
+        export_vocabulary(tokenizer, args.vocab_export)
+        operations_count += 1
+
+    print_separator()
+    print(f"Completed {operations_count} operation(s)")

--- a/tests/entrypoints/cli/test_tokenizer_cli.py
+++ b/tests/entrypoints/cli/test_tokenizer_cli.py
@@ -1,0 +1,590 @@
+"""
+Test cases for tokenizer CLI
+"""
+
+import argparse
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, PropertyMock, patch
+
+
+class MockCLISubcommand:
+    """模拟CLISubcommand基类"""
+
+    pass
+
+
+class MockInputPreprocessor:
+    """模拟InputPreprocessor类"""
+
+    def __init__(self, model_name_or_path):
+        self.model_name_or_path = model_name_or_path
+
+    def create_processor(self):
+        mock_processor = MagicMock()
+        mock_processor.tokenizer = MagicMock()
+        return mock_processor
+
+
+# 导入被测试代码，使用模拟的依赖
+with patch("fastdeploy.entrypoints.cli.types.CLISubcommand", MockCLISubcommand):
+    with patch("fastdeploy.input.preprocess.InputPreprocessor", MockInputPreprocessor):
+        # 这里直接包含被测试的代码内容
+        from fastdeploy.entrypoints.cli.tokenizer import (
+            TokenizerSubcommand,
+            cmd_init,
+            export_vocabulary,
+            get_tokenizer_info,
+            get_vocab_dict,
+            get_vocab_size,
+            main,
+        )
+
+
+class TestTokenizerSubcommand(unittest.TestCase):
+    """测试TokenizerSubcommand类"""
+
+    def test_name_attribute(self):
+        self.assertEqual(TokenizerSubcommand.name, "tokenizer")
+
+    def test_subparser_init(self):
+        subcommand = TokenizerSubcommand()
+        mock_subparsers = MagicMock()
+        mock_parser = MagicMock()
+        mock_subparsers.add_parser.return_value = mock_parser
+
+        parser = subcommand.subparser_init(mock_subparsers)
+
+        # 验证解析器创建
+        mock_subparsers.add_parser.assert_called_once_with(
+            name="tokenizer",
+            help="Start the FastDeploy Tokenizer Server.",
+            description="Start the FastDeploy Tokenizer Server.",
+            usage="fastdeploy tokenizer [--encode/-e TEXT] [--decode/-d TEXT]",
+        )
+        self.assertEqual(parser, mock_parser)
+
+        # 验证参数添加（检查调用次数）
+        self.assertGreater(mock_parser.add_argument.call_count, 0)
+
+    def test_cmd_method(self):
+        subcommand = TokenizerSubcommand()
+        args = argparse.Namespace()
+
+        with patch("fastdeploy.entrypoints.cli.tokenizer.main") as mock_main:
+            subcommand.cmd(args)
+            mock_main.assert_called_once_with(args)
+
+
+class TestCmdInit(unittest.TestCase):
+    """测试cmd_init函数"""
+
+    def test_cmd_init_returns_list(self):
+        result = cmd_init()
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], TokenizerSubcommand)
+
+
+class TestGetVocabSize(unittest.TestCase):
+    """测试get_vocab_size函数"""
+
+    def test_with_vocab_size_attribute(self):
+        mock_tokenizer = MagicMock()
+        # 使用PropertyMock来正确模拟属性
+        type(mock_tokenizer).vocab_size = PropertyMock(return_value=1000)
+        result = get_vocab_size(mock_tokenizer)
+        self.assertEqual(result, 1000)
+
+    def test_with_get_vocab_size_method(self):
+        mock_tokenizer = MagicMock()
+        # 确保vocab_size属性不存在，让代码使用get_vocab_size方法
+        delattr(mock_tokenizer, "vocab_size")
+        mock_tokenizer.get_vocab_size.return_value = 2000
+        result = get_vocab_size(mock_tokenizer)
+        self.assertEqual(result, 2000)
+
+    def test_with_no_methods_available(self):
+        mock_tokenizer = MagicMock()
+        # 移除可能的方法
+        delattr(mock_tokenizer, "vocab_size")
+        delattr(mock_tokenizer, "get_vocab_size")
+        result = get_vocab_size(mock_tokenizer)
+        self.assertEqual(result, 100295)  # 默认值
+
+    def test_exception_handling(self):
+        mock_tokenizer = MagicMock()
+        # 模拟两个方法都抛出异常
+        type(mock_tokenizer).vocab_size = PropertyMock(side_effect=Exception("Error"))
+        mock_tokenizer.get_vocab_size.side_effect = Exception("Error")
+        result = get_vocab_size(mock_tokenizer)
+        self.assertEqual(result, 0)  # 默认值
+
+
+class TestGetTokenizerInfo(unittest.TestCase):
+    """测试get_tokenizer_info函数"""
+
+    def setUp(self):
+        self.mock_tokenizer = MagicMock()
+        type(self.mock_tokenizer).vocab_size = PropertyMock(return_value=1000)
+        type(self.mock_tokenizer).name_or_path = PropertyMock(return_value="test/model")
+        type(self.mock_tokenizer).model_max_length = PropertyMock(return_value=512)
+
+        # 特殊token
+        type(self.mock_tokenizer).bos_token = PropertyMock(return_value="<s>")
+        type(self.mock_tokenizer).eos_token = PropertyMock(return_value="</s>")
+        type(self.mock_tokenizer).unk_token = PropertyMock(return_value="<unk>")
+        type(self.mock_tokenizer).sep_token = PropertyMock(return_value="<sep>")
+        type(self.mock_tokenizer).pad_token = PropertyMock(return_value="<pad>")
+        type(self.mock_tokenizer).cls_token = PropertyMock(return_value="<cls>")
+        type(self.mock_tokenizer).mask_token = PropertyMock(return_value="<mask>")
+
+        # 特殊token ID
+        type(self.mock_tokenizer).bos_token_id = PropertyMock(return_value=1)
+        type(self.mock_tokenizer).eos_token_id = PropertyMock(return_value=2)
+        type(self.mock_tokenizer).unk_token_id = PropertyMock(return_value=3)
+        type(self.mock_tokenizer).sep_token_id = PropertyMock(return_value=4)
+        type(self.mock_tokenizer).pad_token_id = PropertyMock(return_value=0)
+        type(self.mock_tokenizer).cls_token_id = PropertyMock(return_value=5)
+        type(self.mock_tokenizer).mask_token_id = PropertyMock(return_value=6)
+
+    def test_normal_case(self):
+        info = get_tokenizer_info(self.mock_tokenizer)
+
+        self.assertEqual(info["vocab_size"], 1000)
+        self.assertEqual(info["model_name"], "test/model")
+        self.assertEqual(info["tokenizer_type"], "MagicMock")
+        self.assertEqual(info["model_max_length"], 512)
+
+        # 检查特殊token
+        self.assertEqual(info["special_tokens"]["bos_token"], "<s>")
+        self.assertEqual(info["special_token_ids"]["bos_token_id"], 1)
+
+    def test_exception_handling(self):
+        # 模拟在获取属性时抛出异常
+        with patch("fastdeploy.entrypoints.cli.tokenizer.get_vocab_size", side_effect=Exception("Test error")):
+            info = get_tokenizer_info(self.mock_tokenizer)
+            self.assertIn("error", info)
+            self.assertIn("Test error", info["error"])
+
+
+class TestGetVocabDict(unittest.TestCase):
+    """测试get_vocab_dict函数"""
+
+    def test_vocab_attribute(self):
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.vocab = {"hello": 1, "world": 2}
+        result = get_vocab_dict(mock_tokenizer)
+        self.assertEqual(result, {"hello": 1, "world": 2})
+
+    def test_get_vocab_method(self):
+        mock_tokenizer = MagicMock()
+        # 确保vocab属性不存在，让代码使用get_vocab方法
+        delattr(mock_tokenizer, "vocab")
+        mock_tokenizer.get_vocab.return_value = {"a": 1, "b": 2}
+        result = get_vocab_dict(mock_tokenizer)
+        self.assertEqual(result, {"a": 1, "b": 2})
+
+    def test_tokenizer_vocab(self):
+        mock_tokenizer = MagicMock()
+        # 确保vocab和get_vocab都不存在
+        delattr(mock_tokenizer, "vocab")
+        delattr(mock_tokenizer, "get_vocab")
+
+        mock_inner_tokenizer = MagicMock()
+        mock_inner_tokenizer.vocab = {"x": 1}
+        mock_tokenizer.tokenizer = mock_inner_tokenizer
+
+        result = get_vocab_dict(mock_tokenizer)
+        self.assertEqual(result, {"x": 1})
+
+    def test_encoder_attribute(self):
+        mock_tokenizer = MagicMock()
+        # 确保其他属性都不存在
+        delattr(mock_tokenizer, "vocab")
+        delattr(mock_tokenizer, "get_vocab")
+        delattr(mock_tokenizer, "tokenizer")
+
+        mock_tokenizer.encoder = {"token": 0}
+        result = get_vocab_dict(mock_tokenizer)
+        self.assertEqual(result, {"token": 0})
+
+    def test_no_vocab_available(self):
+        mock_tokenizer = MagicMock()
+        # 移除所有可能的属性
+        delattr(mock_tokenizer, "vocab")
+        delattr(mock_tokenizer, "get_vocab")
+        delattr(mock_tokenizer, "tokenizer")
+        delattr(mock_tokenizer, "encoder")
+
+        result = get_vocab_dict(mock_tokenizer)
+        self.assertEqual(result, {})
+
+    def test_exception_handling(self):
+        mock_tokenizer = MagicMock()
+        # 模拟所有方法都抛出异常
+        mock_tokenizer.vocab = {"a": 1}
+        mock_tokenizer.get_vocab.side_effect = Exception("Error")
+        result = get_vocab_dict(mock_tokenizer)
+        self.assertEqual(result, {"a": 1})
+
+
+class TestExportVocabulary(unittest.TestCase):
+    """测试export_vocabulary函数"""
+
+    def setUp(self):
+        self.mock_tokenizer = MagicMock()
+        self.mock_tokenizer.vocab = {"hello": 1, "world": 2, "test": 3}
+
+    def test_export_json_format(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_path = os.path.join(temp_dir, "vocab.json")
+
+            with patch("builtins.print") as mock_print:
+                export_vocabulary(self.mock_tokenizer, file_path)
+
+                # 验证文件内容
+                with open(file_path, "r", encoding="utf-8") as f:
+                    content = json.load(f)
+                self.assertEqual(content, {"hello": 1, "world": 2, "test": 3})
+
+                # 验证打印输出
+                mock_print.assert_any_call(f"Vocabulary exported to: {file_path}")
+                mock_print.assert_any_call("Total tokens: 3")
+
+    def test_export_text_format(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_path = os.path.join(temp_dir, "vocab.txt")
+
+            with patch("builtins.print"):
+                export_vocabulary(self.mock_tokenizer, file_path)
+
+                # 验证文件内容
+                with open(file_path, "r", encoding="utf-8") as f:
+                    lines = f.readlines()
+
+                self.assertEqual(len(lines), 3)
+                # 检查排序和格式 - 注意repr会添加引号
+                self.assertIn("1\t'hello'", lines[0])
+                self.assertIn("2\t'world'", lines[1])
+                self.assertIn("3\t'test'", lines[2])
+
+    def test_empty_vocabulary(self):
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.vocab = {}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_path = os.path.join(temp_dir, "vocab.json")
+
+            with patch("builtins.print") as mock_print:
+                export_vocabulary(mock_tokenizer, file_path)
+                mock_print.assert_any_call("Warning: Could not retrieve vocabulary from tokenizer")
+
+    def test_directory_creation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_path = os.path.join(temp_dir, "newdir", "vocab.json")
+
+            with patch("builtins.print"):
+                export_vocabulary(self.mock_tokenizer, file_path)
+
+                # 验证目录被创建
+                self.assertTrue(os.path.exists(os.path.dirname(file_path)))
+
+    def test_exception_handling(self):
+        with patch("pathlib.Path.mkdir", side_effect=Exception("Permission denied")):
+            with patch("builtins.print") as mock_print:
+                export_vocabulary(self.mock_tokenizer, "/invalid/path/vocab.json")
+                mock_print.assert_any_call("Error exporting vocabulary: Permission denied")
+
+
+class TestMainFunction(unittest.TestCase):
+    """测试main函数"""
+
+    def setUp(self):
+        self.mock_tokenizer = MagicMock()
+        self.mock_preprocessor = MagicMock()
+        self.mock_preprocessor.create_processor.return_value.tokenizer = self.mock_tokenizer
+
+    def test_no_arguments(self):
+        args = argparse.Namespace(
+            model_name_or_path="test/model",
+            encode=None,
+            decode=None,
+            vocab_size=False,
+            info=False,
+            vocab_export=None,
+            enable_mm=False,
+        )
+
+        with patch("builtins.print") as mock_print:
+            main(args)
+            mock_print.assert_called_with(
+                "请至少指定一个参数：--encode, --decode, --vocab-size, --info, --export-vocab"
+            )
+
+    def test_encode_operation(self):
+        self.mock_tokenizer.encode.return_value = [101, 102, 103]
+
+        args = argparse.Namespace(
+            model_name_or_path="test/model",
+            encode="hello world",
+            decode=None,
+            vocab_size=False,
+            info=False,
+            vocab_export=None,
+            enable_mm=False,
+        )
+
+        with patch("fastdeploy.entrypoints.cli.tokenizer.InputPreprocessor", return_value=self.mock_preprocessor):
+            with patch("builtins.print") as mock_print:
+                main(args)
+
+                self.mock_tokenizer.encode.assert_called_once_with("hello world")
+                mock_print.assert_any_call("Input text: hello world")
+                mock_print.assert_any_call("Encoded tokens: [101, 102, 103]")
+
+    def test_decode_operation_list_string(self):
+        self.mock_tokenizer.decode.return_value = "decoded text"
+
+        args = argparse.Namespace(
+            model_name_or_path="test/model",
+            encode=None,
+            decode="[1,2,3]",
+            vocab_size=False,
+            info=False,
+            vocab_export=None,
+            enable_mm=False,
+        )
+
+        with patch("fastdeploy.entrypoints.cli.tokenizer.InputPreprocessor", return_value=self.mock_preprocessor):
+            with patch("builtins.print") as mock_print:
+                main(args)
+
+                self.mock_tokenizer.decode.assert_called_once_with([1, 2, 3])
+                mock_print.assert_any_call("Decoded text: decoded text")
+
+    def test_decode_operation_comma_string(self):
+        self.mock_tokenizer.decode.return_value = "decoded text"
+
+        args = argparse.Namespace(
+            model_name_or_path="test/model",
+            encode=None,
+            decode="1,2,3",
+            vocab_size=False,
+            info=False,
+            vocab_export=None,
+            enable_mm=False,
+        )
+
+        with patch("fastdeploy.entrypoints.cli.tokenizer.InputPreprocessor", return_value=self.mock_preprocessor):
+            with patch("builtins.print"):
+                main(args)
+
+                self.mock_tokenizer.decode.assert_called_once_with([1, 2, 3])
+
+    def test_decode_operation_already_list(self):
+        self.mock_tokenizer.decode.return_value = "decoded text"
+
+        args = argparse.Namespace(
+            model_name_or_path="test/model",
+            encode=None,
+            decode=[1, 2, 3],
+            vocab_size=False,
+            info=False,
+            vocab_export=None,
+            enable_mm=False,
+        )
+
+        with patch("fastdeploy.entrypoints.cli.tokenizer.InputPreprocessor", return_value=self.mock_preprocessor):
+            with patch("builtins.print"):
+                main(args)
+                self.mock_tokenizer.decode.assert_called_once_with([1, 2, 3])
+
+    def test_decode_exception_handling(self):
+        args = argparse.Namespace(
+            model_name_or_path="test/model",
+            encode=None,
+            decode="invalid[1,2",  # 无效的字符串
+            vocab_size=False,
+            info=False,
+            vocab_export=None,
+            enable_mm=False,
+        )
+
+        with patch("fastdeploy.entrypoints.cli.tokenizer.InputPreprocessor", return_value=self.mock_preprocessor):
+            with patch("builtins.print") as mock_print:
+                main(args)
+                # 检查是否有包含"Error decoding tokens:"的打印调用
+                error_calls = [
+                    call for call in mock_print.call_args_list if call[0] and "Error decoding tokens:" in call[0][0]
+                ]
+                self.assertTrue(len(error_calls) > 0)
+
+    def test_vocab_size_operation(self):
+        args = argparse.Namespace(
+            model_name_or_path="test/model",
+            encode=None,
+            decode=None,
+            vocab_size=True,
+            info=False,
+            vocab_export=None,
+            enable_mm=False,
+        )
+
+        with patch("fastdeploy.entrypoints.cli.tokenizer.InputPreprocessor", return_value=self.mock_preprocessor):
+            with patch("fastdeploy.entrypoints.cli.tokenizer.get_vocab_size", return_value=1000) as mock_get_size:
+                with patch("builtins.print") as mock_print:
+                    main(args)
+
+                    mock_get_size.assert_called_once_with(self.mock_tokenizer)
+                    mock_print.assert_any_call("Vocabulary size: 1000")
+
+    def test_info_operation(self):
+        mock_info = {"vocab_size": 1000, "model_name": "test"}
+
+        args = argparse.Namespace(
+            model_name_or_path="test/model",
+            encode=None,
+            decode=None,
+            vocab_size=False,
+            info=True,
+            vocab_export=None,
+            enable_mm=False,
+        )
+
+        with patch("fastdeploy.entrypoints.cli.tokenizer.InputPreprocessor", return_value=self.mock_preprocessor):
+            with patch(
+                "fastdeploy.entrypoints.cli.tokenizer.get_tokenizer_info", return_value=mock_info
+            ) as mock_get_info:
+                with patch("builtins.print") as mock_print:
+                    main(args)
+
+                    mock_get_info.assert_called_once_with(self.mock_tokenizer)
+                    mock_print.assert_any_call(json.dumps(mock_info, indent=2))
+
+    def test_vocab_export_operation(self):
+        args = argparse.Namespace(
+            model_name_or_path="test/model",
+            encode=None,
+            decode=None,
+            vocab_size=False,
+            info=False,
+            vocab_export="/path/to/vocab.json",
+            enable_mm=False,
+        )
+
+        with patch("fastdeploy.entrypoints.cli.tokenizer.InputPreprocessor", return_value=self.mock_preprocessor):
+            with patch("fastdeploy.entrypoints.cli.tokenizer.export_vocabulary") as mock_export:
+                with patch("builtins.print"):
+                    main(args)
+
+                    mock_export.assert_called_once_with(self.mock_tokenizer, "/path/to/vocab.json")
+
+    def test_multiple_operations(self):
+        self.mock_tokenizer.encode.return_value = [1]
+        self.mock_tokenizer.decode.return_value = "test"
+
+        args = argparse.Namespace(
+            model_name_or_path="test/model",
+            encode="hello",
+            decode="1",
+            vocab_size=True,
+            info=True,
+            vocab_export="/path/to/vocab",
+            enable_mm=False,
+        )
+
+        with patch("fastdeploy.entrypoints.cli.tokenizer.InputPreprocessor", return_value=self.mock_preprocessor):
+            with patch("fastdeploy.entrypoints.cli.tokenizer.get_vocab_size", return_value=100):
+                with patch("fastdeploy.entrypoints.cli.tokenizer.get_tokenizer_info", return_value={"size": 100}):
+                    with patch("fastdeploy.entrypoints.cli.tokenizer.export_vocabulary") as mock_export:
+                        with patch("builtins.print") as mock_print:
+                            main(args)
+
+                            # 验证所有操作都被调用
+                            self.assertEqual(self.mock_tokenizer.encode.call_count, 1)
+                            self.assertEqual(self.mock_tokenizer.decode.call_count, 1)
+                            mock_export.assert_called_once()
+
+                            # 验证操作计数
+                            mock_print.assert_any_call("Completed 5 operation(s)")
+
+
+class TestIntegration(unittest.TestCase):
+    """集成测试"""
+
+    def test_full_workflow(self):
+        # 测试完整的CLI工作流程
+        subcommand = TokenizerSubcommand()
+        mock_subparsers = MagicMock()
+        mock_parser = MagicMock()
+        mock_subparsers.add_parser.return_value = mock_parser
+
+        # 初始化解析器
+        subcommand.subparser_init(mock_subparsers)
+
+        # 测试cmd方法
+        args = argparse.Namespace(
+            model_name_or_path="test/model", encode="test", decode=None, vocab_size=True, info=False, vocab_export=None
+        )
+
+        with patch("fastdeploy.entrypoints.cli.tokenizer.main") as mock_main:
+            subcommand.cmd(args)
+            mock_main.assert_called_once_with(args)
+
+    def test_main_functionality(self):
+        """测试main函数的整体功能"""
+        args = argparse.Namespace(
+            model_name_or_path="test/model",
+            encode="hello",
+            decode="1",
+            vocab_size=True,
+            info=True,
+            vocab_export=None,
+            enable_mm=False,
+        )
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.encode.return_value = [1]
+        mock_tokenizer.decode.return_value = "hello"
+
+        mock_preprocessor = MagicMock()
+        mock_preprocessor.create_processor.return_value.tokenizer = mock_tokenizer
+
+        with patch("fastdeploy.entrypoints.cli.tokenizer.InputPreprocessor", return_value=mock_preprocessor):
+            with patch("fastdeploy.entrypoints.cli.tokenizer.get_vocab_size", return_value=1000):
+                with patch("fastdeploy.entrypoints.cli.tokenizer.get_tokenizer_info", return_value={"info": "test"}):
+                    with patch("builtins.print") as mock_print:
+                        main(args)
+
+                        # 验证基本功能正常
+                        self.assertTrue(mock_print.called)
+                        # 验证encode和decode被调用
+                        mock_tokenizer.encode.assert_called_once_with("hello")
+                        mock_tokenizer.decode.assert_called_once_with([1])
+
+
+# class TestTokenizerCli(unittest.TestCase):
+#     def setUp(self):
+#         self.test_args = argparse.Namespace()
+#         self.test_args.model_name_or_path = "baidu/ERNIE-4.5-0.3B-PT"
+#         self.test_args.encode = "Hello, world!"
+#         self.test_args.decode = "[1, 2, 3]"
+#         self.test_args.vocab_size = True
+#         self.test_args.info = True
+#         self.tmpdir = tempfile.TemporaryDirectory()
+#         self.test_args.vocab_export = os.path.join(self.tmpdir.name, "vocab.txt")
+
+#     def tearDown(self):
+#         self.tmpdir.cleanup()
+
+#     def test_main(self):
+#         result = main(self.test_args)
+#         self.assertIsNotNone(result)
+#         self.assertTrue(os.path.exists(self.test_args.vocab_export))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
### PR 描述

为 **FastDeploy CLI** 新增 `tokenizer` 子命令，提供以下功能：

- **模型**：支持通过`--model/-m`指定模型
- **编码/解码**：支持通过 `--encode/-e` 将文本编码为 tokens，或通过 `--decode/-d` 将 tokens 解码为文本。
- **词表相关功能**：
  - `--vocab-size/-vs`：查看词表大小
  - `--info/-i`：查看 tokenizer 的详细信息（特殊符号、ID、最大长度等）
  - `--vocab-export FILE/-ve FILE`：导出词表到文件（支持 `.json` 或文本格式）

### 主要改动

- 新增 `TokenizerSubcommand`，注册到 CLI 子命令系统。
- 实现 `get_vocab_size`、`get_tokenizer_info`、`get_vocab_dict` 等工具方法。
- 支持词表导出，并处理不可打印字符。
- 增加操作输出分隔符，提升 CLI 使用体验。

### 用法示例

```bash
# 编码
fastdeploy tokenizer --model baidu/ERNIE-4.5-0.3B-PT --encode "Hello, world!"

# 解码
fastdeploy tokenizer --model baidu/ERNIE-4.5-0.3B-PT --decode "[1, 2, 3]"

# 查看词表大小
fastdeploy tokenizer --model baidu/ERNIE-4.5-0.3B-PT --vocab-size

# 查看词表元信息
fastdeploy tokenizer --model baidu/ERNIE-4.5-0.3B-PT --info

# 导出词表
fastdeploy tokenizer --model baidu/ERNIE-4.5-0.3B-PT --vocab-export ./vocab.txt

# 支持多模模型
fastdeploy tokenizer --model  baidu/EB-VL-Lite-d  --decode "[5300, 96382]"

# 支持多个同时查看,以及参数简写
fastdeploy tokenizer -m  baidu/ERNIE-4.5-0.3B-PT -e "你好哇" -d "[5300, 96382]"  -i -vs -ve vocab.json
```

