### PR TITLE
【Inference Optimize】Calculate paddle_peak_increase using paddle_allocated_mem_after_run

### DIFF
--- a/fastdeploy/worker/gpu_worker.py
+++ b/fastdeploy/worker/gpu_worker.py
@@ -141,7 +141,7 @@ class GpuWorker(WorkerBase):
         paddle_allocated_mem_after_run = paddle.device.cuda.max_memory_allocated(local_rank)
 
         model_block_memory_used = self.cal_theortical_kvcache()
-        paddle_peak_increase = paddle_reserved_mem_after_run - paddle_allocated_mem_before_run
+        paddle_peak_increase = paddle_allocated_mem_after_run - paddle_allocated_mem_before_run
 
         paddle.device.cuda.empty_cache()
 


### PR DESCRIPTION
Calculate paddle_peak_increase using paddle_allocated_mem_after_run：
`paddle_peak_increase = paddle_allocated_mem_after_run - paddle_allocated_mem_before_run`
This way paddle_peak_increase is closer to the actual situation.

The `reserved` variable returns the current memory size managed by the Allocator. The `allocated` variable returns the current memory size allocated to the Tensor. The difference we are concerned about here is the memory size allocated to the active Tensor before and after the profile. Therefore, theoretically, using `paddle_allocated_mem_after_run - paddle_allocated_mem_before_run` can meet the requirement. Using `reserved` may cause the calculated difference to be artificially high, resulting in a smaller memory size allocated to the kv-cache

