### PR TITLE
[feat] add port conflict detection for cache-queue-port and engine-wor…

### DIFF
--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -278,16 +278,17 @@ class EngineService:
             self.cfg.parallel_config.local_data_parallel_id
         ]
         if not envs.FD_ENGINE_TASK_QUEUE_WITH_SHM:
-            if not is_port_available(master_ip, engine_worker_queue_port):
-                raise Exception(
-                    f"The parameter `engine_worker_queue_port`:{engine_worker_queue_port} is already in use."
-                )
             address = (master_ip, int(engine_worker_queue_port))
         else:
             address = f"/dev/shm/fd_task_queue_{engine_worker_queue_port}.sock"
 
         if start_queue and (self.cfg.host_ip == self.cfg.master_ip or self.cfg.master_ip == "0.0.0.0"):
             self.llm_logger.info(f"Starting engine worker queue server service at {address}")
+            if not envs.FD_ENGINE_TASK_QUEUE_WITH_SHM:
+                if not is_port_available(master_ip, engine_worker_queue_port):
+                    raise Exception(
+                        f"The parameter `engine_worker_queue_port`:{engine_worker_queue_port} is already in use."
+                    )
             self.engine_worker_queue_server = EngineWorkerQueue(
                 address=address,
                 is_server=True,

--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -57,6 +57,7 @@ from fastdeploy.utils import (
     envs,
     get_logger,
     init_bos_client,
+    is_port_available,
     llm_logger,
 )
 
@@ -272,16 +273,18 @@ class EngineService:
         """
         start queue service for engine worker communication
         """
-
+        master_ip = self.cfg.master_ip
+        engine_worker_queue_port = self.cfg.parallel_config.engine_worker_queue_port[
+            self.cfg.parallel_config.local_data_parallel_id
+        ]
         if not envs.FD_ENGINE_TASK_QUEUE_WITH_SHM:
-            address = (
-                self.cfg.master_ip,
-                int(
-                    self.cfg.parallel_config.engine_worker_queue_port[self.cfg.parallel_config.local_data_parallel_id]
-                ),
-            )
+            if not is_port_available(master_ip, engine_worker_queue_port):
+                raise Exception(
+                    f"The parameter `engine_worker_queue_port`:{engine_worker_queue_port} is already in use."
+                )
+            address = (master_ip, int(engine_worker_queue_port))
         else:
-            address = f"/dev/shm/fd_task_queue_{self.cfg.parallel_config.engine_worker_queue_port[self.cfg.parallel_config.local_data_parallel_id]}.sock"
+            address = f"/dev/shm/fd_task_queue_{engine_worker_queue_port}.sock"
 
         if start_queue and (self.cfg.host_ip == self.cfg.master_ip or self.cfg.master_ip == "0.0.0.0"):
             self.llm_logger.info(f"Starting engine worker queue server service at {address}")
@@ -293,24 +296,18 @@ class EngineService:
             )
             # Dynamically updates the port value if an anonymous port is used
             if not envs.FD_ENGINE_TASK_QUEUE_WITH_SHM:
+                engine_worker_queue_port = str(self.engine_worker_queue_server.get_server_port())
+                address = (master_ip, int(engine_worker_queue_port))
                 self.cfg.parallel_config.engine_worker_queue_port[self.cfg.parallel_config.local_data_parallel_id] = (
-                    str(self.engine_worker_queue_server.get_server_port())
-                )
-                address = (
-                    self.cfg.master_ip,
-                    int(
-                        self.cfg.parallel_config.engine_worker_queue_port[
-                            self.cfg.parallel_config.local_data_parallel_id
-                        ]
-                    ),
+                    engine_worker_queue_port
                 )
 
             if self.cfg.cache_config.enable_prefix_caching or self.cfg.scheduler_config.splitwise_role != "mixed":
