### PR TITLE
[Cherry-Pick] [BugFix] fix scheduler hang when input length is very close to max_model_len

### DIFF
--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -574,7 +574,7 @@ class EngineSevice:
             tasks = self.scheduler.get_requests(
                 available_blocks=available_blocks,
                 block_size=self.cfg.cache_config.block_size,
-                reserved_output_blocks=self.cfg.cache_config.enc_dec_block_num,
+                reserved_output_blocks=0,  # self.cfg.cache_config.enc_dec_block_num,
                 max_num_batched_tokens=self.cfg.max_model_len,
                 batch=num_prefill_batch,
             )

--- a/fastdeploy/scheduler/local_scheduler.py
+++ b/fastdeploy/scheduler/local_scheduler.py
@@ -21,7 +21,7 @@ from typing import Dict, List, Optional, Tuple
 from fastdeploy.engine.request import Request, RequestOutput
 from fastdeploy.scheduler.data import ScheduledRequest, ScheduledResponse
 from fastdeploy.utils import scheduler_logger
-
+from fastdeploy import envs
 
 class LocalScheduler:
     """
@@ -253,12 +253,11 @@ class LocalScheduler:
             for request_id in batch_ids:
                 request = self.requests[request_id]
                 required_input_blocks = self.calc_required_blocks(request.prompt_tokens_ids_len, block_size)
-                current_prefill_tokens += request.prompt_tokens_ids_len
                 required_total_blocks += required_input_blocks + reserved_output_blocks
                 if required_total_blocks > available_blocks:
                     break
 
-                if self.enable_chunked_prefill:
+                if not envs.ENABLE_V1_KVCACHE_SCHEDULER and self.enable_chunked_prefill:
                     if request.prompt_tokens_ids_len > self.long_prefill_token_threshold:
                         # 长请求
                         long_partial_requests += 1
@@ -274,6 +273,7 @@ class LocalScheduler:
                         break
 
                 requests.append(request.raw)
+                current_prefill_tokens += request.prompt_tokens_ids_len
             self.ids_read_cursor += len(requests)
 
         if len(batch_ids) > 0 and len(requests) == 0:

--- a/fastdeploy/scheduler/local_scheduler.py
+++ b/fastdeploy/scheduler/local_scheduler.py
@@ -18,10 +18,11 @@ import threading
 import time
 from typing import Dict, List, Optional, Tuple
 
+from fastdeploy import envs
 from fastdeploy.engine.request import Request, RequestOutput
 from fastdeploy.scheduler.data import ScheduledRequest, ScheduledResponse
 from fastdeploy.utils import scheduler_logger
-from fastdeploy import envs
+
 
 class LocalScheduler:
     """


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

修复当输入长度非常接近 max_model_len 时，v1 scheduler 不会拉取该请求的问题

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191) 

## Modifications

<!-- Detail the changes made in this pull request. -->
修改 reserved_output_blocks=0， v1 scheduler 不需要算入预留的解码 block 长度。

## Usage or Command
无
<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests
无
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
