### PR TITLE
[BugFix] Fix list to List

### DIFF
--- a/fastdeploy/engine/kv_cache_interface.py
+++ b/fastdeploy/engine/kv_cache_interface.py
@@ -16,7 +16,7 @@
 
 import copy
 from dataclasses import dataclass
-from typing import list
+from typing import List
 
 from typing_extensions import Self
 
@@ -33,11 +33,11 @@ class KVCacheSpec:
     block_memory_used: int
 
     @classmethod
-    def merge(cls, specs: list[Self]) -> Self:
+    def merge(cls, specs: List[Self]) -> Self:
         """
-        Merge a list of KVCacheSpec objects into a single KVCacheSpec object.
+        Merge a List of KVCacheSpec objects into a single KVCacheSpec object.
         """
-        # check list
+        # check List
         assert all(
             (spec.block_size == specs[0].block_size and spec.block_memory_used == specs[0].block_memory_used)
             for spec in specs[1:]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Fix a type hint syntax error in the code where from typing import list is used incorrectly.

```
Traceback (most recent call last):
  File "/workspace/FirstBuildFD/FastDeploy/tests/test_py.py", line 2, in <module>
    from fastdeploy.engine.kv_cache_interface import KVCacheSpec, AttentionSpec
  File "/usr/local/lib/python3.10/dist-packages/fastdeploy/engine/kv_cache_interface.py", line 19, in <module>
    from typing import list
ImportError: cannot import name 'list' from 'typing' (/usr/lib/python3.10/typing.py)
```
The key reason is that in Python's typing module, the generic list type for type hints is spelled with a capital letter (List), following the convention defined in PEP 484. The lowercase list is a built-in type and not the correct form for generic type hints (e.g., List[int] for a list of integers). Using list here would lead to static type checking errors (e.g., with mypy) and violates standard type hinting practices. https://docs.python.org/3.6/library/typing.html
## Modifications

fix the list to List. 
<!-- Detail the changes made in this pull request. -->

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag :[BugFix]
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
