### PR TITLE
[Metrics]add request reschedule time cost

### DIFF
--- a/fastdeploy/engine/request.py
+++ b/fastdeploy/engine/request.py
@@ -483,6 +483,7 @@ class RequestMetrics:
     preprocess_end_time: Optional[float] = None  # preprocess end time in api server
 
     scheduler_recv_req_time: Optional[float] = None  # scheduler receives request and add to scheduler
+    rescheduler_recv_req_time: Optional[float] = None  # rescheduler receives request and add to scheduler
     engine_get_req_time: Optional[float] = None  # engine gets request from scheduler
     ask_decode_resource_start_time: Optional[float] = None  # engine asks decode resource (only valid for prefill)
     ask_decode_resource_finish_time: Optional[float] = None  # engine has got decode resource (only valid for prefill)

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -276,6 +276,16 @@ class ResourceManagerV1(ResourceManager):
                     preempted_req.cached_block_num = 0
                     self.to_be_rescheduled_request_id_set.add(preempted_req.request_id)
                     llm_logger.info(f"Preemption is triggered! Preempted request id: {preempted_req.request_id}")
+                preempted_req.metrics.rescheduler_recv_req_time = time.time()
+                if preempted_req.metrics.inference_start_time is not None:
+                    request_reschedule_time = (
+                        preempted_req.metrics.rescheduler_recv_req_time - preempted_req.metrics.inference_start_time
+                        if preempted_req.metrics.rescheduler_recv_req_time is not None
+                        else 0.0
+                    )
+                    if request_reschedule_time > 0:
+                        main_process_metrics.request_reschedule_time.observe(request_reschedule_time)
+
                 preempted_reqs.append(preempted_req)
                 scheduled_reqs.append(self._prepare_preempt_task(preempted_req))
 

--- a/fastdeploy/metrics/metrics.py
+++ b/fastdeploy/metrics/metrics.py
@@ -139,6 +139,7 @@ class MetricsManager:
     generation_tokens_total: "Counter"
     request_prefill_time: "Histogram"
     request_decode_time: "Histogram"
+    request_reschedule_time: "Histogram"
     request_generation_tokens: "Histogram"
     request_success_total: "Counter"
     spec_decode_draft_acceptance_rate: "Gauge"
@@ -358,6 +359,12 @@ class MetricsManager:
             "type": Histogram,
             "name": "fastdeploy:request_decode_time_seconds",
             "description": "Time spent in decode phase (from first token to last token)",
