### PR TITLE
[CI] Update build & import handling in run_tests_with_coverage

### DIFF
--- a/.github/workflows/_build_linux.yml
+++ b/.github/workflows/_build_linux.yml
@@ -52,12 +52,16 @@ on:
       wheel_path:
         description: "Output path of the generated wheel"
         value: ${{ jobs.fd-build.outputs.wheel_path }}
+      build_path:
+        description: "Output path of the build workspace "
+        value: ${{ jobs.fd-build.outputs.build_path }}
 jobs:
   fd-build:
     runs-on: [self-hosted, GPU-Build]
     timeout-minutes: 360
     outputs:
       wheel_path: ${{ steps.set_output.outputs.wheel_path }}
+      build_path: ${{ steps.set_output.outputs.build_path }}
     steps:
       - name: Code Prepare
         shell: bash
@@ -167,6 +171,10 @@ jobs:
             export ENABLE_FD_RDMA=1
             bash build.sh 1 python false [${COMPILE_ARCH}]
             ls ./dist/*.whl
+
+            cd ..
+            tar -czf FastDeploy_build.tar.gz FastDeploy
+            mv FastDeploy_build.tar.gz FastDeploy/dist/
             '
       - name: Package Upload
         id: set_output
@@ -201,6 +209,10 @@ jobs:
             echo "Found: $fd_wheel_name"
             tree -L 3
             python ${push_file} fastdeploy*.whl ${target_path}
+            python ${push_file} FastDeploy_build.tar.gz ${target_path}
+
             target_path_stripped="${target_path#paddle-github-action/}"
             WHEEL_PATH=https://paddle-github-action.bj.bcebos.com/${target_path_stripped}/${fd_wheel_name}
+            BUILD_PATH=https://paddle-github-action.bj.bcebos.com/${target_path_stripped}/FastDeploy_build.tar.gz
             echo "wheel_path=${WHEEL_PATH}" >> $GITHUB_OUTPUT
+            echo "build_path=${BUILD_PATH}" >> $GITHUB_OUTPUT

--- a/.github/workflows/_unit_test_coverage.yml
+++ b/.github/workflows/_unit_test_coverage.yml
@@ -72,8 +72,8 @@ jobs:
             '
 
             wget -q --no-proxy ${fd_archive_url}
-            tar -xf FastDeploy.tar.gz
-            rm -rf FastDeploy.tar.gz
+            tar -xf FastDeploy_build.tar.gz
+            rm -rf FastDeploy_build.tar.gz
             cd FastDeploy
             git config --global user.name "FastDeployCI"
             git config --global user.email "fastdeploy_ci@example.com"
@@ -172,10 +172,7 @@ jobs:
           pip config set global.extra-index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
 
           python -m pip install -r scripts/unittest_requirement.txt
-          python -m pip install ${fd_wheel_url}
-          rm -rf fastdeploy
-          # coverage subprocess use
-          python -m pip install ${fd_wheel_url} --no-deps --target=/workspace/FastDeploy
+          python -m pip install -r requirements.txt
           export PYTHONPATH=/workspace/FastDeploy/
           if [ -d "tests/plugins" ]; then
               cd tests/plugins
@@ -354,7 +351,7 @@ jobs:
           diff_cov_file_url: ${{ needs.run_tests_with_coverage.outputs.diff_cov_file_url }}
         run: |
           wget -q --no-proxy ${fd_archive_url}
-          tar -xf FastDeploy.tar.gz
+          tar -xf FastDeploy_build.tar.gz
           cd FastDeploy
           if [ -z "${diff_cov_file_url}" ]; then
             echo "No diff coverage file URL provided."

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -36,11 +36,11 @@ jobs:
 
   unittest_coverage:
     name: Run FastDeploy Unit Tests and Coverage
-    needs: [clone,build]
+    needs: [build]
     uses: ./.github/workflows/_unit_test_coverage.yml
     with:
       DOCKER_IMAGE: ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddleqa:fastdeploy-ciuse-cuda126-dailyupdate
-      FASTDEPLOY_ARCHIVE_URL: ${{ needs.clone.outputs.repo_archive_url }}
+      FASTDEPLOY_ARCHIVE_URL: ${{ needs.build.outputs.build_path }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build.outputs.wheel_path }}
       MODEL_CACHE_DIR: "/ssd2/actions-runner/ModelData"
     secrets:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
Improves the CI process for `run_tests_with_coverage`.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- Updated packaging steps in the build workflow to align with new wheel handling logic.
- Added removal of the `fastdeploy` source directory before running coverage tests to ensure Python imports the installed wheel package.
- Adjusted related environment variable exports and ensured the coverage data is collected from the correct installed package.

<!-- Detail the changes made in this pull request. -->

## Usage or Command
No
<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests
No
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
