### PR TITLE
[Graph Optimization] Increase CustomAllreduce Buffer Size

### DIFF
--- a/fastdeploy/distributed/communication.py
+++ b/fastdeploy/distributed/communication.py
@@ -33,7 +33,7 @@ def capture_custom_allreduce():
         yield
 
 
-def use_custom_allreduce(custom_all_reduce_max_bytes: int = 8192 * 1024):
+def use_custom_allreduce(custom_all_reduce_max_bytes: int = 8192 * 1024 * 32 * 2):
     hcg = fleet.get_hybrid_communicate_group()
     model_parallel_group = hcg.get_model_parallel_group()
     global _TP_AR

--- a/fastdeploy/distributed/custom_all_reduce/custom_all_reduce.py
+++ b/fastdeploy/distributed/custom_all_reduce/custom_all_reduce.py
@@ -48,7 +48,7 @@ class CustomAllreduce:
     _SUPPORTED_WORLD_SIZES = [2, 4, 6, 8]
 
     # max_size: max supported allreduce size
-    def __init__(self, group: Group, max_size: int = 8192 * 1024) -> None:
+    def __init__(self, group: Group, max_size: int = 8192 * 1024 * 32 * 2) -> None:
         """
         Args:
             device: the device to bind the CustomAllreduce to. If None,
@@ -92,7 +92,7 @@ class CustomAllreduce:
         # 8*world_size bytes where world_size is at most 8. Allocating 8MB
         # is enough for 131072 such tuples. The largest model I've seen only
         # needs less than 10000 of registered tuples.
-        self.rank_data = paddle.empty([8 * 1024 * 1024], dtype=paddle.uint8)
+        self.rank_data = paddle.empty([8192 * 1024 * 32 * 2], dtype=paddle.uint8)
 
         self.max_size = max_size
         self.world_size = world_size


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
https://github.com/PaddlePaddle/FastDeploy/pull/4386#issuecomment-3409727960
Buffer 太小，SOT+Cudagraph 会报错，也可以用 `--max-num-batched-tokens 500` 规避

## Modifications
增大 CustomAllreduce 的 Buffer 大小

## Usage or Command
None

## Accuracy Tests
None

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.


cc @gongshaotian @SigureMo @zhink 