+            "kwargs": {"buckets": REQUEST_LATENCY_BUCKETS},
+        },
+        "request_reschedule_time": {
+            "type": Histogram,
+            "name": "fastdeploy:request_reschedule_time_seconds",
+            "description": "Time spent in reschedule",
             "kwargs": {"buckets": REQUEST_LATENCY_BUCKETS},
         },
         "request_generation_tokens": {

--- a/tests/engine/sched/test_resource_manager_v1_preempt_metrics.py
+++ b/tests/engine/sched/test_resource_manager_v1_preempt_metrics.py
@@ -1,0 +1,241 @@
+"""
+Simple test for resource_manager_v1.py preempt metrics functionality
+"""
+
+import unittest
+from unittest.mock import MagicMock, Mock, patch
+
+from fastdeploy.engine.request import Request, RequestMetrics
+
+
+class TestResourceManagerV1PreemptMetricsSimple(unittest.TestCase):
+    """Test the specific metrics observation code in _trigger_preempt method"""
+
+    def test_preempt_metrics_code_path(self):
+        """Test the exact code path for metrics observation"""
+
+        # Create a mock request with metrics
+        request = Mock(spec=Request)
+        request.request_id = "test_request"
+        request.idx = 0
+        request.use_extend_tables = False
+        request.block_tables = [1, 2, 3]
+
+        # Create metrics with valid times
+        request.metrics = Mock(spec=RequestMetrics)
+        request.metrics.inference_start_time = 100.0
+        request.metrics.rescheduler_recv_req_time = 105.0
+
+        # Mock main_process_metrics
+        mock_main_process_metrics = MagicMock()
+        mock_main_process_metrics.request_reschedule_time = MagicMock()
+
+        # Test the exact code logic from lines 280-288
+        with patch("fastdeploy.engine.sched.resource_manager_v1.main_process_metrics", mock_main_process_metrics):
+            # Set the rescheduler_recv_req_time (this happens in _trigger_preempt)
+            request.metrics.rescheduler_recv_req_time = 105.0
+
+            # Execute the exact code from the target lines
+            if request.metrics.inference_start_time is not None:
+                request_reschedule_time = (
+                    request.metrics.rescheduler_recv_req_time - request.metrics.inference_start_time
+                    if request.metrics.rescheduler_recv_req_time is not None
+                    else 0.0
+                )
+                if request_reschedule_time > 0:
+                    mock_main_process_metrics.request_reschedule_time.observe(request_reschedule_time)
+
+        # Verify the metrics were called with the correct value (105.0 - 100.0 = 5.0)
+        mock_main_process_metrics.request_reschedule_time.observe.assert_called_once_with(5.0)
+
+    def test_preempt_metrics_with_none_rescheduler_recv_req_time(self):
+        """Test metrics observation when rescheduler_recv_req_time is None"""
+
+        # Create a mock request with metrics
+        request = Mock(spec=Request)
+        request.request_id = "test_request"
+        request.idx = 0
+        request.use_extend_tables = False
+        request.block_tables = [1, 2, 3]
+
+        # Create metrics with None rescheduler_recv_req_time
+        request.metrics = Mock(spec=RequestMetrics)
+        request.metrics.inference_start_time = 100.0
+        request.metrics.rescheduler_recv_req_time = None
+
+        # Mock main_process_metrics
+        mock_main_process_metrics = MagicMock()
+        mock_main_process_metrics.request_reschedule_time = MagicMock()
+
+        # Test the exact code logic from lines 280-288
+        with patch("fastdeploy.engine.sched.resource_manager_v1.main_process_metrics", mock_main_process_metrics):
+            # Set the rescheduler_recv_req_time (this happens in _trigger_preempt)
+            request.metrics.rescheduler_recv_req_time = None
+
+            # Execute the exact code from the target lines
+            if request.metrics.inference_start_time is not None:
+                request_reschedule_time = (
+                    request.metrics.rescheduler_recv_req_time - request.metrics.inference_start_time
+                    if request.metrics.rescheduler_recv_req_time is not None
+                    else 0.0
+                )
+                if request_reschedule_time > 0:
+                    mock_main_process_metrics.request_reschedule_time.observe(request_reschedule_time)
+
+        # Verify that observe was not called (reschedule_time would be 0.0)
+        mock_main_process_metrics.request_reschedule_time.observe.assert_not_called()
+
+    def test_preempt_metrics_with_negative_reschedule_time(self):
+        """Test metrics observation when reschedule_time is negative"""
+
+        # Create a mock request with metrics
+        request = Mock(spec=Request)
+        request.request_id = "test_request"
+        request.idx = 0
+        request.use_extend_tables = False
+        request.block_tables = [1, 2, 3]
+
+        # Create metrics where rescheduler_recv_req_time < inference_start_time
+        request.metrics = Mock(spec=RequestMetrics)
+        request.metrics.inference_start_time = 105.0
+        request.metrics.rescheduler_recv_req_time = 100.0  # Earlier than inference_start_time
+
+        # Mock main_process_metrics
+        mock_main_process_metrics = MagicMock()
+        mock_main_process_metrics.request_reschedule_time = MagicMock()
+
+        # Test the exact code logic from lines 280-288
+        with patch("fastdeploy.engine.sched.resource_manager_v1.main_process_metrics", mock_main_process_metrics):
+            # Set the rescheduler_recv_req_time (this happens in _trigger_preempt)
+            request.metrics.rescheduler_recv_req_time = 100.0
+
+            # Execute the exact code from the target lines
+            if request.metrics.inference_start_time is not None:
+                request_reschedule_time = (
+                    request.metrics.rescheduler_recv_req_time - request.metrics.inference_start_time
+                    if request.metrics.rescheduler_recv_req_time is not None
+                    else 0.0
+                )
+                if request_reschedule_time > 0:
+                    mock_main_process_metrics.request_reschedule_time.observe(request_reschedule_time)
+
+        # Verify that observe was not called (reschedule_time would be -5.0 <= 0)
+        mock_main_process_metrics.request_reschedule_time.observe.assert_not_called()
+
+    def test_preempt_metrics_with_none_inference_start_time(self):
+        """Test that metrics are not observed when inference_start_time is None"""
+
+        # Create a mock request with metrics
+        request = Mock(spec=Request)
+        request.request_id = "test_request"
+        request.idx = 0
+        request.use_extend_tables = False
+        request.block_tables = [1, 2, 3]
+
+        # Create metrics with None inference_start_time
+        request.metrics = Mock(spec=RequestMetrics)
+        request.metrics.inference_start_time = None
+        request.metrics.rescheduler_recv_req_time = 105.0
+
+        # Mock main_process_metrics
+        mock_main_process_metrics = MagicMock()
+        mock_main_process_metrics.request_reschedule_time = MagicMock()
+
+        # Test the exact code logic from lines 280-288
+        with patch("fastdeploy.engine.sched.resource_manager_v1.main_process_metrics", mock_main_process_metrics):
+            # Set the rescheduler_recv_req_time (this happens in _trigger_preempt)
+            request.metrics.rescheduler_recv_req_time = 105.0
+
+            # Execute the exact code from the target lines
+            if request.metrics.inference_start_time is not None:
+                request_reschedule_time = (
+                    request.metrics.rescheduler_recv_req_time - request.metrics.inference_start_time
+                    if request.metrics.rescheduler_recv_req_time is not None
+                    else 0.0
+                )
+                if request_reschedule_time > 0:
+                    mock_main_process_metrics.request_reschedule_time.observe(request_reschedule_time)
+
+        # Verify that observe was not called (inference_start_time is None)
+        mock_main_process_metrics.request_reschedule_time.observe.assert_not_called()
+
+    def test_preempt_metrics_with_zero_reschedule_time(self):
+        """Test metrics observation when reschedule_time is exactly 0"""
+
+        # Create a mock request with metrics
+        request = Mock(spec=Request)
+        request.request_id = "test_request"
+        request.idx = 0
+        request.use_extend_tables = False
+        request.block_tables = [1, 2, 3]
+
+        # Create metrics where rescheduler_recv_req_time == inference_start_time
+        request.metrics = Mock(spec=RequestMetrics)
+        request.metrics.inference_start_time = 100.0
+        request.metrics.rescheduler_recv_req_time = 100.0
+
+        # Mock main_process_metrics
+        mock_main_process_metrics = MagicMock()
+        mock_main_process_metrics.request_reschedule_time = MagicMock()
+
+        # Test the exact code logic from lines 280-288
+        with patch("fastdeploy.engine.sched.resource_manager_v1.main_process_metrics", mock_main_process_metrics):
+            # Set the rescheduler_recv_req_time (this happens in _trigger_preempt)
+            request.metrics.rescheduler_recv_req_time = 100.0
+
+            # Execute the exact code from the target lines
+            if request.metrics.inference_start_time is not None:
+                request_reschedule_time = (
+                    request.metrics.rescheduler_recv_req_time - request.metrics.inference_start_time
+                    if request.metrics.rescheduler_recv_req_time is not None
+                    else 0.0
+                )
+                if request_reschedule_time > 0:
+                    mock_main_process_metrics.request_reschedule_time.observe(request_reschedule_time)
+
+        # Verify that observe was not called (reschedule_time would be 0.0)
+        mock_main_process_metrics.request_reschedule_time.observe.assert_not_called()
+
+    def test_preempt_metrics_with_small_positive_reschedule_time(self):
+        """Test metrics observation with small positive reschedule_time"""
+
+        # Create a mock request with metrics
+        request = Mock(spec=Request)
+        request.request_id = "test_request"
+        request.idx = 0
+        request.use_extend_tables = False
+        request.block_tables = [1, 2, 3]
+
+        # Create metrics with small positive reschedule_time
+        request.metrics = Mock(spec=RequestMetrics)
+        request.metrics.inference_start_time = 100.0
+        request.metrics.rescheduler_recv_req_time = 100.1  # Small positive difference
+
+        # Mock main_process_metrics
+        mock_main_process_metrics = MagicMock()
+        mock_main_process_metrics.request_reschedule_time = MagicMock()
+
+        # Test the exact code logic from lines 280-288
+        with patch("fastdeploy.engine.sched.resource_manager_v1.main_process_metrics", mock_main_process_metrics):
+            # Set the rescheduler_recv_req_time (this happens in _trigger_preempt)
+            request.metrics.rescheduler_recv_req_time = 100.1
+
+            # Execute the exact code from the target lines
+            if request.metrics.inference_start_time is not None:
+                request_reschedule_time = (
+                    request.metrics.rescheduler_recv_req_time - request.metrics.inference_start_time
+                    if request.metrics.rescheduler_recv_req_time is not None
+                    else 0.0
+                )
+                if request_reschedule_time > 0:
+                    mock_main_process_metrics.request_reschedule_time.observe(request_reschedule_time)
+
+        # Verify that observe was called with small positive reschedule time
+        mock_main_process_metrics.request_reschedule_time.observe.assert_called_once()
+        # Check that the called value is approximately 0.1 (accounting for floating point precision)
+        call_args = mock_main_process_metrics.request_reschedule_time.observe.call_args[0]
+        self.assertAlmostEqual(call_args[0], 0.1, places=5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->


To evaluate the impact of rescheduling on FD inference performance, it is necessary to add a metric that measures the time overhead for rescheduled requests to rejoin the FD inference process.


## Modifications

<!-- Detail the changes made in this pull request. -->

A metric named `request_reschedule_time` has been added to the metrics.


## Usage or Command

visit /metrics

## Accuracy Tests

no effect

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
