### PR TITLE
[CI] Add error log in run_tests_with_coverage

### DIFF
--- a/scripts/coverage_run.sh
+++ b/scripts/coverage_run.sh
@@ -29,6 +29,17 @@ for file in $TEST_FILES; do
     if [ "$status" -ne 0 ]; then
         echo "$file" >> "$failed_tests_file"
         failed_pytest=$((failed_pytest+1))
+        if [ -f "$run_path/server.log" ]; then
+            echo "---------------- server.log ----------------"
+            tail -n 25 "$run_path/server.log"
+            echo "--------------------------------------------"
+        fi
+
+        if [ -f "$run_path/log/workerlog.0" ]; then
+            echo "---------------- log/workerlog.0 -------------------"
+            tail -n 25 "$run_path/log/workerlog.0"
+            echo "----------------------------------------------------"
+        fi
     else
         success_pytest=$((success_pytest+1))
     fi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
The CI unit test workflow previously only surfaced exit codes when failures occurred, which made troubleshooting slow and inefficient.
In many cases, critical server logs were not surfaced, so developers had no visibility into the root cause of failing tests.
To improve debuggability, we need to automatically collect and display relevant logs whenever a test fails.

## Modifications

- When a pytest execution fails, automatically print related logs (server.log, server_prefill.log, server_decode.log, workerlog.*, etc.).
- Print the last 25 lines of each log to make debugging easier.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
