### PR TITLE
[Feature]Add a switch for logprobs/prompt_logprobs token decoding.

### DIFF
--- a/docs/online_serving/README.md
+++ b/docs/online_serving/README.md
@@ -223,6 +223,9 @@ include_draft_logprobs: Optional[bool] = False
 # Whether to return log probabilities during draft stages (e.g., pre-generation or intermediate steps)
 # for debugging or analysis of the generation process (default False means not returned).
 
+include_logprobs_decode_token: Optional[bool] = True
+# Whether to include decoded token in the logprobs/prompt_logprobs results, (default True means the decoded token is always include in results).
+
 logits_processors_args: Optional[Dict] = None
 # Additional arguments for logits processors, enabling customization of generation logic
 # (e.g., dynamically adjusting probability distributions).
@@ -480,6 +483,9 @@ top_p_normalized_logprobs: Optional[bool] = False
 include_draft_logprobs: Optional[bool] = False
 # Whether to return log probabilities during draft stages (e.g., pre-generation or intermediate steps)
 # for debugging or analysis of the generation process (default False means not returned).
+
+include_logprobs_decode_token: Optional[bool] = True
+# Whether to include decoded token in the prompt_logprobs results, (default True means the decoded token is always include in results).
 
 logits_processors_args: Optional[Dict] = None
 # Additional arguments for logits processors, enabling customization of generation logic

--- a/docs/zh/online_serving/README.md
+++ b/docs/zh/online_serving/README.md
@@ -218,6 +218,9 @@ top_p_normalized_logprobs: Optional[bool] = False
 include_draft_logprobs: Optional[bool] = False
 # 是否在预生成或中间步骤返回对数概率（log probabilities），用于调试或分析生成过程（默认 False 表示不返回）。
 
+include_logprobs_decode_token: Optional[bool] = True
+# 是否在logprobs/prompt_logprobs结果中返回解码后的token，（默认的True表示总是在结果中返回）
+
 logits_processors_args: Optional[Dict] = None
 # 传递给 logits 处理器（logits processors）的额外参数，用于自定义生成过程中的逻辑（如动态调整概率分布）。
 
@@ -468,6 +471,9 @@ top_p_normalized_logprobs: Optional[bool] = False
 
 include_draft_logprobs: Optional[bool] = False
 # 是否在预生成或中间步骤返回对数概率（log probabilities），用于调试或分析生成过程（默认 False 表示不返回）。
+
+include_logprobs_decode_token: Optional[bool] = True
+# 是否在prompt_logprobs结果中返回解码后的token，（默认的True表示总是在结果中返回）
 
 logits_processors_args: Optional[Dict] = None
 # 传递给 logits 处理器（logits processors）的额外参数，用于自定义生成过程中的逻辑（如动态调整概率分布）。

--- a/fastdeploy/entrypoints/openai/protocol.py
+++ b/fastdeploy/entrypoints/openai/protocol.py
@@ -457,6 +457,7 @@ class CompletionRequest(BaseModel):
     frequency_penalty: Optional[float] = Field(default=None, ge=-2, le=2)
     logprobs: Optional[int] = None
     include_draft_logprobs: Optional[bool] = False
+    include_logprobs_decode_token: Optional[bool] = True
     prompt_logprobs: Optional[int] = None
     # For logits and logprobs post processing
     temp_scaled_logprobs: bool = False
@@ -620,6 +621,7 @@ class ChatCompletionRequest(BaseModel):
     top_logprobs: Optional[int] = None
     prompt_logprobs: Optional[int] = None
     include_draft_logprobs: Optional[bool] = False
+    include_logprobs_decode_token: Optional[bool] = True
 
     # For logits and logprobs post processing
     temp_scaled_logprobs: bool = False

