### PR TITLE
[CI] set DG_NVCC_OVERRIDE_CPP_STANDARD in test_quantized_linear

### DIFF
--- a/tests/layers/test_quantized_linear.py
+++ b/tests/layers/test_quantized_linear.py
@@ -17,6 +17,8 @@ import os
 import shutil
 import unittest
 
+os.environ.setdefault("DG_NVCC_OVERRIDE_CPP_STANDARD", "17")
+
 import paddle
 
 from fastdeploy.config import (


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
In some environments, running test_quantized_linear.py fails due to a deep_gemm JIT compilation error where nvcc rejects the -std=c++20 flag.
To ensure consistency between runtime and test environments, we set DG_NVCC_OVERRIDE_CPP_STANDARD=17 inside the test script to avoid build failures when the environment variable is not explicitly defined.

## Modifications

Added the following line in tests/layers/test_quantized_linear.py:
```
os.environ.setdefault("DG_NVCC_OVERRIDE_CPP_STANDARD", "17")
```

## Usage or Command
```
python -m pytest -sv tests/layers/test_quantized_linear.py
```

## Accuracy Tests
No need

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
