### PR TITLE
[LogProbs]Enable prompt logprobs output and modify data transmission method for the online interface.

### DIFF
--- a/fastdeploy/engine/request.py
+++ b/fastdeploy/engine/request.py
@@ -531,6 +531,7 @@ class RequestOutput:
             f"prompt={self.prompt!r}, "
             f"prompt_token_ids={self.prompt_token_ids}, "
             f"prompt_logprobs={self.prompt_logprobs}, "
+            f"prompt_logprobs_tensors={self.prompt_logprobs_tensors}, "
             f"output_type={self.output_type}, "
             f"outputs={self.outputs}, "
             f"finished={self.finished}, "
@@ -557,6 +558,7 @@ class RequestOutput:
             "prompt": self.prompt,
             "prompt_token_ids": self.prompt_token_ids,
             "prompt_logprobs": self.prompt_logprobs,
+            "prompt_logprobs_tensors": self.prompt_logprobs_tensors,
             "output_type": self.output_type,
             "outputs": None if self.outputs is None else self.outputs.to_dict(),
             "metrics": None if self.metrics is None else self.metrics.to_dict(),

--- a/fastdeploy/engine/sampling_params.py
+++ b/fastdeploy/engine/sampling_params.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import os
 import random
 from dataclasses import dataclass, fields
 from enum import Enum
@@ -209,8 +208,7 @@ class SamplingParams:
             )
         if self.logprobs is not None and self.logprobs < -1:
             raise ValueError(f"logprobs must be greater than -1, got {self.logprobs}.")
-        if self.logprobs is not None and self.logprobs > 20 and os.getenv("FD_USE_GET_SAVE_OUTPUT_V1", "0") == "0":
-            raise ValueError("Invalid value for 'top_logprobs': must be less than or equal to 20.")
+
         if self.prompt_logprobs is not None and self.prompt_logprobs < -1:
             raise ValueError(f"prompt_logprobs must be greater than or equal to -1, got {self.prompt_logprobs}.")
 

--- a/fastdeploy/entrypoints/engine_client.py
+++ b/fastdeploy/entrypoints/engine_client.py
@@ -69,10 +69,12 @@ class EngineClient:
         enable_prefix_caching=None,
         splitwise_role=None,
         max_processor_cache=0,
+        max_logprobs=20,
     ):
         model_config = ModelConfig({"model": model_name_or_path})
         self.enable_mm = model_config.enable_mm
         enable_processor_cache = self.enable_mm and max_processor_cache > 0