--- a/fastdeploy/entrypoints/openai/serving_chat.py
+++ b/fastdeploy/entrypoints/openai/serving_chat.py
@@ -306,7 +306,7 @@ class OpenAIServingChat:
                                     else self.engine_client.ori_vocab_size
                                 )
                                 prompt_logprobs_res = self._build_prompt_logprobs(
-                                    prompt_logprobs_tensors, num_prompt_logprobs
+                                    prompt_logprobs_tensors, num_prompt_logprobs, request.include_logprobs_decode_token
                                 )
                             choice = ChatCompletionResponseStreamChoice(
                                 index=i,
@@ -373,12 +373,18 @@ class OpenAIServingChat:
                             request.top_logprobs if request.top_logprobs != -1 else self.engine_client.ori_vocab_size
                         )
                         logprobs_res = self._create_chat_logprobs(
-                            output_top_logprobs, request.logprobs, num_top_logprobs
+                            output_top_logprobs,
+                            request.logprobs,
+                            num_top_logprobs,
+                            request.include_logprobs_decode_token,
                         )
 
                         if request.include_draft_logprobs and output_draft_top_logprobs is not None:
                             draft_logprobs_res = self._create_chat_logprobs(
-                                output_draft_top_logprobs, request.logprobs, num_top_logprobs
+                                output_draft_top_logprobs,
+                                request.logprobs,
+                                num_top_logprobs,
+                                request.include_logprobs_decode_token,
                             )
 
                     delta_message = DeltaMessage(
@@ -582,7 +588,10 @@ class OpenAIServingChat:
                         )
                         # logprobs
                         logprobs_res = self._create_chat_logprobs(
-                            output_top_logprobs, request.logprobs, num_top_logprobs
+                            output_top_logprobs,
+                            request.logprobs,
+                            num_top_logprobs,
+                            request.include_logprobs_decode_token,
                         )
                         if logprobs_res and logprobs_res.content is not None:
                             logprob_contents[idx].extend(logprobs_res.content)
@@ -590,7 +599,10 @@ class OpenAIServingChat:
                         # draft_logprobs
                         if request.include_draft_logprobs and output_draft_top_logprobs is not None:
                             draft_logprobs_res = self._create_chat_logprobs(
-                                output_draft_top_logprobs, request.logprobs, num_top_logprobs
+                                output_draft_top_logprobs,
+                                request.logprobs,
+                                num_top_logprobs,
+                                request.include_logprobs_decode_token,
                             )
                             if draft_logprobs_res and draft_logprobs_res.content is not None:
                                 draft_logprob_contents[idx].extend(draft_logprobs_res.content)
@@ -601,7 +613,9 @@ class OpenAIServingChat:
                             if request.prompt_logprobs != -1
                             else self.engine_client.ori_vocab_size
                         )
-                        prompt_logprobs_res = self._build_prompt_logprobs(prompt_logprobs_tensors, num_prompt_logprobs)
+                        prompt_logprobs_res = self._build_prompt_logprobs(
+                            prompt_logprobs_tensors, num_prompt_logprobs, request.include_logprobs_decode_token
+                        )
                         if prompt_logprobs_res:
                             prompt_logprobs_res_list[idx].extend(clamp_prompt_logprobs(prompt_logprobs_res))
                     if data["finished"]:
@@ -743,6 +757,7 @@ class OpenAIServingChat:
         output_top_logprobs,
         request_logprobs: Optional[bool] = None,
         request_top_logprobs: Optional[int] = None,
+        request_decode_flag: Optional[bool] = True,
     ) -> Optional[LogProbs]:
         """Create OpenAI-style logprobs for chat completions."""
         if output_top_logprobs is None or len(output_top_logprobs) < 3 or any(not lst for lst in output_top_logprobs):
@@ -760,6 +775,7 @@ class OpenAIServingChat:
                 request_logprobs=request_logprobs,
                 response_logprobs=top_logprobs,
                 request_top_logprobs=request_top_logprobs,
+                request_decode_flag=request_decode_flag,
             )
             if logprobs_res is None:
                 logprobs_res = step_logprobs_res
@@ -772,6 +788,7 @@ class OpenAIServingChat:
         request_logprobs: bool,
         response_logprobs: Optional[LogprobsLists],
         request_top_logprobs: int,
