### PR TITLE
[BugFix] race condition [is_fetching] causing multiple fetch requests

### DIFF
--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -683,7 +683,6 @@ class EngineService:
         def _fetch_request():
             try:
                 nonlocal is_fetching
-                is_fetching = True
                 num_prefill_batch = min(
                     int(self.resource_manager.available_batch()),
                     self.cfg.max_prefill_batch,
@@ -797,6 +796,7 @@ class EngineService:
                     continue
                 if self.cfg.scheduler_config.splitwise_role != "mixed":
                     if not is_fetching:
+                        is_fetching = True
                         get_request_pool.submit(_fetch_request)
 
                 else:
@@ -807,6 +807,7 @@ class EngineService:
                     ):
                         # Check if the thread pool is still available to avoid submitting tasks to a shutdown thread pool.
                         try:
+                            is_fetching = True
                             get_request_pool.submit(_fetch_request)
                         except RuntimeError as e:
                             if "shutdown" in str(e):

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -414,7 +414,6 @@ class ResourceManagerV1(ResourceManager):
         ):
             input_ids_lst = request.prompt_token_ids + request.output_token_ids
             input_ids = paddle.to_tensor(input_ids_lst, dtype="int64")
-            input_ids = paddle.to_tensor(input_ids_lst, dtype="int64")
             image_patch_id = inputs["image_patch_id"]
 
             if request.multimodal_img_boundaries is None:

--- a/fastdeploy/router/router.py
+++ b/fastdeploy/router/router.py
@@ -32,7 +32,7 @@ class RouterArgs:
     """
     Host address to bind the router server
     """
-    port: str = "9000"
+    port: int = 9000
     """
     Port to bind the router server.
     """
@@ -55,7 +55,7 @@ class RouterArgs:
         )
         parser.add_argument(
             "--port",
-            type=str,
+            type=int,
             default=RouterArgs.port,
             help="Port number to bind the router server",
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation


> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191) 

## Modifications

router.log traceback, port type error
race condition [is_fetching] causing multiple fetch requests

## Usage or Command
```python
import unittest
import time
import threading
from concurrent.futures import ThreadPoolExecutor

class TestRaceCondition(unittest.TestCase):
    def test_fetch_request_race_condition(self):
        """
        测试目标：证明在原有的逻辑下，_fetch_request 会被重复提交。
        """

        # 1. 模拟环境 setup
        is_fetching = False
        execution_count = 0  # 记录 _fetch_request 真正被执行的次数
        submit_count = 0     # 记录 提交给线程池 的次数

        # 创建一个真实的线程池
        executor = ThreadPoolExecutor(max_workers=4)

        # 2. 模拟原本的 _fetch_request 函数
        def _fetch_request():
            nonlocal is_fetching, execution_count

            # 【关键点】：这里模拟线程启动延迟或调度延迟
            # 在修改 is_fetching 之前，我们强制让线程等一下
            # 只要这个时间大于主循环的一次迭代时间，Bug 就会复现
            time.sleep(0.1)

            # 原有逻辑：在内部修改状态
            is_fetching = True

            # 模拟业务逻辑执行
            with threading.Lock(): # 加锁为了计数准确
                execution_count += 1

            # 模拟业务耗时
            time.sleep(0.05)

            # 结束复位
            is_fetching = False

        # 3. 模拟主循环逻辑
        running = True
        loop_counter = 0

        print("开始模拟主循环...")

        # 我们只跑几次循环，足以复现问题
        while running and loop_counter < 5:
            # 模拟原代码中的 check
            # if self.cfg.scheduler_config.splitwise_role != "mixed": ...

            if not is_fetching:
                print(f"[Loop {loop_counter}] 检测到 is_fetching 为 False，提交任务！")
                submit_count += 1
                executor.submit(_fetch_request)
            else:
                print(f"[Loop {loop_counter}] 正常：检测到 is_fetching 为 True，跳过。")

            # 模拟主循环的间隔（通常非常快，这里设为 0.02秒）
            # 因为 0.02 < 子线程启动延迟(0.1)，所以在子线程把 True 改过来之前，
            # 主线程已经跑了好几圈了。
            time.sleep(0.02)
            loop_counter += 1

        # 等待所有任务执行完毕
        executor.shutdown(wait=True)

        print(f"\n结果统计:")
        print(f"主循环提交次数: {submit_count}")
        print(f"实际执行次数: {execution_count}")

        # 4. 断言
        # 如果逻辑正确，应该是提交1次，执行1次。
        # 如果有 Bug，提交次数会 > 1
        self.assertGreater(submit_count, 1, "Bug复现：任务被重复提交了！")
        self.assertGreater(execution_count, 1, "Bug复现：任务被并发执行了！")

if __name__ == '__main__':
    unittest.main()
```
bash start_v1_tp1.sh

## Accuracy Tests

 
## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
