### PR TITLE
[Cherry-Pick] Fix process_response_dict to support async in serving_completion (#5758)

### DIFF
--- a/fastdeploy/entrypoints/openai/serving_completion.py
+++ b/fastdeploy/entrypoints/openai/serving_completion.py
@@ -15,6 +15,7 @@
 """
 
 import asyncio
+import inspect
 import itertools
 import time
 import traceback
@@ -73,6 +74,7 @@ class OpenAIServingCompletion:
         else:
             self.master_ip = "0.0.0.0"
             self.is_master_ip = True
+        self._is_process_response_dict_async = None
         api_server_logger.info(f"master ip: {self.master_ip}")
 
     def _check_master(self):
@@ -310,10 +312,7 @@ class OpenAIServingCompletion:
                         aggregated_prompt_logprobs_tensors[rid] = output_prompt_logprobs_tensors
 
                     aggregated_token_ids[rid].extend(data["outputs"]["token_ids"])
-
-                    self.engine_client.data_processor.process_response_dict(
-                        data, stream=False, include_stop_str_in_output=request.include_stop_str_in_output
-                    )
+                    await self._call_process_response_dict(data, request, stream=False)
                     output_tokens[rid] += len(data["outputs"]["token_ids"])
                     completion_batched_token_ids[rid].extend(data["outputs"]["token_ids"])
 
@@ -487,9 +486,7 @@ class OpenAIServingCompletion:
                             )
                         first_iteration[idx] = False
 
-                    self.engine_client.data_processor.process_response_dict(
-                        res, stream=True, include_stop_str_in_output=request.include_stop_str_in_output
-                    )
+                    await self._call_process_response_dict(res, request, stream=True)
                     if res["metrics"].get("first_token_time") is not None:
                         arrival_time = res["metrics"]["first_token_time"]
                         inference_start_time[idx] = res["metrics"]["inference_start_time"]
@@ -725,6 +722,20 @@ class OpenAIServingCompletion:
             choices=choices,
             usage=usage,
         )
+
+    async def _call_process_response_dict(self, res, request, stream):
+        if self._is_process_response_dict_async is None:
+            self._is_process_response_dict_async = inspect.iscoroutinefunction(
+                self.engine_client.data_processor.process_response_dict
+            )
+        if self._is_process_response_dict_async:
+            await self.engine_client.data_processor.process_response_dict(
+                res, stream=stream, include_stop_str_in_output=request.include_stop_str_in_output
+            )
+        else:
+            self.engine_client.data_processor.process_response_dict(
+                res, stream=stream, include_stop_str_in_output=request.include_stop_str_in_output
+            )
 
     def _create_completion_logprobs(
         self,

--- a/tests/entrypoints/openai/test_max_streaming_tokens.py
+++ b/tests/entrypoints/openai/test_max_streaming_tokens.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import unittest
 from unittest import IsolatedAsyncioTestCase
@@ -725,6 +726,213 @@ class TestMaxStreamingResponseTokens(IsolatedAsyncioTestCase):
             0,
             "reasoning_tokens count mismatch",
         )
+
+    @patch("fastdeploy.entrypoints.openai.serving_completion.api_server_logger")
+    async def test_completion_full_generator_async_process_response_dict(self, mock_logger):
+        final_response_data = [
+            {
+                "request_id": "test_request_id_0",
+                "outputs": {
+                    "token_ids": [7, 8, 9],
+                    "text": " world!",
+                },
+                "finished": True,
+                "metrics": {},
+            },
+            {
+                "request_id": "test_request_id_1",
+                "outputs": {
+                    "token_ids": [10, 11, 12],
+                    "text": " there!",
+                },
+                "finished": True,
+                "metrics": {},
+            },
+        ]
+
+        mock_response_queue = AsyncMock()
+        mock_response_queue.get.side_effect = [
+            [final_response_data[0]],
+            [final_response_data[1]],
+        ]
+
+        mock_dealer = Mock()
+        mock_dealer.write = Mock()
+
+        self.engine_client.connection_manager.get_connection.return_value = (mock_dealer, mock_response_queue)
+
+        expected_completion_response = Mock()
+        self.completion_serving.request_output_to_completion_response = Mock(return_value=expected_completion_response)
+
+        request = CompletionRequest(
+            model="test_model",
+            prompt="Hello",
+            max_tokens=10,
+            stream=False,
+            n=2,
+            echo=False,
+        )
+        num_choices = 2
+        request_id = "test_request_id"
+        created_time = 1655136000
+        model_name = "test_model"
+        prompt_batched_token_ids = [[1, 2, 3], [4, 5, 6]]
+        prompt_tokens_list = ["Hello", "Hello"]
+
+        self.engine_client.data_processor.process_response_dict = AsyncMock()
+
+        actual_response = await self.completion_serving.completion_full_generator(
+            request=request,
+            num_choices=num_choices,
+            request_id=request_id,
+            created_time=created_time,
+            model_name=model_name,
+            prompt_batched_token_ids=prompt_batched_token_ids,
+            prompt_tokens_list=prompt_tokens_list,
+            max_tokens_list=[100, 100],
+        )
+
+        self.assertEqual(actual_response, expected_completion_response)
+        self.assertTrue(inspect.iscoroutinefunction(self.engine_client.data_processor.process_response_dict))
+
+        self.engine_client.data_processor.process_response_dict.assert_awaited()
+
+        actual_call_times = self.engine_client.data_processor.process_response_dict.call_count
+        expected_call_times = len(final_response_data)
+        self.assertEqual(actual_call_times, expected_call_times)
+
+        call_args_list = self.engine_client.data_processor.process_response_dict.call_args_list
+        self.assertEqual(len(call_args_list), expected_call_times)
+
+        for idx, data in enumerate(final_response_data):
+            args, kwargs = call_args_list[idx]
+            self.assertEqual(args[0], data)
+            self.assertEqual(kwargs.get("stream"), False)
+            self.assertEqual(kwargs.get("include_stop_str_in_output"), request.include_stop_str_in_output)
+
+    @patch("fastdeploy.entrypoints.openai.serving_completion.api_server_logger")
+    async def test_completion_stream_generator_async_process_response_dict(self, mock_logger):
+        final_response_data = [
+            [
+                {
+                    "request_id": "test-request-id_0",
+                    "outputs": {
+                        "index": 0,
+                        "send_idx": 0,
+                        "token_ids": [1],
+                        "text": "a",
+                        "top_logprobs": {"a": 0.98, "b": 0.02},
+                        "draft_top_logprobs": {"a": 0.98, "b": 0.02},
+                    },
+                    "finished": False,
+                    "metrics": {
+                        "first_token_time": 1620000000,
+                        "inference_start_time": 1620000000,
+                        "engine_recv_latest_token_time": 1620000000,
+                    },
+                    "error_code": 200,
+                }
+            ],
+            [
+                {
+                    "request_id": "test-request-id_0",
+                    "outputs": {
+                        "index": 0,
+                        "send_idx": 1,
+                        "token_ids": [2],
+                        "text": "b",
+                        "top_logprobs": {"a": 0.98, "b": 0.02},
+                        "draft_top_logprobs": {"a": 0.98, "b": 0.02},
+                    },
+                    "finished": False,
+                    "metrics": {
+                        "first_token_time": 1620000000,
+                        "inference_start_time": 1620000000,
+                        "engine_recv_latest_token_time": 1620000000,
+                    },
+                    "error_code": 200,
+                }
+            ],
+            [
+                {
+                    "request_id": "test-request-id_0",
+                    "outputs": {
+                        "index": 0,
+                        "send_idx": 2,
+                        "token_ids": [7],
+                        "text": "g",
+                        "top_logprobs": {"a": 0.98, "b": 0.02},
+                        "draft_top_logprobs": {"a": 0.98, "b": 0.02},
+                    },
+                    "finished": True,
+                    "metrics": {
+                        "first_token_time": 1620000000,
+                        "inference_start_time": 1620000000,
+                        "engine_recv_latest_token_time": 1620000000,
+                    },
+                    "error_code": 200,
+                }
+            ],
+        ]
+
+        mock_response_queue = AsyncMock()
+        mock_response_queue.get.side_effect = final_response_data
+
+        mock_dealer = Mock()
+        mock_dealer.write = Mock()
+
+        self.engine_client.connection_manager.get_connection = AsyncMock(
+            return_value=(mock_dealer, mock_response_queue)
+        )
+
+        request = CompletionRequest(
+            model="test-model",
+            prompt="Hello",
+            stream=True,
+            max_streaming_response_tokens=3,
+            n=1,
+            echo=False,
+            max_tokens=100,
+        )
+
+        self.engine_client.data_processor.process_response_dict = AsyncMock()
+
+        generator = self.completion_serving.completion_stream_generator(
+            request=request,
+            num_choices=1,
+            request_id="test-request-id",
+            created_time=1620000000,
+            model_name="test-model",
+            prompt_batched_token_ids=[[1, 2, 3]],
+            prompt_tokens_list=["Hello"],
+            max_tokens_list=[100],
+        )
+
+        chunks = []
+        async for chunk in generator:
+            chunks.append(chunk)
+            if "[DONE]" in chunk:
+                break
+        self.assertGreater(len(chunks), 0)
+
+        self.assertTrue(inspect.iscoroutinefunction(self.engine_client.data_processor.process_response_dict))
+        self.engine_client.data_processor.process_response_dict.assert_awaited()
+
+        flat_response_data = []
+        for sub_list in final_response_data:
+            flat_response_data.extend(sub_list)
+        expected_call_times = len(flat_response_data)
+        actual_call_times = self.engine_client.data_processor.process_response_dict.call_count
+        self.assertEqual(actual_call_times, expected_call_times)
+
+        call_args_list = self.engine_client.data_processor.process_response_dict.call_args_list
+        self.assertEqual(len(call_args_list), expected_call_times)
+
+        for idx, data in enumerate(flat_response_data):
+            args, kwargs = call_args_list[idx]
+            self.assertEqual(args[0], data)
+            self.assertEqual(kwargs.get("stream"), True)
+            self.assertEqual(kwargs.get("include_stop_str_in_output"), request.include_stop_str_in_output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…tion (#5758)

* support process_response_dict async initial commit

* fixbug

* add unit test

* optimize

<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
The process_response_dict function in serving_completion.py does not support asynchronous calls, which causes issues when using EB5's processor.

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications
Add a check to determine whether the process_response_dict function is an asynchronous call, enabling support for asynchronous invocations.

## Usage or Command
no change in user command.

## Accuracy Tests
no need

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
