### PR TITLE
[PD Disaggregation]Replace paddle.max by numpy to avoid  useless error log

### DIFF
--- a/fastdeploy/spec_decode/mtp.py
+++ b/fastdeploy/spec_decode/mtp.py
@@ -659,7 +659,7 @@ class MTPProposer(Proposer):
         """
         check whether prefill stage exist
         """
-        if int(paddle.max(self.model_inputs["seq_lens_encoder"])) != 0:
+        if np.any(self.share_inputs["seq_lens_encoder"].numpy() > 0):
             return 1
         else:
             return 0

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -220,13 +220,13 @@ class GPUModelRunner(ModelRunnerBase):
         """
         check whether prefill stage exist
         """
-        return int(paddle.max(self.share_inputs["seq_lens_encoder"])) > 0
+        return np.any(self.share_inputs["seq_lens_encoder"].numpy() > 0)
 
     def exist_decode(self):
         """
         check whether decode stage exist
         """
-        return int(paddle.max(self.share_inputs["seq_lens_decoder"])) > 0
+        return np.any(self.share_inputs["seq_lens_decoder"].numpy() > 0)
 
     def only_prefill(self):
         """
@@ -1266,7 +1266,7 @@ class GPUModelRunner(ModelRunnerBase):
             self.share_inputs["output_padding_offset"].copy_(output_padding_offset, False)
 
         # Update bad tokens len
-        max_bad_tokens_len = paddle.max(self.share_inputs["bad_tokens_len"])
+        max_bad_tokens_len = np.max(self.share_inputs["bad_tokens_len"].numpy())
 
         # Initialize forward meta data
         self.initialize_forward_meta()


### PR DESCRIPTION
## Motivation
当前PD分离下，workerlog里会出现无数条“CUDA error 9 [/paddle/third_party/cccl/cub/cub/util_device.cuh, 83]: invalid configuration argument” ，但并不影响服务使用，为了提升使用体验，和避免这种具有迷惑性且无效的error log，做出替换方案.