### PR TITLE
[CI] Fix archive URL injection in tag image build

### DIFF
--- a/.github/workflows/publish_job.yml
+++ b/.github/workflows/publish_job.yml
@@ -287,11 +287,11 @@ jobs:
         shell: bash
         env:
           docker_image: ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddleqa:fastdeploy-ciuse-cuda126-dailyupdate
-          fd_archive_url: ${{ env.FASTDEPLOY_ARCHIVE_URL }}
         run: |
           set -x
           FULL_REPO="${{ github.repository }}"
           REPO_NAME="${FULL_REPO##*/}"
+          fd_archive_url="${{ needs.clone.outputs.repo_archive_url }}"
 
           # Clean the repository directory before starting
           docker run --rm --net=host -v $(pwd):/workspace -w /workspace \


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
In the presence of a job-level if condition, using needs.outputs in job-level env can lead to unexpected empty or unresolved environment variables due to expression evaluation timing. This caused the image build job to fail when fetching the FastDeploy archive URL.

This PR aims to make the CI pipeline more robust and deterministic by avoiding early evaluation of needs.outputs under job-level if conditions.

## Modifications

- Removed the usage of needs.outputs from job-level env definitions.
- Moved `needs.clone.outputs.repo_archive_url` resolution into the runtime run step using a bash variable.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
