### PR TITLE
[CI] Enable check_pr_template in CI rerun

### DIFF
--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -56,6 +56,16 @@ jobs:
           REPO: ${{ github.event.repository.name }}
           JOB_NAME: 'CI_XPU'
 
+      - name: Rerun Check PR Template
+        if: ${{ contains(github.event.comment.body, 'check_pr_template') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Check PR Template'
+
       - name: Rerun Codestyle-check
         if: ${{ contains(github.event.comment.body, 'codestyle') || contains(github.event.comment.body, 'pre_commit') }}
         uses: ./.github/actions/rerun-workflow

--- a/scripts/CheckPRTemplate.py
+++ b/scripts/CheckPRTemplate.py
@@ -28,7 +28,6 @@ REPO_TEMPLATE = {
             "## Modifications",
             "## Usage or Command",
             "## Accuracy Tests",
-            "## Checklist",
         ]
     }
 }
@@ -65,27 +64,6 @@ def check_section_content(body, section_titles):
     return results
 
 
-def parse_checklist(section_content):
-    """
-    Parse a checklist section and return dict of items with checked status.
-    Example return:
-    {
-        'Add at least a tag in the PR title.': False,
-        'Format your code, run `pre-commit` before commit.': True,
-        ...
-    }
-    """
-    items = {}
-    lines = section_content.splitlines()
-    for line in lines:
-        match = re.match(r"- \[( |x|X)\] (.+)", line)
-        if match:
-            checked = match.group(1).lower() == "x"
-            item_text = match.group(2).strip()
-            items[item_text] = checked
-    return items
-
-
 def check_pr_template(repo, body):
     """Check whether a PR description follows the expected template."""
     body = remove_comments(body)
@@ -107,16 +85,6 @@ def check_pr_template(repo, body):
             messages.append("❌ Missing section: {}. Please complete it.".format(missing[0]))
         else:
             messages.append("❌ Missing sections: {}. Please complete them.".format(", ".join(missing)))
-
-    # Check Checklist items if present
-    checklist_content = results.get("## Checklist", "")
-    if checklist_content:
-        checklist_items = parse_checklist(checklist_content)
-        unchecked = [item for item, checked in checklist_items.items() if not checked]
-        if unchecked:
-            messages.append("❌ The following checklist items are not completed:")
-            for item in unchecked:
-                messages.append(f"   - [ ] {item}")
 
     if messages:
         messages.append(

--- a/scripts/CheckPRTemplate.py
+++ b/scripts/CheckPRTemplate.py
@@ -28,6 +28,7 @@ REPO_TEMPLATE = {
             "## Modifications",
             "## Usage or Command",
             "## Accuracy Tests",
+            "## Checklist",
         ]
     }
 }
@@ -64,6 +65,27 @@ def check_section_content(body, section_titles):
     return results
 
 
+def parse_checklist(section_content):
+    """
+    Parse a checklist section and return dict of items with checked status.
+    Example return:
+    {
+        'Add at least a tag in the PR title.': False,
+        'Format your code, run `pre-commit` before commit.': True,
+        ...
+    }
+    """
+    items = {}
+    lines = section_content.splitlines()
+    for line in lines:
+        match = re.match(r"- \[( |x|X)\] (.+)", line)
+        if match:
+            checked = match.group(1).lower() == "x"
+            item_text = match.group(2).strip()
+            items[item_text] = checked
+    return items
+
+
 def check_pr_template(repo, body):
     """Check whether a PR description follows the expected template."""
     body = remove_comments(body)
@@ -85,6 +107,16 @@ def check_pr_template(repo, body):
             messages.append("❌ Missing section: {}. Please complete it.".format(missing[0]))
         else:
             messages.append("❌ Missing sections: {}. Please complete them.".format(", ".join(missing)))
+
+    # Check Checklist items if present
+    checklist_content = results.get("## Checklist", "")
+    if checklist_content:
+        checklist_items = parse_checklist(checklist_content)
+        unchecked = [item for item, checked in checklist_items.items() if not checked]
+        if unchecked:
+            messages.append("❌ The following checklist items are not completed:")
+            for item in unchecked:
+                messages.append(f"   - [ ] {item}")
 
     if messages:
         messages.append(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
Add a new CI step to allow rerunning the PR template check on demand via a GitHub comment.

## Modifications
Added a new step in the Rerun CI workflow:
```
- name: Rerun Check PR Template
  if: ${{ contains(github.event.comment.body, 'check_pr_template') }}
  uses: ./.github/actions/rerun-workflow
  with:
    PR_ID: ${{ github.event.issue.number }}
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    OWNER: ${{ github.repository_owner }}
    REPO: ${{ github.event.repository.name }}
    JOB_NAME: 'Check PR Template'
```

## Usage or Command
Comment `/re-run check_pr_template` on any PR to rerun the `Check PR Template` job.

## Accuracy Tests
N/A — this change only updates CI workflow.

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
