### PR TITLE
[Cherry-Pick][RL] R3 Support RDMA Store

### DIFF
--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -1167,14 +1167,17 @@ class RoutingReplayConfig:
     """Configuration for Routing Replay used in RL training"""
 
     def __init__(self, args) -> None:
+
         self.enable_routing_replay: bool = False
+
+        # Routing store type: local/rdma
         self.routing_store_type: str = "local"
 
         # Local routing store
         self.local_store_dir: str = "./routing_replay_output"
 
         # RDMA routing store
-        pass
+        self.p2p_store_server: str = ""
 
         if args is not None:
             for key, value in args.items():

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -1177,7 +1177,7 @@ class RoutingReplayConfig:
         self.local_store_dir: str = "./routing_replay_output"
 
         # RDMA routing store
-        self.p2p_store_server: str = ""
+        self.rdma_store_server: str = ""
 
         if args is not None:
             for key, value in args.items():

--- a/fastdeploy/model_executor/layers/moe/routing_indices_cache.py
+++ b/fastdeploy/model_executor/layers/moe/routing_indices_cache.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """
 
+import asyncio
 import copy
 import os
 import shutil
@@ -315,8 +316,49 @@ class RoutingStoreLocal(RoutingStoreBase):
 class RoutingStoreRDMA(RoutingStoreBase):
     """Routing Store using RDMA"""
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, fd_config) -> None:
+        super().__init__(fd_config=fd_config)
+        try:
+            # Only used in RLHF
+            from p2pstore import P2PClient, P2PConfig
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(" RoutingStoreRDMA and p2pstore only support in RLHF. ")
+
+        p2p_store_server = fd_config.routing_replay_config.p2p_store_server
+        p2pConfig = P2PConfig(metadata_server=p2p_store_server)
+        self.p2p_client = P2PClient(p2pConfig)
+
+    def put(self, routing_indices: paddle.Tensor, rollout_id: str, layer_idx: int) -> None:
+        """Put the routing indices into store"""
+        rdma_rollout_key = f"{rollout_id}_{layer_idx}"
+        # async put
+        asyncio.run(self.p2p_client.put(rdma_rollout_key, routing_indices))
+
+    def get(
+        self,
+        rollout_id: str,
+        layer_idx: int = None,
+    ) -> paddle.Tensor:
+        """Get the routing indices from store"""
+        rdma_rollout_key = f"{rollout_id}_{layer_idx}"
+        # sync get
+        tmp_routing = asyncio.run(self.p2p_client.get(rdma_rollout_key))
+        return tmp_routing
+
+    def clear(
+        self,
+        rollout_id: str,
+        layer_idx: int = None,
+    ) -> None:
+        """Clear the routing indices of the request"""
+        rdma_rollout_key = f"{rollout_id}_{layer_idx}"
+        # async delete
+        asyncio.run(self.p2p_client.delete(rdma_rollout_key))
+
+    def clear_store(self):
+        """Clear the routing indices store"""
+        # async clear routing store
+        self.p2p_client.clear()
 
 
 def get_routing_store(fd_config: FDConfig) -> RoutingStoreBase:

--- a/fastdeploy/model_executor/layers/moe/routing_indices_cache.py
+++ b/fastdeploy/model_executor/layers/moe/routing_indices_cache.py
@@ -331,7 +331,7 @@ class RoutingStoreRDMA(RoutingStoreBase):
     def put(self, routing_indices: paddle.Tensor, rollout_id: str, layer_idx: int) -> None:
         """Put the routing indices into store"""
         rdma_rollout_key = f"{rollout_id}_{layer_idx}"
-        # async put
+        # sync put
         asyncio.run(self.p2p_client.put(rdma_rollout_key, routing_indices))
 
     def get(
@@ -352,13 +352,13 @@ class RoutingStoreRDMA(RoutingStoreBase):
     ) -> None:
         """Clear the routing indices of the request"""
         rdma_rollout_key = f"{rollout_id}_{layer_idx}"
-        # async delete
+        # sync delete
         asyncio.run(self.p2p_client.delete(rdma_rollout_key))
 
     def clear_store(self):
         """Clear the routing indices store"""
-        # async clear routing store
-        self.p2p_client.clear()
+        # sync clear routing store
+        asyncio.run(self.p2p_client.clear())
 
 
 def get_routing_store(fd_config: FDConfig) -> RoutingStoreBase:

--- a/fastdeploy/model_executor/layers/moe/routing_indices_cache.py
+++ b/fastdeploy/model_executor/layers/moe/routing_indices_cache.py
@@ -324,8 +324,8 @@ class RoutingStoreRDMA(RoutingStoreBase):
         except ModuleNotFoundError:
             raise ModuleNotFoundError(" RoutingStoreRDMA and p2pstore only support in RLHF. ")
 
-        p2p_store_server = fd_config.routing_replay_config.p2p_store_server
-        p2pConfig = P2PConfig(metadata_server=p2p_store_server)
+        rdma_store_server = fd_config.routing_replay_config.rdma_store_server
+        p2pConfig = P2PConfig(metadata_server=rdma_store_server)
         self.p2p_client = P2PClient(p2pConfig)
 
     def put(self, routing_indices: paddle.Tensor, rollout_id: str, layer_idx: int) -> None:

--- a/fastdeploy/model_executor/layers/moe/routing_indices_cache.py
+++ b/fastdeploy/model_executor/layers/moe/routing_indices_cache.py
@@ -18,6 +18,7 @@ import asyncio
 import copy
 import os
 import shutil
+import time
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional
 
@@ -233,6 +234,11 @@ class RoutingReplayManager:
         rollout_id = reversed_tmp_str[-1][::-1]
         return rollout_id
 
+    def clear_request(self, batch_id: int):
+        """Clear the routing indices of the request"""
+        self._clear_table_slot(batch_id)
+        self.routing_batch_to_request.pop(batch_id, None)
+
 
 class RoutingStoreBase(ABC):
     """Base class for routing store"""
@@ -269,6 +275,7 @@ class RoutingStoreLocal(RoutingStoreBase):
     def __init__(self, fd_config) -> None:
         super().__init__(fd_config=fd_config)
         self.local_store_dir = fd_config.routing_replay_config.local_store_dir
+        self.clear_store()
 
     def put(self, routing_indices: paddle.Tensor, rollout_id: str, layer_idx: int) -> None:
         """Put the routing indices into store"""
@@ -327,12 +334,18 @@ class RoutingStoreRDMA(RoutingStoreBase):
         rdma_store_server = fd_config.routing_replay_config.rdma_store_server
         p2pConfig = P2PConfig(metadata_server=rdma_store_server)
         self.p2p_client = P2PClient(p2pConfig)
+        self.clear_store()
 
     def put(self, routing_indices: paddle.Tensor, rollout_id: str, layer_idx: int) -> None:
         """Put the routing indices into store"""
         rdma_rollout_key = f"{rollout_id}_{layer_idx}"
-        # sync put
-        asyncio.run(self.p2p_client.put(rdma_rollout_key, routing_indices))
+
+        # async put
+        time_before_put = time.perf_counter()
+        routing_indices_pin = routing_indices.pin_memory()
+        routing_indices_np = routing_indices_pin.numpy()
+        asyncio.run(self.p2p_client.put(rdma_rollout_key, routing_indices_np))
+        print(f"Success put with key {rdma_rollout_key}, time cost is {time.perf_counter()-time_before_put} s")
 
     def get(
         self,

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -75,6 +75,9 @@ if not (current_platform.is_dcu() or current_platform.is_iluvatar()):
 from fastdeploy import envs
 from fastdeploy.input.ernie4_5_vl_processor import DataProcessor
 from fastdeploy.model_executor.forward_meta import ForwardMeta
+from fastdeploy.model_executor.layers.moe.routing_indices_cache import (
+    RoutingReplayManager,
+)
 from fastdeploy.model_executor.models.ernie4_5_vl.modeling_resampler import ScatterOp
 from fastdeploy.worker.model_runner_base import ModelRunnerBase
 from fastdeploy.worker.output import ModelOutputData, ModelRunnerOutput
@@ -162,6 +165,11 @@ class GPUModelRunner(ModelRunnerBase):
         # Postprocess Env params
         os.environ["INFERENCE_MSG_QUEUE_ID"] = str(self.parallel_config.engine_worker_queue_port)
         logger.info(f"queue id is {str(self.parallel_config.engine_worker_queue_port)}")
+
+        # Rollout routing replay config
+        self.routing_replay_manager = None
+        if self.fd_config.routing_replay_config.enable_routing_replay:
+            self.routing_replay_manager = RoutingReplayManager(fd_config=self.fd_config)
 
     def exist_prefill(self):
         """
