### PR TITLE
[Feature] Unify the registration name recognition for tool_parser and reasoning_parser to “-”

### DIFF
--- a/benchmarks/yaml/x1-64k-w4a8c8-tp4.yaml
+++ b/benchmarks/yaml/x1-64k-w4a8c8-tp4.yaml
@@ -1,5 +1,5 @@
-reasoning-parser: ernie_x1
-tool_call_parser: ernie_x1
+reasoning-parser: ernie-x1
+tool_call_parser: ernie-x1
 tensor_parallel_size: 4
 max_model_len: 65536
 max_num_seqs: 128

--- a/benchmarks/yaml/x1-a3b-128k-wint8-h800-tp1.yaml
+++ b/benchmarks/yaml/x1-a3b-128k-wint8-h800-tp1.yaml
@@ -1,7 +1,7 @@
 tensor_parallel_size: 1
 max_model_len: 131072
 max_num_seqs: 32
-reasoning_parser: ernie_x1
-tool_call_parser: ernie_x1
+reasoning_parser: ernie-x1
+tool_call_parser: ernie-x1
 load_choices: "default_v1"
 quantization: wint8

--- a/docs/best_practices/ERNIE-4.5-21B-A3B-Thinking.md
+++ b/docs/best_practices/ERNIE-4.5-21B-A3B-Thinking.md
@@ -33,8 +33,8 @@ python -m fastdeploy.entrypoints.openai.api_server \
        --tensor-parallel-size 1 \
        --max-model-len 131072 \
        --quantization wint8 \
-       --reasoning-parser ernie_x1 \
-       --tool-call-parser ernie_x1 \
+       --reasoning-parser ernie-x1 \
+       --tool-call-parser ernie-x1 \
        --max-num-seqs 32
 ```
 - `--quantization`: Indicates the quantization strategy used by the model. Different quantization strategies will result in different performance and accuracy of the model. It could be one of `wint8` / `wint4` / `block_wise_fp8`(Hopper is needed).

--- a/docs/usage/environment_variables.md
+++ b/docs/usage/environment_variables.md
@@ -80,7 +80,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Whether to use Machete for wint4 dense GEMM.
     "FD_USE_MACHETE": lambda: os.getenv("FD_USE_MACHETE", "1"),
 
-    # Used to truncate the string inserted during thinking when reasoning in a model. (</think> for ernie4_5_vl, \n</think>\n\n for ernie_x1)
+    # Used to truncate the string inserted during thinking when reasoning in a model. (</think> for ernie4_5_vl, \n</think>\n\n for ernie-x1)
     "FD_LIMIT_THINKING_CONTENT_TRUNCATE_STR": lambda: os.getenv("FD_LIMIT_THINKING_CONTENT_TRUNCATE_STR", "</think>"),
 
     # Timeout for cache_transfer_manager process exit

--- a/docs/usage/environment_variables.md
+++ b/docs/usage/environment_variables.md
@@ -80,7 +80,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Whether to use Machete for wint4 dense GEMM.
     "FD_USE_MACHETE": lambda: os.getenv("FD_USE_MACHETE", "1"),
 
-    # Used to truncate the string inserted during thinking when reasoning in a model. (</think> for ernie4_5_vl, \n</think>\n\n for ernie-x1)
+    # Used to truncate the string inserted during thinking when reasoning in a model. (</think> for ernie-45-vl, \n</think>\n\n for ernie-x1)
     "FD_LIMIT_THINKING_CONTENT_TRUNCATE_STR": lambda: os.getenv("FD_LIMIT_THINKING_CONTENT_TRUNCATE_STR", "</think>"),
 
     # Timeout for cache_transfer_manager process exit

--- a/docs/zh/best_practices/ERNIE-4.5-21B-A3B-Thinking.md
+++ b/docs/zh/best_practices/ERNIE-4.5-21B-A3B-Thinking.md
@@ -33,8 +33,8 @@ python -m fastdeploy.entrypoints.openai.api_server \
        --tensor-parallel-size 1 \
        --max-model-len 131072 \
        --quantization wint8 \
-       --reasoning-parser ernie_x1 \
-       --tool-call-parser ernie_x1 \
+       --reasoning-parser ernie-x1 \
+       --tool-call-parser ernie-x1 \
        --max-num-seqs 32
 ```
 其中：

