### PR TITLE
[CI] Add /re-run command in PR comments to restart failed CI workflows

### DIFF
--- a/.github/rerun-workflow/action.yml
+++ b/.github/rerun-workflow/action.yml
@@ -1,0 +1,30 @@
+name: 'Rerun Workflow'
+description: 'Re-run GitHub Actions workflow for a given Pull Request'
+inputs:
+  GITHUB_TOKEN:
+    description: 'GitHub token with repo scope'
+    required: true
+  OWNER:
+    description: 'Repository owner'
+    required: true
+  REPO:
+    description: 'Repository name'
+    required: true
+  PR_ID:
+    description: 'Pull Request ID'
+    required: true
+  JOB_NAME:
+    description: 'Job name to rerun'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - run: bash ./.github/actions/rerun-workflow/rerun.sh
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        OWNER: ${{ inputs.OWNER }}
+        REPO: ${{ inputs.REPO }}
+        PR_ID: ${{ inputs.PR_ID }}
+        JOB_NAME: ${{ inputs.JOB_NAME }}

--- a/.github/rerun-workflow/rerun.sh
+++ b/.github/rerun-workflow/rerun.sh
@@ -1,0 +1,77 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+COMMIT_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+  "https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_ID" | jq -r '.head.sha')
+
+echo "Commit SHA: $COMMIT_SHA"
+
+response=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+  "https://api.github.com/repos/$OWNER/$REPO/actions/runs?head_sha=$COMMIT_SHA&per_page=100")
+
+echo "Response: $response"
+
+run_ids=$(echo "$response" | jq -r '.workflow_runs[].id')
+
+if [ -n "$run_ids" ]; then
+  echo "Found run_ids for commit $COMMIT_SHA: $run_ids"
+
+  for run_id in $run_ids; do
+    if [ "$JOB_NAME" = "all-failed" ]; then
+      echo "Rerunning all failed jobs for run_id: $run_id"
+
+      rerun_response=$(curl -X POST -s -w "%{http_code}" -o /dev/null \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        "https://api.github.com/repos/$OWNER/$REPO/actions/runs/$run_id/rerun-failed-jobs")
+      if [ "$rerun_response" -eq 201 ]; then
+        echo "Successfully requested rerun for all blocked jobs in run_id: $run_id"
+      else
+        echo "Failed to request rerun for run_id: $run_id with status code $rerun_response"
+      fi
+
+    else
+      jobs_response=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+      "https://api.github.com/repos/$OWNER/$REPO/actions/runs/$run_id/jobs")
+
+      echo "Jobs Response for run_id $run_id: $jobs_response"
+
+      # if [[ "$JOB_NAME" == *"bypass"* ]]; then
+        block_jobs=$(echo "$jobs_response" | jq -r --arg job_name "$JOB_NAME" \
+        '.jobs[] | select(.name == $job_name) | .id')
+      # else
+      #   block_jobs=$(echo "$jobs_response" | jq -r --arg job_name "$JOB_NAME" \
+      #   '.jobs[] | select(.name == $job_name and .conclusion != "success") | .id')
+      # fi
+
+      if [ -n "$block_jobs" ]; then
+        echo "Found block jobs for run_id $run_id: $block_jobs"
+
+        for job_id in $block_jobs; do
+          echo "Rerunning job_id: $job_id"
+          curl -X POST -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/$OWNER/$REPO/actions/jobs/$job_id/rerun"
+        done
+      else
+        echo "No block jobs found for run_id $run_id with name $JOB_NAME."
+      fi
+    fi
+  done
+else
+  echo "No matching workflow runs found for commit $COMMIT_SHA."
+  exit 1
+fi

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,0 +1,157 @@
+name: Re-run
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  re-run:
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/re-run') && github.event.comment.user.login == github.event.issue.user.login }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
+
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Rerun all failed jobs
+        if: ${{ contains(github.event.comment.body, 'all-failed') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'all-failed'
+
+      - name: Rerun Approval
+        if: ${{ contains(github.event.comment.body, 'approval') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Approval'
+
+      - name: Rerun CI_ILUVATAR
+        if: ${{ contains(github.event.comment.body, 'ci_iluvatar') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'CI_ILUVATAR'
+
+      - name: Rerun CI_XPU
+        if: ${{ contains(github.event.comment.body, 'ci_xpu') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'CI_XPU'
+
+      - name: Rerun Codestyle-check
+        if: ${{ contains(github.event.comment.body, 'codestyle') || contains(github.event.comment.body, 'pre_commit') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Pre Commit'
+
+      - name: Rerun Clone
+        if: ${{ contains(github.event.comment.body, 'clone') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'FD-Clone-Linux / code-clone'
+
+      - name: Rerun Build
+        if: ${{ contains(github.event.comment.body, 'build') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'FD-Build-Linux / fd-build'
+
+      - name: Rerun run_ce_cases
+        if: ${{ contains(github.event.comment.body, 'run_ce_cases') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Extracted partial CE model tasks to run in CI. / run_ce_cases'
+
+      - name: Rerun accuracy_tests
+        if: ${{ contains(github.event.comment.body, 'accuracy_tests') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Run Accuracy Tests / accuracy_tests'
+
+      - name: Rerun base_tests
+        if: ${{ contains(github.event.comment.body, 'base_tests') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Run Base Tests / base_tests'
+
+      - name: Rerun run_tests_logprob
+        if: ${{ contains(github.event.comment.body, 'run_tests_logprob') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Run FastDeploy LogProb Tests / run_tests_logprob'
+
+      - name: Rerun run_tests_with_coverage
+        if: ${{ contains(github.event.comment.body, 'run_tests_with_coverage') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Run FastDeploy Unit Tests and Coverage / run_tests_with_coverage'
+
+      - name: Rerun diff_coverage_report
+        if: ${{ contains(github.event.comment.body, 'diff_coverage_report') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Run FastDeploy Unit Tests and Coverage / diff_coverage_report'
+
+      - name: Rerun stable_tests
+        if: ${{ contains(github.event.comment.body, 'stable_tests') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Run Stable Tests / stable_tests'


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
This PR adds the ability to use the `/re-run` command in PR comments to easily restart any failed CI workflows.  
It aims to improve the developer experience when handling flaky tests or temporary CI issues.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- Added new GitHub Actions workflow file: `.github/workflows/rerun.yml`
- The workflow listens to `issue_comment` events and checks if the comment contains `/re-run`
- Supports selective reruns for specific CI jobs by matching keywords such as:
  - `all-failed`, `approval`, `ci_iluvatar`, `ci_xpu`, `codestyle`, `clone`, `build`, `run_ce_cases`, `accuracy_tests`, `base_tests`, `run_tests_logprob`, `run_tests_with_coverage`, `stable_tests`,etc.
- Automatically ensures rerun requests are only accepted from the PR author
<!-- Detail the changes made in this pull request. -->

## Usage or Command
To re-run CI jobs, comment the following under your Pull Request:

```bash
/re-run all-failed              # all-failed
/re-run approval                # Approval
/re-run ci_iluvatar             # CI_ILUVATAR
/re-run ci_xpu                  # CI_XPU
/re-run codestyle               # Pre Commit(alias: /re-run pre_commit)
/re-run clone                   # FD-Clone-Linux / code-clone
/re-run build                   # FD-Build-Linux / fd-build
/re-run run_ce_cases            # Extracted partial CE model tasks to run in CI. / run_ce_cases
/re-run accuracy_tests          # Run Accuracy Tests / accuracy_tests
/re-run base_tests              # Run Base Tests / base_tests
/re-run run_tests_logprob       # Run FastDeploy LogProb Tests / run_tests_logprob
/re-run run_tests_with_coverage # Run FastDeploy Unit Tests and Coverage / run_tests_with_coverage
/re-run diff_coverage_report    # Run FastDeploy Unit Tests and Coverage / diff_coverage_report
/re-run stable_tests            # Run Stable Tests / stable_tests
```
<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests
This PR only modifies GitHub workflow logic and does not affect model accuracy or inference results.
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.

## Note:

1.	Commands must be commented by the PR author to take effect.
Only the pull request author’s comments will trigger the re-run workflow.
2.	You can trigger multiple re-runs by commenting several commands.
Each /re-run command can be used independently to restart different CI workflows.
3.	Task dependencies and re-run timing:
	•	The following jobs belong to the same execution group:```clone, build, run_ce_cases, accuracy_tests, base_tests, run_tests_logprob, run_tests_with_coverage, stable_tests.```
	•	These jobs have a dependency chain:
	       •	✅ clone → automatically triggers build after success
	       •	✅ build → automatically triggers all test jobs: ```run_ce_cases, accuracy_tests, base_tests, run_tests_logprob, run_tests_with_coverage, stable_tests.```
               •	⚠️ Re-run restriction: **Jobs in the same execution group can only be re-run after all jobs in the group have finished. Triggering a re-run before dependent jobs complete will not take effect.**

## Acknowledgements

- Modification method reference: PaddlePaddle implementation
- Thanks to @SigureMo  and @DrRyanHuang  for their guidance.