### PR TITLE
[CI] Fix partial instability issues

### DIFF
--- a/.github/workflows/_accuracy_test.yml
+++ b/.github/workflows/_accuracy_test.yml
@@ -55,7 +55,7 @@ jobs:
               fi
             '
 
-            wget -q ${fd_archive_url}
+            wget -q --no-proxy ${fd_archive_url}
             tar -xf FastDeploy.tar.gz
             rm -rf FastDeploy.tar.gz
             cd FastDeploy

--- a/.github/workflows/_base_test.yml
+++ b/.github/workflows/_base_test.yml
@@ -55,7 +55,7 @@ jobs:
               fi
             '
 
-            wget -q ${fd_archive_url}
+            wget -q --no-proxy ${fd_archive_url}
             tar -xf FastDeploy.tar.gz
             rm -rf FastDeploy.tar.gz
             cd FastDeploy

--- a/.github/workflows/_build_linux.yml
+++ b/.github/workflows/_build_linux.yml
@@ -82,7 +82,7 @@ jobs:
               fi
             '
 
-            wget -q ${fd_archive_url}
+            wget -q --no-proxy ${fd_archive_url}
             tar -xf FastDeploy.tar.gz
             rm -rf FastDeploy.tar.gz
             cd FastDeploy

--- a/.github/workflows/_ci_image_build.yml
+++ b/.github/workflows/_ci_image_build.yml
@@ -53,7 +53,7 @@ jobs:
               fi
             '
 
-            wget -q ${fd_archive_url}
+            wget -q --no-proxy ${fd_archive_url}
             tar -xf FastDeploy.tar.gz
             rm -rf FastDeploy.tar.gz
             cd FastDeploy

--- a/.github/workflows/_logprob_test_linux.yml
+++ b/.github/workflows/_logprob_test_linux.yml
@@ -32,6 +32,7 @@ on:
 jobs:
   run_tests_logprob:
     runs-on: [self-hosted, GPU-h20-1Cards]
+    timeout-minutes: 60
     steps:
       - name: Code Prepare
         shell: bash
@@ -47,7 +48,7 @@ jobs:
             ${docker_image} /bin/bash -c '
             rm -rf /workspace/*
             '
-            wget -q ${paddletest_archive_url}
+            wget -q --no-proxy ${paddletest_archive_url}
             tar -xf PaddleTest.tar.gz
             rm -rf PaddleTest.tar.gz
             cd PaddleTest

--- a/.github/workflows/_pre_ce_test.yml
+++ b/.github/workflows/_pre_ce_test.yml
@@ -57,7 +57,7 @@ jobs:
               fi
             '
 
-            wget -q ${fd_archive_url}
+            wget -q --no-proxy ${fd_archive_url}
             tar -xf FastDeploy.tar.gz
             rm -rf FastDeploy.tar.gz
             cd FastDeploy

--- a/.github/workflows/_stable_test.yml
+++ b/.github/workflows/_stable_test.yml
@@ -55,7 +55,7 @@ jobs:
               fi
             '
 
-            wget -q ${fd_archive_url}
+            wget -q --no-proxy ${fd_archive_url}
             tar -xf FastDeploy.tar.gz
             rm -rf FastDeploy.tar.gz
             cd FastDeploy

--- a/.github/workflows/_unit_test_coverage.yml
+++ b/.github/workflows/_unit_test_coverage.yml
@@ -71,7 +71,7 @@ jobs:
               fi
             '
 
-            wget -q ${fd_archive_url}
+            wget -q --no-proxy ${fd_archive_url}
             tar -xf FastDeploy.tar.gz
             rm -rf FastDeploy.tar.gz
             cd FastDeploy
@@ -300,7 +300,7 @@ jobs:
         env:
           diff_cov_file_url: ${{ needs.run_tests_with_coverage.outputs.diff_cov_file_url }}
         run: |
-          wget ${fd_archive_url}
+          wget -q --no-proxy ${fd_archive_url}
           tar -xf FastDeploy.tar.gz
           cd FastDeploy
           if [ -z "${diff_cov_file_url}" ]; then

--- a/.github/workflows/publish_job.yml
+++ b/.github/workflows/publish_job.yml
@@ -302,7 +302,7 @@ jobs:
               rm -rf ${REPO_NAME}*
             fi
           '
-          wget -q ${fd_archive_url}
+          wget -q --no-proxy ${fd_archive_url}
           tar -xf FastDeploy.tar.gz
           rm -rf FastDeploy.tar.gz
           cd FastDeploy

--- a/tests/cov_pytest.ini
+++ b/tests/cov_pytest.ini
@@ -6,3 +6,5 @@ addopts =
     --ignore=tests/operators/test_fused_moe.py
     --ignore=tests/operators/test_w4afp8_gemm.py
     --ignore=tests/model_loader/test_w4a8_model.py
+    --ignore=tests/operators/test_speculate_verify.py
+    --ignore=tests/e2e/test_DeepSeek_V3_5layers_serving.py


### PR DESCRIPTION
1. Remove unstable test cases `tests/operators/test_speculate_verify.py` and `tests/e2e/test_DeepSeek_V3_5layers_serving.py` 
2. Add execution timeout mechanism of `run_tests_logprob`
3. Add  `--no-proxy` in download fd_archive_url settings
