### PR TITLE
[BugFix] fix get_request from scheduler

### DIFF
--- a/fastdeploy/scheduler/splitwise_scheduler.py
+++ b/fastdeploy/scheduler/splitwise_scheduler.py
@@ -859,7 +859,7 @@ class InferScheduler:
                         self.reqs_queue.appendleft(req)
                         break
                 else:
-                    if current_prefill_tokens > max_num_batched_tokens:
+                    if current_prefill_tokens > max_num_batched_tokens and len(reqs) > 0:
                         self.reqs_queue.appendleft(req)
                         break
                 # logger.info(f"Get Requests from Scheduler: {req.request_id}")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
修复v1调度下从 splitwise_scheduler 拉不到长请求的问题

v1调度设置scheduler_config.max_num_batched_tokens为8192
```
 if self.scheduler_config.max_num_batched_tokens is None:
            if int(envs.ENABLE_V1_KVCACHE_SCHEDULER):
                if paddle.is_compiled_with_xpu():
                    self.scheduler_config.max_num_batched_tokens = self.model_config.max_model_len
                else:
                    self.scheduler_config.max_num_batched_tokens = 8192  # if set to max_model_len, it's easy to be OOM
            else:
                if self.cache_config.enable_chunked_prefill:
                    self.scheduler_config.max_num_batched_tokens = 2048
                else:
                    self.scheduler_config.max_num_batched_tokens = self.model_config.max_model_len
```

基于scheduler_config.max_num_batched_tokens来从 splitwise_scheduler 拉取请求
```
  if self.cfg.scheduler_config.splitwise_role != "mixed":
      max_num_batched_tokens = self.cfg.scheduler_config.max_num_batched_tokens
  else:
      max_num_batched_tokens = self.cfg.model_config.max_model_len

tasks = self.scheduler.get_requests(
                    available_blocks=available_blocks,
                    block_size=self.cfg.cache_config.block_size,
                    reserved_output_blocks=self.cfg.cache_config.enc_dec_block_num,
                    max_num_batched_tokens=max_num_batched_tokens,
                    batch=num_prefill_batch,
                )
```

## Modifications
修改 splitwise_scheduler 


## Usage or Command
无

## Accuracy Tests
无

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
