### PR TITLE
[XPU] support ep4tp1+v1 loader

### DIFF
--- a/fastdeploy/model_executor/layers/backends/xpu/quantization/weight_only.py
+++ b/fastdeploy/model_executor/layers/backends/xpu/quantization/weight_only.py
@@ -90,44 +90,49 @@ class XPUWeightOnlyLinearMethod(WeightOnlyLinearMethod):
                 is_bias=False,
             )
 
-    def process_loaded_weights(self, layer: nn.Layer, weight: paddle.Tensor) -> None:
-        """
-        loaded_weights using xpu special quantization
-        """
+    def _quantize_weight_in_blocks(self, weight: paddle.Tensor) -> tuple[paddle.Tensor, paddle.Tensor]:
         k, n = weight.shape
-        quanted_weight_tensors = []
-        weight_scale_tensors = []
-        offset = 30720
-        for i in range(0, n, offset):
-            end_n = min(i + offset, n)
-            weight_i = weight[:, i:end_n]
-            quanted_weight_tensor, weight_scale_tensor = weight_quantize_xpu(weight_i, self.quant_config.algo, -1, -1)
-            quanted_weight_tensors.append(quanted_weight_tensor)
-            weight_scale_tensors.append(weight_scale_tensor)
-        quanted_weight_tensor = paddle.concat(quanted_weight_tensors, axis=1)
-        weight_scale_tensor = paddle.concat(weight_scale_tensors, axis=0)
-        layer.weight.set_value(paddle.transpose(quanted_weight_tensor, [1, 0]))
-        layer.weight_scale.set_value(weight_scale_tensor)
+        BLOCK_SIZE = 30720
+
+        quanted_weight_list = []
+        scale_list = []
+
+        for i in range(0, n, BLOCK_SIZE):
+            end_n = min(i + BLOCK_SIZE, n)
+            weight_block = weight[:, i:end_n]
+
+            quanted_weight, scale = weight_quantize_xpu(weight_block, self.quant_config.algo, -1, -1)
+            quanted_weight_list.append(quanted_weight)
+            scale_list.append(scale)
+
+        quanted_weight = paddle.concat(quanted_weight_list, axis=1)
+        weight_scale = paddle.concat(scale_list, axis=0)
+
+        return quanted_weight, weight_scale
+
+    def process_loaded_weights(self, layer: nn.Layer, weight: paddle.Tensor) -> None:
+        quanted_weight, weight_scale = self._quantize_weight_in_blocks(weight)
+        layer.weight.set_value(paddle.transpose(quanted_weight, [1, 0]))
+        layer.weight_scale.set_value(weight_scale)
 
     def process_weights_after_loading(self, layer) -> None:
         if not self.quant_config.is_checkpoint_bf16:
             return
 
-        quanted_weight_tensor, weight_scale_tensor = weight_quantize_xpu(layer.weight, self.quant_config.algo, -1, -1)
-
+        quanted_weight, weight_scale = self._quantize_weight_in_blocks(layer.weight)
         free_tensor(layer.weight)
 
         layer.weight = layer.create_parameter(
-            shape=quanted_weight_tensor.shape[::-1],
+            shape=quanted_weight.shape[::-1],
             dtype="int8",
             is_bias=False,
             default_initializer=paddle.nn.initializer.Constant(0),
         )
         layer.weight_scale = layer.create_parameter(
-            shape=weight_scale_tensor.shape,
-            dtype=weight_scale_tensor.dtype,
+            shape=weight_scale.shape,
+            dtype=weight_scale.dtype,
             is_bias=False,
             default_initializer=paddle.nn.initializer.Constant(0),
         )
-        layer.weight.set_value(paddle.transpose(quanted_weight_tensor, [1, 0]))
-        layer.weight_scale.copy_(weight_scale_tensor, False)
+        layer.weight.set_value(paddle.transpose(quanted_weight, [1, 0]))
+        layer.weight_scale.copy_(weight_scale, False)

--- a/tests/xpu_ci/test_ep4tp1_online.py
+++ b/tests/xpu_ci/test_ep4tp1_online.py
@@ -79,8 +79,6 @@ def test_ep4tp1_online(xpu_env):
             str(port_num + 47873),
             "--gpu-memory-utilization",
             "0.9",
-            "--load-choices",
-            "default",
         ]
 
         # 启动服务器


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

背景：
ep4tp1场景下，权重size太大超过了xpu的最大量化能力，导致v1 loader能力不可用。

## Modifications

<!-- Detail the changes made in this pull request. -->

解决方案：
在process_weights_after_loading这个函数里使用跟process_loaded_weights这个函数一样的分块量化方式解决了问题。

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