@@ -313,11 +321,18 @@ class GPUModelRunner(ModelRunnerBase):
                 self.share_inputs["step_seq_lens_decoder"][idx : idx + 1] = 0
                 self.share_inputs["prompt_lens"][idx : idx + 1] = len(input_ids)
                 self.share_inputs["is_block_step"][idx : idx + 1] = False
+                self.share_inputs["is_chunk_step"][idx : idx + 1] = prefill_end_index < len(input_ids)
                 self.share_inputs["step_idx"][idx : idx + 1] = (
                     len(request.output_token_ids) if prefill_end_index >= len(input_ids) else 0
                 )
                 self.share_inputs["pre_ids"][idx : idx + 1] = -1
                 has_prefill_task = True
+
+                # Routing Replay
+                if self.fd_config.routing_replay_config.enable_routing_replay:
+                    if prefill_start_index == 0:
+                        self.routing_replay_manager.register_request(batch_id=idx, request_id=request.request_id)
+
             elif request.task_type.value == RequestType.DECODE.value:  # decode task
                 logger.debug(f"Handle decode request {request} at idx {idx}")
                 encoder_block_num = len(request.block_tables)
@@ -338,6 +353,11 @@ class GPUModelRunner(ModelRunnerBase):
                 self.share_inputs["seq_lens_encoder"][idx : idx + 1] = 0
                 self.share_inputs["is_block_step"][idx : idx + 1] = False
                 has_preempted_task = True
