### PR TITLE
[Optimize] Reduce comm overhead of engine-worker by obtaining requests asynchronously

### DIFF
--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -160,7 +160,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "FD_ENABLE_E2W_TENSOR_CONVERT": lambda: int(os.getenv("FD_ENABLE_E2W_TENSOR_CONVERT", "0")),
     "FD_ENGINE_TASK_QUEUE_WITH_SHM": lambda: int(os.getenv("FD_ENGINE_TASK_QUEUE_WITH_SHM", "0")),
     "FD_ENABLE_PDL": lambda: int(os.getenv("FD_ENABLE_PDL", "1")),
-    "DISABLE_ENGINE_WORKER_ASYNC_TASK_COMM": lambda: int(os.getenv("DISABLE_ENGINE_WORKER_ASYNC_TASK_COMM", 0)) == 1,
+    "DISABLE_ENGINE_WORKER_ASYNC_TASK_COMM": lambda: int(os.getenv("DISABLE_ENGINE_WORKER_ASYNC_TASK_COMM", "0")) == 1,
 }
 
 

--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -160,6 +160,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "FD_ENABLE_E2W_TENSOR_CONVERT": lambda: int(os.getenv("FD_ENABLE_E2W_TENSOR_CONVERT", "0")),
     "FD_ENGINE_TASK_QUEUE_WITH_SHM": lambda: int(os.getenv("FD_ENGINE_TASK_QUEUE_WITH_SHM", "0")),
     "FD_ENABLE_PDL": lambda: int(os.getenv("FD_ENABLE_PDL", "1")),
+    "DISABLE_ENGINE_WORKER_ASYNC_TASK_COMM": lambda: int(os.getenv("DISABLE_ENGINE_WORKER_ASYNC_TASK_COMM", 0)) == 1,
 }
 
 

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -159,6 +159,27 @@ class PaddleDisWorkerProc:
 
         self.max_chips_per_node = 16 if current_platform.is_iluvatar() else 8
 
+    def _exist_tasks_from_engine(self):
+        """
+        Check if there exists new tasks sent from engine process
+        """
+        if envs.DISABLE_ENGINE_WORKER_ASYNC_TASK_COMM:
+            return self.task_queue.num_tasks() > 0
+        else:
+            return self.local_synced_tasks is not None
+
+    def _get_tasks_from_engine(self):
+        """
+        Get new tasks that sent from engine process
+        """
+        if envs.DISABLE_ENGINE_WORKER_ASYNC_TASK_COMM:
+            return self.task_queue.get_tasks()
+        else:
+            new_tasks, read_finished = self.local_synced_tasks, self.all_local_tp_synced
+            self.local_synced_tasks = None
+            self.all_local_tp_synced = False
+            return new_tasks, read_finished
+
     def init_health_status(self) -> None:
         """
         Initialize the health status of the worker.
@@ -406,7 +427,7 @@ class PaddleDisWorkerProc:
 
             # The first worker detects whether there are tasks in the task queue
             if tp_rank == 0:
-                if self.task_queue.num_tasks() > 0:
+                if self._exist_tasks_from_engine():
                     if envs.ENABLE_V1_KVCACHE_SCHEDULER or not (
                         self.fd_config.model_config.enable_mm and self.worker.exist_prefill()
                     ):
@@ -439,7 +460,7 @@ class PaddleDisWorkerProc:
                         self.worker.model_runner,
                         self.parallel_config.engine_worker_queue_port,
                     )
-                    logger.info(f"current task queue data: {self.task_queue.num_tasks()}")
+                    logger.info(f"current task queue data: {self.local_synced_tasks}")
                     self.task_queue.clear_data()
                     self.model_weights_signal[0] = ModelWeightsStatus.NORMAL
                     logger.info(f"Rank: {self.local_rank} has updated or cleared parameters.")
@@ -448,11 +469,12 @@ class PaddleDisWorkerProc:
                 logger.info(f"Rank: {self.local_rank} Detected new requests.")
                 self.insert_step = True
 
-                tasks, read_finish = self.task_queue.get_tasks()
+                tasks, read_finish = self.task_queue._get_tasks_from_engine()
                 if read_finish:
                     # Ensure that every worker get the task
                     self.exist_task_signal.value[0] = ExistTaskStatus.EMPTY
-                    self.task_queue.read_finish_flag.set(0)
+                    if self.nnode > 1 and tp_size > self.max_chips_per_node:
+                        self.task_queue.read_finish_flag.set(0)
 
                 req_dicts = []
                 for req_dict, bsz in tasks:

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -17,6 +17,7 @@
 import argparse
 import json
 import os
+import threading
 import time
 from multiprocessing import shared_memory
 from typing import Tuple
@@ -159,26 +160,48 @@ class PaddleDisWorkerProc:
 
         self.max_chips_per_node = 16 if current_platform.is_iluvatar() else 8
 
-    def _exist_tasks_from_engine(self):
+        # synced requests from engine
+        self.local_synced_requests = None
+        # flag to determin if all tp process synced
+        self.all_local_tp_synced = False
+
+    def _exist_requests_from_engine(self):
         """
-        Check if there exists new tasks sent from engine process
+        Check if there exists new requests sent from engine process
         """
         if envs.DISABLE_ENGINE_WORKER_ASYNC_TASK_COMM:
             return self.task_queue.num_tasks() > 0
         else:
-            return self.local_synced_tasks is not None
+            return self.local_synced_requests is not None
 
-    def _get_tasks_from_engine(self):
+    def _get_requests_from_engine(self):
         """
-        Get new tasks that sent from engine process
+        Get new requests that sent from engine process
         """
         if envs.DISABLE_ENGINE_WORKER_ASYNC_TASK_COMM:
             return self.task_queue.get_tasks()
         else:
-            new_tasks, read_finished = self.local_synced_tasks, self.all_local_tp_synced
-            self.local_synced_tasks = None
+            new_requests, read_finished = self.local_synced_requests, self.all_local_tp_synced
+            self.local_synced_requests = None
             self.all_local_tp_synced = False
-            return new_tasks, read_finished
+            return new_requests, read_finished
+
+    def _sync_requests_from_engine_loop(self):
+        """
+        A thread that keeps sync all the new requests from engine process to worker process.
+        This function must be called in `event_loop_normal` since the `task_queue` is available
+        in that function.
+        """
+        try:
+            while True:
+                if self.local_synced_requests is None and self.task_queue.num_tasks() > 0:
+                    self.local_synced_requests, self.all_local_tp_synced = self.task_queue.get_tasks()
+        except Exception as e:
+            logger.error(
+                "There's unexcepted issue happend to get tasks from engine, this will cause the worker process cannot insert any new request! error={}".format(
+                    e
+                )
+            )
 
     def init_health_status(self) -> None:
         """
@@ -304,6 +327,8 @@ class PaddleDisWorkerProc:
         """Main event loop for Paddle Distributed Workers.
         TODO(gongshaotian): support remote calling of functions that control worker.
         """
+        sync_request_thread = threading.Thread(target=self._sync_requests_from_engine_loop, daemon=True)
+        sync_request_thread.start()
         if self.eplb_config.enable_redundant_experts:
             self.last_dump_expert_workload_ts = 0
             self.experts_manager = RedundantExpertManager(


### PR DESCRIPTION
通过异步的方式从Engine同步新插入的请求至worker，从而将Worker进程被cpu打断的开销降至0

<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
当前分析在0.3B模型上，```num_tasks```与```get_tasks```的cpu调用开销之和接近1ms，通过此PR优化消除
## Modifications

<!-- Detail the changes made in this pull request. -->

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
