### PR TITLE
[Cherry-pick] Fix profile run in pd-disaggregated deployment

### DIFF
--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -759,6 +759,9 @@ class EngineService:
                 else:
                     time.sleep(0.005)
 
+            except RuntimeError as e:
+                if "cannot schedule new futures after shutdown" in str(e):
+                    break
             except Exception as e:
                 err_msg = "Error happend while insert task to engine: {}, {}.".format(e, str(traceback.format_exc()))
                 self.llm_logger.error(err_msg)

--- a/fastdeploy/engine/engine.py
+++ b/fastdeploy/engine/engine.py
@@ -113,10 +113,10 @@ class LLMEngine:
             | 1       | 1     | 0           | 0               | 0               |
             | 1       | 0     | 1           | 0               | 1               |
             | 1       | 0     | 0           | 0               | 1               |
-            | 0       | 1     | 1           | 1               | 0               |
+            | 0       | 1     | 1           | 0               | 1               |
             | 0       | 1     | 0           | 0               | 0               |
-            | 0       | 0     | 1           | 0               | 1               |
-            | 0       | 0     | 0           | 0               | 1               |
+            | 0       | 0     | 1           | 1               | 0               |
+            | 0       | 0     | 0           | 1               | 0               |
 
         4. Finally, inform user the engine has successfully started.
 
@@ -134,9 +134,8 @@ class LLMEngine:
         self.engine.create_data_processor()
         self.data_processor = self.engine.data_processor
 
-
         # If block numer is specified and model is deployed in mixed mode, start cache manager first
-        if not self.do_profile and self.cfg.scheduler_config.splitwise_role == "mixed" and self.cfg.cache_config.enable_prefix_caching:
+        if not self.do_profile and self.cfg.scheduler_config.splitwise_role != "mixed":
             device_ids = self.cfg.parallel_config.device_ids.split(",")
             self.cache_manager_processes = self.engine.start_cache_service(device_ids, self.ipc_signal_suffix)
 
@@ -170,7 +169,7 @@ class LLMEngine:
         # and then start the cache manager
         if self.do_profile:
             self._stop_profile()
-        elif self.cfg.scheduler_config.splitwise_role != "mixed":
+        elif self.cfg.scheduler_config.splitwise_role == "mixed" and self.cfg.cache_config.enable_prefix_caching:
             device_ids = self.cfg.parallel_config.device_ids.split(",")
             self.cache_manager_processes = self.engine.start_cache_service(device_ids, self.ipc_signal_suffix)
 

--- a/fastdeploy/engine/engine.py
+++ b/fastdeploy/engine/engine.py
@@ -101,6 +101,25 @@ class LLMEngine:
         Initializes the engine and starts its sub-services.
         If `api_server_pid` is defined, will launch a thread
         to keep getting request from zmq_server.