+
+                # Routing Replay
+                if self.fd_config.routing_replay_config.enable_routing_replay:
+                    self.routing_replay_manager.clear_request(batch_id=idx)
+
                 continue
 
             assert len(request.eos_token_ids) == self.model_config.eos_tokens_lens
@@ -716,6 +736,7 @@ class GPUModelRunner(ModelRunnerBase):
         self.share_inputs["bad_tokens_len"] = paddle.full([max_num_seqs], 1, dtype="int64")
         self.share_inputs["next_tokens"] = paddle.full([max_num_seqs, 1], -1, dtype="int64")
         self.share_inputs["is_block_step"] = paddle.full([max_num_seqs], False, dtype="bool")
+        self.share_inputs["is_chunk_step"] = paddle.full([max_num_seqs], False, dtype="bool").cpu()
         self.share_inputs["encoder_block_lens"] = paddle.full([max_num_seqs], 0, dtype="int32")
         self.share_inputs["step_block_list"] = paddle.full([max_num_seqs], -1, dtype="int32")
         self.share_inputs["step_lens"] = paddle.full([1], 0, dtype="int32")
@@ -972,6 +993,9 @@ class GPUModelRunner(ModelRunnerBase):
         Initialize forward meta and attention meta data
         """
         # Initialize forward meta
+        routing_replay_table = None
+        if self.routing_replay_manager is not None:
+            routing_replay_table = self.routing_replay_manager.get_routing_table()
         self.forward_meta = ForwardMeta(
             input_ids=self.share_inputs["input_ids"],
             ids_remove_padding=self.share_inputs["ids_remove_padding"],
@@ -989,6 +1013,7 @@ class GPUModelRunner(ModelRunnerBase):
             cu_seqlens_k=self.share_inputs["cu_seqlens_k"],
             block_tables=self.share_inputs["block_tables"],
             caches=self.share_inputs["caches"],
+            routing_replay_table=routing_replay_table,
         )
 
         # Update Batch type for cuda graph
@@ -1313,6 +1338,9 @@ class GPUModelRunner(ModelRunnerBase):
 
             if int((self.share_inputs["seq_lens_this_time"] > 0).sum()) == 0:
                 break
+
+        if self.fd_config.routing_replay_config.enable_routing_replay:
+            self.routing_replay_manager.clear_routing_table()
 
     def _update_chunked_prefill(self, tasks):
         """
@@ -1694,6 +1722,17 @@ class GPUModelRunner(ModelRunnerBase):
         self.seq_lens_this_time_buffer[:num_running_requests].copy_(
             self.share_inputs["seq_lens_this_time"][:num_running_requests], False
         )
+
+        # Routing replay
+        if self.fd_config.routing_replay_config.enable_routing_replay:
+            if (
+                not self.exist_prefill()
+                and not self.exist_decode()
+                and self.share_inputs["is_block_step"].sum() == 0
+                and self.share_inputs["is_chunk_step"].sum() == 0
+            ):
+                self.routing_replay_manager.put_table_to_store()
+
         return None
 
     def _add_cache(self, model_forward_batch) -> None:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191) 

Performance comparison between `RoutingStoreLocal` and `RoutingStoreRDMA`:
~~~
1. paddle.load overhead:
   Number of successfully `get` files: 37/37
   Mean overhead: 0.0395 s
   Min overhead: 0.0127 s
   Max overhead: 0.1590 s
   Total overhead: 1.4610 s

2. paddle.save overhead:
   Number of successfully `save` files: 37/37
   Mean overhead:  0.0872 s
   Min overhead: 0.0692 s
   Max overhead: 0.1226 s
   Total overhead: 3.2273 s

3. p2pstore.put overhead:
   Number of successfully `put` files: 37/37
   Mean overhead: 0.0073 s
   Min overhead: 0.0063 s
   Max overhead: 0.0076 s
   Total overhead: 0.2691 s

4. p2pstore.get overhead:
   Number of successfully `get` files: 37/37
   Mean overhead: 0.0027 s
   Min overhead: 0.0027 s
   Max overhead: 0.0029 s
   Total overhead: 0.1008 s

~~~

release/2.4 PR: https://github.com/PaddlePaddle/FastDeploy/pull/5468
develop PR: https://github.com/PaddlePaddle/FastDeploy/pull/5467

## Modifications

<!-- Detail the changes made in this pull request. -->

Add `RoutingStoreRDMA`, using P2P communication to transmit routing. 
+ Routing will be stored in the `WorkerProcess` process where the `RoutingStoreRDMA` is located and will not be actively released.
+ The`p2pstore` dependency library and 'RoutingStoreRDMA' can only be used in RLHF of PaddlePaddle

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

Add new parameters for `RoutingReplayConfig`:

~~~ bash
--routing-replay-config '{"enable_routing_replay":true, "routing_store_type":"rdma", "rdma_store_server":"zmq://x.x.x.x:5765,x.x.x.x:5766"}' 
~~~

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
