### PR TITLE
[Speculative Decoding] split draft_tokens into standalone post-processing path

### DIFF
--- a/fastdeploy/engine/request.py
+++ b/fastdeploy/engine/request.py
@@ -316,7 +316,19 @@ class Request:
 
     def __repr__(self) -> str:
         """Safe string representation that ignores private and None fields."""
-        return ""
+        try:
+            if not envs.FD_DEBUG:
+                return f"Request(request_id={self.request_id})"
+            else:
+                attrs_snapshot = dict(vars(self))
+                non_none_fields = [
+                    f"{attr}={value!r}"
+                    for attr, value in attrs_snapshot.items()
+                    if value is not None and not attr.startswith("_")
+                ]
+                return f"Request({', '.join(non_none_fields)})"
+        except Exception as e:
+            return f"<Request repr failed: {e}>"
 
 
 @dataclass(slots=True)

--- a/fastdeploy/entrypoints/openai/serving_chat.py
+++ b/fastdeploy/entrypoints/openai/serving_chat.py
@@ -571,6 +571,7 @@ class OpenAIServingChat:
                             num_input_video_tokens=num_input_video_tokens,
                             num_image_tokens=num_image_tokens,
                             logprob_contents=logprob_contents,
+                            draft_logprob_contents=draft_logprob_contents,
                             response_processor=response_processor,
                             max_tokens=max_tokens,
                         )
@@ -622,6 +623,7 @@ class OpenAIServingChat:
         num_input_video_tokens: list,
         num_image_tokens: list,
         logprob_contents: list,
+        draft_logprob_contents: list,
         response_processor: ChatResponseProcessor,
         max_tokens: int,
     ) -> ChatCompletionResponseChoice:
@@ -649,6 +651,9 @@ class OpenAIServingChat:
         logprobs_full_res = None
         if logprob_contents[idx]:
             logprobs_full_res = LogProbs(content=logprob_contents[idx])
+        draft_logprobs_full_res = None
+        if draft_logprob_contents[idx]:
+            draft_logprobs_full_res = LogProbs(content=draft_logprob_contents[idx])
 
         num_cached_tokens[idx] = data.get("num_cached_tokens", 0)
         num_input_image_tokens[idx] = data.get("num_input_image_tokens", 0)
@@ -669,6 +674,7 @@ class OpenAIServingChat:
             index=idx,
             message=message,
             logprobs=logprobs_full_res,
+            draft_logprobs=draft_logprobs_full_res,
             finish_reason=finish_reason,
         )
 

--- a/fastdeploy/output/token_processor.py
+++ b/fastdeploy/output/token_processor.py
@@ -557,6 +557,60 @@ class TokenProcessor:
                 self.total_step = 0
         self.speculative_stats_step += 1
 
+    def _process_batch_draft_tokens(self, mtype, batch, accept_num, tokens, scores, ranks):
+        """
+        Process batch draft tokens and generate corresponding request outputs
+
+        Args:
+            mtype (int): Message type (3=target token, 4=draft token)
+            batch (int): Batch size
+            accept_num (list): List of accepted token counts per request
+            tokens (paddle.Tensor): Generated draft token IDs tensor
+            scores (paddle.Tensor): Token scores tensor
+            ranks (paddle.Tensor): Token sampling ranks tensor
+
+        Returns:
+            list[RequestOutput]: List containing processed results for all requests
+        """
+        batch_result = list()
+        for i in range(batch):
+            if self.resource_manager.stop_flags[i]:
+                continue
+            task = self.resource_manager.tasks_list[i]
+            task_id = task.request_id
+            result = RequestOutput(
+                request_id=task_id,
+                output_type=mtype,
+                outputs=CompletionOutput(
+                    index=i,
+                    send_idx=None,
+                    token_ids=[],
+                    draft_token_ids=[],
+                ),
+                finished=False,
+                metrics=None,
+            )
+
+            token_ids = tokens[i][:, 0].tolist()[: accept_num[i]]
+            for batch_token_index in range(len(token_ids)):
+                result.outputs.logprob = float(scores[i, batch_token_index, 0])
+                topk_token_ids = tokens[i, batch_token_index, :].tolist()
+                topk_logprobs = scores[i, batch_token_index, :].tolist()
+                sampled_rank = ranks[i, batch_token_index].item()
+
+                if result.outputs.draft_top_logprobs is None:
+                    result.outputs.draft_top_logprobs = LogprobsLists(
+                        logprob_token_ids=[topk_token_ids],
+                        logprobs=[topk_logprobs],
+                        sampled_token_ranks=[sampled_rank],
+                    )
+                else:
+                    result.outputs.draft_top_logprobs.logprob_token_ids.extend([topk_token_ids])
+                    result.outputs.draft_top_logprobs.logprobs.extend([topk_logprobs])
+                    result.outputs.draft_top_logprobs.sampled_token_ranks.extend([sampled_rank])
+            batch_result.append(result)
+        return batch_result
+
     def _process_batch_output(self):
         """
         batch post-processing function
@@ -581,6 +635,12 @@ class TokenProcessor:
                     .reshape([batch, MAX_DRAFT_TOKENS, K + 1])
                 )
                 ranks = self.output_ranks[: batch * MAX_DRAFT_TOKENS].numpy().reshape([batch, MAX_DRAFT_TOKENS])
+
+                # split draft_tokens into standalone post-processing path for MTP + logprobs
+                if mtype == 4:
+                    batch_result = self._process_batch_draft_tokens(mtype, batch, accept_num, tokens, scores, ranks)
+                    self.postprocess(batch_result, mtype)
+                    return
             else:
                 batch = self.output_tokens[1]
                 accept_num = tokens[2 : batch + 2]
@@ -708,8 +768,7 @@ class TokenProcessor:
                     if not (envs.FD_ENABLE_INTERNAL_ADAPTER and token_id in task.eos_token_ids):
                         result.outputs.token_ids.append(token_id)
 
-                    if mtype == 3:
-                        task.output_token_ids.append(token_id)
+                    task.output_token_ids.append(token_id)
 
                     if self.use_logprobs:
                         if self.cfg.speculative_config.method:
@@ -723,29 +782,18 @@ class TokenProcessor:
                             topk_logprobs = scores[i, :].tolist()
                             sampled_rank = ranks[i].item()
 
-                        if mtype == 3:  # top_logprobs
-                            if result.outputs.top_logprobs is None:
-                                result.outputs.top_logprobs = LogprobsLists(
-                                    logprob_token_ids=[topk_token_ids],
-                                    logprobs=[topk_logprobs],
-                                    sampled_token_ranks=[sampled_rank],
-                                )
-                            else:
-                                result.outputs.top_logprobs.logprob_token_ids.extend([topk_token_ids])
-                                result.outputs.top_logprobs.logprobs.extend([topk_logprobs])
-                                result.outputs.top_logprobs.sampled_token_ranks.extend([sampled_rank])
-                        elif mtype == 4:  # draft_top_logprobs
-                            if result.outputs.draft_top_logprobs is None:
-                                result.outputs.draft_top_logprobs = LogprobsLists(
-                                    logprob_token_ids=[topk_token_ids],
-                                    logprobs=[topk_logprobs],
-                                    sampled_token_ranks=[sampled_rank],
-                                )
-                            else:
-                                result.outputs.draft_top_logprobs.logprob_token_ids.extend([topk_token_ids])
-                                result.outputs.draft_top_logprobs.logprobs.extend([topk_logprobs])
-                                result.outputs.draft_top_logprobs.sampled_token_ranks.extend([sampled_rank])
-                if mtype == 3 and (token_id in task.eos_token_ids or is_prefill or recovery_stop):
+                        if result.outputs.top_logprobs is None:
+                            result.outputs.top_logprobs = LogprobsLists(
+                                logprob_token_ids=[topk_token_ids],
+                                logprobs=[topk_logprobs],
+                                sampled_token_ranks=[sampled_rank],
+                            )
+                        else:
+                            result.outputs.top_logprobs.logprob_token_ids.extend([topk_token_ids])
+                            result.outputs.top_logprobs.logprobs.extend([topk_logprobs])
+                            result.outputs.top_logprobs.sampled_token_ranks.extend([sampled_rank])
+
+                if token_id in task.eos_token_ids or is_prefill or recovery_stop:
                     result.finished = True
                     if recovery_stop:
                         result.error_msg = "Recover is not supported, the result is incomplete!"

--- a/tests/input/test_text_processor.py
+++ b/tests/input/test_text_processor.py
@@ -1,89 +1,569 @@
+"""
+# Copyright (c) 2025  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
+import importlib
+import importlib.util
+import sys
+import types
 import unittest