+        request_decode_flag: bool,
     ) -> Optional[LogProbs]:
         """
         Construct a logprobs response object in line with the OpenAI style.
@@ -801,12 +818,16 @@ class OpenAIServingChat:
             # Construct the candidate token structure (LogProbEntry) of topk
             top_logprob_entries: List[LogProbEntry] = []
             for tid, lp in zip(topk_token_ids, topk_logprobs):
-                token_str = self.engine_client.data_processor.process_logprob_response(
-                    [tid], clean_up_tokenization_spaces=False
-                )
-                token_bytes = token_str.encode("utf-8", errors="replace")
-                if "\ufffd" in token_str:
-                    token_str = "bytes:" + "".join(f"\\x{byte:02x}" for byte in token_bytes)
+                if request_decode_flag:
+                    token_str = self.engine_client.data_processor.process_logprob_response(
+                        [tid], clean_up_tokenization_spaces=False
+                    )
+                    token_bytes = token_str.encode("utf-8", errors="replace")
+                    if "\ufffd" in token_str:
+                        token_str = "bytes:" + "".join(f"\\x{byte:02x}" for byte in token_bytes)
+                else:
+                    token_str = ""
+                    token_bytes = []
                 entry = LogProbEntry(token=token_str, logprob=lp, bytes=list(token_bytes))
                 top_logprob_entries.append(entry)
             # Construct the sampled token object (avoid sharing references with top_logprob_entries)
@@ -845,6 +866,7 @@ class OpenAIServingChat:
         self,
         prompt_logprobs_tensors: LogprobsTensors,
         num_prompt_logprobs: int,
+        include_logprobs_decode_token: bool,
     ):
         """Update with prompt logprobs from worker.
         Args:
@@ -856,10 +878,13 @@ class OpenAIServingChat:
 
         # Detokenize non-incrementally.
         # Output is flat: [num_tok, num_lps] -> [num_tok * num_lps]
-        decoded_tokens = [
-            self.engine_client.data_processor.process_logprob_response(token_id)
-            for token_id in token_ids.flatten().tolist()
-        ]
+        if include_logprobs_decode_token:
+            decoded_tokens = [
+                self.engine_client.data_processor.process_logprob_response(token_id)
+                for token_id in token_ids.flatten().tolist()
+            ]
+        else:
+            decoded_tokens = None
 
         # Recover shapes.
         num_prompt_tokens, num_logprobs = logprobs.shape

