### PR TITLE
[BugFix] Fix return value inconsistency for `ep_moe_expert_combine` op

### DIFF
--- a/fastdeploy/model_executor/layers/moe/fused_moe_cutlass_backend.py
+++ b/fastdeploy/model_executor/layers/moe/fused_moe_cutlass_backend.py
@@ -210,7 +210,7 @@ class CutlassMoEMethod(UnquantizedFusedMoEMethod):
                 None,  # down_proj_bias,
                 False,  # norm_topk_prob
                 1.0,
-            )[0]
+            )
         else:
             tmp_ffn_out = recv_x
 

--- a/fastdeploy/model_executor/layers/moe/fused_moe_deepgemm_backend.py
+++ b/fastdeploy/model_executor/layers/moe/fused_moe_deepgemm_backend.py
@@ -250,7 +250,7 @@ class DeepGemmFusedMoeMethod(MoEMethodBase):
                 None,  # down_proj_bias
                 False,  # norm_topk_prob
                 1.0,
-            )[0]
+            )
 
         else:
             tmp_ffn_out = paddle.cast(recv_x[0], paddle.bfloat16)
@@ -448,6 +448,6 @@ class DeepGemmFusedMoeMethod(MoEMethodBase):
             None,
             False,  # norm_topk_prob
             1.0,
-        )[0]
+        )
 
         return tmp_ffn_out


### PR DESCRIPTION
## Motivation

`FastDeploy` 现有自定义算子存在分流，动态图走 C++ EXTENSION(PYBIND)，静态图走 C++ 自定义算子（要注册到IR上）

C++ EXTENSION(PYBIND) 比较灵活，返回值可以是 `Tensor` / `vector<Tensor>`，而 C++ 自定义算子 要求返回值必须是 `vector<Tensor>`

所以为了统一 C++ EXTENSION(PYBIND) 与 C++ 自定义算子的写法，通常要求函数的返回值为 `vector<Tensor>`

如果返回值只有一个值， C++ 自定义算子在 CodeGen 的过程中会自动做**解包索引**操作：

```
# 文件位置（需要编译 FastDeploy）：fastdeploy/model_executor/ops/gpu/fastdeploy_ops/__init__.py

@unified
def static_op_speculate_get_output(x,rank_id,wait_flag,get_each_rank):
    if in_dynamic_or_pir_mode():
        ......
        return res[0] if len(res)==1 else res #  <------ 解包索引操作
```

为了与 C++ 自定义算子对齐，FastDeploy 也做了类似的操作：
（同时这个函数会自动选择走 C++ EXTENSION 还是走 C++ 自定义算子）

https://github.com/PaddlePaddle/FastDeploy/blob/ffb3ccff7436ab8da5411edcc1c9daf5e9887a7b/fastdeploy/import_ops.py#L77-L86

但这个函数起作用的前提是，用 `PD_BUILD_STATIC_OP` 做声明（给 op 名字加个 `static_op_` 前缀）

如果不加 `static_op_` 前缀，就不会进 for 循环
https://github.com/PaddlePaddle/FastDeploy/blob/ffb3ccff7436ab8da5411edcc1c9daf5e9887a7b/fastdeploy/import_ops.py#L102-L113

由于 `ep_moe_expert_combine` 没用 `PD_BUILD_STATIC_OP` 做声明，所以也不会走如下逻辑：

```python
                if isinstance(res, list) and len(res) == 1:
                    return res[0]
```

所以在 #5762 合入之前——也就是添加 `PD_BUILD_STATIC_OP` 声明之前—— `fastdeploy.model_executor.ops.gpu.ep_moe_expert_combine` 的返回值是一个 list，里面只有一个元素，所以需要索引解包索引操作

#5762 合入之前则不再需要 `[0]` 索引解包索引操作，否则报：

```
RuntimeError: Failed: Asertion error paddle/fluid/distributed/collective/deep_ep/deep_ep.cpp:822 'x.dim()==2 && x.is_contiguous()'
```


## Modifications

移除了函数 `fastdeploy.model_executor.ops.gpu.ep_moe_expert_combine` 返回值的索引 `[0]`

## Usage or Command

NO NEED

## Accuracy Tests

NO NEED

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
