### PR TITLE
[CI] add output for last_token in test_streaming_with_stop_str

### DIFF
--- a/tests/ci_use/EB_Lite/test_EB_Lite_serving.py
+++ b/tests/ci_use/EB_Lite/test_EB_Lite_serving.py
@@ -385,14 +385,14 @@ def test_streaming_with_stop_str(openai_client):
         messages=[{"role": "user", "content": "Hello, how are you?"}],
         temperature=1,
         max_tokens=5,
-        extra_body={"include_stop_str_in_output": True},
+        extra_body={"min_tokens": 1, "include_stop_str_in_output": True},
         stream=True,
     )
     # Assertions to check the response structure
     last_token = ""
     for chunk in response:
         last_token = chunk.choices[0].delta.content
-    assert last_token.endswith("</s>")
+    assert last_token.endswith("</s>"), f"last_token did not end with '</s>': {last_token!r}"
 
     response = openai_client.chat.completions.create(
         model="default",

--- a/tests/e2e/test_EB_Lite_serving.py
+++ b/tests/e2e/test_EB_Lite_serving.py
@@ -539,14 +539,14 @@ def test_streaming_with_stop_str(openai_client):
         messages=[{"role": "user", "content": "Hello, how are you?"}],
         temperature=1,
         max_tokens=5,
-        extra_body={"include_stop_str_in_output": True},
+        extra_body={"min_tokens": 1, "include_stop_str_in_output": True},
         stream=True,
     )
     # Assertions to check the response structure
     last_token = ""
     for chunk in response:
         last_token = chunk.choices[0].delta.content
-    assert last_token.endswith("</s>")
+    assert last_token.endswith("</s>"), f"last_token did not end with '</s>': {last_token!r}"
 
     response = openai_client.chat.completions.create(
         model="default",


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
In the streaming chat test, the `last_token` may be `empty` or not end with `</s>`, causing CI failures. This change ensures that when the assertion fails, the actual last_token is printed for debugging. Additionally, `"min_tokens": 1` is added to the request to guarantee at least one token is returned.

## Modifications

- Updated test_streaming_with_stop_str:
   - Added `"min_tokens": 1` in the request payload.
   - Modified the assertion to print last_token if it does not end with `</s>`.
   - Maintains the streaming call logic without altering functionality.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