+        self.max_logprobs = max_logprobs
         input_processor = InputPreprocessor(
             model_config,
             reasoning_parser,
@@ -84,6 +86,11 @@ class EngineClient:
         self.enable_logprob = enable_logprob
         self.reasoning_parser = reasoning_parser
         self.data_processor = input_processor.create_processor()
+        self.ori_vocab_size = (
+            len(self.data_processor.tokenizer.sp_model)
+            if hasattr(self.data_processor.tokenizer, "sp_model")
+            else len(self.data_processor.tokenizer.vocab)
+        )
         self.max_model_len = max_model_len
         self.enable_prefix_caching = enable_prefix_caching
         self.enable_splitwise = splitwise_role != "mixed"
@@ -321,6 +328,34 @@ class EngineClient:
         elif logprobs:
             raise ParameterError("logprobs", "Invalid type for 'logprobs'")
 
+        max_logprobs = self.max_logprobs
+        if max_logprobs == -1:
+            max_logprobs = self.ori_vocab_size
+        if max_logprobs < -1:
+            err_msg = f"Invalid 'max_logprobs': must be >= -1, got {max_logprobs}."
+            api_server_logger.error(err_msg)
+            raise ValueError("max_logprobs", err_msg)
+
+        prompt_logprobs = data.get("prompt_logprobs", None)
+        if prompt_logprobs is not None:
+            if not self.enable_logprob:
+                err_msg = "Logprobs is disabled, please enable it in startup config."
+                api_server_logger.error(err_msg)
+                raise ParameterError("logprobs", err_msg)
+
+            if prompt_logprobs == -1:
+                prompt_logprobs = self.ori_vocab_size
+
+            if prompt_logprobs < -1:
+                err_msg = f"Invalid 'prompt_logprobs': must be >= -1, got {prompt_logprobs}."
+                api_server_logger.error(err_msg)
+                raise ValueError("prompt_logprobs", err_msg)
+
+            if prompt_logprobs > max_logprobs:
+                err_msg = "Number of prompt_logprobs requested ({prompt_logprobs}) exceeds maximum allowed value ({max_logprobs})."
+                api_server_logger.error(err_msg)
+                raise ValueError("prompt_logprobs", err_msg)
+
         # enable_logprob
         if top_logprobs:
             if not self.enable_logprob:
@@ -334,15 +369,20 @@ class EngineClient:
                 api_server_logger.error(err_msg)
                 raise ParameterError("top_logprobs", err_msg)
 
-            if top_logprobs < 0:
-                err_msg = f"Invalid 'top_logprobs': must be >= 0, got {top_logprobs}."
-                api_server_logger.error(err_msg)
-                raise ParameterError("top_logprobs", err_msg)
+            if top_logprobs == -1:
+                top_logprobs = self.ori_vocab_size
 
-            if top_logprobs > 20:
-                err_msg = "Invalid value for 'top_logprobs': must be <= 20."
+            if top_logprobs < -1:
+                err_msg = f"Invalid 'top_logprobs': must be >= -1, got {top_logprobs}."
                 api_server_logger.error(err_msg)
-                raise ParameterError("top_logprobs", err_msg)
+                raise ValueError("top_logprobs", err_msg)
+
+            if top_logprobs > max_logprobs:
+                err_msg = (
+                    f"Number of logprobs requested ({top_logprobs}) exceeds maximum allowed value ({max_logprobs})."
+                )
+                api_server_logger.error(err_msg)
+                raise ValueError("top_logprobs", err_msg)
 
     def check_health(self, time_interval_threashold=30):
         """

--- a/fastdeploy/entrypoints/openai/api_server.py
+++ b/fastdeploy/entrypoints/openai/api_server.py
@@ -196,6 +196,7 @@ async def lifespan(app: FastAPI):
         enable_prefix_caching=args.enable_prefix_caching,
         splitwise_role=args.splitwise_role,
         max_processor_cache=args.max_processor_cache,
+        max_logprobs=args.max_logprobs,
     )
     await engine_client.connection_manager.initialize()
     app.state.dynamic_load_weight = args.dynamic_load_weight

--- a/fastdeploy/entrypoints/openai/protocol.py
+++ b/fastdeploy/entrypoints/openai/protocol.py
@@ -24,6 +24,7 @@ from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
 from fastdeploy.engine.pooling_params import PoolingParams
+from fastdeploy.worker.output import PromptLogprobs
 
 
 class InvalidParameterException(Exception):
@@ -218,6 +219,7 @@ class ChatCompletionResponseChoice(BaseModel):
     message: ChatMessage
     logprobs: Optional[LogProbs] = None
     draft_logprobs: Optional[LogProbs] = None
+    prompt_logprobs: Optional[PromptLogprobs] = None
     finish_reason: Optional[Literal["stop", "length", "tool_calls", "recover_stop"]]
 
 
@@ -279,6 +281,7 @@ class ChatCompletionResponseStreamChoice(BaseModel):
     delta: DeltaMessage
     logprobs: Optional[LogProbs] = None
     draft_logprobs: Optional[LogProbs] = None
+    prompt_logprobs: Optional[PromptLogprobs] = None
     finish_reason: Optional[Literal["stop", "length", "tool_calls"]] = None
     arrival_time: Optional[float] = None
 
@@ -310,6 +313,7 @@ class CompletionResponseChoice(BaseModel):
     arrival_time: Optional[float] = None
     logprobs: Optional[CompletionLogprobs] = None
     draft_logprobs: Optional[CompletionLogprobs] = None
+    prompt_logprobs: Optional[PromptLogprobs] = None
     reasoning_content: Optional[str] = None
     finish_reason: Optional[Literal["stop", "length", "tool_calls"]]
     tool_calls: Optional[List[DeltaToolCall | ToolCall]] = None
@@ -349,6 +353,7 @@ class CompletionResponseStreamChoice(BaseModel):
     arrival_time: float = None
     logprobs: Optional[CompletionLogprobs] = None
     draft_logprobs: Optional[CompletionLogprobs] = None
+    prompt_logprobs: Optional[PromptLogprobs] = None
     prompt_token_ids: Optional[List[int]] = None
     completion_token_ids: Optional[List[int]] = None
     prompt_tokens: Optional[str] = None
@@ -437,6 +442,7 @@ class CompletionRequest(BaseModel):
     frequency_penalty: Optional[float] = Field(default=None, ge=-2, le=2)
     logprobs: Optional[int] = None
     include_draft_logprobs: Optional[bool] = False
+    prompt_logprobs: Optional[int] = None
     # For logits and logprobs post processing
     temp_scaled_logprobs: bool = False
     top_p_normalized_logprobs: bool = False
@@ -569,6 +575,18 @@ class CompletionRequest(BaseModel):
 
         return data
 
+    @model_validator(mode="before")
+    @classmethod
+    def check_logprobs(cls, data):
+        if (logprobs := data.get("logprobs")) is not None:
+            if logprobs < -1:
+                raise ValueError("`logprobs` must be a greater than -1.")
+
+        if (prompt_logprobs := data.get("prompt_logprobs")) is not None:
+            if prompt_logprobs < -1:
+                raise ValueError("`prompt_logprobs` must be a greater than -1.")
+        return data
+
 
 class ChatCompletionRequest(BaseModel):
     """
@@ -583,6 +601,7 @@ class ChatCompletionRequest(BaseModel):
     frequency_penalty: Optional[float] = Field(None, le=2, ge=-2)
     logprobs: Optional[bool] = False
     top_logprobs: Optional[int] = 0
+    prompt_logprobs: Optional[int] = None
     include_draft_logprobs: Optional[bool] = False
 
     # For logits and logprobs post processing
@@ -651,6 +670,7 @@ class ChatCompletionRequest(BaseModel):
 
         req_dict["max_tokens"] = self.max_completion_tokens or self.max_tokens
         req_dict["logprobs"] = self.top_logprobs if self.logprobs else None
+        req_dict["prompt_logprobs"] = self.prompt_logprobs
         req_dict["temp_scaled_logprobs"] = self.temp_scaled_logprobs
         req_dict["top_p_normalized_logprobs"] = self.top_p_normalized_logprobs
 
@@ -754,12 +774,15 @@ class ChatCompletionRequest(BaseModel):
     def check_logprobs(cls, data):
 
         if (top_logprobs := data.get("top_logprobs")) is not None:
-            if top_logprobs < 0:
-                raise ValueError("`top_logprobs` must be a positive value.")
+            if top_logprobs < -1:
+                raise ValueError("`top_logprobs` must be a greater than -1.")
 
             if top_logprobs > 0 and not data.get("logprobs"):
                 raise ValueError("when using `top_logprobs`, `logprobs` must be set to true.")
 
+        if (prompt_logprobs := data.get("prompt_logprobs")) is not None:
+            if prompt_logprobs < -1:
+                raise ValueError("`prompt_logprobs` must be a greater than -1.")
         return data
 
 

--- a/fastdeploy/entrypoints/openai/serving_chat.py
+++ b/fastdeploy/entrypoints/openai/serving_chat.py
@@ -15,9 +15,11 @@
 """
 
 import asyncio
+import itertools
 import time
 import traceback
 import uuid
+from collections.abc import Iterable
 from typing import List, Optional
 
 import numpy as np
@@ -45,9 +47,17 @@ from fastdeploy.utils import (
     ErrorType,
     ParameterError,
     api_server_logger,
+    clamp_prompt_logprobs,
     get_host_ip,
 )
-from fastdeploy.worker.output import LogprobsLists
+from fastdeploy.worker.output import (
+    Logprob,
+    LogprobsLists,
+    LogprobsTensors,
+    PromptLogprobs,
+)
+
+NONES = itertools.repeat(None)
 
 
 class OpenAIServingChat:
@@ -282,6 +292,17 @@ class OpenAIServingChat:
                         num_input_image_tokens = res.get("num_input_image_tokens", 0)
                         num_input_video_tokens = res.get("num_input_video_tokens", 0)
                         for i in range(num_choices):
+                            prompt_logprobs_res: Optional[PromptLogprobs] = None
+                            prompt_logprobs_tensors = res.get("prompt_logprobs_tensors", None)
+                            if request.prompt_logprobs and prompt_logprobs_tensors is not None:
+                                num_prompt_logprobs = (
+                                    request.prompt_logprobs
+                                    if request.prompt_logprobs != -1
+                                    else self.engine_client.ori_vocab_size
+                                )
+                                prompt_logprobs_res = self._build_prompt_logprobs(
+                                    prompt_logprobs_tensors, num_prompt_logprobs
+                                )
                             choice = ChatCompletionResponseStreamChoice(
                                 index=i,
                                 delta=DeltaMessage(
@@ -291,6 +312,7 @@ class OpenAIServingChat:
                                     prompt_token_ids=None,
                                     completion_token_ids=None,
                                 ),
+                                prompt_logprobs=clamp_prompt_logprobs(prompt_logprobs_res),
                             )
                             if response_processor.enable_multimodal_content():
                                 choice.delta.multimodal_content = [
@@ -339,12 +361,16 @@ class OpenAIServingChat:
                     logprobs_res: Optional[LogProbs] = None
                     draft_logprobs_res: Optional[LogProbs] = None
                     if request.logprobs and output_top_logprobs is not None:
-                        logprobs_res = self._create_chat_logprobs(
-                            output_top_logprobs, request.logprobs, request.top_logprobs
+                        num_top_logprobs = (
+                            request.top_logprobs if request.top_logprobs != -1 else self.engine_client.ori_vocab_size
                         )
+                        logprobs_res = self._create_chat_logprobs(
+                            output_top_logprobs, request.logprobs, num_top_logprobs
+                        )
+
                         if request.include_draft_logprobs and output_draft_top_logprobs is not None:
                             draft_logprobs_res = self._create_chat_logprobs(
-                                output_draft_top_logprobs, request.logprobs, request.top_logprobs
+                                output_draft_top_logprobs, request.logprobs, num_top_logprobs
                             )
 
                     delta_message = DeltaMessage(
@@ -491,6 +517,7 @@ class OpenAIServingChat:
                 enable_mm_output=self.enable_mm_output,
                 decoder_base_url=self.tokenizer_base_url,
             )
+            prompt_logprobs_res_list = [[] for _ in range(num_choices)]
             choices = []
             while num_choices > 0:
                 if self.engine_client.check_model_weight_status():
@@ -533,9 +560,12 @@ class OpenAIServingChat:
                     output_top_logprobs = output["top_logprobs"]
                     output_draft_top_logprobs = output["draft_top_logprobs"]
                     if output_top_logprobs is not None:
+                        num_top_logprobs = (
+                            request.top_logprobs if request.top_logprobs != -1 else self.engine_client.ori_vocab_size
+                        )
                         # logprobs
                         logprobs_res = self._create_chat_logprobs(
-                            output_top_logprobs, request.logprobs, request.top_logprobs
+                            output_top_logprobs, request.logprobs, num_top_logprobs
                         )
                         if logprobs_res and logprobs_res.content is not None:
                             logprob_contents[idx].extend(logprobs_res.content)
@@ -543,11 +573,20 @@ class OpenAIServingChat:
                         # draft_logprobs
                         if request.include_draft_logprobs and output_draft_top_logprobs is not None:
                             draft_logprobs_res = self._create_chat_logprobs(
-                                output_draft_top_logprobs, request.logprobs, request.top_logprobs
+                                output_draft_top_logprobs, request.logprobs, num_top_logprobs
                             )
                             if draft_logprobs_res and draft_logprobs_res.content is not None:
                                 draft_logprob_contents[idx].extend(draft_logprobs_res.content)
-
+                    prompt_logprobs_tensors = data.get("prompt_logprobs_tensors", None)
+                    if request.prompt_logprobs and prompt_logprobs_tensors is not None:
+                        num_prompt_logprobs = (
+                            request.prompt_logprobs
+                            if request.prompt_logprobs != -1
+                            else self.engine_client.ori_vocab_size
+                        )
+                        prompt_logprobs_res = self._build_prompt_logprobs(prompt_logprobs_tensors, num_prompt_logprobs)
+                        if prompt_logprobs_res:
+                            prompt_logprobs_res_list[idx].extend(clamp_prompt_logprobs(prompt_logprobs_res))
                     if data["finished"]:
                         num_choices -= 1
                         reasoning_num_tokens[idx] = data["outputs"].get("reasoning_token_num", 0)
@@ -567,6 +606,7 @@ class OpenAIServingChat:
                             num_image_tokens=num_image_tokens,
                             logprob_contents=logprob_contents,
                             response_processor=response_processor,
+                            prompt_logprobs_res_list=prompt_logprobs_res_list,
                         )
                         choices.append(choice)
         finally:
@@ -615,6 +655,7 @@ class OpenAIServingChat:
         num_input_video_tokens: list,
         num_image_tokens: list,
         logprob_contents: list,
+        prompt_logprobs_res_list: list,
         response_processor: ChatResponseProcessor,
     ) -> ChatCompletionResponseChoice:
         idx = int(data["request_id"].split("_")[-1])
@@ -641,6 +682,8 @@ class OpenAIServingChat:
         logprobs_full_res = None
         if logprob_contents[idx]:
             logprobs_full_res = LogProbs(content=logprob_contents[idx])
+        if prompt_logprobs_res_list[idx]:
+            prompt_logprobs_full_res = prompt_logprobs_res_list[idx]
 
         has_no_token_limit = request.max_tokens is None and request.max_completion_tokens is None
         max_tokens = request.max_completion_tokens or request.max_tokens
@@ -663,6 +706,7 @@ class OpenAIServingChat:
             index=idx,
             message=message,
             logprobs=logprobs_full_res,
+            prompt_logprobs=prompt_logprobs_full_res,
             finish_reason=finish_reason,
         )
 
@@ -768,3 +812,86 @@ class OpenAIServingChat:
                 else:
                     enable_thinking = True
         return enable_thinking
+
+    def _build_prompt_logprobs(
+        self,
+        prompt_logprobs_tensors: LogprobsTensors,
+        num_prompt_logprobs: int,
+    ):
+        """Update with prompt logprobs from worker.
+        Args:
+          prompt_logprobs_tensors: tuple containing the prompt logprobs
+                                   tensors.
+        """
+
+        token_ids, logprobs, ranks = prompt_logprobs_tensors
+
+        # Detokenize non-incrementally.
+        # Output is flat: [num_tok, num_lps] -> [num_tok * num_lps]
+        decoded_tokens = [
+            self.engine_client.data_processor.process_logprob_response(token_id)
+            for token_id in token_ids.flatten().tolist()
+        ]
+
+        # Recover shapes.
+        num_prompt_tokens, num_logprobs = logprobs.shape
+
+        # Pythonize the paddle tensors.
+        prompt_token_ranks = ranks.tolist()
+        prompt_logprobs = logprobs.tolist()
+        token_ids = token_ids.tolist()
+        result: Optional[PromptLogprobs] = []
+        # Make Logprob for each position.
+        for pos in range(num_prompt_tokens):
+            # Handle flattening.
+            offset = pos * num_logprobs
+            offset_end = offset + num_logprobs
+            decoded_tokens_for_pos = NONES if decoded_tokens is None else decoded_tokens[offset:offset_end]
+
+            # Update with the Logprob dictionary for this pos.
+            result.append(
+                self._make_logprob_dict(
+                    prompt_logprobs[pos],
+                    token_ids[pos],
+                    decoded_tokens_for_pos,
+                    prompt_token_ranks[pos],
+                    num_prompt_logprobs,
+                )
+            )
+        return result
+
+    @staticmethod
+    def _make_logprob_dict(
+        logprobs: list[float],
+        logprob_token_ids: list[int],
+        decoded_tokens: Iterable[str | None],
+        rank: int,
+        num_logprobs: int,
+    ) -> dict[int, Logprob]:
+        """Make a Logprob dictionary for a position.
+        Args:
+          logprobs: list of log probabilities
+          logprob_token_ids: list of top token ids
+          decoded_tokens: list of decoded top tokens
+          rank: rank of the sampled token
+          num_logprobs: number of logprobs requested
+            by the user (in addition to sampled logprob)
+        Returns:
+          dict[token id, Logprob]
+        """
+        if num_logprobs == -1:
+            num_logprobs = len(logprobs)
+        # We do not need a special case for the sampled token
+        # being in the topk, since inserting duplicated data
+        # into a dictionary twice is the same as doing it once.
+        topk_ranks = range(1, num_logprobs + 1)
+        ranks = itertools.chain((rank,), topk_ranks)
+
+        return {
+            token_id: Logprob(
+                logprob=logprob,
+                rank=rank,
+                decoded_token=token,
+            )
+            for token_id, logprob, rank, token in zip(logprob_token_ids, logprobs, ranks, decoded_tokens)
+        }

--- a/fastdeploy/entrypoints/openai/serving_completion.py
+++ b/fastdeploy/entrypoints/openai/serving_completion.py
@@ -15,9 +15,11 @@
 """
 
 import asyncio
+import itertools
 import time
 import traceback
 import uuid
+from collections.abc import Iterable
 from typing import List, Optional
 
 import numpy as np
@@ -41,9 +43,17 @@ from fastdeploy.utils import (
     ErrorType,
     ParameterError,
     api_server_logger,
+    clamp_prompt_logprobs,
     get_host_ip,
 )
-from fastdeploy.worker.output import LogprobsLists
+from fastdeploy.worker.output import (
+    Logprob,
+    LogprobsLists,
+    LogprobsTensors,
+    PromptLogprobs,
+)
+
+NONES = itertools.repeat(None)
 
 
 class OpenAIServingCompletion:
@@ -242,6 +252,7 @@ class OpenAIServingCompletion:
             aggregated_top_logprobs = [[[], [], []] for _ in range(num_choices)]
             aggregated_draft_top_logprobs = [[[], [], []] for _ in range(num_choices)]
             aggregated_token_ids = [[] for _ in range(num_choices)]
+            aggregated_prompt_logprobs_tensors = [None] * num_choices
             completion_batched_token_ids = [[] for _ in range(num_choices)]
             current_waiting_time = 0
             while num_choices > 0:
@@ -286,6 +297,10 @@ class OpenAIServingCompletion:
                             aggregated_draft_top_logprobs[rid][1].extend(output_draft_top_logprobs[1])
                             aggregated_draft_top_logprobs[rid][2].extend(output_draft_top_logprobs[2])
 
+                    output_prompt_logprobs_tensors = data.get("prompt_logprobs_tensors") or None
+                    if output_prompt_logprobs_tensors is not None:
+                        aggregated_prompt_logprobs_tensors[rid] = output_prompt_logprobs_tensors
+
                     aggregated_token_ids[rid].extend(data["outputs"]["token_ids"])
 
                     self.engine_client.data_processor.process_response_dict(
@@ -298,6 +313,7 @@ class OpenAIServingCompletion:
                         data["outputs"]["top_logprobs"] = aggregated_top_logprobs[rid]
                         data["outputs"]["draft_top_logprobs"] = aggregated_draft_top_logprobs[rid]
                         data["outputs"]["token_ids"] = aggregated_token_ids[rid]
+                        data["prompt_logprobs_tensors"] = aggregated_prompt_logprobs_tensors[rid]
                         valid_results[rid] = data
                         num_choices -= 1
                         break
@@ -416,8 +432,18 @@ class OpenAIServingCompletion:
                     idx = int(res["request_id"].split("_")[-1])
                     if res.get("error_code", 200) != 200:
                         raise ValueError("{}".format(res["error_msg"]))
-
+                    prompt_logprobs_res: Optional[PromptLogprobs] = None
                     if first_iteration[idx]:
+                        prompt_logprobs_tensors = res.get("prompt_logprobs_tensors", None)
+                        if request.prompt_logprobs and prompt_logprobs_tensors is not None:
+                            num_prompt_logprobs = (
+                                request.prompt_logprobs
+                                if request.prompt_logprobs != -1
+                                else self.engine_client.ori_vocab_size
+                            )
+                            prompt_logprobs_res = self._build_prompt_logprobs(
+                                prompt_logprobs_tensors, num_prompt_logprobs
+                            )
                         if request.return_token_ids:
                             chunk = CompletionStreamResponse(
                                 id=request_id,
@@ -430,6 +456,7 @@ class OpenAIServingCompletion:
                                         prompt_token_ids=list(
                                             prompt_batched_token_ids[idx // (1 if request.n is None else request.n)]
                                         ),
+                                        prompt_logprobs=clamp_prompt_logprobs(prompt_logprobs_res),
                                         prompt_tokens=prompt_tokens_list[
                                             idx // (1 if request.n is None else request.n)
                                         ],
@@ -459,12 +486,15 @@ class OpenAIServingCompletion:
                     logprobs_res: Optional[CompletionLogprobs] = None
                     draft_logprobs_res: Optional[CompletionLogprobs] = None
                     if request.logprobs and output_top_logprobs is not None:
-                        logprobs_res = self._create_completion_logprobs(output_top_logprobs, request.logprobs, 0)
+                        num_logprobs = (
+                            request.logprobs if request.logprobs != -1 else self.engine_client.ori_vocab_size
+                        )
+                        logprobs_res = self._create_completion_logprobs(output_top_logprobs, num_logprobs, 0)
 
                         # draft logprobs
                         if request.include_draft_logprobs and output_draft_top_logprobs is not None:
                             draft_logprobs_res = self._create_completion_logprobs(
-                                output_draft_top_logprobs, request.logprobs, 0
+                                output_draft_top_logprobs, num_logprobs, 0
                             )
                     output_tokens[idx] += len(output.get("token_ids", [])) or 0
                     num_cache_tokens[idx] += output.get("num_cache_tokens") or 0
@@ -482,6 +512,7 @@ class OpenAIServingCompletion:
                         reasoning_content="",
                         arrival_time=arrival_time,
                         logprobs=logprobs_res,
+                        prompt_logprobs=clamp_prompt_logprobs(prompt_logprobs_res),
                         draft_logprobs=draft_logprobs_res,
                     )
                     if not res["finished"] and "delta_message" in output:
@@ -587,15 +618,22 @@ class OpenAIServingCompletion:
             output_draft_top_logprobs = output.get("draft_top_logprobs") or None
 
             aggregated_logprobs: Optional[CompletionLogprobs] = None
+            num_logprobs = request.logprobs if request.logprobs != -1 else self.engine_client.ori_vocab_size
             if output_top_logprobs is not None:
-                aggregated_logprobs = self._create_completion_logprobs(output_top_logprobs, request.logprobs, 0)
+                aggregated_logprobs = self._create_completion_logprobs(output_top_logprobs, num_logprobs, 0)
 
             aggregated_draft_logprobs: Optional[CompletionLogprobs] = None
             if output_draft_top_logprobs is not None:
                 aggregated_draft_logprobs = self._create_completion_logprobs(
-                    output_draft_top_logprobs, request.logprobs, 0
+                    output_draft_top_logprobs, num_logprobs, 0
                 )
-
+            prompt_logprobs_res: Optional[PromptLogprobs] = None
+            prompt_logprobs_tensors = final_res.get("prompt_logprobs_tensors", None)
+            if request.prompt_logprobs and prompt_logprobs_tensors is not None:
+                num_prompt_logprobs = (
+                    request.prompt_logprobs if request.prompt_logprobs != -1 else self.engine_client.ori_vocab_size
+                )
+                prompt_logprobs_res = self._build_prompt_logprobs(prompt_logprobs_tensors, num_prompt_logprobs)
             if request.echo:
                 prompt_text = self._echo_back_prompt(request, idx // (1 if request.n is None else request.n))
                 token_ids = [*prompt_token_ids, *output["token_ids"]]
@@ -621,6 +659,7 @@ class OpenAIServingCompletion:
                 tool_calls=output.get("tool_call"),
                 logprobs=aggregated_logprobs,
                 draft_logprobs=aggregated_draft_logprobs,
+                prompt_logprobs=clamp_prompt_logprobs(prompt_logprobs_res),
                 finish_reason=finish_reason,
             )
             choices.append(choice_data)
@@ -750,3 +789,86 @@ class OpenAIServingCompletion:
         except Exception as e:
             api_server_logger.error(f"Error in _build_logprobs_response: {str(e)}, {str(traceback.format_exc())}")
             return None
+
+    def _build_prompt_logprobs(
+        self,
+        prompt_logprobs_tensors: LogprobsTensors,
+        num_prompt_logprobs: int,
+    ):
+        """Update with prompt logprobs from worker.
+        Args:
+          prompt_logprobs_tensors: tuple containing the prompt logprobs
+                                   tensors.
+        """
+
+        token_ids, logprobs, ranks = prompt_logprobs_tensors
+
+        # Detokenize non-incrementally.
+        # Output is flat: [num_tok, num_lps] -> [num_tok * num_lps]
+        decoded_tokens = [
+            self.engine_client.data_processor.process_logprob_response(token_id)
+            for token_id in token_ids.flatten().tolist()
+        ]
+
+        # Recover shapes.
+        num_prompt_tokens, num_logprobs = logprobs.shape
+
+        # Pythonize the paddle tensors.
+        prompt_token_ranks = ranks.tolist()
+        prompt_logprobs = logprobs.tolist()
+        token_ids = token_ids.tolist()
+        result: Optional[PromptLogprobs] = []
+        # Make Logprob for each position.
+        for pos in range(num_prompt_tokens):
+            # Handle flattening.
+            offset = pos * num_logprobs
+            offset_end = offset + num_logprobs
+            decoded_tokens_for_pos = NONES if decoded_tokens is None else decoded_tokens[offset:offset_end]
+
+            # Update with the Logprob dictionary for this pos.
+            result.append(
+                self._make_logprob_dict(
+                    prompt_logprobs[pos],
+                    token_ids[pos],
+                    decoded_tokens_for_pos,
+                    prompt_token_ranks[pos],
+                    num_prompt_logprobs,
+                )
+            )
+        return result
+
+    @staticmethod
+    def _make_logprob_dict(
+        logprobs: list[float],
+        logprob_token_ids: list[int],
+        decoded_tokens: Iterable[str | None],
+        rank: int,
+        num_logprobs: int,
+    ) -> dict[int, Logprob]:
+        """Make a Logprob dictionary for a position.
+        Args:
+          logprobs: list of log probabilities
+          logprob_token_ids: list of top token ids
+          decoded_tokens: list of decoded top tokens
+          rank: rank of the sampled token
+          num_logprobs: number of logprobs requested
+            by the user (in addition to sampled logprob)
+        Returns:
+          dict[token id, Logprob]
+        """
+        if num_logprobs == -1:
+            num_logprobs = len(logprobs)
+        # We do not need a special case for the sampled token
+        # being in the topk, since inserting duplicated data
+        # into a dictionary twice is the same as doing it once.
+        topk_ranks = range(1, num_logprobs + 1)
+        ranks = itertools.chain((rank,), topk_ranks)
+
+        return {
+            token_id: Logprob(
+                logprob=logprob,
+                rank=rank,
+                decoded_token=token,
+            )
+            for token_id, logprob, rank, token in zip(logprob_token_ids, logprobs, ranks, decoded_tokens)
+        }

--- a/fastdeploy/entrypoints/openai/utils.py
+++ b/fastdeploy/entrypoints/openai/utils.py
@@ -17,9 +17,9 @@
 import asyncio
 import heapq
 import random
+from multiprocessing.reduction import ForkingPickler
 
 import aiozmq
-import msgpack
 import zmq
 
 from fastdeploy.engine.args_utils import EngineArgs
@@ -121,7 +121,7 @@ class DealerConnectionManager:
         while self.running:
             try:
                 raw_data = await dealer.read()
-                response = msgpack.unpackb(raw_data[-1])
+                response = ForkingPickler.loads(raw_data[-1])
                 request_id = response[-1]["request_id"]
                 if request_id[:4] in ["cmpl", "embd"]:
                     request_id = request_id.rsplit("_", 1)[0]

--- a/fastdeploy/inter_communicator/zmq_server.py
+++ b/fastdeploy/inter_communicator/zmq_server.py
@@ -83,7 +83,7 @@ class ZmqServerBase(ABC):
         if len(data) > 1:
             for response in data[1:]:
                 result.add(response)
-        result = msgpack.packb([result.to_dict()])
+        result = ForkingPickler.dumps([result.to_dict()])
         return result
 
     def receive_json_once(self, block=False):
@@ -172,9 +172,9 @@ class ZmqServerBase(ABC):
                 if self.aggregate_send:
                     result = self.pack_aggregated_data(new_data)
                 else:
-                    result = msgpack.packb([response.to_dict() for response in new_data])
+                    result = ForkingPickler.dumps([response.to_dict() for response in new_data])
                 with self.response_token_lock:
-                    self.socket.send_multipart([self.req_dict[req_id], b"", result])
+                    self.socket.send_multipart([self.req_dict[req_id], b"", result], copy=False)
                 llm_logger.debug(
                     f"send_multipart result: {req_id} len {len(new_data)} elapse: {time.time()-start_send}"
                 )

--- a/fastdeploy/utils.py
+++ b/fastdeploy/utils.py
@@ -50,6 +50,7 @@ from typing_extensions import TypeIs, assert_never
 from fastdeploy import envs
 from fastdeploy.entrypoints.openai.protocol import ErrorInfo, ErrorResponse
 from fastdeploy.logger.logger import FastDeployLogger
+from fastdeploy.worker.output import PromptLogprobs
 
 T = TypeVar("T")
 from typing import Callable, Optional
@@ -1004,3 +1005,18 @@ def optional_type(return_type: Callable[[str], T]) -> Callable[[str], Optional[T
         return parse_type(return_type)(val)
 
     return _optional_type
+
+
+def clamp_prompt_logprobs(
+    prompt_logprobs: PromptLogprobs | None,
+) -> PromptLogprobs | None:
+    if prompt_logprobs is None:
+        return prompt_logprobs
+
+    for logprob_dict in prompt_logprobs:
+        if logprob_dict is None:
+            continue
+        for logprob_values in logprob_dict.values():
+            if logprob_values.logprob == float("-inf"):
+                logprob_values.logprob = -9999.0
+    return prompt_logprobs

--- a/fastdeploy/worker/output.py
+++ b/fastdeploy/worker/output.py
@@ -117,11 +117,12 @@ class LogprobsTensors(NamedTuple):
         Slice rows.
         Keeps the number of max_num_logprobs unchanged.
         """
-        return LogprobsTensors(
-            self.logprob_token_ids[start:end],
-            self.logprobs[start:end],
-            self.selected_token_ranks[start:end],
-        )
+        with paddle.no_grad():
+            return LogprobsTensors(
+                self.logprob_token_ids[start:end],
+                self.logprobs[start:end],
+                self.selected_token_ranks[start:end],
+            )
 
 
 @dataclass

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -340,11 +340,14 @@ class PaddleDisWorkerProc:
                 mmap_infos = create_mmap(
                     [MODEL_MAIN_NAME], self.local_rank, self.ranks, shm_uuid=os.getenv("SHM_UUID", ""), logger=logger
                 )
+
+        tp_size = self.parallel_config.tensor_parallel_size
         # Currently, only support single node
-        self.nnode = int((self.parallel_config.tensor_parallel_size + 7) // 8)
+        self.nnode = int((tp_size + 7) // 8)
         req_ids = []
         num_running_requests = 0
-        local_rank = self.local_rank % self.parallel_config.tensor_parallel_size
+        tp_rank = self.local_rank % tp_size
+
         self.model_weights_signal = np.zeros([1], dtype=np.int32)
         while True:
             if self.eplb_config.enable_redundant_experts:
@@ -385,35 +388,34 @@ class PaddleDisWorkerProc:
                     if self.local_rank == 0:
                         rearrange_experts_status_array[0] = RearrangeExpertState.done.value
                     logger.info("redundant_expert: done")
-            if self.local_rank % self.parallel_config.tensor_parallel_size == 0:
+            if tp_rank == 0:
                 if self.model_weights_status.value[0] != ModelWeightsStatus.NORMAL:
                     self.model_weights_signal[0] = int(self.model_weights_status.value[0])
                 if self.fd_config.load_config.dynamic_load_weight and self.parallel_config.enable_expert_parallel:
                     self.model_weights_signal[0] = self._broadcast_model_weights_signal(
                         src=0, group=self.parallel_config.ep_group
                     )
-            if self.fd_config.load_config.dynamic_load_weight and self.parallel_config.tensor_parallel_size > 1:
+            if self.fd_config.load_config.dynamic_load_weight and tp_size > 1:
                 self.model_weights_signal[0] = self._broadcast_model_weights_signal(
                     src=0, group=self.parallel_config.tp_group
                 )
 
             self.insert_step = False
             req_dicts = None
-            local_rank = self.local_rank % self.parallel_config.tensor_parallel_size
-            self.worker_healthy_live_signal.value[local_rank % self.max_chips_per_node] = int(time.time())
+            self.worker_healthy_live_signal.value[tp_rank % self.max_chips_per_node] = int(time.time())
 
             # The first worker detects whether there are tasks in the task queue
-            if local_rank == 0:
+            if tp_rank == 0:
                 if self.task_queue.num_tasks() > 0:
                     if envs.ENABLE_V1_KVCACHE_SCHEDULER or not (
                         self.fd_config.model_config.enable_mm and self.worker.exist_prefill()
                     ):
-                        if self.nnode > 1 and self.parallel_config.tensor_parallel_size > self.max_chips_per_node:
+                        if self.nnode > 1 and tp_size > self.max_chips_per_node:
                             self.task_queue.read_finish_flag.set(1)
                         else:
                             self.exist_task_signal.value[0] = ExistTaskStatus.EXIST
 
-            if self.parallel_config.tensor_parallel_size > 1:
+            if tp_size > 1:
                 # Synchronize the signal for other workers
                 self._tp_barrier_wait()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

- Currently, only the offline generate() interface supports outputting prompt logprobs results; the online interfaces, specifically v1/chat/completions and v1/completions, do not support prompt logprobs output.
- The v1/chat/completions and v1/completions interfaces do not support outputting the default vocabulary size when logprobs is set to -1; this requires improvement.
- The current transmission path from the engine layer to the API layer does not support the transfer of tensor data, and involves unnecessary memory copies, resulting in low efficiency when transmitting large volumes of data.

## Modifications

<!-- Detail the changes made in this pull request. -->

- Added support and validation for the prompt_logprobs parameter input across both interfaces.
- Implemented logic in both interfaces for processing prompt_logprobs results and constructing the corresponding PromptLogprobs response.
- Modified the logprobs related logic in both interfaces to support the case where logprobs is set to -1.
- Revised the data transmission logic between the engine and API layers to support Paddle.Tensor transfer, utilizing ForkingPickler serialization and achieving zero-copy transfer.

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->
```
curl --location 'http://yq01-sys-rpm36jsah8z.yq01.baidu.com:8180/v1/completions' \
--header 'Content-Type: application/json' \
--data '{
  "prompt": "请生成一篇关于理想的作文,不超过100字",
  "logprobs":-1,
  "prompt_logprobs":5,
  "stream": "true",
  "stream_options":{
    "include_usage":"true"
  }
}'
```

```
curl --location 'http://yq01-sys-rpm36jsah8z.yq01.baidu.com:8180/v1/completions' \
--header 'Content-Type: application/json' \
--data '{
  "prompt": "请生成一篇关于理想的作文,不超过100字",
  "logprobs":5,
  "prompt_logprobs":5
}'
```

```
curl --location 'http://yq01-sys-rpm36jsah8z.yq01.baidu.com:8180/v1/chat/completions' \
--header 'Content-Type: application/json' \
--data '{
    "messages": [
        {
            "role": "system",
            "content": "I'\''m a helpful AI assistant."
        },
        {
            "role": "user",
            "content": "give me three letter randdomly, just tell me letter without anything else"
        }
    ],
    "logprobs":"true",
    "top_logprobs":5,
    "prompt_logprobs":5
}'
```

```
curl --location 'http://yq01-sys-rpm36jsah8z.yq01.baidu.com:8180/v1/chat/completions' \
--header 'Content-Type: application/json' \
--data '{
    "messages": [
        {
            "role": "system",
            "content": "I'\''m a helpful AI assistant."
        },
        {
            "role": "user",
            "content": "give me three letter randdomly, just tell me letter without anything else"
        }
    ],
    "logprobs":"true",
    "top_logprobs":5,
    "prompt_logprobs":5,
    "stream":true
}'
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
When streaming output, the prompt_logprobs are included only in the first package (or chunk).

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
