### PR TITLE
[CI] Add Cherry-Pick PR check logic

### DIFF
--- a/scripts/check_approval.sh
+++ b/scripts/check_approval.sh
@@ -75,6 +75,22 @@ if [ "${HAS_SPECULATIVE_DECODING_MODIFY}" != "" ] && [ "${PR_ID}" != "" ]; then
     check_approval "$echo_line1" 1 freeliuzc Deleter-D
 fi
 
+if [[ "${BRANCH}" != "develop" ]] && [[ -n "${PR_ID}" ]]; then
+    pr_info=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
+        https://api.github.com/repos/PaddlePaddle/FastDeploy/pulls/${PR_ID})
+
+    pr_title=$(echo "$pr_info" | jq -r '.title')
+    echo "==> PR title: ${pr_title}"
+
+    has_cp_tag=$(echo "$pr_title" | grep -o "\[Cherry-Pick\]" || true)
+    has_pr_number=$(echo "$pr_title" | grep -oE "#[0-9]{2,6}" || true)
+
+    if [[ -z "$has_cp_tag" ]] || [[ -z "$has_pr_number" ]]; then
+        echo_line="Cherry-Pick PR must come from develop and the title must contain [Cherry-Pick] and the original develop PR number (e.g., #5010). Approval required from FastDeploy RD: qingqing01(dangqingqing), Jiang-Jia-Jun(jiangjiajun), heavengate(dengkaipeng)."
+        check_approval "$echo_line" 1 qingqing01 Jiang-Jia-Jun heavengate
+    fi
+fi
+
 if [ -n "${echo_list}" ];then
   echo "****************"
   echo -e "${echo_list[@]}"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
This PR adds a check logic for Cherry-Pick PRs targeting `release/*` or `feature/*` branches. It ensures that:

- The PR originates must come from the `develop` branch.
- The PR title contains `[Cherry-Pick]`.
- The PR title includes the original develop PR number (e.g., `#5010`).

If the PR title does not meet the requirements, approval from the following FastDeploy RDs is required: `qingqing01`, `Jiang-Jia-Jun` or `heavengate`.

The goal is to enforce proper `Cherry-Pick` practices and maintain approval compliance in release or feature branches.

## Modifications
- Added Cherry-Pick check logic in `check_approval.sh`.
- Validates PR title format and source branch.
- Triggers CI approval checks if requirements are not met.

## Usage or Command
No direct usage for end users. 

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
