### PR TITLE
[Feature] Support attention dp balance for mixed deployment

### DIFF
--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -1133,6 +1133,8 @@ class FDConfig:
         early_stop_config: Optional[Dict[str, Any]] = None,
         tool_parser: str = None,
         test_mode=False,
+        enable_attention_dp_balance: bool = False,
+        attention_dp_time_out_iters: int = 0,
     ):
         self.model_config: ModelConfig = model_config  # type: ignore
         self.cache_config: CacheConfig = cache_config  # type: ignore
@@ -1147,6 +1149,8 @@ class FDConfig:
         self.decoding_config: DecodingConfig = decoding_config  # type: ignore
         self.cache_config: CacheConfig = cache_config  # type: ignore
         self.moba_attention_config: Optional[MobaAttentionConfig] = moba_attention_config
+        self.enable_attention_dp_balance = enable_attention_dp_balance
+        self.attention_dp_time_out_iters = attention_dp_time_out_iters
         # Initialize cuda graph capture list
         if self.graph_opt_config.cudagraph_capture_sizes is None:
             self.graph_opt_config._set_cudagraph_sizes(max_num_seqs=self.parallel_config.max_num_seqs)

--- a/fastdeploy/engine/args_utils.py
+++ b/fastdeploy/engine/args_utils.py
@@ -386,6 +386,16 @@ class EngineArgs:
     Flag to specify the dtype of lm_head as FP32. Default is False (Using model default dtype).
     """
 
+    enable_attention_dp_balance: bool = False
+    """
+    Flag to enable attention dp balance
+    """
+
+    attention_dp_time_out_iters: int = 0
+    """
+    Max waiting steps to sync all dp for prefill tasks available
+    """
+
     def __post_init__(self):
         """
         Post-initialization processing to set default tokenizer if not provided.
@@ -810,6 +820,20 @@ class EngineArgs:
             help="ports for rdma communication.",
         )
 
+        perf_group.add_argument(
+            "--enable_attention_dp_balance",
+            action="store_true",
+            default=EngineArgs.enable_attention_dp_balance,
+            help="enable attention dp balance",
+        )
+
+        perf_group.add_argument(
+            "--attention_dp_time_out_iters",
+            type=int,
+            default=EngineArgs.attention_dp_time_out_iters,
+            help="max waiting steps to sync all dp for prefill tasks available",
+        )
+
         # Scheduler parameters group
         scheduler_group = parser.add_argument_group("Scheduler")
         scheduler_group.add_argument(
@@ -1079,4 +1103,6 @@ class EngineArgs:
             guided_decoding_backend=self.guided_decoding_backend,
             disable_any_whitespace=self.guided_decoding_disable_any_whitespace,
             early_stop_config=early_stop_cfg,
+            enable_attention_dp_balance=self.enable_attention_dp_balance,
+            attention_dp_time_out_iters=self.attention_dp_time_out_iters,
         )

--- a/fastdeploy/engine/args_utils.py
+++ b/fastdeploy/engine/args_utils.py
@@ -821,14 +821,14 @@ class EngineArgs:
         )
 
         perf_group.add_argument(
-            "--enable_attention_dp_balance",
+            "--enable-attention-dp-balance",
             action="store_true",
             default=EngineArgs.enable_attention_dp_balance,
             help="enable attention dp balance",
         )
 
         perf_group.add_argument(
-            "--attention_dp_time_out_iters",
+            "--attention-dp-time-out-iters",
             type=int,
             default=EngineArgs.attention_dp_time_out_iters,
             help="max waiting steps to sync all dp for prefill tasks available",

--- a/fastdeploy/engine/engine.py
+++ b/fastdeploy/engine/engine.py
@@ -459,6 +459,7 @@ class LLMEngine:
             f" --early_stop_config '{self.cfg.early_stop_config.to_json_string()}'"
             f" --load_choices {self.cfg.load_config.load_choices}"
             f" --moba_attention_config '{self.cfg.moba_attention_config.to_json_string()}'"
+            f" --attention_dp_time_out_iters {self.cfg.attention_dp_time_out_iters}"
             f" --ips {ips}"
         )
 
@@ -473,6 +474,7 @@ class LLMEngine:
             "use_internode_ll_two_stage": self.cfg.parallel_config.use_internode_ll_two_stage,
             "enable_logprob": self.cfg.model_config.enable_logprob,
             "lm_head_fp32": self.cfg.model_config.lm_head_fp32,
+            "enable_attention_dp_balance": self.cfg.enable_attention_dp_balance,
         }
         for worker_flag, value in worker_append_flag.items():
             if value:

