### PR TITLE
[CI] Add workflow to auto-remove `skip-ci` labels after new commits

### DIFF
--- a/.github/workflows/_unit_test_coverage.yml
+++ b/.github/workflows/_unit_test_coverage.yml
@@ -43,6 +43,7 @@ jobs:
     runs-on: [self-hosted, GPU-h1z1-2Cards]
     timeout-minutes: 90
     needs: check_cov_skip
+    if: needs.check_cov_skip.outputs.can-skip != 'true'
     outputs:
       diff_cov_file_url: ${{ steps.cov_upload.outputs.diff_cov_file_url }}
       unittest_failed_url: ${{ steps.cov_upload.outputs.unittest_failed_url }}
@@ -319,7 +320,7 @@ jobs:
           echo "All tests passed"
 
       - name: Verify Code Coverage Threshold (80%)
-        if: ${{ github.event_name == 'pull_request' && (needs.check_cov_skip.outputs['can-skip'] != 'true') }}
+        if: ${{ github.event_name == 'pull_request' }}
         shell: bash
         run: |
           cd FastDeploy

--- a/.github/workflows/remove-skip-ci-labels.yml
+++ b/.github/workflows/remove-skip-ci-labels.yml
@@ -1,0 +1,53 @@
+name: Remove Skip-CI Labels
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remove-skip-ci-labels:
+    name: Remove skip-ci labels on new commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR labels
+        id: get-labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const skipCiLabels = labels
+              .filter(label => label.name.startsWith('skip-ci:'))
+              .map(label => label.name);
+
+            console.log('Found skip-ci labels:', skipCiLabels);
+            core.setOutput('skip-ci-labels', JSON.stringify(skipCiLabels));
+            core.setOutput('has-skip-ci-labels', skipCiLabels.length > 0 ? 'true' : 'false');
+
+      - name: Remove skip-ci labels
+        if: steps.get-labels.outputs.has-skip-ci-labels == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const skipCiLabels = JSON.parse('${{ steps.get-labels.outputs.skip-ci-labels }}');
+
+            for (const label of skipCiLabels) {
+              console.log(`Removing label: ${label}`);
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: label
+              });
+            }
+
+            console.log(`Successfully removed ${skipCiLabels.length} skip-ci label(s)`);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
This PR improves the CI workflow for coverage-related checks.
It introduces automation for cleaning up `skip-ci` labels after new commits and refines the coverage logic so that PRs marked with `skip-ci: coverage` no longer trigger the `run_tests_with_coverage` workflow.

## Modifications
1. Added a new workflow: `.github/workflows/remove-skip-ci-labels.yml`, which automatically removes `skip-ci` labels when new commits are pushed to a PR.
2. Updated the coverage pipeline so that PRs explicitly marked with `skip-ci: coverage` can skip the `run_tests_with_coverage` job.

## Usage or Command
No new commands required.

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
