### PR TITLE
【fix】Remove the logic that assigns the default value of 80% to reasoning_max_tokens in the offline component of FastDeploy

### DIFF
--- a/fastdeploy/engine/engine.py
+++ b/fastdeploy/engine/engine.py
@@ -236,9 +236,6 @@ class LLMEngine:
                 request.get("max_tokens"),
             ),
         )
-        if request.get("reasoning_max_tokens") is None:
-            default_reasoning_max_tokens = max(int(request.get("max_tokens") * 0.8), 1)
-            request.set("reasoning_max_tokens", default_reasoning_max_tokens)
         min_tokens = request.get("min_tokens")
         if input_ids_len + min_tokens >= self.cfg.max_model_len:
             error_msg = (


### PR DESCRIPTION
Remove the logic that assigns the default value of 80% to reasoning_max_tokens in the offline component of FastDeploy