--- a/fastdeploy/rl/rollout_config.py
+++ b/fastdeploy/rl/rollout_config.py
@@ -62,6 +62,8 @@ class RolloutModelConfig:
         moba_attention_config: str = None,
         data_parallel_size: int = 1,
         num_nextn_predict_layers: int = 0,
+        enable_attention_dp_balance: bool = False,
+        attention_dp_time_out_iters: int = 0,
     ):
         # Required parameters
         self.model = model_name_or_path
@@ -109,6 +111,8 @@ class RolloutModelConfig:
         self.ips = None
         self.moba_attention_config = moba_attention_config
         self.num_nextn_predict_layers = num_nextn_predict_layers
+        self.enable_attention_dp_balance = enable_attention_dp_balance
+        self.attention_dp_time_out_iters = attention_dp_time_out_iters
 
     def __str__(self):
         return "\n".join(f"{k}: {v}" for k, v in self.__dict__.items())

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -172,6 +172,22 @@ class GPUModelRunner(ModelRunnerBase):
         else:
             return 0
 
+    def exist_decode(self):
+        """
+        check whether decode stage exist
+        """
+        if paddle.any(self.share_inputs["seq_lens_decoder"].cast("int64") >= self.share_inputs["prompt_lens"]):
+            return 1
+        else:
+            return 0
+
+    def get_real_bsz(self):
+        real_bsz = 0
+        for i in range(self.share_inputs["stop_flags"].shape[0] - 1, -1, -1):
+            if not self.share_inputs["stop_flags"][i][0]:
+                return i + 1
+        return real_bsz
+
     def _init_speculative_proposer(self):
         """
         Init speculative proposer
@@ -1652,6 +1668,8 @@ class GPUModelRunner(ModelRunnerBase):
                 self.speculative_config.num_speculative_tokens,
             )
 
+        if num_running_requests is None:
+            num_running_requests = self.get_real_bsz()
         self.seq_lens_this_time_buffer[:num_running_requests].copy_(
             self.share_inputs["seq_lens_this_time"][:num_running_requests], False
         )

--- a/fastdeploy/worker/gpu_worker.py
+++ b/fastdeploy/worker/gpu_worker.py
@@ -97,7 +97,7 @@ class GpuWorker(WorkerBase):
 
     def exist_decode(self):
         """
-        check whether prefill stage exist
+        check whether decode stage exist
         """
         return self.model_runner.exist_decode()
 

--- a/fastdeploy/worker/gpu_worker.py
+++ b/fastdeploy/worker/gpu_worker.py
@@ -95,6 +95,18 @@ class GpuWorker(WorkerBase):
         """
         return self.model_runner.exist_prefill()
 
+    def exist_decode(self):
+        """
+        check whether prefill stage exist
+        """
+        return self.model_runner.exist_decode()
+
+    def get_real_bsz(self):
+        """
+        Get real bsz
+        """
+        return self.model_runner.get_real_bsz()
+
     def determine_available_memory(self) -> int:
         """
         Profiles the peak memory usage of the model to determine how much

--- a/fastdeploy/worker/worker_base.py
+++ b/fastdeploy/worker/worker_base.py
@@ -97,18 +97,18 @@ class WorkerBase(ABC):
         """Basic health check (override for device-specific checks)."""
         return NotImplementedError
 
-    def exist_prefill(self) -> None:
+    def exist_prefill(self):
         """check whether prefill stage exist."""
-        raise True
+        return True
 
-    def exist_decode(self) -> None:
+    def exist_decode(self):
         """
         check whether decode stage exist
         """
-        raise False
+        return False
 
-    def get_real_bsz(self) -> None:
+    def get_real_bsz(self):
         """
         Get real bsz
         """
-        raise 0
+        return 0

--- a/fastdeploy/worker/worker_base.py
+++ b/fastdeploy/worker/worker_base.py
@@ -97,21 +97,18 @@ class WorkerBase(ABC):
         """Basic health check (override for device-specific checks)."""
         return NotImplementedError
 
-    @abstractmethod
     def exist_prefill(self) -> None:
         """check whether prefill stage exist."""
-        raise NotImplementedError
+        raise True
 
-    @abstractmethod
     def exist_decode(self) -> None:
         """
         check whether decode stage exist
         """
-        raise NotImplementedError
+        raise False
 
-    @abstractmethod
     def get_real_bsz(self) -> None:
         """
         Get real bsz
         """
-        raise NotImplementedError
+        raise 0

--- a/fastdeploy/worker/worker_base.py
+++ b/fastdeploy/worker/worker_base.py
@@ -97,6 +97,21 @@ class WorkerBase(ABC):
         """Basic health check (override for device-specific checks)."""
         return NotImplementedError
 
-    def exist_prefill(self):
+    @abstractmethod
+    def exist_prefill(self) -> None:
         """check whether prefill stage exist."""
-        return True
+        raise NotImplementedError
+
+    @abstractmethod
+    def exist_decode(self) -> None:
+        """
+        check whether decode stage exist
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_real_bsz(self) -> None:
+        """
+        Get real bsz
+        """
+        raise NotImplementedError

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -280,7 +280,6 @@ class PaddleDisWorkerProc:
                 )
 
             self.insert_step = False