--- a/docs/zh/usage/environment_variables.md
+++ b/docs/zh/usage/environment_variables.md
@@ -80,7 +80,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # 是否使用 Machete 后端的 wint4 GEMM.
     "FD_USE_MACHETE": lambda: os.getenv("FD_USE_MACHETE", "1"),
 
-    # Used to truncate the string inserted during thinking when reasoning in a model. (</think> for ernie4_5_vl, \n</think>\n\n for ernie_x1)
+    # Used to truncate the string inserted during thinking when reasoning in a model. (</think> for ernie4_5_vl, \n</think>\n\n for ernie-x1)
     "FD_LIMIT_THINKING_CONTENT_TRUNCATE_STR": lambda: os.getenv("FD_LIMIT_THINKING_CONTENT_TRUNCATE_STR", "</think>"),
 
     # cache_transfer_manager 进程残留时退出等待超时时间

--- a/docs/zh/usage/environment_variables.md
+++ b/docs/zh/usage/environment_variables.md
@@ -80,7 +80,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # 是否使用 Machete 后端的 wint4 GEMM.
     "FD_USE_MACHETE": lambda: os.getenv("FD_USE_MACHETE", "1"),
 
-    # Used to truncate the string inserted during thinking when reasoning in a model. (</think> for ernie4_5_vl, \n</think>\n\n for ernie-x1)
+    # Used to truncate the string inserted during thinking when reasoning in a model. (</think> for ernie-45-vl, \n</think>\n\n for ernie-x1)
     "FD_LIMIT_THINKING_CONTENT_TRUNCATE_STR": lambda: os.getenv("FD_LIMIT_THINKING_CONTENT_TRUNCATE_STR", "</think>"),
 
     # cache_transfer_manager 进程残留时退出等待超时时间

--- a/fastdeploy/entrypoints/openai/tool_parsers/abstract_tool_parser.py
+++ b/fastdeploy/entrypoints/openai/tool_parsers/abstract_tool_parser.py
@@ -95,6 +95,7 @@ class ToolParserManager:
 
         Raise a KeyError exception if the name is not registered.
         """
+        name = name.replace("_", "-")
         if name in cls.tool_parsers:
             return cls.tool_parsers[name]
 

--- a/fastdeploy/entrypoints/openai/tool_parsers/ernie_45_vl_thinking_tool_parser.py
+++ b/fastdeploy/entrypoints/openai/tool_parsers/ernie_45_vl_thinking_tool_parser.py
@@ -44,7 +44,7 @@ from fastdeploy.entrypoints.openai.tool_parsers.abstract_tool_parser import (
 from fastdeploy.utils import data_processor_logger
 
 
-@ToolParserManager.register_module("ernie_45-vl-thinking")
+@ToolParserManager.register_module("ernie-45-vl-thinking")
 class Ernie45VLThinkingToolParser(ToolParser):
     """
     Tool parser for Ernie model version 4.5.1.