-from unittest.mock import MagicMock, patch
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
-from fastdeploy.engine.request import Request
-from fastdeploy.input.text_processor import DataProcessor
+import numpy as np
 
 
-class TestDataProcessorProcess(unittest.TestCase):
-    def setUp(self):
-        # 创建 DataProcessor 实例的模拟对象
-        with patch.object(DataProcessor, "__init__", return_value=None) as mock_init:
-            self.processor = DataProcessor("model_path")
-            mock_init.side_effect = lambda *args, **kwargs: print(f"__init__ called with {args}, {kwargs}")
+class DummyTokenizer:
+    bos_token = "<s>"
+    cls_token = "<cls>"
+    sep_token = "</s>"
+    eos_token = "</eos>"
+    mask_token = "<mask>"
+    chat_template = "dummy"
 
-        # 设置必要的属性
-        self.processor.tokenizer = MagicMock()
-        self.processor.tokenizer.eos_token_id = 1
-        self.processor.decode_status = {}
-        self.processor.reasoning_end_dict = {}
-        self.processor.tool_parser_dict = {}
-        self.processor.generation_config = MagicMock()
-        self.processor.eos_token_ids = [1]
-        self.processor.reasoning_parser = MagicMock()
+    def __init__(self):
+        self.pad_token_id = 1
+        self.eos_token_id = 2
+        self.eos_token = 2
+        self.vocab_size = 256
+        self.bos_token_id = self._convert_token_to_id(self.bos_token)
+        self.cls_token_id = self._convert_token_to_id(self.cls_token)
+        self.sep_token_id = self._convert_token_to_id(self.sep_token)
+        self.mask_token_id = self._convert_token_to_id(self.mask_token)
 
-        def mock_messages2ids(request, **kwargs):
-            if "chat_template" in kwargs:
-                return [1]
+    def _convert_token_to_id(self, token):
+        return len(str(token))
+
+    def __call__(self, text, **kwargs):
+        if isinstance(text, list):
+            values = [self._value(item) for item in text]
+        else:
+            values = [self._value(text)]
+        max_length = kwargs.get("max_length")
+        if max_length is not None:
+            values = values[:max_length]
+        return {"input_ids": np.array([values], dtype=np.int64)}
+
+    def _value(self, item):
+        if isinstance(item, str):
+            return len(item)
+        return int(item)
+
+    def tokenize(self, text):
+        if isinstance(text, str):
+            return [text]
+        return [str(text)]
+
+    def convert_tokens_to_ids(self, tokens):
+        return [self._value(token) for token in tokens]
+
+    def decode(self, token_ids, **kwargs):
+        return " ".join(str(t) for t in token_ids)
+
+    def decode_token(self, token_ids, prefix_offset, read_offset):
+        start = read_offset
+        delta_tokens = token_ids[start:]
+        delta = "".join(str(t) for t in delta_tokens)
+        prefix_offset += len(token_ids)
+        read_offset += len(delta_tokens)
+        return delta, prefix_offset, read_offset
+
+    def batch_decode(self, batch, **kwargs):
+        return [self.decode(seq) for seq in batch]
+
+    def apply_chat_template(self, request, **kwargs):
+        if isinstance(request, dict):
+            system = request.get("system")
+            messages = request.get("messages", [])
+        else:
+            system = getattr(request, "system", None)
+            messages = getattr(request, "messages", [])
+        parts = [system] if system else []
+        parts.extend(msg.get("content", "") for msg in messages)
+        return " ".join(part for part in parts if part)
+
+
+class DummyLlamaTokenizer(DummyTokenizer):
+    pass
+
+
+class DummyAutoTokenizer:
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        return DummyTokenizer()
+
+
+class DummyHFTokenizer:
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        return DummyTokenizer()
+
+
+def _create_dummy_modules():
+    """Create all dummy modules needed for testing fastdeploy.input.text_processor."""
+    repo_root = Path(__file__).resolve().parents[2]
+
+    dummy_logger = SimpleNamespace(
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+        debug=lambda *args, **kwargs: None,
+    )
+
+    utils_module = types.ModuleType("fastdeploy.utils")
+    utils_module.data_processor_logger = dummy_logger
+
+    envs_module = types.ModuleType("fastdeploy.envs")
+    envs_module.FD_USE_HF_TOKENIZER = False
+
+    generation_module = types.ModuleType("paddleformers.generation")
+
+    class DummyGenerationConfig:
+        def __init__(self):
+            self.top_p = 0.8
+            self.temperature = 0.9
+            self.repetition_penalty = 1.1
+            self.frequency_penalty = 0.2
+            self.presence_penalty = 0.1
+
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            return cls()
+
+    generation_module.GenerationConfig = DummyGenerationConfig
+
+    transformers_module = types.ModuleType("paddleformers.transformers")
+    transformers_module.AutoTokenizer = DummyAutoTokenizer
+    transformers_module.LlamaTokenizer = DummyLlamaTokenizer
+    transformers_module.Llama3Tokenizer = DummyLlamaTokenizer
+
+    hf_transformers_module = types.ModuleType("transformers")
+    hf_transformers_module.AutoTokenizer = DummyHFTokenizer
+
+    llm_utils_module = types.ModuleType("paddleformers.trl.llm_utils")
+    llm_utils_module.get_eos_token_id = lambda tokenizer, config: [tokenizer.eos_token_id]
+
+    fastdeploy_module = types.ModuleType("fastdeploy")
+    fastdeploy_module.__path__ = [str(repo_root / "fastdeploy")]
+    fastdeploy_module.utils = utils_module
+    fastdeploy_module.envs = envs_module
+
+    return {
+        "fastdeploy": fastdeploy_module,
+        "fastdeploy.utils": utils_module,
+        "fastdeploy.envs": envs_module,
+        "paddleformers.generation": generation_module,
+        "paddleformers.transformers": transformers_module,
+        "transformers": hf_transformers_module,
+        "paddleformers.trl.llm_utils": llm_utils_module,
+    }
+
+
+def _import_text_processor(use_hf_tokenizer=False):
+    modules = _create_dummy_modules()
+
+    modules["fastdeploy.envs"].FD_USE_HF_TOKENIZER = use_hf_tokenizer
+
+    previous_modules = {}
+    for name, module in modules.items():
+        previous_modules[name] = sys.modules.get(name)
+        sys.modules[name] = module
+
+    try:
+        text_processor_module = importlib.import_module("fastdeploy.input.text_processor")
+        importlib.reload(text_processor_module)
+    except Exception:
+        for name, original in previous_modules.items():
+            if original is None:
+                sys.modules.pop(name, None)
             else:
-                return [0]
+                sys.modules[name] = original
+        raise
 