-            req_dicts = None
             self.worker_healthy_live_signal.value[local_rank % self.max_chips_per_node] = int(time.time())
 
             # The first worker detects whether there are tasks in the task queue
@@ -339,13 +338,6 @@ class PaddleDisWorkerProc:
                     num_running_requests = int(bsz)
                     req_dicts.extend(req_dict)
 
-            if (not self.parallel_config.use_ep) and (not self.worker.model_runner.not_need_stop()):
-                if self.ranks > 1:
-                    paddle.distributed.barrier(self.parallel_config.tp_group)
-
-                time.sleep(0.001)
-                continue
-
             if (
                 envs.ENABLE_V1_KVCACHE_SCHEDULER
                 and self.fd_config.enable_attention_dp_balance
@@ -393,6 +385,11 @@ class PaddleDisWorkerProc:
                     f"Rank: {self.local_rank}, num_running_requests: {num_running_requests}, "
                     f"num_insert_requests: {len(req_dicts)}, req_ids: {req_ids}"
                 )
+            if (not self.parallel_config.use_ep) and (not self.worker.model_runner.not_need_stop()):
+                if self.ranks > 1:
+                    paddle.distributed.barrier(self.parallel_config.tp_group)
+                time.sleep(0.001)
+                continue
             # Execute model to generate token. The generated token will be written to the buffer.
             # These generated tokens can be obtained through get_output op.
             self.worker.execute_model(req_dicts, num_running_requests)

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -39,6 +39,7 @@ from fastdeploy.config import (
     ParallelConfig,
     SpeculativeConfig,
 )
+from fastdeploy.engine.request import RequestType
 from fastdeploy.input.ernie4_5_tokenizer import Ernie4_5Tokenizer
 from fastdeploy.inter_communicator import EngineWorkerQueue as TaskQueue
 from fastdeploy.inter_communicator import IPCSignal
@@ -263,6 +264,8 @@ class PaddleDisWorkerProc:
         num_running_requests = 0
         local_rank = self.local_rank % self.parallel_config.tensor_parallel_size
         self.model_weights_signal = np.zeros([1], dtype=np.int32)
+        attention_dp_cached_prefill_tasks = []
+        attention_dp_wait_prefill_iters = 0
         while True:
             if local_rank == 0:
                 if self.model_weights_status.value[0] != 0:
@@ -320,6 +323,7 @@ class PaddleDisWorkerProc:
                     self.model_weights_signal[0] = 0
                     logger.info(f"Rank: {self.local_rank} has updated or cleared parameters.")
 
+            req_dicts = []
             if self.exist_task_signal.value[0] == 1 or self.task_queue.read_finish_flag.get() == 1:
                 logger.info(f"Rank: {self.local_rank} Detected new requests.")
                 self.insert_step = True
@@ -330,19 +334,10 @@ class PaddleDisWorkerProc:
                     self.exist_task_signal.value[0] = 0
                     self.task_queue.read_finish_flag.set(0)
 
-                req_dicts = []
+                # req_dicts = []
                 for req_dict, bsz in tasks:
                     num_running_requests = int(bsz)
                     req_dicts.extend(req_dict)
-
-                req_ids = [req.request_id for req in req_dicts]
-                logger.info(
-                    f"Rank: {self.local_rank}, num_running_requests: {num_running_requests}, "
-                    f"num_insert_requests: {len(req_dicts)}, req_ids: {req_ids}"
-                )
-
-                # Process prefill inputs
-                self.worker.preprocess_new_task(req_dicts, num_running_requests)
 
             if (not self.parallel_config.use_ep) and (not self.worker.model_runner.not_need_stop()):
                 if self.ranks > 1:
@@ -351,6 +346,53 @@ class PaddleDisWorkerProc:
                 time.sleep(0.001)
                 continue
 
