### PR TITLE
【Hackathon 9th No.109】[CppExtension] Support build Custom OP in setuptools 80+ -part

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ kernel_meta*
 fastdeploy_ops.py
 version.txt
 EGG-INFO/
+**/fastdeploy_ops/__init__.py
 
 # fp8 generated codes
 autogen/

--- a/build.sh
+++ b/build.sh
@@ -77,27 +77,27 @@ function copy_ops(){
     WHEEL_MODERN_NAME="fastdeploy_ops"
     WHEEL_MODERN_CPU_NAME="fastdeploy_cpu_ops"
 
-    # Handle GPU ops directories (WHEEL_NAME and WHEEL_MODERN_NAME)
-    if [ -d "./${OPS_TMP_DIR}/${WHEEL_NAME}" ]; then
-        echo -e "${YELLOW}[Warning]${NONE} ${WHEEL_NAME} directory exists. This is a deprecated packaging and distribution method."
+    # Handle GPU ops directories (WHEEL_MODERN_NAME and WHEEL_NAME)
+    if [ -d "./${OPS_TMP_DIR}/${WHEEL_MODERN_NAME}" ]; then
+        echo -e "${GREEN}[Info]${NONE} Ready to copy ops from modern directory ${WHEEL_MODERN_NAME} to target directory"
+        # Set WHEEL_NAME to empty string to ignore the directory path
+        WHEEL_NAME=""
     else
-        # If deprecated directory doesn't exist, check for modern directory
-        if [ -d "./${OPS_TMP_DIR}/${WHEEL_MODERN_NAME}" ]; then
-            echo -e "${GREEN}[Info]${NONE} Copying ops from modern directory ${WHEEL_MODERN_NAME} to ${WHEEL_NAME}"
-            mkdir -p "./${OPS_TMP_DIR}/${WHEEL_NAME}"
-            cp -r "./${OPS_TMP_DIR}/${WHEEL_MODERN_NAME}" "./${OPS_TMP_DIR}/${WHEEL_NAME}/"
+        # If modern directory doesn't exist, check for deprecated directory
+        if [ -d "./${OPS_TMP_DIR}/${WHEEL_NAME}" ]; then
+            echo -e "${YELLOW}[Warning]${NONE} ${WHEEL_NAME} directory exists. This is a deprecated packaging and distribution method."
         fi
     fi
 
-    # Handle CPU ops directories (WHEEL_CPU_NAME and WHEEL_MODERN_CPU_NAME)
-    if [ -d "./${OPS_TMP_DIR}/${WHEEL_CPU_NAME}" ]; then
-        echo -e "${YELLOW}[Warning]${NONE} ${WHEEL_CPU_NAME} directory exists. This is a deprecated packaging and distribution method."
+    # Handle CPU ops directories (WHEEL_MODERN_CPU_NAME and WHEEL_CPU_NAME)
+    if [ -d "./${OPS_TMP_DIR}/${WHEEL_MODERN_CPU_NAME}" ]; then
+        echo -e "${GREEN}[Info]${NONE} Ready to copy ops from modern directory ${WHEEL_MODERN_CPU_NAME} to target directory"
+        # Set WHEEL_CPU_NAME to empty string to ignore the directory path
+        WHEEL_CPU_NAME=""
     else
-        # If deprecated directory doesn't exist, check for modern directory
-        if [ -d "./${OPS_TMP_DIR}/${WHEEL_MODERN_CPU_NAME}" ]; then
-            echo -e "${GREEN}[Info]${NONE} Copying ops from modern directory ${WHEEL_MODERN_CPU_NAME} to ${WHEEL_CPU_NAME}"
-            mkdir -p "./${OPS_TMP_DIR}/${WHEEL_CPU_NAME}"
-            cp -r "./${OPS_TMP_DIR}/${WHEEL_MODERN_CPU_NAME}" "./${OPS_TMP_DIR}/${WHEEL_CPU_NAME}/"
+        # If modern directory doesn't exist, check for deprecated directory
+        if [ -d "./${OPS_TMP_DIR}/${WHEEL_CPU_NAME}" ]; then
+            echo -e "${YELLOW}[Warning]${NONE} ${WHEEL_CPU_NAME} directory exists. This is a deprecated packaging and distribution method."
         fi
     fi
     is_rocm=`$python -c "import paddle; print(paddle.is_compiled_with_rocm())"`

--- a/build.sh
+++ b/build.sh
@@ -72,6 +72,34 @@ function copy_ops(){
     PROCESSOR_VERSION=`${python} -c "import platform; print(platform.processor())"`
     WHEEL_NAME="fastdeploy_ops-${OPS_VERSION}-${PY_VERSION}-${SYSTEM_VERSION}-${PROCESSOR_VERSION}.egg"
     WHEEL_CPU_NAME="fastdeploy_cpu_ops-${OPS_VERSION}-${PY_VERSION}-${SYSTEM_VERSION}-${PROCESSOR_VERSION}.egg"
+
+    # Add compatibility for modern python packaging methods
+    WHEEL_MODERN_NAME="fastdeploy_ops"
+    WHEEL_MODERN_CPU_NAME="fastdeploy_cpu_ops"
+
+    # Handle GPU ops directories (WHEEL_NAME and WHEEL_MODERN_NAME)
+    if [ -d "./${OPS_TMP_DIR}/${WHEEL_NAME}" ]; then
+        echo -e "${YELLOW}[Warning]${NONE} ${WHEEL_NAME} directory exists. This is a deprecated packaging and distribution method."
+    else
+        # If deprecated directory doesn't exist, check for modern directory
+        if [ -d "./${OPS_TMP_DIR}/${WHEEL_MODERN_NAME}" ]; then
+            echo -e "${GREEN}[Info]${NONE} Copying ops from modern directory ${WHEEL_MODERN_NAME} to ${WHEEL_NAME}"
+            mkdir -p "./${OPS_TMP_DIR}/${WHEEL_NAME}"
+            cp -r "./${OPS_TMP_DIR}/${WHEEL_MODERN_NAME}" "./${OPS_TMP_DIR}/${WHEEL_NAME}/"
+        fi
+    fi
+
+    # Handle CPU ops directories (WHEEL_CPU_NAME and WHEEL_MODERN_CPU_NAME)
+    if [ -d "./${OPS_TMP_DIR}/${WHEEL_CPU_NAME}" ]; then
+        echo -e "${YELLOW}[Warning]${NONE} ${WHEEL_CPU_NAME} directory exists. This is a deprecated packaging and distribution method."
+    else
+        # If deprecated directory doesn't exist, check for modern directory
+        if [ -d "./${OPS_TMP_DIR}/${WHEEL_MODERN_CPU_NAME}" ]; then
+            echo -e "${GREEN}[Info]${NONE} Copying ops from modern directory ${WHEEL_MODERN_CPU_NAME} to ${WHEEL_CPU_NAME}"
+            mkdir -p "./${OPS_TMP_DIR}/${WHEEL_CPU_NAME}"
+            cp -r "./${OPS_TMP_DIR}/${WHEEL_MODERN_CPU_NAME}" "./${OPS_TMP_DIR}/${WHEEL_CPU_NAME}/"
+        fi
+    fi
     is_rocm=`$python -c "import paddle; print(paddle.is_compiled_with_rocm())"`
     if [ "$is_rocm" = "True" ]; then
       DEVICE_TYPE="rocm"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

关联 https://github.com/PaddlePaddle/Paddle/pull/76008

框架兼容 setuptools80+ 之后，cpp_extension 的打包方式发生了改变，因此需要修改 FD 中 copy_ops 的逻辑。

## Modifications

<!-- Detail the changes made in this pull request. -->

1. 增加 `WHEEL_MODERN_NAME` `WHEEL_MODERN_CPU_NAME` 这两个变量，分别表示新打包方式下算子生成的目录。
2. 先判断是否存在旧的 `WHEEL_NAME` `WHEEL_CPU_NAME` 这两个目录，如果存在，说明使用的是旧的框架代码（注意，不是旧的 setuptools 版本，新的框架代码不区分 setuptools 版本）。此时，后续逻辑不做改变。
3. 如果不存在这两个目录，则判断 `WHEEL_MODERN_NAME` `WHEEL_MODERN_CPU_NAME` 这两个目录是否存在，如果存在，则说明使用的是新的框架代码，然后，将 `WHEEL_MODERN_NAME` `WHEEL_MODERN_CPU_NAME` 这两个目录（注意，不是目录中的文件）整个复制到 `WHEEL_NAME` `WHEEL_CPU_NAME` 中（需要先新建）。之后的逻辑也不变。

## Usage or Command

```shell
bash build.sh
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

这里在本地测试，修改 `custom_ops/setup_ops.py` ，只测试 cpu 算子（gpu 编译不了，cuda 版本太低了 ... ...）

``` python

use_bf16 = False # envs.FD_CPU_USE_BF16 == "True"

# cc flags
paddle_extra_compile_args = [
    "-std=c++17",
    "-shared",
    "-fPIC",
    "-Wno-parentheses",
    "-DPADDLE_WITH_CUSTOM_KERNEL",
    "-DPADDLE_ON_INFERENCE",
    "-Wall",
    "-O3",
    "-g",
    "-lstdc++fs",
    "-D_GLIBCXX_USE_CXX11_ABI=1",
    "-DPy_LIMITED_API=0x03090000",
]

setup(
    name="fastdeploy_cpu_ops",
    ext_modules=CppExtension(
        sources=[
            "gpu_ops/save_with_output_msg.cc",
            "gpu_ops/get_output.cc",
            "gpu_ops/get_output_msg_with_topk.cc",
            "gpu_ops/save_output_msg_with_topk.cc",
            "gpu_ops/transfer_output.cc",
            "cpu_ops/rebuild_padding.cc",
            # "cpu_ops/simd_sort.cc",
            # "cpu_ops/set_value_by_flags.cc",
            # "cpu_ops/token_penalty_multi_scores.cc",
            "cpu_ops/stop_generation_multi_ends.cc",
            # "cpu_ops/update_inputs.cc",
            # "cpu_ops/get_padding_offset.cc",
        ],
        extra_link_args=[
            "-Wl,-rpath,$ORIGIN/x86-simd-sort/builddir",
            "-Wl,-rpath,$ORIGIN/xFasterTransformer/build",
        ],
        extra_compile_args=paddle_extra_compile_args,
    ),
    packages=find_namespace_packages(where="third_party"),
    package_dir={"": "third_party"},
    include_package_data=True,
)

```

进行安装：

``` shell

➜  custom_ops git:(setuptools80) ✗ pip show setuptools           
Name: setuptools
Version: 57.1.0
Summary: Easily download, build, install, upgrade, and uninstall Python packages
Home-page: https://github.com/pypa/setuptools
Author: Python Packaging Authority
Author-email: distutils-sig@python.org
License: UNKNOWN
Location: /usr/local/lib/python3.9/dist-packages
Requires: 
Required-by: astroid, nodeenv, wandb
➜  custom_ops git:(setuptools80) ✗ python setup_ops.py install --install-lib /paddle/Paddle/build/tmp_setuptools/tmp_install
running install
running build
running build_py
package init file 'third_party/cutlass/__init__.py' not found (or not a regular file)
package init file 'third_party/nlohmann_json/__init__.py' not found (or not a regular file)
package init file 'third_party/DeepGEMM/__init__.py' not found (or not a regular file)
running egg_info
writing third_party/fastdeploy_cpu_ops.egg-info/PKG-INFO
writing dependency_links to third_party/fastdeploy_cpu_ops.egg-info/dependency_links.txt
writing top-level names to third_party/fastdeploy_cpu_ops.egg-info/top_level.txt
reading manifest file 'third_party/fastdeploy_cpu_ops.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching '*.so' under directory 'third_party/x86-simd-sort'
warning: no files found matching '*.h' under directory 'third_party/x86-simd-sort'
warning: no files found matching '*.so' under directory 'third_party/xFasterTransformer'
warning: no files found matching '*.h' under directory 'third_party/xFasterTransformer'
writing manifest file 'third_party/fastdeploy_cpu_ops.egg-info/SOURCES.txt'
running build_ext
Compiling user custom op, it will cost a few seconds.....
building 'fastdeploy_cpu_ops' extension
creating /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build
creating /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops
creating /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9
creating /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/cpu_ops
creating /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops
/usr/local/bin/ccache x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/local/lib/python3.9/dist-packages/paddle/include -I/usr/local/lib/python3.9/dist-packages/paddle/include/third_party -I/usr/local/lib/python3.9/dist-packages/paddle/include/paddle/phi/api/include/compat -I/usr/local/lib/python3.9/dist-packages/paddle/include/paddle/phi/api/include/compat/torch/csrc/api/include -I/usr/include/python3.9 -I/usr/include/python3.9 -c /paddle/FastDeploy/custom_ops/cpu_ops/rebuild_padding.cc -o /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/cpu_ops/rebuild_padding.o -std=c++17 -shared -fPIC -Wno-parentheses -DPADDLE_WITH_CUSTOM_KERNEL -DPADDLE_ON_INFERENCE -Wall -O3 -g -lstdc++fs -D_GLIBCXX_USE_CXX11_ABI=1 -DPy_LIMITED_API=0x03090000 -w -DPADDLE_WITH_CUSTOM_KERNEL -DPADDLE_EXTENSION_NAME=fastdeploy_cpu_ops -D_GLIBCXX_USE_CXX11_ABI=1
/usr/local/bin/ccache x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/local/lib/python3.9/dist-packages/paddle/include -I/usr/local/lib/python3.9/dist-packages/paddle/include/third_party -I/usr/local/lib/python3.9/dist-packages/paddle/include/paddle/phi/api/include/compat -I/usr/local/lib/python3.9/dist-packages/paddle/include/paddle/phi/api/include/compat/torch/csrc/api/include -I/usr/include/python3.9 -I/usr/include/python3.9 -c /paddle/FastDeploy/custom_ops/cpu_ops/stop_generation_multi_ends.cc -o /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/cpu_ops/stop_generation_multi_ends.o -std=c++17 -shared -fPIC -Wno-parentheses -DPADDLE_WITH_CUSTOM_KERNEL -DPADDLE_ON_INFERENCE -Wall -O3 -g -lstdc++fs -D_GLIBCXX_USE_CXX11_ABI=1 -DPy_LIMITED_API=0x03090000 -w -DPADDLE_WITH_CUSTOM_KERNEL -DPADDLE_EXTENSION_NAME=fastdeploy_cpu_ops -D_GLIBCXX_USE_CXX11_ABI=1
/usr/local/bin/ccache x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/local/lib/python3.9/dist-packages/paddle/include -I/usr/local/lib/python3.9/dist-packages/paddle/include/third_party -I/usr/local/lib/python3.9/dist-packages/paddle/include/paddle/phi/api/include/compat -I/usr/local/lib/python3.9/dist-packages/paddle/include/paddle/phi/api/include/compat/torch/csrc/api/include -I/usr/include/python3.9 -I/usr/include/python3.9 -c /paddle/FastDeploy/custom_ops/gpu_ops/get_output.cc -o /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/get_output.o -std=c++17 -shared -fPIC -Wno-parentheses -DPADDLE_WITH_CUSTOM_KERNEL -DPADDLE_ON_INFERENCE -Wall -O3 -g -lstdc++fs -D_GLIBCXX_USE_CXX11_ABI=1 -DPy_LIMITED_API=0x03090000 -w -DPADDLE_WITH_CUSTOM_KERNEL -DPADDLE_EXTENSION_NAME=fastdeploy_cpu_ops -D_GLIBCXX_USE_CXX11_ABI=1
/usr/local/bin/ccache x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/local/lib/python3.9/dist-packages/paddle/include -I/usr/local/lib/python3.9/dist-packages/paddle/include/third_party -I/usr/local/lib/python3.9/dist-packages/paddle/include/paddle/phi/api/include/compat -I/usr/local/lib/python3.9/dist-packages/paddle/include/paddle/phi/api/include/compat/torch/csrc/api/include -I/usr/include/python3.9 -I/usr/include/python3.9 -c /paddle/FastDeploy/custom_ops/gpu_ops/get_output_msg_with_topk.cc -o /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/get_output_msg_with_topk.o -std=c++17 -shared -fPIC -Wno-parentheses -DPADDLE_WITH_CUSTOM_KERNEL -DPADDLE_ON_INFERENCE -Wall -O3 -g -lstdc++fs -D_GLIBCXX_USE_CXX11_ABI=1 -DPy_LIMITED_API=0x03090000 -w -DPADDLE_WITH_CUSTOM_KERNEL -DPADDLE_EXTENSION_NAME=fastdeploy_cpu_ops -D_GLIBCXX_USE_CXX11_ABI=1
/usr/local/bin/ccache x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/local/lib/python3.9/dist-packages/paddle/include -I/usr/local/lib/python3.9/dist-packages/paddle/include/third_party -I/usr/local/lib/python3.9/dist-packages/paddle/include/paddle/phi/api/include/compat -I/usr/local/lib/python3.9/dist-packages/paddle/include/paddle/phi/api/include/compat/torch/csrc/api/include -I/usr/include/python3.9 -I/usr/include/python3.9 -c /paddle/FastDeploy/custom_ops/gpu_ops/save_output_msg_with_topk.cc -o /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/save_output_msg_with_topk.o -std=c++17 -shared -fPIC -Wno-parentheses -DPADDLE_WITH_CUSTOM_KERNEL -DPADDLE_ON_INFERENCE -Wall -O3 -g -lstdc++fs -D_GLIBCXX_USE_CXX11_ABI=1 -DPy_LIMITED_API=0x03090000 -w -DPADDLE_WITH_CUSTOM_KERNEL -DPADDLE_EXTENSION_NAME=fastdeploy_cpu_ops -D_GLIBCXX_USE_CXX11_ABI=1
/usr/local/bin/ccache x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/local/lib/python3.9/dist-packages/paddle/include -I/usr/local/lib/python3.9/dist-packages/paddle/include/third_party -I/usr/local/lib/python3.9/dist-packages/paddle/include/paddle/phi/api/include/compat -I/usr/local/lib/python3.9/dist-packages/paddle/include/paddle/phi/api/include/compat/torch/csrc/api/include -I/usr/include/python3.9 -I/usr/include/python3.9 -c /paddle/FastDeploy/custom_ops/gpu_ops/save_with_output_msg.cc -o /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/save_with_output_msg.o -std=c++17 -shared -fPIC -Wno-parentheses -DPADDLE_WITH_CUSTOM_KERNEL -DPADDLE_ON_INFERENCE -Wall -O3 -g -lstdc++fs -D_GLIBCXX_USE_CXX11_ABI=1 -DPy_LIMITED_API=0x03090000 -w -DPADDLE_WITH_CUSTOM_KERNEL -DPADDLE_EXTENSION_NAME=fastdeploy_cpu_ops -D_GLIBCXX_USE_CXX11_ABI=1
/usr/local/bin/ccache x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/local/lib/python3.9/dist-packages/paddle/include -I/usr/local/lib/python3.9/dist-packages/paddle/include/third_party -I/usr/local/lib/python3.9/dist-packages/paddle/include/paddle/phi/api/include/compat -I/usr/local/lib/python3.9/dist-packages/paddle/include/paddle/phi/api/include/compat/torch/csrc/api/include -I/usr/include/python3.9 -I/usr/include/python3.9 -c /paddle/FastDeploy/custom_ops/gpu_ops/transfer_output.cc -o /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/transfer_output.o -std=c++17 -shared -fPIC -Wno-parentheses -DPADDLE_WITH_CUSTOM_KERNEL -DPADDLE_ON_INFERENCE -Wall -O3 -g -lstdc++fs -D_GLIBCXX_USE_CXX11_ABI=1 -DPy_LIMITED_API=0x03090000 -w -DPADDLE_WITH_CUSTOM_KERNEL -DPADDLE_EXTENSION_NAME=fastdeploy_cpu_ops -D_GLIBCXX_USE_CXX11_ABI=1
/paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/cpu_ops/stop_generation_multi_ends.o is compiled
/paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/get_output.o is compiled
/paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/save_output_msg_with_topk.o is compiled
/paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/get_output_msg_with_topk.o is compiled
/paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/save_with_output_msg.o is compiled
/paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/transfer_output.o is compiled
/paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/cpu_ops/rebuild_padding.o is compiled
x86_64-linux-gnu-g++ -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -g -fwrapv -O2 -Wl,-Bsymbolic-functions -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/cpu_ops/rebuild_padding.o /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/cpu_ops/stop_generation_multi_ends.o /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/get_output.o /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/get_output_msg_with_topk.o /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/save_output_msg_with_topk.o /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/save_with_output_msg.o /paddle/FastDeploy/custom_ops/build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/transfer_output.o -L/usr/local/lib/python3.9/dist-packages/paddle/libs -L/usr/local/lib/python3.9/dist-packages/paddle/base -Wl,--enable-new-dtags,-R/usr/local/lib/python3.9/dist-packages/paddle/libs -Wl,--enable-new-dtags,-R/usr/local/lib/python3.9/dist-packages/paddle/base -o build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/fastdeploy_cpu_ops.so -Wl,-rpath,$ORIGIN/x86-simd-sort/builddir -Wl,-rpath,$ORIGIN/xFasterTransformer/build -l:libpaddle.so
Received len(custom_op) = 9, using custom operator
Removed: build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/get_output.o
Removed: build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/save_with_output_msg.o
Removed: build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/save_output_msg_with_topk.o
Removed: build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/transfer_output.o
Removed: build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops/get_output_msg_with_topk.o
Removed: build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/cpu_ops/rebuild_padding.o
Removed: build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/cpu_ops/stop_generation_multi_ends.o
running install_lib
copying build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/fastdeploy_cpu_ops.py -> /paddle/Paddle/build/tmp_setuptools/tmp_install
creating /paddle/Paddle/build/tmp_setuptools/tmp_install/build
creating /paddle/Paddle/build/tmp_setuptools/tmp_install/build/fastdeploy_cpu_ops
creating /paddle/Paddle/build/tmp_setuptools/tmp_install/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9
creating /paddle/Paddle/build/tmp_setuptools/tmp_install/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/gpu_ops
creating /paddle/Paddle/build/tmp_setuptools/tmp_install/build/fastdeploy_cpu_ops/temp.linux-x86_64-3.9/cpu_ops
copying build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/fastdeploy_cpu_ops.so -> /paddle/Paddle/build/tmp_setuptools/tmp_install
copying build/fastdeploy_cpu_ops/lib.linux-x86_64-3.9/version.txt -> /paddle/Paddle/build/tmp_setuptools/tmp_install
byte-compiling /paddle/Paddle/build/tmp_setuptools/tmp_install/fastdeploy_cpu_ops.py to fastdeploy_cpu_ops.cpython-39.pyc
running install_egg_info
Copying third_party/fastdeploy_cpu_ops.egg-info to /paddle/Paddle/build/tmp_setuptools/tmp_install/fastdeploy_cpu_ops-0.0.0-py3.9.egg-info
running install_scripts

```

此时，`tmp_install` 目录中已经安装好算子，并可以加载：

``` python

# 这是安装的目录
➜  tmp_install git:(setuptools80) ✗ l
total 28K
drwxr-xr-x 6 root root 4.0K Nov 12 06:27 .
drwxr-xr-x 3 1000 1000 4.0K Nov 12 05:29 ..
drwxr-xr-x 2 root root 4.0K Nov 12 06:27 __pycache__
drwxr-xr-x 3 root root 4.0K Nov 12 06:27 build
drwxr-xr-x 3 root root 4.0K Nov 12 06:27 fastdeploy_cpu_ops
drwxr-xr-x 2 root root 4.0K Nov 12 06:27 fastdeploy_cpu_ops-0.0.0-py3.9.egg-info
-rw-r--r-- 1 root root 1.7K Nov 12 06:27 version.txt

# 删除掉其他的目录，模仿 cp fastdeploy_cpu_ops 目录的效果
➜  tmp_install git:(setuptools80) ✗ rm -rf build fastdeploy_cpu_ops-0.0.0-py3.9.egg-info 
➜  tmp_install git:(setuptools80) ✗ l
total 20K
drwxr-xr-x 4 root root 4.0K Nov 12 06:27 .
drwxr-xr-x 3 1000 1000 4.0K Nov 12 05:29 ..
drwxr-xr-x 2 root root 4.0K Nov 12 06:27 __pycache__
drwxr-xr-x 3 root root 4.0K Nov 12 06:27 fastdeploy_cpu_ops
-rw-r--r-- 1 root root 1.7K Nov 12 06:27 version.txt

# 此时，在其他目录无法使用此算子
➜  tmp_install git:(setuptools80) ✗ cd ..
➜  tmp_setuptools git:(setuptools80) ✗ ipython
Python 3.9.18 (main, Aug 25 2023, 13:20:04) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.18.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import fastdeploy_cpu_ops
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[1], line 1
----> 1 import fastdeploy_cpu_ops

ModuleNotFoundError: No module named 'fastdeploy_cpu_ops'

In [2]: exit

# 在安装的目录可以正常加载算子
➜  tmp_setuptools git:(setuptools80) ✗ cd tmp_install 
➜  tmp_install git:(setuptools80) ✗ l
total 20K
drwxr-xr-x 4 root root 4.0K Nov 12 06:27 .
drwxr-xr-x 3 1000 1000 4.0K Nov 12 05:29 ..
drwxr-xr-x 2 root root 4.0K Nov 12 06:27 __pycache__
drwxr-xr-x 3 root root 4.0K Nov 12 06:27 fastdeploy_cpu_ops
-rw-r--r-- 1 root root 1.7K Nov 12 06:27 version.txt
➜  tmp_install git:(setuptools80) ✗ ipython
Python 3.9.18 (main, Aug 25 2023, 13:20:04) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.18.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import fastdeploy_cpu_ops

In [2]: fastdeploy_cpu_ops.static_op_get_output_dynamic
Out[2]: <function fastdeploy_cpu_ops.static_op_get_output_dynamic(x, rank_id, wait_flag, msg_queue_id)>

In [3]: pip show setuptools
Name: setuptools
Version: 57.1.0
Summary: Easily download, build, install, upgrade, and uninstall Python packages
Home-page: https://github.com/pypa/setuptools
Author: Python Packaging Authority
Author-email: distutils-sig@python.org
License: UNKNOWN
Location: /usr/local/lib/python3.9/dist-packages
Requires: 
Required-by: astroid, nodeenv, wandb
Note: you may need to restart the kernel to use updated packages.

In [4]: 

```

`setuptools` 的版本为 `80.9.0` 也同样的效果。

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.

@SigureMo 