### PR TITLE
[BugFix][Models] Add `tie_word_embeddings` for lmhead

### DIFF
--- a/fastdeploy/model_executor/models/qwen2.py
+++ b/fastdeploy/model_executor/models/qwen2.py
@@ -314,7 +314,7 @@ class Qwen2ForCausalLM(ModelForCasualLM):
         self.qwen2 = Qwen2Model(fd_config=fd_config)
 
         self.ori_vocab_size = fd_config.model_config.ori_vocab_size
-
+        self.tie_word_embeddings = fd_config.model_config.tie_word_embeddings
         self.lm_head = ParallelLMHead(
             fd_config=fd_config,
             embedding_dim=fd_config.model_config.hidden_size,
@@ -379,6 +379,8 @@ class Qwen2ForCausalLM(ModelForCasualLM):
                 weight_loader(param, loaded_weight)
             model_sublayer_name = re.sub(r"\.(weight)$", "", model_param_name)
             process_weights_after_loading_fn(model_sublayer_name, param)
+        if self.tie_word_embeddings:
+            self.lm_head.load_state_dict({self.lm_head.weight_key: self.qwen2.embed_tokens.embeddings.weight})
 
     @classmethod
     def name(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

**动态图**运行 `Qwen2-0.5B` 报错：

```
RuntimeError: (PreconditionNotMet) Tensor's dimension is out of bound.Tensor's dimension must be equal or less than the size of its memory.But received Tensor's dimension is 272269312, memory's size is 0.
  [Hint: Expected numel() * SizeOf(dtype()) <= memory_size(), but received numel() * SizeOf(dtype()):272269312 > memory_size():0.] (at /workspace/Paddle/paddle/phi/core/dense_tensor_impl.cc:48)
  [operator < linear > error]
```

定位到是 `self.lm_head.weight` 权重没有初始化


`Qwen2-0.5B / 1.5B` 等小模型为了减少总参数量，提升小模型核心部分的参数占比，开启 `tie_word_embeddings=True` 将输入 Embedding 参数与输出 lm_head 的参数共享

#3502 没有考虑 `Qwen2-0.5B / 1.5B` 这类小模型，没有像 #3255 一样给 `lm_head` 做初始化，故本PR添加

## Modifications

给 Qwen2 组网部分添加 `lm_head` 的权重初始化

## Usage or Command

```shell
MODEL=/workspace/MODELS/Qwen2-0.5B-Instruct
rm -rf log/*

export export FD_USE_MACHETE=0
export CUDA_VISIBLE_DEVICES=0
export PORT=39905

python -m fastdeploy.entrypoints.openai.api_server \
  --model $MODEL \
  --metrics-port 39717 \
  --port $PORT \
  --engine-worker-queue-port 39719 \
  --max-model-len 32768 \
  --max-num-seqs 256 \
  --kv-cache-ratio 0.75 \
  --tensor-parallel-size 1 \
  --graph-optimization-config '{"graph_opt_level": 0, "use_cudagraph": false, "full_cuda_graph": false}' \
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