+            if (
+                envs.ENABLE_V1_KVCACHE_SCHEDULER
+                and self.fd_config.enable_attention_dp_balance
+                and self.parallel_config.splitwise_role == "mixed"
+            ):
+                exist_decode = self.worker.exist_decode()
+                exist_prefill = False
+                tmp_need_cached_prefills = []
+                if len(req_dicts) > 0:
+                    for request in req_dicts:
+                        if request.task_type.value == RequestType.PREFILL.value:
+                            tmp_need_cached_prefills.append(request)
+                if tmp_need_cached_prefills:
+                    attention_dp_cached_prefill_tasks.append(tmp_need_cached_prefills)
+                for request in tmp_need_cached_prefills:
+                    req_dicts.remove(request)
+                # judge whether all ranks have prefill tasks
+                if (len(attention_dp_cached_prefill_tasks) > 0) or (not exist_decode):
+                    exist_prefill = True
+                only_prefill_batch_list = []
+                paddle.distributed.all_gather_object(only_prefill_batch_list, exist_prefill)
+                if_only_prefill = all(only_prefill_batch_list)
+                if if_only_prefill:  # all ranks have prefill tasks
+                    # add a prefill task to current step
+                    if len(attention_dp_cached_prefill_tasks) > 0:
+                        req_dicts.extend(attention_dp_cached_prefill_tasks.pop(0))
+                    attention_dp_wait_prefill_iters = 0
+                else:
+                    # wait until all ranks have prefill tasks or reached timeout
+                    attention_dp_wait_prefill_iters += 1
+                    if attention_dp_wait_prefill_iters > self.fd_config.attention_dp_time_out_iters:
+                        if len(attention_dp_cached_prefill_tasks) > 0:
+                            req_dicts.extend(attention_dp_cached_prefill_tasks.pop(0))
+                        attention_dp_wait_prefill_iters = 0
+
+            if len(req_dicts) > 0:
+                req_ids = [req.request_id for req in req_dicts]
+                # Process prefill inputs
+                if self.fd_config.enable_attention_dp_balance:  # real_bsz may be different with scheduler's view
+                    self.worker.preprocess_new_task(req_dicts, None)
+                    num_running_requests = self.worker.get_real_bsz()
+                else:
+                    self.worker.preprocess_new_task(req_dicts, num_running_requests)
+                logger.info(
+                    f"Rank: {self.local_rank}, num_running_requests: {num_running_requests}, "
+                    f"num_insert_requests: {len(req_dicts)}, req_ids: {req_ids}"
+                )
             # Execute model to generate token. The generated token will be written to the buffer.
             # These generated tokens can be obtained through get_output op.
             self.worker.execute_model(req_dicts, num_running_requests)
@@ -654,6 +696,19 @@ def parse_args():
         help="Flag to specify dtype of lm_head as FP32",
     )
 
+    parser.add_argument(
+        "--enable_attention_dp_balance",
+        action="store_true",
+        help="enable attention dp balance",
+    )
+
+    parser.add_argument(
+        "--attention_dp_time_out_iters",
+        type=int,
+        default=0,
+        help="max waiting steps to sync all dp for prefill tasks available",
+    )
+
     args = parser.parse_args()
     return args
 
@@ -784,7 +839,8 @@ def initialize_fd_config(args, ranks: int = 1, local_rank: int = 0) -> FDConfig:
     if parallel_config.guided_decoding_backend != "off":
         logger.info("Set ENABLE_V1_KVCACHE_SCHEDULER to 0 due to not supported guided_decoding.")
         envs.ENABLE_V1_KVCACHE_SCHEDULER = 0
-
+    logger.info(f"enable_attention_dp_balance:{args.enable_attention_dp_balance}")
+    logger.info(f"attention_dp_time_out_iters:{args.attention_dp_time_out_iters}")
     fd_config = FDConfig(
         model_config=model_config,
         parallel_config=parallel_config,
@@ -799,6 +855,8 @@ def initialize_fd_config(args, ranks: int = 1, local_rank: int = 0) -> FDConfig:
         engine_worker_queue_port=args.engine_worker_queue_port,
         ips=args.ips,
         moba_attention_config=moba_attention_config,
+        enable_attention_dp_balance=args.enable_attention_dp_balance,
+        attention_dp_time_out_iters=args.attention_dp_time_out_iters,
     )
     update_fd_config_for_mm(fd_config)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
For moe models, EP + Attention DP is commonly used for deployment. However, different DP may occured load imbalance.
When prefill and decode task mixed in one step, prefill task will make TPOT performance degradation.
Refer to [ADP strategy](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/blogs/tech_blog/blog10_ADP_Balance_Strategy.md#adp-balance-strategy) , we make a implementation to try to keep prefill tasks in different dp computed in a common step.

### How to enable:
E.g.
--enable-attention-dp-balance 
--attention-dp-time-out-iters 16