### PR TITLE
[Graph Optimization][CI] Add ERNIE45T 21B sot test

### DIFF
--- a/.github/workflows/_base_test.yml
+++ b/.github/workflows/_base_test.yml
@@ -208,6 +208,13 @@ jobs:
 
           curl -X POST http://0.0.0.0:${FLASK_PORT}/switch \
             -H "Content-Type: application/json" \
+            -d "{\"--model\": \"/MODELDATA/ernie-4_5-21b-a3b-bf16-paddle\", \"--config\": \"ernie45t_21b_sot.yaml\", \"--enable-logprob\": \"False\"}"
+          check_service 360
+          export TEMPLATE=TOKEN_NORMAL
+          python -m pytest -sv test_seed_usage.py -k "not test_seed_stream" || TEST_EXIT_CODE=1
+
+          curl -X POST http://0.0.0.0:${FLASK_PORT}/switch \
+            -H "Content-Type: application/json" \
             -d "{\"--model\": \"/MODELDATA/ernie-4_5-21b-a3b-bf16-paddle\", \"--config\": \"ernie45t_21b_cinn.yaml\", \"--enable-logprob\": \"False\"}"
           check_service 360
           export TEMPLATE=TOKEN_NORMAL

--- a/fastdeploy/model_executor/layers/attention/append_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/append_attn_backend.py
@@ -244,8 +244,6 @@ class AppendAttentionBackend(AttentionBackend):
                 # 128 is qwen3
                 # 32 is glm
                 assert forward_meta.rotary_embs.shape[4] in [128, 32]
-            else:
-                assert forward_meta.rotary_embs.shape == [2, 1, self.max_seq_len, 1, 64]
 
         if self.pd_disaggregation_mode == "per_query":
             metadata.kv_signal_data_list[layer.layer_id] = init_signal_layerwise(

--- a/fastdeploy/model_executor/layers/attention/append_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/append_attn_backend.py
@@ -244,6 +244,8 @@ class AppendAttentionBackend(AttentionBackend):
                 # 128 is qwen3
                 # 32 is glm
                 assert forward_meta.rotary_embs.shape[4] in [128, 32]
+            else:
+                assert forward_meta.rotary_embs.shape == [2, 1, self.max_seq_len, 1, 64]
 
         if self.pd_disaggregation_mode == "per_query":
             metadata.kv_signal_data_list[layer.layer_id] = init_signal_layerwise(

--- a/tests/ce/deploy/ernie45t_21b_sot.yaml
+++ b/tests/ce/deploy/ernie45t_21b_sot.yaml
@@ -1,0 +1,8 @@
+max_model_len: 32768
+max_num_seqs: 128
+tensor_parallel_size: 1
+quantization: wint4
+graph_optimization_config:
+  graph_opt_level: 1
+  sot_warmup_sizes: [2,16,32,64]
+  use_cudagraph: True


### PR DESCRIPTION
## Motivation
https://github.com/PaddlePaddle/FastDeploy/pull/5445 导致所有 SOT + CUDAGraph 模型全部运行失败

https://github.com/PaddlePaddle/FastDeploy/blob/bebd722b5dc94fe97628bb9370dcb7c0650fad7d/fastdeploy/model_executor/layers/attention/append_attn_backend.py#L248
这一行的 assert 语句中， `.shape` 和之前 #5495 一样，引入 `memcpy_h2d`
第一维是个动态shape，会出现 `forward_meta.rotary_embs.shape[0]` 是个 Tensor 和 2 比较的情况(其余位置常量折叠了)，是这个 2 引入的 h2d

CI 没拦住的原因是：
https://github.com/PaddlePaddle/FastDeploy/pull/5495 添加的单测是 CINN 的，CINN的DCE（死代码消除）把上面的 `memcpy_h2d` 消除了🤣🤣🤣🤣

鸣谢： @EmmonsCurse 老师🫡

## Modifications
添加 ERNIE45T 21B SOT 测试

## Usage or Command
NO NEED

## Accuracy Tests
NO NEED

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
