### PR TITLE
[Docs] fix: correct typo in nvidia_gpu.md

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ mkdocs-get-deps
 mkdocs-material
 mkdocs-material-extensions
 mkdocs-multilang
+mkdocs-static-i18n

--- a/docs/zh/get_started/installation/nvidia_gpu.md
+++ b/docs/zh/get_started/installation/nvidia_gpu.md
@@ -14,7 +14,7 @@
 
 ## 1. 预编译Docker安装(推荐)
 
-**注意**： 如下镜像仅支持SM 80/90架构GPU（A800/H800等），如果你是在L20/L40/4090等SM 86/69架构的GPU上部署，请在创建容器后，卸载```fastdeploy-gpu```再重新安装如下文档指定支持86/89架构的`fastdeploy-gpu`包。
+**注意**： 如下镜像仅支持SM 80/90架构GPU（A800/H800等），如果你是在L20/L40/4090等SM 86/89架构的GPU上部署，请在创建容器后，卸载```fastdeploy-gpu```再重新安装如下文档指定支持86/89架构的`fastdeploy-gpu`包。
 
 ``` shell
 docker pull ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/fastdeploy-cuda-12.6:2.3.0-rc0


### PR DESCRIPTION
This pull request introduces a minor update to the documentation and its dependencies. The main changes are the addition of a new documentation dependency and a correction to the GPU architecture information in the Chinese installation guide.

Documentation dependency update:
* Added `mkdocs-static-i18n` to `docs/requirements.txt` to support static internationalization for documentation.

Documentation correction:
* Fixed a typo in the supported GPU architectures in `docs/zh/get_started/installation/nvidia_gpu.md`, changing "SM 86/69" to "SM 86/89" for improved accuracy.