### PR TITLE
[BugFix] skip model executing after clearing/updating is done

### DIFF
--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -409,6 +409,7 @@ class PaddleDisWorkerProc:
         """Main event loop for Paddle Distributed Workers.
         TODO(gongshaotian): support remote calling of functions that control worker.
         """
+        first_run_after_unfrozen = False
         # init eplb signal
         self._init_eplb_signal()
         tp_size = self.parallel_config.tensor_parallel_size
@@ -479,6 +480,7 @@ class PaddleDisWorkerProc:
                     self.model_weights_signal[0] = ModelWeightsStatus.NORMAL
                     logger.info(f"Rank: {self.local_rank} has updated or cleared parameters.")
                     while self.model_weights_status.value[0] == ModelWeightsStatus.CLEARED:
+                        first_run_after_unfrozen = True
                         time.sleep(0.01)
 
             if self.exist_task_signal.value[0] == ExistTaskStatus.EXIST or self.task_queue.read_finish_flag.get() == 1:
@@ -512,12 +514,13 @@ class PaddleDisWorkerProc:
                 time.sleep(0.001)
                 continue
 
-            # Execute model to generate token. The generated token will be written to the buffer.
-            # These generated tokens can be obtained through get_output op.
-            start_execute_time = time.time()
-            self.worker.execute_model(req_dicts, num_running_requests)
-            self.exist_prefill_task_signal.value[0] = self.worker.exist_prefill()
-            logger.debug(f"execute model cost: {time.time()-start_execute_time:.5f} s")
+            if not first_run_after_unfrozen:
+                # Execute model to generate token. The generated token will be written to the buffer.
+                # These generated tokens can be obtained through get_output op.
+                start_execute_time = time.time()
+                self.worker.execute_model(req_dicts, num_running_requests)
+                self.exist_prefill_task_signal.value[0] = self.worker.exist_prefill()
+                logger.debug(f"execute model cost: {time.time()-start_execute_time:.5f} s")
 
     def initialize_kv_cache(self) -> None:
         """Profiles the peak memory usage of the model to determine how many

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -409,7 +409,6 @@ class PaddleDisWorkerProc:
         """Main event loop for Paddle Distributed Workers.
         TODO(gongshaotian): support remote calling of functions that control worker.
         """
-        first_run_after_unfrozen = False
         # init eplb signal
         self._init_eplb_signal()
         tp_size = self.parallel_config.tensor_parallel_size
@@ -480,7 +479,6 @@ class PaddleDisWorkerProc:
                     self.model_weights_signal[0] = ModelWeightsStatus.NORMAL
                     logger.info(f"Rank: {self.local_rank} has updated or cleared parameters.")
                     while self.model_weights_status.value[0] == ModelWeightsStatus.CLEARED:
-                        first_run_after_unfrozen = True
                         time.sleep(0.01)
 
             if self.exist_task_signal.value[0] == ExistTaskStatus.EXIST or self.task_queue.read_finish_flag.get() == 1:
@@ -514,7 +512,7 @@ class PaddleDisWorkerProc:
                 time.sleep(0.001)
                 continue
 
-            if not first_run_after_unfrozen:
+            if self.model_weights_status.value[0] == ModelWeightsStatus.NORMAL:
                 # Execute model to generate token. The generated token will be written to the buffer.
                 # These generated tokens can be obtained through get_output op.
                 start_execute_time = time.time()

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -480,6 +480,7 @@ class PaddleDisWorkerProc:
                     logger.info(f"Rank: {self.local_rank} has updated or cleared parameters.")
                     while self.model_weights_status.value[0] == ModelWeightsStatus.CLEARED:
                         time.sleep(0.01)
+                    continue
 
             if self.exist_task_signal.value[0] == ExistTaskStatus.EXIST or self.task_queue.read_finish_flag.get() == 1:
                 logger.info(f"Rank: {self.local_rank} Detected new requests.")
@@ -512,13 +513,12 @@ class PaddleDisWorkerProc:
                 time.sleep(0.001)
                 continue
 
-            if self.model_weights_status.value[0] == ModelWeightsStatus.NORMAL:
-                # Execute model to generate token. The generated token will be written to the buffer.
-                # These generated tokens can be obtained through get_output op.
-                start_execute_time = time.time()
-                self.worker.execute_model(req_dicts, num_running_requests)
-                self.exist_prefill_task_signal.value[0] = self.worker.exist_prefill()
-                logger.debug(f"execute model cost: {time.time()-start_execute_time:.5f} s")
+            # Execute model to generate token. The generated token will be written to the buffer.
+            # These generated tokens can be obtained through get_output op.
+            start_execute_time = time.time()
+            self.worker.execute_model(req_dicts, num_running_requests)
+            self.exist_prefill_task_signal.value[0] = self.worker.exist_prefill()
+            logger.debug(f"execute model cost: {time.time()-start_execute_time:.5f} s")
 
     def initialize_kv_cache(self) -> None:
         """Profiles the peak memory usage of the model to determine how many


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

对于 EP 模型，清除权重后的下一次权重更新，会直接执行一次 event_loop_normal 后半段的 execute_model，而此时 weight/cache 都还没有重建，导致执行出错。

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191) 

## Modifications

在权重清除/更新后，让 worker 跳过后半段的执行，回到 event_loop_normal 的开头，重新读取状态信号。此项改动对于权重清除场景是必要的，对于权重更新场景也是无害的。

<!-- Detail the changes made in this pull request. -->

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
