### PR TITLE
[Benchmark] Update benchmark

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -45,6 +45,7 @@ python -m pip install -r requirements.txt
 --debug：开启debug模式，逐条打印payload和output内容，默认False
 --shuffle：是否打乱数据集，默认False不打乱
 --seed：打乱数据集时的随机种子，默认0
+--pd-metrics：开启PD分离metrics指标收集，会添加请求参数collect_metrics=True，默认False
 ```
 
 ##### /v1/chat/completions接口压测单条数据调试

--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -74,6 +74,73 @@ class RequestFuncOutput:
     prompt_len: int = 0
     prompt_tokens: int = 0  # 推理侧返回输入token数
     error: str = ""
+    metrics: dict = field(default_factory=dict)
+
+
+def safe_cost(a, b):
+    """时间差计算"""
+    if a is None or b is None:
+        return None
+    return a - b
+
+
+def metrics_summary(metrics, token_timestamps):
+    """Summarize metrics"""
+    if not metrics or len(token_timestamps) < 2:
+        return {}
+
+    m0 = metrics[0]
+    m_last = metrics[-1]
+
+    summary = {}
+
+    arrival_time = m0.get("arrival_time")
+    inference_start_time = m0.get("inference_start_time")
+
+    # prefill 总耗时
+    summary["prefill_cost_time"] = safe_cost(m0.get("send_request_output_to_decode_time"), arrival_time)
+    # prefill准备耗时
+    summary["prefill_prepare_cost_time"] = safe_cost(inference_start_time, arrival_time)
+    # 预处理耗时
+    summary["preprocess_cost_time"] = safe_cost(m0.get("scheduler_recv_req_time"), arrival_time)
+    # 请求缓存耗时
+    summary["cache_in_scheduler_cost_time"] = safe_cost(
+        m0.get("engine_get_req_time"), m0.get("scheduler_recv_req_time")
+    )
+    # 申请 decode资源耗时
+    summary["ask_decode_resource_cost_time"] = safe_cost(
+        m0.get("ask_decode_resource_finish_time"), m0.get("ask_decode_resource_start_time")
+    )
+    # prefill 的首 token 推理耗时
+    summary["prefill_first_token_infer_cost_time"] = safe_cost(
+        m0.get("engine_recv_first_token_time"), inference_start_time
+    )
+    # prefill 等待 cache 传输耗时
+    summary["wait_sending_cache_cost_time"] = safe_cost(
+        m0.get("send_request_output_to_decode_time"), m0.get("wait_for_sending_cache_time")
+    )
+    # decode分配资源耗时
+    summary["decode_preallocate_cost_time"] = safe_cost(
+        m_last.get("decode_preallocate_req_time"), m_last.get("decode_recv_req_time")
+    )
+    # decode准备推理耗时
+    summary["decode_prepare_cost_time"] = safe_cost(
+        m_last.get("decode_inference_start_time"), m_last.get("decode_recv_first_token_time")
+    )
+    # decode次token推理耗时
+    summary["decode_second_token_infer_cost_time"] = safe_cost(
+        m_last.get("decode_recv_second_token_time"), m_last.get("decode_inference_start_time")
+    )
+    # 返回首 token 链路耗时
+    summary["first_token_transmission_cost_time"] = safe_cost(
+        token_timestamps[0], m_last.get("decode_recv_first_token_time")
+    )
+    # 返回次 token 链路耗时
+    summary["second_token_transmission_cost_time"] = safe_cost(
+        token_timestamps[1], m_last.get("decode_recv_second_token_time")
+    )
+
+    return summary
 
 
 async def async_request_eb_openai_chat_completions(
@@ -125,11 +192,13 @@ async def async_request_eb_openai_chat_completions(
         output = RequestFuncOutput()
         output.prompt_len = 0
         output.no = request_func_input.no
+        metrics_list = []
         request_id = "None"
 
         ttft = 0.0
         st = time.perf_counter()
         most_recent_timestamp = st
+        token_timestamps = []
         try:
             async with session.post(url=api_url, json=payload, headers=headers) as response:
                 data = {}
@@ -144,6 +213,10 @@ async def async_request_eb_openai_chat_completions(
                             # print("####chunk:", chunk, type(chunk))
                             timestamp = time.perf_counter()
                             data = json.loads(chunk)
+                            # print("####data:", json.dumps(data, indent=2, ensure_ascii=False))
+
+                            if "metrics" in data:
+                                metrics_list.append(data["metrics"])
 
                             if request_id == "None" and "id" in data:
                                 request_id = data["id"]
@@ -169,16 +242,22 @@ async def async_request_eb_openai_chat_completions(
 
                                 output.generated_text += content or ""
                                 output.reasoning_content += reason_content or ""
+                                # print(f"####content:{data}")
                                 output.arrival_time.append(choices[0].get("arrival_time", timestamp))
                             elif usage := data.get("usage", {}):
                                 output.output_tokens = usage.get("completion_tokens", 0)
                                 output.prompt_tokens = usage.get("prompt_tokens", 0)
 
                             most_recent_timestamp = timestamp
+                            token_timestamps.append(time.time())
 
                     # output.generated_text = generated_text
                     # 在流式结束时，记录最后一个 chunk 收到的时间戳
                     output.end_timestamp = most_recent_timestamp
+
+                    # 新增metrics统计，计算首token过滤空包
+                    output.metrics = metrics_summary(metrics_list, token_timestamps[1:])
+
                     if output.generated_text.strip() == "":
                         output.success = False
                         output.error = "No generated text found!"

--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -51,6 +51,7 @@ class RequestFuncInput:
     ignore_eos: bool = False
     language: Optional[str] = None
     debug: bool = False
+    pd_metrics: bool = False
     response_format: Optional[dict] = None
     random_flag: bool = False
 
@@ -164,6 +165,7 @@ async def async_request_eb_openai_chat_completions(
                 "continuous_usage_stats": True,
             },
             "max_tokens": request_func_input.output_len,
+            "collect_metrics": request_func_input.pd_metrics,
         }
         if request_func_input.response_format:
             payload["response_format"] = request_func_input.response_format

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -318,6 +318,7 @@ async def benchmark(
     selected_percentiles: list[float],
     ignore_eos: bool,
     debug: bool,
+    pd_metrics: bool,
     goodput_config_dict: dict[str, float],
     max_concurrency: Optional[int],
     lora_modules: Optional[Iterable[str]],
@@ -352,6 +353,7 @@ async def benchmark(
         logprobs=logprobs,
         ignore_eos=ignore_eos,
         debug=debug,
+        pd_metrics=pd_metrics,
         extra_body=extra_body,
         response_format=response_format,
         random_flag=random_flag,
@@ -446,6 +448,7 @@ async def benchmark(
             output_len=output_len,
             logprobs=logprobs,
             debug=debug,
+            pd_metrics=pd_metrics,
             ignore_eos=ignore_eos,
             extra_body=extra_body,
             response_format=response_format,
@@ -594,7 +597,7 @@ async def benchmark(
                 percentiles.append(float(p))
         for item in model_outputs:
             metrics = item.metrics
-            if metric_key in metrics:
+            if metrics.get(metric_key, None) is not None:
                 values.append(metrics[metric_key])
 
         if not values:
@@ -604,12 +607,6 @@ async def benchmark(
         arr = np.array(values) * 1000  # 秒 -> 毫秒
 
         print("{s:{c}^{n}}".format(s=metric_key, n=50, c="-"))
-        print(
-            "{:<40} {:<10.2f}".format(
-                f"Successful {metric_key}:",
-                len(arr),
-            )
-        )
         print(
             "{:<40} {:<10.2f}".format(
                 f"Mean {metric_key} (ms):",
@@ -624,7 +621,14 @@ async def benchmark(
         )
         for p in percentiles:
             v = np.percentile(arr, p)
-            print(f"P{str(int(p)) if int(p) == p else str(p)} {metric_key} (ms): {v:10.2f}")
+            print("{:<40} {:<10.2f}".format(f"P{str(int(p)) if int(p) == p else str(p)} {metric_key} (ms):", v))
+            # print(f"P{str(int(p)) if int(p) == p else str(p)} {metric_key} (ms): {v:10.2f}")
+        print(
+            "{:<40} {:<10.2f}".format(
+                f"Successful {metric_key}:",
+                len(arr),
+            )
+        )
 
     def process_one_length(
         # E.g., "ttft"
@@ -997,6 +1001,7 @@ def main(args: argparse.Namespace):
             selected_percentiles=[float(p) for p in args.metric_percentiles.split(",")],
             ignore_eos=args.ignore_eos,
             debug=args.debug,
+            pd_metrics=args.pd_metrics,
             goodput_config_dict=goodput_config_dict,
             max_concurrency=args.max_concurrency,
             lora_modules=args.lora_modules,
@@ -1184,6 +1189,11 @@ if __name__ == "__main__":
         "--shuffle",
         action="store_true",
         help="shuffle dataset",
+    )
+    parser.add_argument(
+        "--pd-metrics",
+        action="store_true",
+        help="请求时增加PD分离参数，metrics: True",
     )
     parser.add_argument(
         "--drop-ratio",

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -548,6 +548,7 @@ async def benchmark(
         "generated_texts": [output.generated_text for output in outputs],
         "reasoning_contents": [output.reasoning_content for output in outputs],
         "errors": [output.error for output in outputs],
+        "metrics": [output.metrics for output in outputs],
     }
 
     def process_one_metric(
@@ -582,6 +583,48 @@ async def benchmark(
             p_word = str(int(p)) if int(p) == p else str(p)
             print("{:<40} {:<10.2f}".format(f"P{p_word} {metric_name} (ms):", value))
             result[f"p{p_word}_{metric_attribute_name}_ms"] = value
+
+    def process_pd_metrics(model_outputs, metric_key):
+        # 收集所有该 metric 的数值
+        values = []
+        percentiles = []
+        for p in args.metric_percentiles.split(","):
+            p = p.strip()
+            if p:
+                percentiles.append(float(p))
+        for item in model_outputs:
+            metrics = item.metrics
+            if metric_key in metrics:
+                values.append(metrics[metric_key])
+
+        if not values:
+            print(f"[WARN] metric_key '{metric_key}' not found in outputs.")
+            return
+
+        arr = np.array(values) * 1000  # 秒 -> 毫秒
+
+        print("{s:{c}^{n}}".format(s=metric_key, n=50, c="-"))
+        print(
+            "{:<40} {:<10.2f}".format(
+                f"Successful {metric_key}:",
+                len(arr),
+            )
+        )
+        print(
+            "{:<40} {:<10.2f}".format(
+                f"Mean {metric_key} (ms):",
+                np.mean(arr),
+            )
+        )
+        print(
+            "{:<40} {:<10.2f}".format(
+                f"Median {metric_key} (ms):",
+                np.median(arr),
+            )
+        )
+        for p in percentiles:
+            v = np.percentile(arr, p)
+            print(f"P{str(int(p)) if int(p) == p else str(p)} {metric_key} (ms): {v:10.2f}")
 
     def process_one_length(
         # E.g., "ttft"
@@ -624,6 +667,19 @@ async def benchmark(
     process_one_metric("s_itl", "S_ITL", "Infer Inter-token Latency")
     process_one_metric("e2el", "E2EL", "End-to-end Latency")
     process_one_metric("s_e2el", "S_E2EL", "Infer End-to-end Latency")
+    if any(item.metrics for item in outputs):
+        process_pd_metrics(outputs, "prefill_cost_time")
+        process_pd_metrics(outputs, "prefill_prepare_cost_time")
+        process_pd_metrics(outputs, "preprocess_cost_time")
+        process_pd_metrics(outputs, "cache_in_scheduler_cost_time")
+        process_pd_metrics(outputs, "ask_decode_resource_cost_time")
+        process_pd_metrics(outputs, "prefill_first_token_infer_cost_time")
+        process_pd_metrics(outputs, "wait_sending_cache_cost_time")
+        process_pd_metrics(outputs, "decode_preallocate_cost_time")
+        process_pd_metrics(outputs, "decode_prepare_cost_time")
+        process_pd_metrics(outputs, "decode_second_token_infer_cost_time")
+        process_pd_metrics(outputs, "first_token_transmission_cost_time")
+        process_pd_metrics(outputs, "second_token_transmission_cost_time")
     process_one_length("input_len", "Cached Tokens", "Cached Tokens")
     process_one_length("s_input_len", "Input Length", "Infer Input Length")
     process_one_length("output_len", "Output Length", "Output Length")


### PR DESCRIPTION
## Motivation

支持PD分离metrics指标统计，需要在请求中增加collect_metrics: True，即可开启相关指标统计，也可通过--pd-metrics打开
结果示例：
```
----------------prefill_cost_time-----------------
Mean prefill_cost_time (ms):             7522.43   
Median prefill_cost_time (ms):           8335.17   
P80 prefill_cost_time (ms):              8496.60   
P95 prefill_cost_time (ms):              8500.37   
P99 prefill_cost_time (ms):              8501.43   
P99.9 prefill_cost_time (ms):            8501.67   
P99.95 prefill_cost_time (ms):           8501.68   
P99.99 prefill_cost_time (ms):           8501.69   
Successful prefill_cost_time:            10.00     
------------prefill_prepare_cost_time-------------
Mean prefill_prepare_cost_time (ms):     2501.88   
Median prefill_prepare_cost_time (ms):   183.69    
P80 prefill_prepare_cost_time (ms):      7968.76   
P95 prefill_prepare_cost_time (ms):      7979.63   
P99 prefill_prepare_cost_time (ms):      7982.61   
P99.9 prefill_prepare_cost_time (ms):    7983.28   
P99.95 prefill_prepare_cost_time (ms):   7983.32   
P99.99 prefill_prepare_cost_time (ms):   7983.35   
Successful prefill_prepare_cost_time:    10.00     
---------------preprocess_cost_time---------------
Mean preprocess_cost_time (ms):          19.78     
Median preprocess_cost_time (ms):        19.51     
P80 preprocess_cost_time (ms):           25.71     
P95 preprocess_cost_time (ms):           28.42     
P99 preprocess_cost_time (ms):           30.05     
P99.9 preprocess_cost_time (ms):         30.41     
P99.95 preprocess_cost_time (ms):        30.43     
P99.99 preprocess_cost_time (ms):        30.45     
Successful preprocess_cost_time:         10.00     
-----------cache_in_scheduler_cost_time-----------
Mean cache_in_scheduler_cost_time (ms):  77.14     
Median cache_in_scheduler_cost_time (ms): 74.50     
P80 cache_in_scheduler_cost_time (ms):   123.42    
P95 cache_in_scheduler_cost_time (ms):   148.48    
P99 cache_in_scheduler_cost_time (ms):   151.59    
P99.9 cache_in_scheduler_cost_time (ms): 152.29    
P99.95 cache_in_scheduler_cost_time (ms): 152.33    
P99.99 cache_in_scheduler_cost_time (ms): 152.36    
Successful cache_in_scheduler_cost_time: 10.00     
----------ask_decode_resource_cost_time-----------
Mean ask_decode_resource_cost_time (ms): 17.76     
Median ask_decode_resource_cost_time (ms): 16.06     
P80 ask_decode_resource_cost_time (ms):  21.11     
P95 ask_decode_resource_cost_time (ms):  29.40     
P99 ask_decode_resource_cost_time (ms):  32.05     
P99.9 ask_decode_resource_cost_time (ms): 32.64     
P99.95 ask_decode_resource_cost_time (ms): 32.67     
P99.99 ask_decode_resource_cost_time (ms): 32.70     
Successful ask_decode_resource_cost_time: 10.00     
-------prefill_first_token_infer_cost_time--------
Mean prefill_first_token_infer_cost_time (ms): 4974.50   
Median prefill_first_token_infer_cost_time (ms): 7940.72   
P80 prefill_first_token_infer_cost_time (ms): 8037.38   
P95 prefill_first_token_infer_cost_time (ms): 8147.14   
P99 prefill_first_token_infer_cost_time (ms): 8149.01   
P99.9 prefill_first_token_infer_cost_time (ms): 8149.43   
P99.95 prefill_first_token_infer_cost_time (ms): 8149.45   
P99.99 prefill_first_token_infer_cost_time (ms): 8149.47   
Successful prefill_first_token_infer_cost_time: 10.00     
-----------wait_sending_cache_cost_time-----------
Mean wait_sending_cache_cost_time (ms):  45.37     
Median wait_sending_cache_cost_time (ms): 4.60      
P80 wait_sending_cache_cost_time (ms):   121.10    
P95 wait_sending_cache_cost_time (ms):   152.47    
P99 wait_sending_cache_cost_time (ms):   165.89    
P99.9 wait_sending_cache_cost_time (ms): 168.91    
P99.95 wait_sending_cache_cost_time (ms): 169.07    
P99.99 wait_sending_cache_cost_time (ms): 169.21    
Successful wait_sending_cache_cost_time: 10.00     
-----------decode_preallocate_cost_time-----------
Mean decode_preallocate_cost_time (ms):  0.37      
Median decode_preallocate_cost_time (ms): 0.30      
P80 decode_preallocate_cost_time (ms):   0.53      
P95 decode_preallocate_cost_time (ms):   0.70      
P99 decode_preallocate_cost_time (ms):   0.71      
P99.9 decode_preallocate_cost_time (ms): 0.71      
P99.95 decode_preallocate_cost_time (ms): 0.71      
P99.99 decode_preallocate_cost_time (ms): 0.71      
Successful decode_preallocate_cost_time: 10.00     
-------------decode_prepare_cost_time-------------
Mean decode_prepare_cost_time (ms):      7.49      
Median decode_prepare_cost_time (ms):    5.17      
P80 decode_prepare_cost_time (ms):       13.49     
P95 decode_prepare_cost_time (ms):       15.45     
P99 decode_prepare_cost_time (ms):       16.37     
P99.9 decode_prepare_cost_time (ms):     16.58     
P99.95 decode_prepare_cost_time (ms):    16.59     
P99.99 decode_prepare_cost_time (ms):    16.60     
Successful decode_prepare_cost_time:     10.00     
-------decode_second_token_infer_cost_time--------
Mean decode_second_token_infer_cost_time (ms): 47.10     
Median decode_second_token_infer_cost_time (ms): 48.60     
P80 decode_second_token_infer_cost_time (ms): 58.06     
P95 decode_second_token_infer_cost_time (ms): 59.25     
P99 decode_second_token_infer_cost_time (ms): 59.31     
P99.9 decode_second_token_infer_cost_time (ms): 59.32     
P99.95 decode_second_token_infer_cost_time (ms): 59.32     
P99.99 decode_second_token_infer_cost_time (ms): 59.32     
Successful decode_second_token_infer_cost_time: 10.00     
--------first_token_transmission_cost_time--------
Mean first_token_transmission_cost_time (ms): 12.76     
Median first_token_transmission_cost_time (ms): 12.35     
P80 first_token_transmission_cost_time (ms): 19.97     
P95 first_token_transmission_cost_time (ms): 24.13     
P99 first_token_transmission_cost_time (ms): 25.33     
P99.9 first_token_transmission_cost_time (ms): 25.60     
P99.95 first_token_transmission_cost_time (ms): 25.62     
P99.99 first_token_transmission_cost_time (ms): 25.63     
Successful first_token_transmission_cost_time: 10.00     
-------second_token_transmission_cost_time--------
Mean second_token_transmission_cost_time (ms): 9.36      
Median second_token_transmission_cost_time (ms): 8.79      
P80 second_token_transmission_cost_time (ms): 13.31     
P95 second_token_transmission_cost_time (ms): 13.84     
P99 second_token_transmission_cost_time (ms): 13.85     
P99.9 second_token_transmission_cost_time (ms): 13.85     
P99.95 second_token_transmission_cost_time (ms): 13.85     
P99.99 second_token_transmission_cost_time (ms): 13.85     
Successful second_token_transmission_cost_time: 10.00 
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
