### PR TITLE
[Cherry-Pick] [BugFix] fix work metrics not returned by metrics api

### DIFF
--- a/fastdeploy/__init__.py
+++ b/fastdeploy/__init__.py
@@ -17,11 +17,20 @@
 import os
 import subprocess
 import sys
+import uuid
 
 # suppress warning log from paddlepaddle
 os.environ["GLOG_minloglevel"] = "2"
 # suppress log from aistudio
 os.environ["AISTUDIO_LOG"] = "critical"
+# set prometheus dir
+if os.getenv("PROMETHEUS_MULTIPROC_DIR", "") == "":
+    prom_dir = f"/tmp/fd_prom_{str(uuid.uuid4())}"
+    os.environ["PROMETHEUS_MULTIPROC_DIR"] = prom_dir
+    if os.path.exists(prom_dir):
+        os.rmdir(prom_dir)
+    os.mkdir(prom_dir)
+
 import typing
 
 from paddleformers.utils.log import logger as pf_logger

--- a/fastdeploy/entrypoints/openai/api_server.py
+++ b/fastdeploy/entrypoints/openai/api_server.py
@@ -60,7 +60,6 @@ from fastdeploy.entrypoints.openai.utils import UVICORN_CONFIG, make_arg_parser
 from fastdeploy.envs import environment_variables
 from fastdeploy.metrics.metrics import (
     EXCLUDE_LABELS,
-    cleanup_prometheus_files,
     get_filtered_metrics,
     main_process_metrics,
 )
@@ -586,8 +585,9 @@ def launch_metrics_server():
     if not is_port_available(args.host, args.metrics_port):
         raise Exception(f"The parameter `metrics_port`:{args.metrics_port} is already in use.")
 
-    prom_dir = cleanup_prometheus_files(True)
-    os.environ["PROMETHEUS_MULTIPROC_DIR"] = prom_dir
+    # Move setting prometheus directory to fastdeploy/__init__.py
+    # prom_dir = cleanup_prometheus_files(True)
+    # os.environ["PROMETHEUS_MULTIPROC_DIR"] = prom_dir
     metrics_server_thread = threading.Thread(target=run_metrics_server, daemon=True)
     metrics_server_thread.start()
     time.sleep(1)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

当前的 metrics 接口，只返回了 `main_process_metrics` 的信息，而没有返回 `work_process_metrics` 中包含的指标。排查到是因为 `PROMETHEUS_MULTIPROC_DIR` 环境变量的设置晚于 `work_process_metrics` 的实例化导致的，`work_process_metrics` 中的指标没有以多进程的模式被初始化，从而 `multiprocess.MultiProcessCollector` 没有到收集相关信息。

## Modifications

将环境变量 `PROMETHEUS_MULTIPROC_DIR` 的初始化提前到 `fastdeploy/__init__.py` 文件中，这样通过 `python -m fastdeploy.entrypoints.openai.api_server` 启动服务时立即初始化该环境变量。

## Usage or Command
```
python -m fastdeploy.entrypoints.openai.api_server \
    --model baidu/ERNIE-4.5-0.3B-Paddle \
    --port 8580 \
    --metrics-port 8581 \
    --engine-worker-queue-port 8582 \
    --cache-queue-port 8583 \
    --max-model-len 65536
```
## Accuracy Tests
```
$ curl -X POST "http://0.0.0.0:8580/v1/completions" -H "Content-Type: application/json" -d '{
  "prompt": "鲁迅是谁"
}'
{"id":"cmpl-67fb8a8d-3f03-464c-b9a3-ef97ecd8e89e","object":"text_completion","created":1762757964,"model":"/root/PaddlePaddle/ERNIE-4.5-0.3B-Paddle","choices":[{"index":0,"text":"？\n\nA.阿基米德\nB.巴比伦人\nC.伊拉克人\nD.埃及人\n\n请解答这个问题。\n\n**答案**：A.阿基米德\n\n**解析**：阿基米德是古希腊数学家、哲学家，被认为是西方数学和哲学之父，是古希腊“三贤”之一。","prompt_token_ids":null,"completion_token_ids":null,"prompt_tokens":null,"completion_tokens":null,"arrival_time":null,"logprobs":null,"draft_logprobs":null,"reasoning_content":null,"finish_reason":"stop","tool_calls":null}],"usage":{"prompt_tokens":2,"total_tokens":80,"completion_tokens":78,"prompt_tokens_details":{"cached_tokens":0,"image_tokens":null,"video_tokens":null},"completion_tokens_details":{"reasoning_tokens":0,"image_tokens":0}}}

$ curl -i http://0.0.0.0:8581/metrics | grep prompt_tokens_total
# HELP fastdeploy:prompt_tokens_total Total number of prompt tokens processed
# TYPE fastdeploy:prompt_tokens_total counter
fastdeploy:prompt_tokens_total 2.0
```
## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