--- a/fastdeploy/entrypoints/openai/tool_parsers/ernie_x1_tool_parser.py
+++ b/fastdeploy/entrypoints/openai/tool_parsers/ernie_x1_tool_parser.py
@@ -44,7 +44,7 @@ from fastdeploy.entrypoints.openai.tool_parsers.abstract_tool_parser import (
 from fastdeploy.utils import data_processor_logger
 
 
-@ToolParserManager.register_module("ernie_x1")
+@ToolParserManager.register_module("ernie-x1")
 class ErnieX1ToolParser(ToolParser):
     """
     Tool parser for Ernie model version 4.5.1.

--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -122,7 +122,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "FD_ENABLE_SWAP_SPACE_CLEARING": lambda: int(os.getenv("FD_ENABLE_SWAP_SPACE_CLEARING", "0")),
     # enable return text, used when FD_ENABLE_INTERNAL_ADAPTER=1
     "FD_ENABLE_RETURN_TEXT": lambda: bool(int(os.getenv("FD_ENABLE_RETURN_TEXT", "0"))),
-    # Used to truncate the string inserted during thinking when reasoning in a model. (</think> for ernie4_5_vl, \n</think>\n\n for ernie_x1)
+    # Used to truncate the string inserted during thinking when reasoning in a model. (</think> for ernie4_5_vl, \n</think>\n\n for ernie-x1)
     "FD_LIMIT_THINKING_CONTENT_TRUNCATE_STR": lambda: os.getenv("FD_LIMIT_THINKING_CONTENT_TRUNCATE_STR", "</think>"),
     # Timeout for cache_transfer_manager process exit
     "FD_CACHE_PROC_EXIT_TIMEOUT": lambda: int(os.getenv("FD_CACHE_PROC_EXIT_TIMEOUT", "600")),

--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -122,7 +122,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "FD_ENABLE_SWAP_SPACE_CLEARING": lambda: int(os.getenv("FD_ENABLE_SWAP_SPACE_CLEARING", "0")),
     # enable return text, used when FD_ENABLE_INTERNAL_ADAPTER=1
     "FD_ENABLE_RETURN_TEXT": lambda: bool(int(os.getenv("FD_ENABLE_RETURN_TEXT", "0"))),
-    # Used to truncate the string inserted during thinking when reasoning in a model. (</think> for ernie4_5_vl, \n</think>\n\n for ernie-x1)
+    # Used to truncate the string inserted during thinking when reasoning in a model. (</think> for ernie-45-vl, \n</think>\n\n for ernie-x1)
     "FD_LIMIT_THINKING_CONTENT_TRUNCATE_STR": lambda: os.getenv("FD_LIMIT_THINKING_CONTENT_TRUNCATE_STR", "</think>"),
     # Timeout for cache_transfer_manager process exit
     "FD_CACHE_PROC_EXIT_TIMEOUT": lambda: int(os.getenv("FD_CACHE_PROC_EXIT_TIMEOUT", "600")),

--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -110,7 +110,7 @@ def limit_thinking_content_length(
             think_end_id,
         )
     elif limit_strategy == "\n</think>\n\n":
-        # for ernie_x1
+        # for ernie-x1
         assert line_break_id > 0
         limit_thinking_content_length_v2(
             sampled_token_ids,
@@ -147,7 +147,7 @@ def speculate_limit_thinking_content_length(
             think_end_id,
         )
     elif limit_strategy == "\n</think>\n\n":
-        # for ernie_x1
+        # for ernie-x1
         assert line_break_id > 0
         speculate_limit_thinking_content_length_v2(
             accept_tokens,

--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -101,7 +101,7 @@ def limit_thinking_content_length(
     line_break_id: int = None,
 ):
     if limit_strategy == "</think>":
-        # for ernie4_5_vl
+        # for ernie-45-vl
         limit_thinking_content_length_v1(
             sampled_token_ids,
             max_think_lens,
@@ -136,7 +136,7 @@ def speculate_limit_thinking_content_length(
     line_break_id: int = None,
 ):
     if limit_strategy == "</think>":
-        # for ernie4_5_vl
+        # for ernie-45-vl
         speculate_limit_thinking_content_length_v1(
             accept_tokens,
             max_think_lens,

--- a/fastdeploy/reasoning/abs_reasoning_parsers.py
+++ b/fastdeploy/reasoning/abs_reasoning_parsers.py
@@ -125,6 +125,7 @@ class ReasoningParserManager:
 
         Raise a KeyError exception if the name is not registered.
         """
+        name = name.replace("_", "-")
         if name in cls.reasoning_parsers:
             return cls.reasoning_parsers[name]
 

--- a/fastdeploy/reasoning/ernie_x1_reasoning_parsers.py
+++ b/fastdeploy/reasoning/ernie_x1_reasoning_parsers.py
@@ -8,7 +8,7 @@ from fastdeploy.reasoning import ReasoningParser, ReasoningParserManager
 @ReasoningParserManager.register_module("ernie-x1")
 class ErnieX1ReasoningParser(ReasoningParser):
     """
-    Reasoning parser for ernie_x1 model with stricter boundary checking.
+    Reasoning parser for ernie-x1 model with stricter boundary checking.
 
     Unified rules:
     - Do not strip newline before </think>

--- a/fastdeploy/reasoning/ernie_x1_reasoning_parsers.py
+++ b/fastdeploy/reasoning/ernie_x1_reasoning_parsers.py
@@ -5,7 +5,7 @@ from fastdeploy.entrypoints.openai.protocol import ChatCompletionRequest, DeltaM
 from fastdeploy.reasoning import ReasoningParser, ReasoningParserManager
 
 
-@ReasoningParserManager.register_module("ernie_x1")
+@ReasoningParserManager.register_module("ernie-x1")
 class ErnieX1ReasoningParser(ReasoningParser):
     """
     Reasoning parser for ernie_x1 model with stricter boundary checking.

--- a/fastdeploy/worker/xpu_model_runner.py
+++ b/fastdeploy/worker/xpu_model_runner.py
@@ -212,7 +212,7 @@ def xpu_post_process(
                 think_end_id,
             )
         elif limit_strategy == "\n</think>\n\n":
-            # for ernie_x1
+            # for ernie-x1
             assert line_break_id > 0
             limit_thinking_content_length_v2(
                 sampled_token_ids,

--- a/fastdeploy/worker/xpu_model_runner.py
+++ b/fastdeploy/worker/xpu_model_runner.py
@@ -203,7 +203,7 @@ def xpu_post_process(
         step_idx = share_inputs["step_idx"]
         limit_think_status = share_inputs["limit_think_status"]
         if limit_strategy == "</think>":
-            # for ernie4_5_vl
+            # for ernie-45-vl
             limit_thinking_content_length_v1(
                 sampled_token_ids,
                 max_think_lens,

--- a/tests/entrypoints/openai/test_serving_completion.py
+++ b/tests/entrypoints/openai/test_serving_completion.py
@@ -73,9 +73,9 @@ class TestOpenAIServingCompletion(unittest.TestCase):
         self.assertTrue(serving_completion._check_master())
 
     def test_calc_finish_reason_tool_calls(self):
-        # 创建一个模拟的engine_client，并设置reasoning_parser为"ernie_x1"
+        # 创建一个模拟的engine_client，并设置reasoning_parser为"ernie-x1"
         engine_client = Mock()
-        engine_client.reasoning_parser = "ernie_x1"
+        engine_client.reasoning_parser = "ernie-x1"
         # 创建一个OpenAIServingCompletion实例
         serving_completion = OpenAIServingCompletion(engine_client, None, "pid", "ips", 360)
         # 创建一个模拟的output，并设置finish_reason为"tool_call"
@@ -86,9 +86,9 @@ class TestOpenAIServingCompletion(unittest.TestCase):
         assert result == "tool_calls"
 
     def test_calc_finish_reason_stop(self):
-        # 创建一个模拟的engine_client，并设置reasoning_parser为"ernie_x1"
+        # 创建一个模拟的engine_client，并设置reasoning_parser为"ernie-x1"
         engine_client = Mock()
-        engine_client.reasoning_parser = "ernie_x1"
+        engine_client.reasoning_parser = "ernie-x1"
         # 创建一个OpenAIServingCompletion实例
         serving_completion = OpenAIServingCompletion(engine_client, None, "pid", "ips", 360)
         # 创建一个模拟的output，并设置finish_reason为其他值

--- a/tests/reasoning/test_reasoning_parser.py
+++ b/tests/reasoning/test_reasoning_parser.py
@@ -91,7 +91,7 @@ class TestReasoningParserManager(unittest.TestCase):
         Test that a parser can be registered and retrieved successfully.
         Verifies normal registration and retrieval functionality.
         """
-        ReasoningParserManager.register_module(module=TestReasoningParser, name="test_parser", force=True)
+        ReasoningParserManager.register_module(module=TestReasoningParser, name="test-parser", force=True)
         parser_cls = ReasoningParserManager.get_reasoning_parser("test_parser")
         self.assertIs(parser_cls, TestReasoningParser)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
The registered names for tool_parser and reasoning_parser currently use either “-” or “_”; they need to be standardized.

## Modifications
The registered names for `tool_parser` and `reasoning_parser` uniformly use the hyphen (`-`). When retrieving parsers via their names in the base class, the underscore is replaced with a hyphen.

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
