### PR TITLE
[BugFix] Fix ernie_vl_reasoning_parsers.py 'end_token' to 'think_end_token'

### DIFF
--- a/fastdeploy/reasoning/ernie_vl_reasoning_parsers.py
+++ b/fastdeploy/reasoning/ernie_vl_reasoning_parsers.py
@@ -70,9 +70,9 @@ class ErnieVLReasoningParser(ReasoningParser):
         if len(delta_token_ids) == 1 and delta_token_ids[0] == self.think_end_token_id:
             return None
         if self.think_end_token_id in delta_token_ids:
-            end_index = delta_text.find(self.end_token)
+            end_index = delta_text.find(self.think_end_token)
             reasoning_content = delta_text[:end_index]
-            content = delta_text[end_index + len(self.end_token) :]
+            content = delta_text[end_index + len(self.think_end_token) :]
             return DeltaMessage(reasoning_content=reasoning_content, content=content)
         elif self.think_end_token_id in previous_token_ids:
             return DeltaMessage(content=delta_text)

--- a/tests/reasoning/test_reasoning_parser.py
+++ b/tests/reasoning/test_reasoning_parser.py
@@ -21,6 +21,7 @@ from fastdeploy.reasoning import ReasoningParser, ReasoningParserManager
 from fastdeploy.reasoning.ernie_45_vl_thinking_reasoning_parser import (
     Ernie45VLThinkingReasoningParser,
 )
+from fastdeploy.reasoning.ernie_vl_reasoning_parsers import ErnieVLReasoningParser
 from fastdeploy.reasoning.ernie_x1_reasoning_parsers import ErnieX1ReasoningParser
 
 
@@ -423,6 +424,61 @@ class TestErnie45VLThinkingReasoningParser(unittest.TestCase):
         )
         self.assertEqual(reasoning, "reasoning")
         self.assertEqual(content, "\n\n  actual response")
+
+
+class TestErnieVLReasoningParser(unittest.TestCase):
+    def setUp(self):
+        self.tokenizer = DummyTokenizer()
+        self.parser = ErnieVLReasoningParser(tokenizer=self.tokenizer)
+        self.test_request = ChatCompletionRequest(
+            model="ernie-test", messages=[{"role": "user", "content": "test prompt"}]
+        )
+
+    def test_extract_reasoning_content_stream(self):
+        result = self.parser.extract_reasoning_content_streaming(
+            previous_text="abc",
+            current_text="abc</think>xyz",
+            delta_text="</think>xyz",
+            previous_token_ids=[200, 201, 202],
+            current_token_ids=[200, 201, 202, 100, 110, 120, 130],
+            delta_token_ids=[100, 110, 120, 130],
+        )
+        self.assertIsInstance(result, DeltaMessage)
+        self.assertEqual(result.reasoning_content, "")
+        self.assertEqual(result.content, "xyz")
+
+    def test_extract_reasoning_content_stream_think_in_previous(self):
+        result = self.parser.extract_reasoning_content_streaming(
+            previous_text="abc</think>",
+            current_text="abc</think>xyz",
+            delta_text="xyz",
+            previous_token_ids=[200, 201, 202, 100],
+            current_token_ids=[200, 201, 202, 100, 110, 120, 130],
+            delta_token_ids=[110, 120, 130],
+        )
+        self.assertIsInstance(result, DeltaMessage)
+        self.assertIsNone(result.reasoning_content)
+        self.assertEqual(result.content, "xyz")
+
+    def test_extract_reasoning_content_stream_no_think_token(self):
+        result = self.parser.extract_reasoning_content_streaming(
+            previous_text="abc",
+            current_text="abcxyz",
+            delta_text="xyz",
+            previous_token_ids=[200, 201, 202],
+            current_token_ids=[200, 201, 202, 110, 120, 130],
+            delta_token_ids=[110, 120, 130],
+        )
+        self.assertIsInstance(result, DeltaMessage)
+        self.assertIsNone(result.content)
+        self.assertEqual(result.reasoning_content, "xyz")
+
+    def test_extract_reasoning_content(self):
+        reasoning, content = self.parser.extract_reasoning_content(
+            model_output="reasoning</think>\nactual response", request=self.test_request
+        )
+        self.assertEqual(reasoning, "reasoning")
+        self.assertEqual(content, "\nactual response")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
In the file `ernie_vl_reasoning_parsers.py`, two instances of ‘think_end_token’ have been erroneously written as ‘end_token’.

## Modifications
The ‘end_token’ in the ernie_vl_reasoning_parsers.py file has been changed to ‘think_end_token’.

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
