### PR TITLE
[Intel HPU] fix bug about RP 5138

### DIFF
--- a/fastdeploy/worker/hpu_model_runner.py
+++ b/fastdeploy/worker/hpu_model_runner.py
@@ -210,6 +210,7 @@ def rebuild_padding_v3_1(
     return output_data
 
 
+from fastdeploy.model_executor.forward_meta import ForwardMeta
 from fastdeploy.model_executor.layers.linear import QKVParallelLinear, RowParallelLinear
 from fastdeploy.model_executor.ops.intel_hpu import fused_mlp
 
@@ -259,10 +260,21 @@ def fused_self_atten_forward(
     return atten_out
 
 
-def fused_mlp_forward(self, x):
-    """ """
+def fused_mlp_forward(
+    self,
+    hidden_states: paddle.Tensor,
+    forward_meta: Optional[ForwardMeta] = None,
+):
+    """
+    The forward function for the MLP (Multi-Layer Perceptron) layer.
+    Args:
+        hidden_states (paddle.Tensor): The input tensor to the MLP layer.
+        forward_meta (Optional[ForwardMeta]): Optional metadata for the forward pass.
+    Returns:
+        paddle.Tensor: The output tensor after applying the MLP layer and (optionally) all-reduce.
+    """
     out = fused_mlp(
-        x,
+        hidden_states,
         self.up_gate_proj.weight,
         None,
         self.down_proj.weight,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
https://github.com/PaddlePaddle/FastDeploy/pull/5138 breaks hpu function, fixed it

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191) 

## Modifications
hpu_model_runner.py
<!-- Detail the changes made in this pull request. -->

## Usage or Command
no command usage change
<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests
no impact on accuracy
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [Done] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [Done] Format your code, run `pre-commit` before commit.
- [Done] Add unit tests. Please write the reason in this PR if no unit tests.
  conducted by local tests
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