--- a/fastdeploy/entrypoints/openai/serving_completion.py
+++ b/fastdeploy/entrypoints/openai/serving_completion.py
@@ -452,7 +452,7 @@ class OpenAIServingCompletion:
                                 else self.engine_client.ori_vocab_size
                             )
                             prompt_logprobs_res = self._build_prompt_logprobs(
-                                prompt_logprobs_tensors, num_prompt_logprobs
+                                prompt_logprobs_tensors, num_prompt_logprobs, request.include_logprobs_decode_token
                             )
                         if request.return_token_ids:
                             chunk = CompletionStreamResponse(
@@ -651,7 +651,9 @@ class OpenAIServingCompletion:
                 num_prompt_logprobs = (
                     request.prompt_logprobs if request.prompt_logprobs != -1 else self.engine_client.ori_vocab_size
                 )
-                prompt_logprobs_res = self._build_prompt_logprobs(prompt_logprobs_tensors, num_prompt_logprobs)
+                prompt_logprobs_res = self._build_prompt_logprobs(
+                    prompt_logprobs_tensors, num_prompt_logprobs, request.include_logprobs_decode_token
+                )
             if request.echo:
                 prompt_text = self._echo_back_prompt(request, idx // (1 if request.n is None else request.n))
                 token_ids = [*prompt_token_ids, *output["token_ids"]]
@@ -817,6 +819,7 @@ class OpenAIServingCompletion:
         self,
         prompt_logprobs_tensors: LogprobsTensors,
         num_prompt_logprobs: int,
+        include_logprobs_decode_token: bool,
     ):
         """Update with prompt logprobs from worker.
         Args:
@@ -828,10 +831,13 @@ class OpenAIServingCompletion:
 
         # Detokenize non-incrementally.
         # Output is flat: [num_tok, num_lps] -> [num_tok * num_lps]
-        decoded_tokens = [
-            self.engine_client.data_processor.process_logprob_response(token_id)
-            for token_id in token_ids.flatten().tolist()
-        ]
+        if include_logprobs_decode_token:
+            decoded_tokens = [
+                self.engine_client.data_processor.process_logprob_response(token_id)
+                for token_id in token_ids.flatten().tolist()
+            ]
+        else:
+            decoded_tokens = None
 
         # Recover shapes.
         num_prompt_tokens, num_logprobs = logprobs.shape

--- a/tests/entrypoints/openai/test_serving_chat.py
+++ b/tests/entrypoints/openai/test_serving_chat.py
@@ -89,7 +89,7 @@ class TestOpenAIServingCompletion(unittest.IsolatedAsyncioTestCase):
         ) as mock_decode:
             mock_decode.side_effect = ["token1", "token2", "token3", "token4", "token5", "token6"]
 
-            result = self.chat_completion_handler._build_prompt_logprobs(prompt_logprobs_tensors, num_logprobs)
+            result = self.chat_completion_handler._build_prompt_logprobs(prompt_logprobs_tensors, num_logprobs, True)
 
             # Verify result structure (first element is None, then actual results)
             self.assertEqual(len(result), num_prompt_tokens + 1)
@@ -127,7 +127,7 @@ class TestOpenAIServingCompletion(unittest.IsolatedAsyncioTestCase):
         ) as mock_decode:
             mock_decode.side_effect = ["hello", "world"]
 
-            result = self.chat_completion_handler._build_prompt_logprobs(prompt_logprobs_tensors, -1)
+            result = self.chat_completion_handler._build_prompt_logprobs(prompt_logprobs_tensors, -1, True)
 
             self.assertEqual(len(result), num_prompt_tokens + 1)
             self.assertIsNone(result[0])
@@ -154,7 +154,7 @@ class TestOpenAIServingCompletion(unittest.IsolatedAsyncioTestCase):
         ) as mock_decode:
             mock_decode.return_value = "single_token"
 
-            result = self.chat_completion_handler._build_prompt_logprobs(prompt_logprobs_tensors, num_logprobs)
+            result = self.chat_completion_handler._build_prompt_logprobs(prompt_logprobs_tensors, num_logprobs, True)
 
             self.assertEqual(len(result), num_prompt_tokens + 1)
             self.assertIsNone(result[0])
@@ -183,7 +183,7 @@ class TestOpenAIServingCompletion(unittest.IsolatedAsyncioTestCase):
         ) as mock_decode:
             mock_decode.side_effect = ["t1", "t2", "t3", "t4", "t5", "t6"]
 
-            result = self.chat_completion_handler._build_prompt_logprobs(prompt_logprobs_tensors, num_logprobs)
+            result = self.chat_completion_handler._build_prompt_logprobs(prompt_logprobs_tensors, num_logprobs, True)
 
             self.assertEqual(len(result), num_prompt_tokens + 1)
             self.assertIsNone(result[0])
@@ -217,7 +217,7 @@ class TestOpenAIServingCompletion(unittest.IsolatedAsyncioTestCase):
 
         prompt_logprobs_tensors = LogprobsTensors(token_ids, logprobs, ranks)
 
-        result = self.chat_completion_handler._build_prompt_logprobs(prompt_logprobs_tensors, num_logprobs)
+        result = self.chat_completion_handler._build_prompt_logprobs(prompt_logprobs_tensors, num_logprobs, True)
 
         self.assertEqual(len(result), num_prompt_tokens + 1)
         self.assertIsNone(result[0])

--- a/tests/entrypoints/openai/test_serving_completion.py
+++ b/tests/entrypoints/openai/test_serving_completion.py
@@ -208,7 +208,7 @@ class TestOpenAIServingCompletion(unittest.IsolatedAsyncioTestCase):
         ) as mock_decode:
             mock_decode.side_effect = ["token1", "token2", "token3", "token4", "token5", "token6"]
 
-            result = self.serving_completion._build_prompt_logprobs(prompt_logprobs_tensors, num_logprobs)
+            result = self.serving_completion._build_prompt_logprobs(prompt_logprobs_tensors, num_logprobs, True)
 
             # Verify result structure (first element is None, then actual results)
             self.assertEqual(len(result), num_prompt_tokens + 1)
@@ -246,7 +246,7 @@ class TestOpenAIServingCompletion(unittest.IsolatedAsyncioTestCase):
         ) as mock_decode:
             mock_decode.side_effect = ["hello", "world"]
 
-            result = self.serving_completion._build_prompt_logprobs(prompt_logprobs_tensors, -1)
+            result = self.serving_completion._build_prompt_logprobs(prompt_logprobs_tensors, -1, True)
 
             self.assertEqual(len(result), num_prompt_tokens + 1)
             self.assertIsNone(result[0])
@@ -273,7 +273,7 @@ class TestOpenAIServingCompletion(unittest.IsolatedAsyncioTestCase):
         ) as mock_decode:
             mock_decode.return_value = "single_token"
 
-            result = self.serving_completion._build_prompt_logprobs(prompt_logprobs_tensors, num_logprobs)
+            result = self.serving_completion._build_prompt_logprobs(prompt_logprobs_tensors, num_logprobs, True)
 
             self.assertEqual(len(result), num_prompt_tokens + 1)
             self.assertIsNone(result[0])
@@ -302,7 +302,7 @@ class TestOpenAIServingCompletion(unittest.IsolatedAsyncioTestCase):
         ) as mock_decode:
             mock_decode.side_effect = ["t1", "t2", "t3", "t4", "t5", "t6"]
 
-            result = self.serving_completion._build_prompt_logprobs(prompt_logprobs_tensors, num_logprobs)
+            result = self.serving_completion._build_prompt_logprobs(prompt_logprobs_tensors, num_logprobs, True)
 
             self.assertEqual(len(result), num_prompt_tokens + 1)
             self.assertIsNone(result[0])
@@ -336,7 +336,7 @@ class TestOpenAIServingCompletion(unittest.IsolatedAsyncioTestCase):
 
         prompt_logprobs_tensors = LogprobsTensors(token_ids, logprobs, ranks)
 
-        result = self.serving_completion._build_prompt_logprobs(prompt_logprobs_tensors, num_logprobs)
+        result = self.serving_completion._build_prompt_logprobs(prompt_logprobs_tensors, num_logprobs, True)
 
         self.assertEqual(len(result), num_prompt_tokens + 1)
         self.assertIsNone(result[0])


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191) 

It has been observed during current project usage that when logprobs or prompt_logprobs take a particularly large value, the process of converting token IDs to tokens consumes a significant amount of time. In some scenarios, the decoded tokens are not frequently used. Therefore, a switch needs to be added to control whether the decoding from token ID to token is enabled for logprobs and prompt_logprobs on a specific request.

## Modifications

<!-- Detail the changes made in this pull request. -->

Add the control parameter `include_logprobs_decode_token` to the online link request, which is enabled by default.

- For the v1/chat/completions interface:
  - When include_logprobs_decode_token is enabled, the results for logprobs and prompt_logprobs are output in the normal format.
  - When include_logprobs_decode_token is disabled, the token and bytes fields in the logprobs result are empty, and the decoded_tokens field in prompt_logprobs is empty.
- For the v1/completions interface:
  - When include_logprobs_decode_token is enabled, the results for logprobs and prompt_logprobs are output in the normal format.
  - When include_logprobs_decode_token is disabled, the logprobs result is output in the normal format, and the decoded_tokens field in prompt_logprobs is empty.

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->
v1/chat/completions：
```
curl --location 'http://0:0:0:0:8180/v1/completions' \
--header 'Content-Type: application/json' \
--data '{
  "prompt": "请生成一篇关于理想的作文,不超过100字",
  "logprobs":3,
  "prompt_logprobs":3,
   "include_logprobs_decode_token":false
}
'
```

v1/completions：
```
curl --location 'http://0:0:0:0:8180/v1/chat/completions' \
--header 'Content-Type: application/json' \
--data '{
    "messages": [
        {
            "role": "system",
            "content": "I'\''m a helpful AI assistant."
        },
        {
            "role": "user",
            "content": "give me three letter randdomly, just tell me letter without anything else"
        }
    ],
    "logprobs":"true",
    "top_logprobs":3,
    "prompt_logprobs":3,
    "include_logprobs_decode_token":false
}'
```


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
