### PR TITLE
[Loader][BugFix] Fix some parameters place on CPU in PaddleOCR-VL

### DIFF
--- a/fastdeploy/model_executor/models/paddleocr_vl/projector.py
+++ b/fastdeploy/model_executor/models/paddleocr_vl/projector.py
@@ -20,6 +20,8 @@ from typing import Optional
 import paddle
 import paddle.nn as nn
 
+from fastdeploy.model_executor.utils import h2d_copy
+
 
 class GELUActivation(nn.Layer):
     """
@@ -97,6 +99,8 @@ class Projector(nn.Layer):
 
     def weight_loader(self, param, loaded_weight, loaded_shard_id: Optional[str] = None):
         loaded_weight = loaded_weight.transpose([1, 0])
+        if not param._is_initialized():
+            param.initialize()
         assert param.shape == loaded_weight.shape, (
             f" Attempted to load weight ({loaded_weight.shape}) " f"into parameter ({param.shape})"
         )
@@ -106,4 +110,4 @@ class Projector(nn.Layer):
                 loaded_weight = loaded_weight.view(param.dtype)
             else:
                 loaded_weight = loaded_weight.cast(param.dtype)
-        param.copy_(loaded_weight, False)
+        h2d_copy(param, loaded_weight)

--- a/fastdeploy/model_executor/models/paddleocr_vl/siglip.py
+++ b/fastdeploy/model_executor/models/paddleocr_vl/siglip.py
@@ -23,6 +23,7 @@ import paddle.nn as nn
 import paddle.nn.functional as F
 from paddleformers.transformers.model_utils import PretrainedModel
 
+from fastdeploy.model_executor.layers.utils import get_tensor
 from fastdeploy.model_executor.utils import h2d_copy, slice_fn
 
 from .config import PaddleOCRVisionConfig
@@ -69,6 +70,7 @@ class SiglipAttention(nn.Layer):
             self.flash_attn_kwargs = {"scale": self.scale, "training": False}
 
     def qkv_weight_loader(self, param, loaded_weight, loaded_shard_id: Optional[str] = None):
+        # loaded_weight = get_tensor(loaded_weight)
         # Tensor parallelism splits the weight along the output_dim
         if loaded_weight.dim() == 2:
             loaded_weight = loaded_weight.transpose([1, 0])
@@ -100,6 +102,8 @@ class SiglipAttention(nn.Layer):
 
     def out_proj_weight_loader(self, param, loaded_weight, loaded_shard_id: Optional[str] = None):
         loaded_weight = loaded_weight.transpose([1, 0])
+        if not param._is_initialized():
+            param.initialize()
         assert param.shape == loaded_weight.shape, (
             f" Attempted to load weight ({loaded_weight.shape}) " f"into parameter ({param.shape})"
         )
@@ -109,7 +113,8 @@ class SiglipAttention(nn.Layer):
                 loaded_weight = loaded_weight.view(param.dtype)
             else:
                 loaded_weight = loaded_weight.cast(param.dtype)
-        param.copy_(loaded_weight, False)
+        h2d_copy(param, loaded_weight)
+
 
     def forward(
         self,
@@ -287,6 +292,8 @@ class SiglipMLP(nn.Layer):
 
     def weight_loader(self, param, loaded_weight, loaded_shard_id: Optional[str] = None):
         loaded_weight = loaded_weight.transpose([1, 0])
+        if not param._is_initialized():
+            param.initialize()
         assert param.shape == loaded_weight.shape, (
             f" Attempted to load weight ({loaded_weight.shape}) " f"into parameter ({param.shape})"
         )
@@ -296,7 +303,8 @@ class SiglipMLP(nn.Layer):
                 loaded_weight = loaded_weight.view(param.dtype)
             else:
                 loaded_weight = loaded_weight.cast(param.dtype)
-        param.copy_(loaded_weight, False)
+        h2d_copy(param, loaded_weight)
+
 
     def forward(self, hidden_states: paddle.Tensor) -> paddle.Tensor:
         hidden_states = self.fc1(hidden_states)

--- a/fastdeploy/model_executor/models/paddleocr_vl/siglip.py
+++ b/fastdeploy/model_executor/models/paddleocr_vl/siglip.py
@@ -70,7 +70,6 @@ class SiglipAttention(nn.Layer):
             self.flash_attn_kwargs = {"scale": self.scale, "training": False}
 
     def qkv_weight_loader(self, param, loaded_weight, loaded_shard_id: Optional[str] = None):
-        # loaded_weight = get_tensor(loaded_weight)
         # Tensor parallelism splits the weight along the output_dim
         if loaded_weight.dim() == 2:
             loaded_weight = loaded_weight.transpose([1, 0])

--- a/fastdeploy/model_executor/models/paddleocr_vl/siglip.py
+++ b/fastdeploy/model_executor/models/paddleocr_vl/siglip.py
@@ -23,7 +23,6 @@ import paddle.nn as nn
 import paddle.nn.functional as F
 from paddleformers.transformers.model_utils import PretrainedModel
 
-from fastdeploy.model_executor.layers.utils import get_tensor
 from fastdeploy.model_executor.utils import h2d_copy, slice_fn
 
 from .config import PaddleOCRVisionConfig
@@ -113,7 +112,6 @@ class SiglipAttention(nn.Layer):
             else:
                 loaded_weight = loaded_weight.cast(param.dtype)
         h2d_copy(param, loaded_weight)
-
 
     def forward(
         self,
@@ -303,7 +301,6 @@ class SiglipMLP(nn.Layer):
             else:
                 loaded_weight = loaded_weight.cast(param.dtype)
         h2d_copy(param, loaded_weight)
-
 
     def forward(self, hidden_states: paddle.Tensor) -> paddle.Tensor:
         hidden_states = self.fc1(hidden_states)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191) 

`LazyGuard` 下的参数是未初始化的，而 `uninit_tensor.copy_(data)` 结果会是 CPU 的，这导致了 OCR 里的参数加载后基本都是 CPU 的

此前使用了 `get_tensor` 强制 H2D，因此即便没有初始化仍然正确放在 GPU

但是 #4532 移除了 `get_tensor`，这就导致这些参数最后都在 CPU，性能惨不忍睹

另外 #4532 影响面不确定，本 PR 只测了 OCR 模型，其他的建议都查查

## Modifications

<!-- Detail the changes made in this pull request. -->

补全 OCR 中缺失的针对未初始化参数的 `init` 逻辑，并统一使用 `h2d_copy`

不过这个 `h2d_copy` 名字感觉不太合适啊，看着像强制 h2d，但是实现并不是

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

```
python -m fastdeploy.entrypoints.openai.api_server \
        --model /root/paddlejob/tmpspace/MODELS/PaddlePaddle/PaddleOCR-VL \
        --port 8295 \
        --metrics-port 8296 \
        --engine-worker-queue-port 8297 \
        --cache-queue-port 55660 \
        --max-model-len 16384 \
        --max-num-batched-tokens 16384 \
        --gpu-memory-utilization 0.7 \
        --max-num-seqs 256 \
        --workers 2 \
        --graph-optimization-config '{"graph_opt_level":0, "use_cudagraph":true}'
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

无

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
