### PR TITLE
[Cherry-Pick][Loader]fix deepseek torch loading #5410 [loader]fix bf16 deepseek #5379 [Loader]Adapting DeepSeek weights for PyTorch loading

### DIFF
--- a/fastdeploy/model_executor/layers/linear.py
+++ b/fastdeploy/model_executor/layers/linear.py
@@ -367,11 +367,14 @@ class MergedReplicatedLinear(ReplicatedLinear):
             # loaded_shard_id == "kv_a"
             param_shard_offset = self.output_sizes[0]
             param_shard_size = self.output_sizes[1]
-        param_output_dim = True
         if hasattr(param, "tensor_track"):
-            param_output_dim = param.tensor_track.output_dim
             param.tensor_track.mark(start=param_shard_offset, end=param_shard_offset + param_shard_size)
-        param = slice_fn(param, param_output_dim, start=param_shard_offset, end=param_shard_offset + param_shard_size)
+        param = slice_fn(
+            param,
+            (self.fd_config.model_config.model_format == "torch") ^ True,
+            start=param_shard_offset,
+            end=param_shard_offset + param_shard_size,
+        )
         assert param.shape == loaded_weight.shape, (
             f" Attempted to load weight ({loaded_weight.shape}) " f"into parameter ({param.shape})"
         )
@@ -974,7 +977,12 @@ class KVBatchLinear(nn.Layer):
     def process_weights_after_loading(self):
         if self.fd_config.load_config.dynamic_load_weight:
             return
-        w = self.kv_b_proj.weight.reshape(
+        w = (
+            self.kv_b_proj.weight.transpose([1, 0])
+            if self.fd_config.model_config.model_format == "torch"
+            else self.kv_b_proj.weight
+        )
+        w = w.reshape(
             [
                 self.kv_lora_rank,
                 self.num_heads_per_partition,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191) 

## Modifications

<!-- Detail the changes made in this pull request. -->

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
