### PR TITLE
[CI] Temporarily skip cinn_graph tests due to instability

### DIFF
--- a/tests/graph_optimization/test_graph_opt_backend.py
+++ b/tests/graph_optimization/test_graph_opt_backend.py
@@ -192,6 +192,7 @@ class TestGraphOptBackend(unittest.TestCase):
         fd_config = self._setup_test_config(graph_opt_level=1, use_cudagraph=False)
         self._run_model_test(fd_config, "static_graph")
 
+    @unittest.skip("Temporarily skip this case due to CINN error.")
     def test_cinn_graph(self):
         """Test CINN optimization mode"""
         # Note: CINN is not opened yet
@@ -208,6 +209,7 @@ class TestGraphOptBackend(unittest.TestCase):
         fd_config = self._setup_test_config(graph_opt_level=1, use_cudagraph=True)
         self._run_model_test(fd_config, "static_graph_cudagraph")
 
+    @unittest.skip("Temporarily skip this case due to CINN error.")
     def test_cinn_graph_with_cudagraph(self):
         """Test CINN + CudaGraph mode"""
         # Note: CINN is not opened yet


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
[CI] Temporarily skip cinn_graph tests due to instability
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Remove `test_graph_opt_backend.py::TestGraphOptBackend::test_cinn_graph` and `test_graph_opt_backend.py::TestGraphOptBackend::test_cinn_graph_with_cudagraph` due to CINN error.
<!-- Detail the changes made in this pull request. -->

## Usage or Command
Fix CI
<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests
No need
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
