### PR TITLE
[PD Disaggregation]remove unsed para in RDMACommManager

### DIFF
--- a/fastdeploy/cache_manager/cache_messager.py
+++ b/fastdeploy/cache_manager/cache_messager.py
@@ -242,7 +242,6 @@ class CacheMessager:
                 logger.info(f"splitwise_role rdma: {self.splitwise_role}, rank: {self.rank}, gpu_id: {gpu_id}")
                 self.messager[protocol] = RDMACommManager(
                     splitwise_role,
-                    rank,
                     gpu_id,
                     cache_k_ptr_list,
                     cache_v_ptr_list,
@@ -572,7 +571,6 @@ class CacheMessagerV1:
 
                 self.messager[protocol] = RDMACommManager(
                     splitwise_role,
-                    rank,
                     gpu_id,
                     cache_k_ptr_list,
                     cache_v_ptr_list,

--- a/fastdeploy/cache_manager/transfer_factory/rdma_cache_transfer.py
+++ b/fastdeploy/cache_manager/transfer_factory/rdma_cache_transfer.py
@@ -30,7 +30,6 @@ class RDMACommManager:
     def __init__(
         self,
         splitwise_role,
-        rank,
         gpu_id,
         cache_k_ptr_list,
         cache_v_ptr_list,

--- a/tests/cache_manager/test_rdma_transfer.py
+++ b/tests/cache_manager/test_rdma_transfer.py
@@ -25,7 +25,6 @@ class TestRDMACommManager(unittest.TestCase):
     def setUp(self):
         self.args = {
             "splitwise_role": "prefill",
-            "rank": 0,
             "gpu_id": 0,
             "cache_k_ptr_list": [1, 2, 3],
             "cache_v_ptr_list": [4, 5, 6],


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

RDMACommManager 构造函数中的rank参数没有用到，给删掉

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications


RDMACommManager 构造函数中的rank参数没有用到，给删掉

<!-- Detail the changes made in this pull request. -->

## Usage or Command

None

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

None


## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