-        def mock_apply_default_parameters(request):
-            return request
+    def cleanup():
+        sys.modules.pop("fastdeploy.input.text_processor", None)
+        for name, original in previous_modules.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
 
-        self.processor.messages2ids = mock_messages2ids
-        self.processor._apply_default_parameters = mock_apply_default_parameters
+    return text_processor_module, cleanup
 
-    def test_process_request(self):
-        request = Request.from_dict(
-            {
-                "request_id": "123",
-                "messages": [{"role": "user", "content": "Hello!"}],
-                "eos_token_ids": [1],
-                "temperature": 1,
-                "top_p": 1,
-            }
+
+class DummyRequest:
+    def __init__(self, **kwargs):
+        self.request_id = kwargs.get("request_id", "req")
+        self.prompt = kwargs.get("prompt")
+        self.prompt_token_ids = kwargs.get("prompt_token_ids")
+        self.messages = kwargs.get("messages")
+        self.eos_token_ids = kwargs.get("eos_token_ids")
+        self.chat_template = kwargs.get("chat_template")
+        self.enable_thinking = kwargs.get("enable_thinking")
+        self.history = kwargs.get("history")
+        self.tools = kwargs.get("tools")
+        self.system = kwargs.get("system")
+        self.sampling_params = SimpleNamespace(
+            top_p=kwargs.get("top_p"),
+            temperature=kwargs.get("temperature"),
+            repetition_penalty=kwargs.get("repetition_penalty"),
+            frequency_penalty=kwargs.get("frequency_penalty"),
+            presence_penalty=kwargs.get("presence_penalty"),
+            stop=kwargs.get("stop"),
+            stop_token_ids=kwargs.get("stop_token_ids"),
+            stop_seqs_len=kwargs.get("stop_seqs_len"),
+            bad_words=kwargs.get("bad_words"),
+            bad_words_token_ids=kwargs.get("bad_words_token_ids"),
+            max_tokens=kwargs.get("max_tokens"),
         )
-        chat_template_kwargs = {"chat_template": "Hello!"}
-        result = self.processor.process_request(request, 100, chat_template_kwargs=chat_template_kwargs)
-        self.assertEqual(result.prompt_token_ids, [1])
 
-    def test_process_request_dict(self):
-        request_dict = {
-            "messages": [{"role": "user", "content": "Hello!"}],
-            "chat_template_kwargs": {"chat_template": "Hello!"},
-            "eos_token_ids": [1],
-            "temperature": 1,
-            "top_p": 1,
+    def get(self, key, default=None):
+        if hasattr(self, key) and getattr(self, key) is not None:
+            return getattr(self, key)
+        return getattr(self.sampling_params, key, default)
+
+    def set(self, key, value):
+        if hasattr(self.sampling_params, key):
+            setattr(self.sampling_params, key, value)
+        else:
+            setattr(self, key, value)
+
+    def to_dict(self):
+        return {
+            "request_id": self.request_id,
+            "messages": self.messages,
+            "prompt": self.prompt,
+            "system": self.system,
+            "history": self.history,
+            "tools": self.tools,
+            "chat_template": self.chat_template,
+            "enable_thinking": self.enable_thinking,
         }
-        result = self.processor.process_request_dict(request_dict, 100)
-        self.assertEqual(result["prompt_token_ids"], [1])
 
-    def test_process_response_dict_normal(self):
-        self.processor.tokenizer.decode_token = MagicMock(return_value=("Mock decoded text", 0, 0))
-        self.processor.reasoning_parser.extract_reasoning_content = MagicMock(
-            return_value=("Mock reasoning content", "Mock final text")
+    def __getitem__(self, key):
+        return self.get(key)
+
+    def __setitem__(self, key, value):
+        self.set(key, value)
+
+
+class DataProcessorTestCase(unittest.TestCase):
+    @staticmethod
+    def create_dummy_reasoning(tokenizer, reasoning_content="think"):
+        class DummyReasoning:
+            def __init__(self, tokenizer):
+                self.tokenizer = tokenizer
+
+            def extract_reasoning_content(self, full_text, response_dict):
+                return reasoning_content, f"{full_text}!"
+
+        return DummyReasoning(tokenizer)
+
+    @staticmethod
+    def create_dummy_tool_parser(tokenizer, content="tool-text"):
+        class DummyToolParser:
+            def __init__(self, tokenizer):
+                self.tokenizer = tokenizer
+
+            def extract_tool_calls(self, full_text, response_dict):
+                return SimpleNamespace(tools_called=True, tool_calls=["tool"], content=content)
+
+        return DummyToolParser
+
+    def setUp(self):
+        module, cleanup = _import_text_processor()
+        self.text_processor_module = module
+        self.addCleanup(cleanup)
+        self.processor = self.text_processor_module.DataProcessor("stub-model")
+
+    def test_base_data_processor_contract(self):
+        text_processor_module = self.text_processor_module
+
+        class MinimalProcessor(text_processor_module.BaseDataProcessor):
+            def __init__(self):
+                self.generation_config = SimpleNamespace(
+                    top_p=0.5,
+                    temperature=0.6,
+                    repetition_penalty=1.1,
+                    frequency_penalty=0.2,
+                    presence_penalty=0.3,
+                )
+                super().__init__()
+
+            def _load_tokenizer(self):
+                return DummyTokenizer()
+
+            def process_request(self, request, **kwargs):
+                return super().process_request(request, **kwargs)
+
+            def process_response(self, response_dict):
+                return super().process_response(response_dict)
+
+        processor = MinimalProcessor()
+        defaults = processor._apply_default_parameters({})
+        self.assertAlmostEqual(defaults["top_p"], 0.5)
+        with self.assertRaises(NotImplementedError):
+            processor.process_request({}, max_model_len=None)
+        with self.assertRaises(NotImplementedError):
+            processor.process_response({})
+        with self.assertRaises(NotImplementedError):
+            processor.text2ids("text")
+        with self.assertRaises(NotImplementedError):
+            processor.messages2ids([])
+        with self.assertRaises(NotImplementedError):
+            processor.ids2tokens([1], "task")
+
+    def test_process_request_dict_prompt_defaults(self):
+        request = {"prompt": "hi", "temperature": 0, "top_p": 0, "stop": ["stop"]}
+        processed = self.processor.process_request_dict(request, max_model_len=5)
+
+        self.assertEqual(processed["prompt_token_ids"], [2])
+        self.assertEqual(processed["stop_token_ids"], [[4]])
+        self.assertEqual(processed["stop_seqs_len"], [1])
+        self.assertEqual(processed["temperature"], 1)
+        self.assertAlmostEqual(processed["top_p"], 1e-5)
+        self.assertEqual(processed["max_tokens"], 4)
+
+    def test_process_request_dict_messages_template(self):
+        request = {
+            "request_id": "chat",
+            "messages": [{"role": "user", "content": "hello"}],
+            "chat_template_kwargs": {"system": "system prompt"},
+        }
+        processed = self.processor.process_request_dict(request, max_model_len=6)
+
+        self.assertEqual(processed["prompt_token_ids"], [len("system prompt hello")])
+        self.assertEqual(processed["system"], "system prompt")
+        self.assertTrue(processed["enable_thinking"])
+        self.assertEqual(processed["prompt_tokens"], "system prompt hello")
+
+    def test_process_request_object_handles_sequences(self):
+        request = DummyRequest(
+            prompt=[1, 2, 3, 4, 5, 6],
+            stop=["stop"],
+            bad_words=["zz"],
+            temperature=0,
+            top_p=0,
         )
-        mock_tokens = ["mock", "reasoning", "tokens"]
-        self.processor.tokenizer.tokenize = MagicMock(return_value=mock_tokens)
-        self.processor.tool_parser_obj = None
-        response_dict = {
-            "request_id": "request-id_0",
-            "outputs": {
-                "token_ids": [2, 3, 4, 5, 1],
-                "text": "Hello",
-                "top_logprobs": [{"a": 0.1}, {"b": 0.2}, {"c": 0.3}],
-            },
-            "finish_reason": "stop",
+        processed = self.processor.process_request(request, max_model_len=5)
+
+        self.assertEqual(processed.prompt_token_ids, [1, 2, 3, 4])
+        self.assertEqual(processed.sampling_params.max_tokens, 1)
+        self.assertEqual(processed.sampling_params.stop_token_ids, [[4]])
+        self.assertEqual(set(processed.sampling_params.bad_words_token_ids), {2, 3})
+        self.assertEqual(processed.sampling_params.temperature, 1)
+        self.assertAlmostEqual(processed.sampling_params.top_p, 1e-5)
+
+    def test_process_request_requires_prompt_or_messages(self):
+        request = DummyRequest(prompt=None, messages=None, prompt_token_ids=None)
+        with self.assertRaisesRegex(ValueError, "should have `input_ids`, `text` or `messages`"):
+            self.processor.process_request(request, max_model_len=5)
+
+    def test_process_request_dict_rejects_bad_kwargs(self):
+        request = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "chat_template_kwargs": "invalid",
+        }
+        with self.assertRaisesRegex(ValueError, "chat_template_kwargs must be a dict"):
+            self.processor.process_request_dict(request)
+
+    def test_ids2tokens_and_clear_request_status(self):
+        delta, _, _ = self.processor.ids2tokens([3], "task-1")
+        self.assertEqual(delta, "3")
+        delta, _, _ = self.processor.ids2tokens([4], "task-1")
+        self.assertEqual(delta, "4")
+
+        combined = self.processor.clear_request_status("task-1")
+        self.assertEqual(combined, "34")
+        self.assertNotIn("task-1", self.processor.decode_status)
+
+    def test_clear_request_status_hf_branch(self):
+        module, cleanup = _import_text_processor(use_hf_tokenizer=True)
+        self.addCleanup(cleanup)
+        processor = module.DataProcessor("stub-model")
+        processor.decode_status = {"task": [[], [], "transcript"]}
+
+        self.assertEqual(processor.clear_request_status("task"), "transcript")
+        self.assertNotIn("task", processor.decode_status)
+
+    def test_data_processor_init_handles_missing_generation_config(self):
+        with mock.patch.object(
+            self.text_processor_module.GenerationConfig,
+            "from_pretrained",
+            side_effect=OSError("missing"),
+        ):
+            processor = self.text_processor_module.DataProcessor("stub-model")
+        self.assertIsNone(processor.generation_config)
+
+    def test_process_response_with_reasoning_and_tools(self):
+        processor = self.processor
+
+        processor.reasoning_parser = self.create_dummy_reasoning(processor.tokenizer)
+        processor.tool_parser_obj = self.create_dummy_tool_parser(processor.tokenizer, content="tool-only")
+
+        response = SimpleNamespace(
+            request_id="resp",
+            outputs=SimpleNamespace(token_ids=[1, processor.tokenizer.eos_token_id]),
+        )
+
+        processed = processor.process_response(response)
+        self.assertEqual(processed.outputs.text, "tool-only")
+        self.assertEqual(processed.outputs.reasoning_content, "think")
+        self.assertEqual(processed.outputs.tool_calls, ["tool"])
+
+    def test_process_response_streaming_clears_state(self):
+        processor = self.processor
+        req_id = "stream"
+        processor.decode_status[req_id] = [0, 0, [], ""]
+        response = {"finished": True, "request_id": req_id, "outputs": {"token_ids": [7]}}
+
+        result = processor.process_response_dict_streaming(response, enable_thinking=False)
+        self.assertEqual(result["outputs"]["text"], "7")
+        self.assertNotIn(req_id, processor.decode_status)
+
+    def test_process_response_dict_normal_with_reasoning(self):
+        processor = self.processor
+
+        processor.reasoning_parser = self.create_dummy_reasoning(processor.tokenizer, reasoning_content="because")
+        processor.tool_parser_obj = self.create_dummy_tool_parser(processor.tokenizer, content="tool-text")
+
+        response = {
             "finished": True,
+            "request_id": "normal",
+            "outputs": {"token_ids": [7, processor.tokenizer.eos_token_id]},
         }
-        kwargs = {"enable_thinking": True}
-        with patch("fastdeploy.input.text_processor.data_processor_logger"):
-            result = self.processor.process_response_dict_normal(response_dict, **kwargs)
-        self.assertEqual(result["outputs"]["reasoning_content"], "Mock reasoning content")
-        self.assertEqual(result["outputs"]["reasoning_token_num"], len(mock_tokens))
-        self.assertEqual(result["outputs"]["text"], "Mock final text")
-        self.assertIn("completion_tokens", result["outputs"])
+
+        result = processor.process_response_dict_normal(response, enable_thinking=True)
+        self.assertEqual(result["outputs"]["completion_tokens"], "7")
+        self.assertEqual(result["outputs"]["text"], "tool-text")
+        self.assertEqual(result["outputs"]["reasoning_content"], "because")
+        self.assertEqual(result["outputs"]["reasoning_token_num"], 1)
+
+    def test_process_response_dict_dispatch(self):
+        processor = self.processor
+        calls = {}
+
+        def fake_stream(response_dict, **kwargs):
+            calls["stream"] = kwargs
+            return "stream"
+
+        def fake_normal(response_dict, **kwargs):
+            calls["normal"] = kwargs
+            return "normal"
+
+        original_stream = processor.process_response_dict_streaming
+        original_normal = processor.process_response_dict_normal
+        processor.process_response_dict_streaming = fake_stream
+        processor.process_response_dict_normal = fake_normal
+        self.addCleanup(lambda: setattr(processor, "process_response_dict_streaming", original_stream))
+        self.addCleanup(lambda: setattr(processor, "process_response_dict_normal", original_normal))
+
+        response = {"outputs": {}, "finished": False, "request_id": "req"}
+        self.assertEqual(processor.process_response_dict(response), "stream")
+        self.assertTrue(calls["stream"]["enable_thinking"])
+        self.assertEqual(
+            processor.process_response_dict(response, stream=False, enable_thinking=None),
+            "normal",
+        )
+        self.assertTrue(calls["normal"]["enable_thinking"])
+
+    def test_update_stop_seq_excludes_eos(self):
+        stop_seqs, stop_len = self.processor.update_stop_seq(["stop", self.processor.tokenizer.eos_token_id])
+        self.assertEqual(stop_seqs, [[4]])
+        self.assertEqual(stop_len, [1])
+
+    def test_pad_batch_data_left_padding(self):
+        padded, lengths = self.processor.pad_batch_data(
+            [[1], [2, 3]],
+            pad_id=-1,
+            return_seq_len=True,
+            return_array=False,
+            pad_style="left",
+        )
+        self.assertEqual(padded, [[-1, 1], [2, 3]])
+        self.assertEqual(lengths, [1, 2])
+
+    def test_pad_batch_data_empty_returns_array(self):
+        padded, lengths = self.processor.pad_batch_data([], return_seq_len=True)
+        self.assertEqual(padded.shape, (1, 0))
+        self.assertEqual(lengths.shape, (0,))
+
+    def test_get_pad_id_prefers_eos_when_missing(self):
+        processor = self.text_processor_module.DataProcessor("stub-model")
+        llama_tokenizer = DummyLlamaTokenizer()
+        llama_tokenizer.pad_token_id = None
+        llama_tokenizer.eos_token = 99
+        processor.tokenizer = llama_tokenizer
+
+        self.assertEqual(processor.get_pad_id(), 99)
+
+    def test_load_tokenizer_hf_branch(self):
+        module, cleanup = _import_text_processor(use_hf_tokenizer=True)
+        self.addCleanup(cleanup)
+        processor = module.DataProcessor("stub-model")
+        self.assertIsInstance(processor.tokenizer, DummyTokenizer)
+
+    def test_text2ids_hf_branch(self):
+        module, cleanup = _import_text_processor(use_hf_tokenizer=True)
+        self.addCleanup(cleanup)
+        processor = module.DataProcessor("stub-model")
+        ids = processor.text2ids("hi", max_model_len=5)
+        self.assertEqual(ids.tolist(), [2, 0, 0, 0, 0][: len(ids)])
+
+    def test_process_logprob_response(self):
+        self.assertEqual(self.processor.process_logprob_response([1, 2]), "1 2")
+
+    def test_process_request_dict_uses_existing_ids(self):
+        request = {"prompt_token_ids": [1, 2, 3], "max_tokens": 5}
+        processed = self.processor.process_request_dict(request, max_model_len=6)
+        self.assertEqual(processed["prompt_token_ids"], [1, 2, 3])
+        self.assertEqual(processed["max_tokens"], 5)
+
+    def test_process_request_dict_requires_chat_template(self):
+        original_template = self.processor.tokenizer.chat_template
+        self.processor.tokenizer.chat_template = None
+        self.addCleanup(lambda: setattr(self.processor.tokenizer, "chat_template", original_template))
+        with self.assertRaisesRegex(ValueError, "chat_template"):
+            self.processor.process_request_dict({"messages": [{"role": "user", "content": "hi"}]})
+
+    def test_update_bad_words_with_warnings(self):
+        processor = self.processor
+
+        def custom_tokenize(text):
+            base = text.strip()
+            if base == "combo":
+                return ["co", "mbo"]
+            if base == "oversize":
+                return [base]
+            return [base]
+
+        def custom_convert(tokens):
+            if tokens == ["co", "mbo"]:
+                return [1, 2]
+            if tokens == ["oversize"]:
+                return [processor.tokenizer.vocab_size + 1]
+            return [len(tokens[0])]
+
+        original_tokenize = processor.tokenizer.tokenize
+        original_convert = processor.tokenizer.convert_tokens_to_ids
+        processor.tokenizer.tokenize = custom_tokenize
+        processor.tokenizer.convert_tokens_to_ids = custom_convert
+        self.addCleanup(lambda: setattr(processor.tokenizer, "tokenize", original_tokenize))
+        self.addCleanup(lambda: setattr(processor.tokenizer, "convert_tokens_to_ids", original_convert))
+
+        self.assertEqual(processor.update_bad_words(["combo", "oversize"], []), [])
 
 
 if __name__ == "__main__":

--- a/tests/model_executor/test_tp_utils.py
+++ b/tests/model_executor/test_tp_utils.py
@@ -1,0 +1,490 @@
+"""
+# Copyright (c) 2025  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Unit tests for tensor parallel utility helpers.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from functools import partial
+from pathlib import Path
+
+import numpy as np
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _DummyLogger:
+    def __init__(self):
+        self.errors = []
+
+    def error(self, message):
+        self.errors.append(message)
+
+    def clear(self):
+        self.errors.clear()
+
+
+def _ensure_module(name: str) -> types.ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    return module
+
+
+def _install_dependency_stubs():
+    # Stub paddle and paddle.distributed used during module imports.
+    paddle = _ensure_module("paddle")
+    paddle.__dict__.setdefault("__version__", "0.0.0")
+    paddle.Tensor = np.ndarray
+
+    def _split(array, sections, axis=0):
+        if isinstance(sections, int):
+            return np.array_split(array, sections, axis=axis)
+        raise NotImplementedError("sections must be an integer in tests")
+
+    def _concat(arrays, axis=0):
+        return np.concatenate(list(arrays), axis=axis)
+
+    def _to_tensor(array, dtype=None):
+        return np.asarray(array, dtype=dtype)
+
+    def _get_default_dtype():
+        return np.float32
+
+    class _CUDAPinnedPlace:
+        def __repr__(self):  # pragma: no cover - representation helper
+            return "CUDAPinnedPlace()"
+
+    paddle.split = _split
+    paddle.concat = _concat
+    paddle.to_tensor = _to_tensor
+    paddle.get_default_dtype = _get_default_dtype
+    paddle.CUDAPinnedPlace = _CUDAPinnedPlace
+    dist = types.ModuleType("paddle.distributed")
+    dist.get_world_size = lambda: 1
+    dist.get_rank = lambda: 0
+    dist.is_initialized = lambda: False
+    sys.modules["paddle.distributed"] = dist
+    paddle.distributed = dist
+
+    # Stub paddleformers pieces referenced by tp_utils.
+    paddleformers = _ensure_module("paddleformers")
+    paddleformers.__path__ = []
+
+    transformers = types.ModuleType("paddleformers.transformers")
+
+    class _PretrainedModel:
+        @classmethod
+        def _get_tensor_parallel_mappings(cls, *_args, **_kwargs):
+            return {}
+
+        @classmethod
+        def _resolve_prefix_keys(cls, keys, _safetensor_keys):
+            return {k: k for k in keys}
+
+    transformers.PretrainedModel = _PretrainedModel
+    sys.modules["paddleformers.transformers"] = transformers
+    paddleformers.transformers = transformers
+
+    conversion_utils = types.ModuleType("paddleformers.transformers.conversion_utils")
+
+    def _split_or_merge_func(is_split, tensor_parallel_degree, tensor_parallel_rank, **_kwargs):
+        axis = -1
+
+        def _fn(weight, *, is_column=True, **_kwargs):
+            current_axis = axis if is_column else 0
+            if is_split:
+                chunks = np.array_split(weight, tensor_parallel_degree, axis=current_axis)
+                if tensor_parallel_rank is None:
+                    return chunks
+                return chunks[tensor_parallel_rank]
+            return np.concatenate(weight, axis=current_axis)
+
+        return _fn
+
+    conversion_utils.split_or_merge_func = _split_or_merge_func
+    sys.modules["paddleformers.transformers.conversion_utils"] = conversion_utils
+
+    utils_pkg = types.ModuleType("paddleformers.utils")
+    utils_pkg.__path__ = []
+    sys.modules["paddleformers.utils"] = utils_pkg
+
+    log_module = types.ModuleType("paddleformers.utils.log")
+    log_module.logger = _DummyLogger()
+    sys.modules["paddleformers.utils.log"] = log_module
+    utils_pkg.log = log_module
+
+    # Provide a lightweight FDConfig replacement consumed by tp_utils.
+    fastdeploy_pkg = _ensure_module("fastdeploy")
+    fastdeploy_pkg.__path__ = [str(PROJECT_ROOT / "fastdeploy")]
+
+    fd_config_module = types.ModuleType("fastdeploy.config")
+
+    class _ParallelConfig:
+        def __init__(self, tensor_parallel_size):
+            self.tensor_parallel_size = tensor_parallel_size
+
+    class _ModelConfig:
+        def __init__(self, pretrained_config):
+            self.pretrained_config = pretrained_config
+
+    class FDConfig:
+        def __init__(self, tensor_parallel_size=1, pretrained_config=None):
+            self.parallel_config = _ParallelConfig(tensor_parallel_size)
+            self.model_config = _ModelConfig(pretrained_config)
+
+    fd_config_module.FDConfig = FDConfig
+    sys.modules["fastdeploy.config"] = fd_config_module
+    fastdeploy_pkg.config = fd_config_module
+
+    model_executor_pkg = _ensure_module("fastdeploy.model_executor")
+    model_executor_pkg.__path__ = [str(PROJECT_ROOT / "fastdeploy" / "model_executor")]
+    models_pkg = _ensure_module("fastdeploy.model_executor.models")
+    models_pkg.__path__ = [str(PROJECT_ROOT / "fastdeploy" / "model_executor" / "models")]
+
+    # Load the real utils module so enums are shared with production code.
+    utils_name = "fastdeploy.model_executor.models.utils"
+    if utils_name not in sys.modules:
+        utils_spec = importlib.util.spec_from_file_location(
+            utils_name, PROJECT_ROOT / "fastdeploy" / "model_executor" / "models" / "utils.py"
+        )
+        utils_module = importlib.util.module_from_spec(utils_spec)
+        utils_spec.loader.exec_module(utils_module)
+        sys.modules[utils_name] = utils_module
+        models_pkg.utils = utils_module
+
+
+def _load_tp_utils():
+    module_name = "fastdeploy.model_executor.models.tp_utils"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+
+    _install_dependency_stubs()
+
+    spec = importlib.util.spec_from_file_location(
+        module_name, PROJECT_ROOT / "fastdeploy" / "model_executor" / "models" / "tp_utils.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    sys.modules[module_name] = module
+
+    parent = sys.modules["fastdeploy.model_executor.models"]
+    parent.tp_utils = module
+    return module
+
+
+_tp_utils = _load_tp_utils()
+_logger = sys.modules["paddleformers.utils.log"].logger
+
+
+class CheckTensorParallelPrerequisitesTest(unittest.TestCase):
+    def setUp(self):
+        _logger.clear()
+
+    def test_tensor_parallel_disabled_noop(self):
+        cfg = sys.modules["fastdeploy.config"].FDConfig(tensor_parallel_size=1, pretrained_config={})
+        filtered = {}
+
+        _tp_utils.check_tensor_parallel_prerequisites(cfg, _tp_utils.PretrainedModel, filtered, safetensor_keys=[])
+
+        self.assertEqual(filtered, {})
+        self.assertEqual(_logger.errors, [])
+
+    def test_tensor_parallel_mappings_populated(self):
+        calls = {"is_split": [], "keys": None, "safetensor": None}
+
+        class _PopulatedModel(_tp_utils.PretrainedModel):
+            @classmethod
+            def _get_tensor_parallel_mappings(cls, _config, is_split=True):
+                calls["is_split"].append(is_split)
+                return {"encoder": partial(lambda prefix, value: (prefix, value), "encoder")}
+
+            @classmethod
+            def _resolve_prefix_keys(cls, keys, safetensor_keys):
+                calls["keys"] = tuple(keys)
+                calls["safetensor"] = tuple(safetensor_keys)
+                return {"encoder": "encoder.layer.weight"}
+
+        cfg = sys.modules["fastdeploy.config"].FDConfig(tensor_parallel_size=2, pretrained_config={})
+        filtered = {}
+
+        _tp_utils.check_tensor_parallel_prerequisites(
+            cfg,
+            _PopulatedModel,
+            filtered,
+            safetensor_keys=["encoder.layer.weight", "decoder.layer.weight"],
+        )
+
+        self.assertEqual(list(filtered.keys()), ["encoder.layer.weight"])
+        self.assertEqual(filtered["encoder.layer.weight"]("data"), ("encoder", "data"))
+        self.assertEqual(_logger.errors, [])
+        self.assertEqual(calls["is_split"], [True])
+        self.assertEqual(calls["keys"], ("encoder",))
+        self.assertEqual(calls["safetensor"], ("encoder.layer.weight", "decoder.layer.weight"))
+
+    def test_missing_tensor_parallel_map_logs_error(self):
+        class _EmptyModel(_tp_utils.PretrainedModel):
+            @classmethod
+            def _get_tensor_parallel_mappings(cls, *_args, **_kwargs):
+                return {}
+
+        cfg = sys.modules["fastdeploy.config"].FDConfig(tensor_parallel_size=4, pretrained_config={})
+        filtered = {}
+
+        _tp_utils.check_tensor_parallel_prerequisites(
+            cfg, _EmptyModel, filtered, safetensor_keys=["encoder.layer.weight"]
+        )
+
+        self.assertEqual(filtered, {})
+        self.assertTrue(any("filtered_quant_map" in msg for msg in _logger.errors))
+
+    def test_inconsistent_tensor_parallel_keys_logs_error(self):
+        class _InconsistentModel(_tp_utils.PretrainedModel):
+            @classmethod
+            def _get_tensor_parallel_mappings(cls, *_args, **_kwargs):
+                return {"encoder": partial(lambda: None)}
+
+            @classmethod
+            def _resolve_prefix_keys(cls, keys, safetensor_keys):
+                return {}
+
+        cfg = sys.modules["fastdeploy.config"].FDConfig(tensor_parallel_size=8, pretrained_config={})
+        filtered = {}
+
+        _tp_utils.check_tensor_parallel_prerequisites(
+            cfg, _InconsistentModel, filtered, safetensor_keys=["encoder.layer.weight"]
+        )
+
+        self.assertEqual(filtered, {})
+        self.assertTrue(any("tensor_parallel_filtered_map" in msg for msg in _logger.errors))
+
+
+class HelperFunctionTest(unittest.TestCase):
+    def test_extract_prefix_variants(self):
+        self.assertEqual(_tp_utils.extract_prefix("layer.weight"), "layer")
+        self.assertEqual(_tp_utils.extract_prefix("bias"), "")
+        self.assertEqual(_tp_utils.extract_prefix(".hidden"), "")
+
+    def test_has_prefix(self):
+        self.assertTrue(_tp_utils.has_prefix("layer", "layer.weight"))
+        self.assertFalse(_tp_utils.has_prefix("layer", "other.weight"))
+
+    def test_extract_placeholders(self):
+        placeholders = _tp_utils.extract_placeholders("proj.{layer_id}.weight")
+        self.assertEqual(placeholders, {"layer_id"})
+
+    def test_safe_dict_preserves_unknown(self):
+        mapping = _tp_utils.SafeDict({"known": "value"})
+        self.assertEqual(mapping["known"], "value")
+        self.assertEqual(mapping["missing"], "{missing}")
+
+    def test_has_placeholders(self):
+        self.assertTrue(_tp_utils.has_placeholders({"a"}))
+        self.assertFalse(_tp_utils.has_placeholders(set()))
+
+    def test_update_final_actions_formats_keys(self):
+        final_actions = {}
+        _tp_utils.update_final_actions({"layer_id": 3}, final_actions, "proj.{layer_id}", "action")
+        self.assertEqual(final_actions, {"proj.3": "action"})
+
+
+class BuildExpandedKeysTest(unittest.TestCase):
+    def test_no_placeholder_keys_pass_through(self):
+        actions = {"weight": "copy"}
+        expanded = _tp_utils.build_expanded_keys(actions, num_layers=2)
+        self.assertEqual(expanded, actions)
+
+    def test_layer_id_placeholder(self):
+        actions = {"layer.{layer_id}.weight": "split"}
+        expanded = _tp_utils.build_expanded_keys(actions, num_layers=3)
+        expected = {
+            "layer.0.weight": "split",
+            "layer.1.weight": "split",
+            "layer.2.weight": "split",
+        }
+        self.assertEqual(expanded, expected)
+
+    def test_ffn_layer_id_requires_start(self):
+        actions = {"ffn.{ffn_layer_id}.weight": "split"}
+        expanded = _tp_utils.build_expanded_keys(actions, num_layers=4, start_layer=3)
+        expected = {
+            "ffn.0.weight": "split",
+            "ffn.1.weight": "split",
+            "ffn.2.weight": "split",
+        }
+        self.assertEqual(expanded, expected)
+
+    def test_moe_layer_and_expert_id(self):
+        actions = {"moe.{moe_layer_id}.expert.{export_id}": "dispatch"}
+        expanded = _tp_utils.build_expanded_keys(actions, num_layers=4, start_layer=1, num_experts=2)
+        expected_keys = {
+            "moe.1.expert.0",
+            "moe.1.expert.1",
+            "moe.2.expert.0",
+            "moe.2.expert.1",
+            "moe.3.expert.0",
+            "moe.3.expert.1",
+        }
+        self.assertEqual(set(expanded.keys()), expected_keys)
+        self.assertTrue(all(value == "dispatch" for value in expanded.values()))
+
+    def test_moe_layer_and_text_expert_id(self):
+        actions = {"moe.{moe_layer_id}.text.{text_export_id}": "dispatch"}
+        expanded = _tp_utils.build_expanded_keys(actions, num_layers=3, start_layer=0, text_num_experts=2)
+        expected_keys = {
+            "moe.0.text.0",
+            "moe.0.text.1",
+            "moe.1.text.0",
+            "moe.1.text.1",
+            "moe.2.text.0",
+            "moe.2.text.1",
+        }
+        self.assertEqual(set(expanded.keys()), expected_keys)
+
+    def test_moe_layer_and_image_expert_id(self):
+        actions = {"moe.{moe_layer_id}.img.{img_export_id}": "dispatch"}
+        expanded = _tp_utils.build_expanded_keys(
+            actions,
+            num_layers=2,
+            start_layer=0,
+            text_num_experts=1,
+            img_num_experts=2,
+        )
+        expected_keys = {
+            "moe.0.img.1",
+            "moe.0.img.2",
+            "moe.1.img.1",
+            "moe.1.img.2",
+        }
+        self.assertEqual(set(expanded.keys()), expected_keys)
+
+    def test_moe_layer_only(self):
+        actions = {"moe.{moe_layer_id}.shared": "collect"}
+        expanded = _tp_utils.build_expanded_keys(actions, num_layers=4, start_layer=2)
+        self.assertEqual(
+            expanded,
+            {
+                "moe.2.shared": "collect",
+                "moe.3.shared": "collect",
+            },
+        )
+
+    def test_invalid_placeholder_raises(self):
+        actions = {"unsupported.{unknown}": "noop"}
+        with self.assertRaises(ValueError):
+            _tp_utils.build_expanded_keys(actions, num_layers=1)
+
+
+class GQATensorOpsTest(unittest.TestCase):
+    def test_gqa_split_returns_all_partitions(self):
+        func = _tp_utils.gqa_qkv_split_func(
+            tensor_parallel_degree=2,
+            tensor_parallel_rank=None,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=1,
+        )
+        weights = np.arange(8, dtype=np.float32)
+        shards = func(weights, is_column=True)
+
+        self.assertEqual(len(shards), 2)
+        np.testing.assert_array_equal(shards[0], np.array([0, 1, 4, 6], dtype=np.float32))
+        np.testing.assert_array_equal(shards[1], np.array([2, 3, 5, 7], dtype=np.float32))
+
+    def test_gqa_split_with_rank_and_repeat_kv(self):
+        func = _tp_utils.gqa_qkv_split_func(
+            tensor_parallel_degree=2,
+            tensor_parallel_rank=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=2,
+        )
+        weights = np.arange(8, dtype=np.float32)
+        shard = func(weights, is_column=True)
+        np.testing.assert_array_equal(shard, np.array([2, 3, 4, 5, 6, 7], dtype=np.float32))
+
+    def test_gqa_split_on_matrix_rows(self):
+        func = _tp_utils.gqa_qkv_split_func(
+            tensor_parallel_degree=2,
+            tensor_parallel_rank=None,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=1,
+        )
+        weights = np.arange(16, dtype=np.float32).reshape(2, 8)
+        shards = func(weights, is_column=False)
+        self.assertEqual(len(shards), 2)
+        np.testing.assert_array_equal(shards[0], np.array([[0, 1, 2, 3, 4, 5, 6, 7]], dtype=np.float32))
+
+    def test_gqa_merge_reconstructs_weights(self):
+        weight_list = [
+            np.array([0, 1, 4, 6], dtype=np.float32),
+            np.array([2, 3, 5, 7], dtype=np.float32),
+        ]
+        merge = _tp_utils.gqa_qkv_merge_func(num_attention_heads=4, num_key_value_heads=2, head_dim=1)
+        merged = merge(weight_list, is_column=True)
+        np.testing.assert_array_equal(merged, np.arange(8, dtype=np.float32))
+
+    def test_split_or_merge_qkv_dispatch(self):
+        weights = np.arange(8, dtype=np.float32)
+        split = _tp_utils.split_or_merge_qkv_func(True, 2, None, 4, 2, 1)
+        shards = split(weights, is_column=True)
+        merge = _tp_utils.split_or_merge_qkv_func(False, 2, None, 4, 2, 1)
+        restored = merge(shards, is_column=True)
+        np.testing.assert_array_equal(restored, weights)
+
+    def test_split_or_merge_func_v1_row_bias(self):
+        fn = _tp_utils.split_or_merge_func_v1(
+            is_split=True,
+            tensor_parallel_degree=4,
+            tensor_parallel_rank=0,
+        )
+        bias = np.ones(4, dtype=np.float32)
+        scaled = fn(bias, is_tp_row_bias=True)
+        np.testing.assert_array_equal(scaled, np.ones(4, dtype=np.float32) / 4)
+
+    def test_split_or_merge_func_v1_gqa_path(self):
+        fn = _tp_utils.split_or_merge_func_v1(
+            is_split=True,
+            tensor_parallel_degree=2,
+            tensor_parallel_rank=None,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=1,
+        )
+        weights = np.arange(8, dtype=np.float32).reshape(2, 4)
+        shards = fn(weights, is_gqa=True, is_column=False)
+        self.assertEqual(len(shards), 2)
+
+    def test_split_or_merge_func_v1_default_path(self):
+        fn = _tp_utils.split_or_merge_func_v1(
+            is_split=False,
+            tensor_parallel_degree=2,
+            tensor_parallel_rank=None,
+            num_attention_heads=4,
+        )
+        parts = [np.array([0, 1], dtype=np.float32), np.array([2, 3], dtype=np.float32)]
+        merged = fn(parts, is_column=True)
+        np.testing.assert_array_equal(merged, np.array([0, 1, 2, 3], dtype=np.float32))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/output/test_process_batch_draft_tokens.py
+++ b/tests/output/test_process_batch_draft_tokens.py
@@ -1,0 +1,157 @@
+"""
+# Copyright (c) 2025  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+import paddle
+
+from fastdeploy.engine.request import RequestOutput
+from fastdeploy.output.token_processor import TokenProcessor
+
+
+class TestProcessBatchDraftTokens(unittest.TestCase):
+
+    def setUp(self):
+        # 模拟 cfg
+        cfg = MagicMock()
+        cfg.speculative_config = MagicMock()
+        cfg.speculative_config.method = "mtp"
+        cfg.speculative_config.num_speculative_tokens = 3
+        cfg.model_config = MagicMock()
+        cfg.model_config.enable_logprob = True
+
+        self.processor = TokenProcessor(
+            cfg=cfg, cached_generated_tokens=MagicMock(), engine_worker_queue=MagicMock(), split_connector=MagicMock()
+        )
+
+        # mock resource_manager
+        self.processor.resource_manager = MagicMock()
+        self.processor.resource_manager.stop_flags = [False] * 512
+        self.processor.resource_manager.tasks_list = [MagicMock()] * 512
+
+        for task in self.processor.resource_manager.tasks_list:
+            task.request_id = "test_request"
+            task.eos_token_ids = [2]
+
+    def test_process_batch_draft_tokens_normal_case(self):
+        """测试正常情况下的target处理"""
+        batch = 2
+        accept_num = [3, 2]
+        K = 20
+        MAX_DRAFT_TOKENS = 6
+
+        tokens = np.random.randint(100, 200, size=(batch, MAX_DRAFT_TOKENS, K + 1))
+        scores = np.random.rand(batch, MAX_DRAFT_TOKENS, K + 1).astype(np.float32)
+        ranks = np.random.randint(0, K, size=(batch, MAX_DRAFT_TOKENS))
+
+        results = self.processor._process_batch_draft_tokens(
+            mtype=4,
+            batch=batch,
+            accept_num=accept_num,
+            tokens=paddle.to_tensor(tokens),
+            scores=paddle.to_tensor(scores),
+            ranks=paddle.to_tensor(ranks),
+        )
+
+        self.assertEqual(len(results), batch)
+        for i, result in enumerate(results):
+            self.assertIsInstance(result, RequestOutput)
+            self.assertEqual(result.output_type, 4)
+            self.assertEqual(result.outputs.index, i)
+            self.assertEqual(len(result.outputs.draft_top_logprobs.logprob_token_ids), accept_num[i])
+            self.assertEqual(len(result.outputs.draft_top_logprobs.logprobs), accept_num[i])
+            self.assertEqual(len(result.outputs.draft_top_logprobs.sampled_token_ranks), accept_num[i])
+
+    def test_process_batch_draft_tokens_with_stop_flag(self):
+        """测试有停止标志的情况"""
+        batch = 3
+        self.processor.resource_manager.stop_flags[1] = True  # 第二个 request 停止
+
+        accept_num = [3, 2, 1]
+        K = 20
+        MAX_DRAFT_TOKENS = 6
+
+        tokens = np.random.randint(100, 200, size=(batch, MAX_DRAFT_TOKENS, K + 1))
+        scores = np.random.rand(batch, MAX_DRAFT_TOKENS, K + 1).astype(np.float32)
+        ranks = np.random.randint(0, K, size=(batch, MAX_DRAFT_TOKENS))
+
+        results = self.processor._process_batch_draft_tokens(
+            mtype=4,
+            batch=batch,
+            accept_num=accept_num,
+            tokens=paddle.to_tensor(tokens),
+            scores=paddle.to_tensor(scores),
+            ranks=paddle.to_tensor(ranks),
+        )
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0].outputs.index, 0)
+        self.assertEqual(results[1].outputs.index, 2)
+
+    def test_process_batch_draft_tokens_empty_accept(self):
+        """测试 accept_num 为 0 的情况"""
+        batch = 2
+        accept_num = [0, 0]
+
+        K = 20
+        MAX_DRAFT_TOKENS = 6
+        tokens = np.random.randint(100, 200, size=(batch, MAX_DRAFT_TOKENS, K + 1))
+        scores = np.random.rand(batch, MAX_DRAFT_TOKENS, K + 1).astype(np.float32)
+        ranks = np.random.randint(0, K, size=(batch, MAX_DRAFT_TOKENS))
+
+        results = self.processor._process_batch_draft_tokens(
+            mtype=4,
+            batch=batch,
+            accept_num=accept_num,
+            tokens=paddle.to_tensor(tokens),
+            scores=paddle.to_tensor(scores),
+            ranks=paddle.to_tensor(ranks),
+        )
+
+        self.assertEqual(len(results), batch)
+        for result in results:
+            self.assertIsNone(result.outputs.draft_top_logprobs)
+
+    def test_process_batch_draft_tokens_different_k_values(self):
+        """测试不同 K 值情况"""
+        batch = 2
+        accept_num = [3, 2]
+
+        K = 5
+        MAX_DRAFT_TOKENS = 6
+        tokens = np.random.randint(100, 200, size=(batch, MAX_DRAFT_TOKENS, K + 1))
+        scores = np.random.rand(batch, MAX_DRAFT_TOKENS, K + 1).astype(np.float32)
+        ranks = np.random.randint(0, K, size=(batch, MAX_DRAFT_TOKENS))
+
+        results = self.processor._process_batch_draft_tokens(
+            mtype=4,
+            batch=batch,
+            accept_num=accept_num,
+            tokens=paddle.to_tensor(tokens),
+            scores=paddle.to_tensor(scores),
+            ranks=paddle.to_tensor(ranks),
+        )
+
+        self.assertEqual(len(results), batch)
+        for i, result in enumerate(results):
+            self.assertEqual(len(result.outputs.draft_top_logprobs.logprob_token_ids[0]), K + 1)
+            self.assertEqual(len(result.outputs.draft_top_logprobs.logprobs[0]), K + 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/output/test_process_batch_output_use_zmq.py
+++ b/tests/output/test_process_batch_output_use_zmq.py
@@ -1,3 +1,19 @@
+"""
+# Copyright (c) 2025  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
 import unittest
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
## Motivation

<!-- Describe the purpose and goals of this pull request. -->

This PR refactors the speculative decoding pipeline by extracting `draft_tokens` into a standalone post-processing branch.
The goal is to improve the clarity of the MTP (Multi-Token Prediction) workflow and provide a cleaner and more extensible structure for logprobs generation under draft mode.
This also prepares the codebase for future enhancements in speculative decoding.

## Modifications

<!-- Detail the changes made in this pull request. -->

* Added a dedicated post-processing path for `draft_tokens`.
* Refactored the MTP handling logic to separate draft-token flow from standard completion flow.
* Updated logprobs computation to properly support draft token outputs.
* Improved readability and maintainability of the speculative decoding code.
* Adjusted related data structures and RequestOutput construction to align with the new branch.

## Usage or Command

Although this PR does not introduce new public APIs, it affects the behavior of draft-token logprobs in speculative decoding.
Below are example requests demonstrating how draft logprobs can be enabled through existing REST interfaces.

### **/v1/chat/completions Example**

```bash
curl --location 'http://120.0.0.1:8000/v1/chat/completions' \
--header 'Content-Type: application/json' \
--data '{
    "messages": [
        {
            "role": "user",
            "content": "你是谁？"
        }
    ],
    "logprobs": true,
    "top_logprobs": 5,
    "include_draft_logprobs": true,
    "stream": true
}'
```

### **/v1/completions Example**

```bash
curl --location 'http://120.0.0.1:8000/v1/completions' \
--header 'Content-Type: application/json' \
--data '{
    "prompt": "你好",
    "stream": false,
    "logprobs": 5,
    "include_draft_logprobs": true
}'
```

These examples demonstrate how to enable:

* `logprobs`
* `top_logprobs`
* `include_draft_logprobs`
* streaming / non-streaming outputs

## Accuracy Tests

<!-- Provide accuracy test results if model output changed. -->

This PR does not affect model forward computation or kernel behavior; it only refactors post-processing logic.
The generated outputs for both:

* standard MTP mode, and
* draft token mode with logprobs
  remain consistent with previous behavior.

Unit tests were updated and extended to ensure correctness of:

* draft token post-processing
* stop-flag handling
* variable acceptance count (`accept_num`)
* different K top-logprobs values

## Checklist

* [x] Add at least a tag in the PR title.
  * Recommended tag: **`[Speculative Decoding]`**
* [x] Format your code, run `pre-commit` before commit.
* [x] Add unit tests.
* [ ] Provide accuracy results.
  *(Not required if behavior is unchanged, but leave unchecked per template.)*
* [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.