+
+        NOTE: To clarify the launch order of the components of the LLM engine:
+        1. First, launch splitwise scheduler (if necessary) and expert services (if necessary).
+        2. Then, launch common engine, which includes some background threads that inserts tasks and receives ouptuts.
+        3. Most importantly, launch workers and cache services. The launch order of them are listed as follows.
+
+            | Profile | Mixed | PrefixCache | Cache -> Worker | Worker -> Cache |
+            |---------|-------|-------------|-----------------|-----------------|
+            | 1       | 1     | 1           | 0               | 1               |
+            | 1       | 1     | 0           | 0               | 0               |
+            | 1       | 0     | 1           | 0               | 1               |
+            | 1       | 0     | 0           | 0               | 1               |
+            | 0       | 1     | 1           | 1               | 0               |
+            | 0       | 1     | 0           | 0               | 0               |
+            | 0       | 0     | 1           | 0               | 1               |
+            | 0       | 0     | 0           | 0               | 1               |
+
+        4. Finally, inform user the engine has successfully started.
+
         """
         assert not self.is_started, "The engine is already started."
         start_time = time.time()
@@ -109,15 +128,15 @@ class LLMEngine:
         self.ipc_signal_suffix = self.cfg.parallel_config.engine_worker_queue_port[0]
         self._init_worker_signals()
 
-        # Launch components: scheduler, cache_manager, expert_service et.al.
         self.launch_components()
 
         self.engine.start()
         self.engine.create_data_processor()
         self.data_processor = self.engine.data_processor
 
+
         # If block numer is specified and model is deployed in mixed mode, start cache manager first
-        if not self.do_profile and self.cfg.scheduler_config.splitwise_role != "mixed":
+        if not self.do_profile and self.cfg.scheduler_config.splitwise_role == "mixed" and self.cfg.cache_config.enable_prefix_caching:
             device_ids = self.cfg.parallel_config.device_ids.split(",")
             self.cache_manager_processes = self.engine.start_cache_service(device_ids, self.ipc_signal_suffix)
 
@@ -151,7 +170,7 @@ class LLMEngine:
         # and then start the cache manager
         if self.do_profile:
             self._stop_profile()
-        elif self.cfg.cache_config.enable_prefix_caching:
+        elif self.cfg.scheduler_config.splitwise_role != "mixed":
             device_ids = self.cfg.parallel_config.device_ids.split(",")
             self.cache_manager_processes = self.engine.start_cache_service(device_ids, self.ipc_signal_suffix)
 

--- a/fastdeploy/inter_communicator/ipc_signal.py
+++ b/fastdeploy/inter_communicator/ipc_signal.py
@@ -80,6 +80,7 @@ class IPCSignal:
             name = name + f".{suffix}"
 
         if create:
+            llm_logger.debug(f"creating ipc signal: {name}")
             if shared_memory_exists(name):
                 llm_logger.warning(f"ShareMemory: {name} already exists, delete it")
                 SharedMemory(name=name, create=False).unlink()
@@ -87,6 +88,7 @@ class IPCSignal:
             self.value: np.ndarray = np.ndarray(array.shape, dtype=array.dtype, buffer=self.shm.buf)
             self.value[:] = array  # Initialize with input array data
         else:
+            llm_logger.debug(f"attaching ipc signal: {name}")
             self.shm = SharedMemory(name=name)
             self.value: np.ndarray = np.ndarray(array.shape, dtype=array.dtype, buffer=self.shm.buf)
 

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -41,7 +41,12 @@ from fastdeploy.config import (
     StructuredOutputsConfig,
 )
 from fastdeploy.inter_communicator import EngineWorkerQueue as TaskQueue
-from fastdeploy.inter_communicator import ExistTaskStatus, IPCSignal, ModelWeightsStatus, shared_memory_exists
+from fastdeploy.inter_communicator import (
+    ExistTaskStatus,
+    IPCSignal,
+    ModelWeightsStatus,
+    shared_memory_exists,
+)
 from fastdeploy.model_executor.layers.quantization import parse_quant_config
 from fastdeploy.model_executor.utils import v1_loader_support
 from fastdeploy.platforms import current_platform

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -41,7 +41,7 @@ from fastdeploy.config import (
     StructuredOutputsConfig,
 )
 from fastdeploy.inter_communicator import EngineWorkerQueue as TaskQueue
-from fastdeploy.inter_communicator import ExistTaskStatus, IPCSignal, ModelWeightsStatus
+from fastdeploy.inter_communicator import ExistTaskStatus, IPCSignal, ModelWeightsStatus, shared_memory_exists
 from fastdeploy.model_executor.layers.quantization import parse_quant_config
 from fastdeploy.model_executor.utils import v1_loader_support
 from fastdeploy.platforms import current_platform
@@ -427,7 +427,7 @@ class PaddleDisWorkerProc:
                 array=prefilled_step_idx_data,
                 dtype=np.int32,
                 suffix=gpu_id,
-                create=False,
+                create=not shared_memory_exists(prefilled_step_name),
             )
             step_shm_value.value[0] = -1
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

修复当前代码在 PD 分离场景 profile run 跑不通的问题 (cherry-picked from https://github.com/PaddlePaddle/FastDeploy/pull/4584)

## Modifications

重新梳理 cache service (cache transfer + cache messager 的统称) 和 worker 的启动顺序，当前 engine.start() 有两种组件的启动顺序：
1. 对于不指定 block 数量的场景，先启动 worker，让 worker 加载权重、跑 profile run 以确定实际的 block 数量，再启动 cache service。然后由 worker 或 cache service 其中一方创建 cache ，另一方读取 cache；
    - 对于 PD 分离场景，由于 cache 需要通过 cache messager 传输，因此实际的 cache 需要在 cache messager 中管理。需要 cache messager 创建 cache 并通过 `set_data_ipc` 设置共享内存指针，cache_transfer 和 worker 在等待 cache 被创建之后 (`cache_ready_signal=1`) 通过 `share_external_data` 读取 cache；
    - 对于集中式部署场景，cache 不需要跨机传输，因此不需要 cache messager。另一方面，需要支持通过 /clear_load_weight 接口一并清除 weights & cache，需要复用 `paddle.empty_cache` 操作，因此将 cache 放到 worker 中管理。需要 worker 创建 cache 并通过 `set_data_ipc` 设置共享内存指针，cache transfer 在等待 cache 被创建之后通过 `share_external_data` 读取 cache。

2. 对于指定 block 数量的场景，先启动 cache service 直接创建 cache，再启动 worker 读取 cache；
3. 对于禁用 prefix cache 的集中式部署场景，不需要启动 cache service。

各种场景的启动顺序逻辑真值表如下：

| Profile | Mixed | PrefixCache | Cache -> Worker | Worker -> Cache |
|---------|-------|-------------|-----------------|-----------------|
| 1       | 1     | 1           | 0               | 1               |
| 1       | 1     | 0           | 0               | 0               |
| 1       | 0     | 1           | 0               | 1               |
| 1       | 0     | 0           | 0               | 1               |
| 0       | 1     | 1           | 0               | 1               |
| 0       | 1     | 0           | 0               | 0               |
| 0       | 0     | 1           | 1              | 0               |
| 0       | 0     | 0           | 1               | 0               |

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->
```
python yiyanadapter/api_server.py \
       --port "9600" \
       --metrics-port "3113" \
       --model "$MODEL_PATH" \
       --engine-worker-queue-port "1477,1478,1479,1480,1481,1482,1483,1484" \
       --pd-comm-port "9800,9801,9802,9803,9804,9805,9806,9807" \
       --tensor-parallel-size 4 \
       --data-parallel-size 16 \
       --max-model-len 65536 \
       --enable-expert-parallel \
       --enable-chunked-prefill \
       --max-num-seqs 5 \
       --workers 1 \
       --scheduler-ttl 9000 \
       --scheduler-topic "test"  \
       --scheduler-host XXXX \
       --scheduler-port 6379 \
       --scheduler-password XXXX \
       --disable-custom-all-reduce \
       --splitwise-role "prefill" \
       --scheduler-name "dp" \
       --gpu-memory-utilization 0.9 \
       --quantization block_wise_fp8 \
       --max-num-batched-tokens 2048 \
       --cache-transfer-protocol "rdma" \
       --rdma-comm-ports "8501,8502,8503,8504,8505,8506,8507,8508" \
       --cache-queue-port "9978" \
       --ips $ip_list \
       --graph-optimization-config '{"use_cudagraph":false,"use_unique_memory_pool":true,"cudagraph_capture_sizes":[1]}' > log/console_fd.log 2>&1 &
```
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