+                cache_queue_port = self.cfg.cache_config.cache_queue_port
+                if not is_port_available(master_ip, cache_queue_port):
+                    raise Exception(f"The parameter `cache_queue_port`:{engine_worker_queue_port} is already in use.")
                 self.cache_task_queue = EngineCacheQueue(
-                    address=(
-                        self.cfg.master_ip,
-                        self.cfg.cache_config.cache_queue_port,
-                    ),
+                    address=(master_ip, int(cache_queue_port)),
                     authkey=b"cache_queue_service",
                     is_server=True,
                     num_client=self.cfg.parallel_config.tensor_parallel_size,

--- a/fastdeploy/engine/engine.py
+++ b/fastdeploy/engine/engine.py
@@ -739,13 +739,15 @@ class LLMEngine:
                     if not envs.FD_ENGINE_TASK_QUEUE_WITH_SHM:
                         if not is_port_available(master_ip, engine_worker_queue_port):
                             raise Exception(
-                                f"The parameter `engine_worker_queue_port`:{engine_worker_queue_port} is already in use."
+                                f"The parameter `dp[{i}].engine_worker_queue_port`:{engine_worker_queue_port} is already in use."
                             )
                         address = (master_ip, int(engine_worker_queue_port))
                     else:
                         address = f"/dev/shm/fd_task_queue_{engine_worker_queue_port}.sock"
 
                     llm_logger.info(f"dp start queue service {address}")
+
+                    print(f"=====address:{i}={address}")
                     self.dp_engine_worker_queue_server.append(
                         EngineWorkerQueue(
                             address=address,

--- a/fastdeploy/engine/engine.py
+++ b/fastdeploy/engine/engine.py
@@ -41,7 +41,13 @@ from fastdeploy.engine.request import Request
 from fastdeploy.inter_communicator import EngineWorkerQueue, IPCSignal
 from fastdeploy.metrics.metrics import main_process_metrics
 from fastdeploy.platforms import current_platform
-from fastdeploy.utils import EngineError, console_logger, envs, llm_logger
+from fastdeploy.utils import (
+    EngineError,
+    console_logger,
+    envs,
+    is_port_available,
+    llm_logger,
+)
 
 
 class LLMEngine:
@@ -728,13 +734,16 @@ class LLMEngine:
                     1,
                     self.cfg.parallel_config.data_parallel_size // self.cfg.nnode,
                 ):
+                    master_ip = self.cfg.master_ip
+                    engine_worker_queue_port = self.cfg.parallel_config.engine_worker_queue_port[i]
                     if not envs.FD_ENGINE_TASK_QUEUE_WITH_SHM:
-                        address = (
-                            self.cfg.master_ip,
-                            int(self.cfg.parallel_config.engine_worker_queue_port[i]),
-                        )
+                        if not is_port_available(master_ip, engine_worker_queue_port):
+                            raise Exception(
+                                f"The parameter `engine_worker_queue_port`:{engine_worker_queue_port} is already in use."
+                            )
+                        address = (master_ip, int(engine_worker_queue_port))
                     else:
-                        address = f"/dev/shm/fd_task_queue_{self.cfg.parallel_config.engine_worker_queue_port[i]}.sock"
+                        address = f"/dev/shm/fd_task_queue_{engine_worker_queue_port}.sock"
 
                     llm_logger.info(f"dp start queue service {address}")
                     self.dp_engine_worker_queue_server.append(

--- a/fastdeploy/utils.py
+++ b/fastdeploy/utils.py
@@ -609,6 +609,8 @@ def is_port_available(host, port):
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         try:
+            if isinstance(port, str):
+                port = int(port)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.bind((host, port))
             return True

--- a/tests/engine/test_common_engine.py
+++ b/tests/engine/test_common_engine.py
@@ -1,0 +1,127 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from fastdeploy.engine.common_engine import EngineService
+
+
+class TestStartWorkerQueueService:
+    @pytest.fixture
+    def engine(self):
+        # 创建完全模拟的 EngineService 实例
+        engine = MagicMock(spec=EngineService)
+        engine.cfg = MagicMock()
+        engine.cfg.master_ip = "127.0.0.1"
+        engine.cfg.parallel_config = MagicMock()
+        engine.cfg.parallel_config.engine_worker_queue_port = ["8080"]
+        engine.cfg.parallel_config.local_data_parallel_id = 0
+        engine.cfg.parallel_config.tensor_parallel_size = 1
+        engine.cfg.parallel_config.data_parallel_size = 1
+        engine.cfg.host_ip = "127.0.0.1"
+        engine.cfg.cache_config = MagicMock()
+        engine.cfg.cache_config.enable_prefix_caching = False
+        engine.cfg.cache_config.cache_queue_port = "9090"
+        engine.cfg.scheduler_config = MagicMock()
+        engine.cfg.scheduler_config.splitwise_role = "mixed"
+        engine.cfg.worker_num_per_node = 1
+        engine.cfg.node_rank = 0
+        engine.llm_logger = MagicMock()
+        return engine
+
+    def test_start_with_tcp_port(self, engine):
+        # 模拟方法行为
+        def mock_start_worker_queue_service(start_queue):
+            if start_queue:
+                engine.cfg.parallel_config.engine_worker_queue_port[0] = "8081"
+
+        engine.start_worker_queue_service = mock_start_worker_queue_service
+
+        # 调用方法
+        engine.start_worker_queue_service(start_queue=True)
+
+        # 验证配置更新
+        assert engine.cfg.parallel_config.engine_worker_queue_port[0] == "8081"
+
+    def test_port_in_use_exception(self, engine):
+        # 模拟方法行为
+        def mock_start_worker_queue_service(start_queue):
+            if start_queue:
+                raise Exception("The parameter `engine_worker_queue_port`:8080 is already in use.")
+
+        engine.start_worker_queue_service = mock_start_worker_queue_service
+
+        # 验证异常
+        with pytest.raises(Exception) as excinfo:
+            engine.start_worker_queue_service(start_queue=True)
+
+        assert "is already in use" in str(excinfo.value)
+
+    def test_start_with_shm(self, engine):
+        # 模拟方法行为
+        def mock_start_worker_queue_service(start_queue):
+            if start_queue:
+                engine.engine_worker_queue_server = MagicMock()
+                engine.engine_worker_queue_server.address = "/dev/shm/fd_task_queue_8080.sock"
+
+        engine.start_worker_queue_service = mock_start_worker_queue_service
+
+        # 调用方法
+        engine.start_worker_queue_service(start_queue=True)
+
+        # 验证地址设置
+        assert hasattr(engine, "engine_worker_queue_server")
+        assert "shm" in engine.engine_worker_queue_server.address
+
+    def test_start_cache_queue(self, engine):
+        # 模拟方法行为
+        def mock_start_worker_queue_service(start_queue):
+            if start_queue:
+                engine.cfg.cache_config.enable_prefix_caching = True
+                engine.cache_task_queue = MagicMock()
+                engine.cache_task_queue.get_server_port.return_value = "9091"
+
+        engine.start_worker_queue_service = mock_start_worker_queue_service
+
+        # 调用方法
+        engine.start_worker_queue_service(start_queue=True)
+
+        # 验证缓存队列设置
+        assert engine.cfg.cache_config.enable_prefix_caching is True
+        assert hasattr(engine, "cache_task_queue")
+
+    def test_start_with_different_master_ip(self, engine):
+        # 模拟方法行为
+        def mock_start_worker_queue_service(start_queue):
+            if start_queue and engine.cfg.master_ip == "0.0.0.0":
+                engine.engine_worker_queue_server = MagicMock()
+                engine.engine_worker_queue_server.address = ("0.0.0.0", 8080)
+
+        engine.start_worker_queue_service = mock_start_worker_queue_service
+        engine.cfg.master_ip = "0.0.0.0"
+
+        # 调用方法
+        engine.start_worker_queue_service(start_queue=True)
+
+        # 验证地址设置
+        assert engine.engine_worker_queue_server.address[0] == "0.0.0.0"
+
+    def test_client_mode(self, engine):
+        # 模拟方法行为
+        def mock_start_worker_queue_service(start_queue):
+            if not start_queue:
+                engine.engine_worker_queue = MagicMock()
+                engine.engine_worker_queue.address = ("127.0.0.1", 8080)
+                engine.engine_worker_queue.is_server = False
+
+        engine.start_worker_queue_service = mock_start_worker_queue_service
+
+        # 调用方法
+        engine.start_worker_queue_service(start_queue=False)
+
+        # 验证客户端模式设置
+        assert engine.engine_worker_queue.is_server is False
+        assert engine.engine_worker_queue.address[0] == "127.0.0.1"

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -1,0 +1,127 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fastdeploy.engine.engine import LLMEngine as Engine
+
+
+class TestLaunchComponents:
+    @pytest.fixture
+    def engine(self):
+        eng = MagicMock()
+        eng.cfg = MagicMock()
+        eng.cfg.parallel_config = MagicMock()
+        eng.cfg.parallel_config.enable_expert_parallel = False
+        eng.cfg.scheduler_config = MagicMock()
+        eng.engine = MagicMock()
+        eng.engine.scheduler = MagicMock()
+        eng.engine.split_connector = MagicMock()
+        eng.launched_expert_service_signal = MagicMock()
+        eng.dp_processed = []
+        eng.dp_engine_worker_queue_server = []
+        return eng
+
+    def test_launch_components_splitwise_role_not_mixed(self, engine):
+        engine.cfg.scheduler_config.splitwise_role = "not_mixed"
+        engine.cfg.scheduler_config.name = "splitwise"
+
+        with patch("threading.Thread") as mock_thread:
+            Engine.launch_components(engine)
+
+            mock_thread.assert_called_once_with(target=engine.engine.split_connector.start_receiver, args=())
+            mock_thread.return_value.start.assert_called_once()
+
+    def test_launch_components_splitwise_scheduler(self, engine):
+        engine.cfg.scheduler_config.splitwise_role = "role1"
+        engine.cfg.scheduler_config.name = "splitwise"
+        engine.cfg.host_ip = "127.0.0.1"
+        engine.cfg.disaggregate_info = "info"
+
+        Engine.launch_components(engine)
+
+        engine.engine.scheduler.start.assert_called_once_with("role1", "127.0.0.1", "info")
+
+    def test_launch_components_dp_scheduler(self, engine):
+        engine.cfg.scheduler_config.name = "dp"
+        engine.cfg.node_rank = 1
+        engine.cfg.worker_num_per_node = 2
+        engine.cfg.parallel_config = MagicMock()
+        engine.cfg.parallel_config.data_parallel_size = 2
+
+        with patch("multiprocessing.Queue"):
+            Engine.launch_components(engine)
+
+            assert len(engine.engine.scheduler.start.call_args[0]) == 3
+            assert engine.engine.scheduler.start.call_args[0][0] == 0  # calculated node rank
+
+    def test_launch_components_expert_parallel(self, engine):
+        engine.cfg.scheduler_config.name = "dp"
+        engine.cfg.parallel_config = MagicMock()
+        engine.cfg.parallel_config.enable_expert_parallel = True
+        engine.cfg.parallel_config.data_parallel_size = 4
+        engine.cfg.nnode = 2
+        engine.cfg.master_ip = "127.0.0.1"
+        engine.cfg.parallel_config.engine_worker_queue_port = [0, 1234, 5678]
+        engine.cfg.parallel_config.tensor_parallel_size = 2
+        engine.launched_expert_service_signal.value = [1] * 4  # mock 默认启动成功，避免阻塞
+
+        with (
+            patch("multiprocessing.Queue"),
+            patch("multiprocessing.Process") as mock_process,
+            patch("fastdeploy.engine.engine.EngineWorkerQueue") as mock_queue,
+            patch("fastdeploy.utils.is_port_available", return_value=True),
+            patch("fastdeploy.engine.expert_service.start_data_parallel_service"),
+            patch.dict("os.environ", {"FD_ENABLE_MULTI_API_SERVER": "0", "FD_ENGINE_TASK_QUEUE_WITH_SHM": "0"}),
+        ):
+            mock_process.return_value.start = MagicMock()
+            Engine.launch_components(engine)
+
+            assert mock_process.call_count == 1
+            assert mock_queue.call_count == 1
+            assert engine.launched_expert_service_signal.value[0] == 1
+
+    def test_launch_components_port_unavailable(self, engine):
+        engine.cfg.scheduler_config.name = "dp"
+        engine.cfg.parallel_config = MagicMock()
+        engine.cfg.parallel_config.enable_expert_parallel = True
+        engine.cfg.parallel_config.data_parallel_size = 4
+        engine.cfg.nnode = 2
+        engine.cfg.master_ip = "127.0.0.1"
+        engine.cfg.parallel_config.engine_worker_queue_port = [8000, 8001, 8002, 8003]
+        engine.launched_expert_service_signal.value = [0] * 4
+
+        with (
+            patch("multiprocessing.Queue"),
+            patch("fastdeploy.engine.engine.is_port_available", return_value=False),
+            patch.dict("os.environ", {"FD_ENABLE_MULTI_API_SERVER": "0", "FD_ENGINE_TASK_QUEUE_WITH_SHM": "0"}),
+        ):
+
+            with pytest.raises(Exception) as excinfo:
+                Engine.launch_components(engine)
+            assert "is already in use" in str(excinfo.value)
+
+    def test_launch_components_with_shm(self, engine):
+        engine.cfg.scheduler_config.name = "dp"
+        engine.cfg.parallel_config = MagicMock()
+        engine.cfg.parallel_config.enable_expert_parallel = True
+        engine.cfg.parallel_config.data_parallel_size = 4
+        engine.cfg.nnode = 1
+        engine.cfg.master_ip = "127.0.0.1"
+        engine.cfg.parallel_config.engine_worker_queue_port = [8000, 8001, 8002, 8003]
+        engine.launched_expert_service_signal.value = [1] * 4  # mock 默认启动成功，避免阻塞
+
+        with (
+            patch("multiprocessing.Queue"),
+            patch("multiprocessing.Process"),
+            patch("fastdeploy.engine.engine.EngineWorkerQueue") as mock_queue,
+            patch("fastdeploy.engine.engine.is_port_available"),
+            patch("fastdeploy.engine.engine.start_data_parallel_service"),
+            patch.dict("os.environ", {"FD_ENABLE_MULTI_API_SERVER": "0", "FD_ENGINE_TASK_QUEUE_WITH_SHM": "1"}),
+        ):
+
+            Engine.launch_components(engine)
+
+            calls = mock_queue.call_args_list
+            assert calls[0].kwargs["address"] == "/dev/shm/fd_task_queue_8001.sock"
+            assert calls[1].kwargs["address"] == "/dev/shm/fd_task_queue_8002.sock"
+            assert calls[2].kwargs["address"] == "/dev/shm/fd_task_queue_8003.sock"


### PR DESCRIPTION
## Motivation

为提升系统在多组件并行启动场景下的稳定性，本 PR 新增了 **cache-queue-port** 与 **engine-worker-queue-port** 的端口冲突检测逻辑。当用户显式指定端口且端口已被占用时，系统将提前识别并快速失败及提示，避免在启动hang住，从而提升整体用户体验与可用性。

## Modifications

* 新增对 `cache-queue-port` 的端口可用性检查逻辑
* 新增对 `engine-worker-queue-port` 的端口可用性检查逻辑
* 优化错误提示信息，明确冲突来源与解决方式
* 增强 Engine 相关模块在多实例部署时的健壮性

## Command

当前服务启动时，可指定四类端口

```bash
python -m fastdeploy.entrypoints.openai.api_server \
       --model /workspace/ERNIE-4.5-0.3B-Paddle \
       --port 8680 \
       --engine-worker-queue-port 8386 \
       --cache-queue-port 8683 \
       --metrics-port 8682 \
```

端口冲突示例
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/workspace/FastDeploy/fastdeploy/entrypoints/openai/api_server.py", line 738, in <module>
    main()
  File "/workspace/FastDeploy/fastdeploy/entrypoints/openai/api_server.py", line 717, in main
    if not load_engine():
  File "/workspace/FastDeploy/fastdeploy/entrypoints/openai/api_server.py", line 123, in load_engine
    engine = LLMEngine.from_engine_args(engine_args)
  File "/workspace/FastDeploy/fastdeploy/engine/engine.py", line 75, in from_engine_args
    config = engine_args.create_engine_config()
  File "/workspace/FastDeploy/fastdeploy/engine/args_utils.py", line 1229, in create_engine_config
    assert is_port_available(
AssertionError: The parameter `engine_worker_queue_port`:['8386'] is already in use.
```

## Accuracy Tests

该改动不涉及模型推理逻辑或 kernel 修改，对模型精度无影响。

## Checklist

* [x] Add at least a tag in the PR title. 
* [x] Code formatted; `pre-commit` 已通过
* [ ] Add unit tests
* [x] No accuracy-related changes