### PR TITLE
[Cherry-Pick][XPU]MAX_BSZ aligns gpu settings and disable prefix cache in OCR VL (#5831)

### DIFF
--- a/custom_ops/xpu_ops/src/ops/get_output_msg_with_topk.cc
+++ b/custom_ops/xpu_ops/src/ops/get_output_msg_with_topk.cc
@@ -23,8 +23,8 @@
 #define PD_BUILD_STATIC_OP(name) PD_BUILD_OP(static_op_##name)
 #endif
 
-#define MAX_BSZ 128
-#define K 5
+#define MAX_BSZ 512
+#define K 20
 
 struct msgdata {
   long mtype;

--- a/custom_ops/xpu_ops/src/ops/save_output_msg_with_topk.cc
+++ b/custom_ops/xpu_ops/src/ops/save_output_msg_with_topk.cc
@@ -23,8 +23,8 @@
 #define PD_BUILD_STATIC_OP(name) PD_BUILD_OP(static_op_##name)
 #endif
 
-#define MAX_BSZ 128
-#define K 5
+#define MAX_BSZ 512
+#define K 20
 // #define SAVE_WITH_OUTPUT_DEBUG
 
 struct msgdata {

--- a/custom_ops/xpu_ops/src/ops/save_with_output_msg.cc
+++ b/custom_ops/xpu_ops/src/ops/save_with_output_msg.cc
@@ -17,19 +17,12 @@
 #include <sys/ipc.h>
 #include <sys/msg.h>
 #include <sys/types.h>
+#include "msg_utils.h"
 #include "paddle/extension.h"
 
-#define MAX_BSZ 256
-
 // #define SAVE_WITH_OUTPUT_DEBUG
-struct msgdata {
-  long mtype;
-  int mtext[MAX_BSZ + 2];  // stop_flag, bsz, tokens
-};
-
-// #define SAVE_WITH_OUTPUT_DEBUG
-void SaveOutMmsg(const paddle::Tensor &x,
-                 const paddle::Tensor &not_need_stop,
+void SaveOutMmsg(const paddle::Tensor& x,
+                 const paddle::Tensor& not_need_stop,
                  int64_t rank_id,
                  int msg_queue_id,
                  bool save_each_rank) {
@@ -37,10 +30,10 @@ void SaveOutMmsg(const paddle::Tensor &x,
     return;
   }
   auto x_cpu = x.copy_to(paddle::CPUPlace(), false);
-  int64_t *x_data = x_cpu.data<int64_t>();
+  int64_t* x_data = x_cpu.data<int64_t>();
   static struct msgdata msg_sed;
 
-  if (const char *inference_msg_queue_id_env_p =
+  if (const char* inference_msg_queue_id_env_p =
           std::getenv("INFERENCE_MSG_QUEUE_ID")) {
     std::string inference_msg_queue_id_env_str(inference_msg_queue_id_env_p);
     int inference_msg_queue_id_from_env =
@@ -57,7 +50,7 @@ void SaveOutMmsg(const paddle::Tensor &x,
 #endif
   }
   int inference_msg_id_from_env = 1;
-  if (const char *inference_msg_id_env_p = std::getenv("INFERENCE_MSG_ID")) {
+  if (const char* inference_msg_id_env_p = std::getenv("INFERENCE_MSG_ID")) {
     std::string inference_msg_id_env_str(inference_msg_id_env_p);
     inference_msg_id_from_env = std::stoi(inference_msg_id_env_str);
     if (inference_msg_id_from_env == 2) {
@@ -111,15 +104,15 @@ void SaveOutMmsg(const paddle::Tensor &x,
   return;
 }
 
-void SaveOutMmsgStatic(const paddle::Tensor &x,
-                       const paddle::Tensor &not_need_stop,
+void SaveOutMmsgStatic(const paddle::Tensor& x,
+                       const paddle::Tensor& not_need_stop,
                        int64_t rank_id,
                        bool save_each_rank) {
   SaveOutMmsg(x, not_need_stop, rank_id, 1, save_each_rank);
 }
 
-void SaveOutMmsgDynamic(const paddle::Tensor &x,
-                        const paddle::Tensor &not_need_stop,
+void SaveOutMmsgDynamic(const paddle::Tensor& x,
+                        const paddle::Tensor& not_need_stop,
                         int64_t rank_id,
                         int msg_queue_id,
                         bool save_each_rank) {

--- a/fastdeploy/output/token_processor.py
+++ b/fastdeploy/output/token_processor.py
@@ -49,12 +49,9 @@ RECOVERY_STOP_SIGNAL = -3
 MAX_DRAFT_TOKENS = 6
 SPECULATE_MAX_BSZ = 256
 
-if current_platform.is_xpu():
-    MAX_BSZ = 128
-    K = 5
-else:
-    MAX_BSZ = 512
-    K = 20
+
+MAX_BSZ = 512
+K = 20
 
 
 class TokenProcessor:


### PR DESCRIPTION

## Motivation
1. xpu的MAX_BSZ设置对齐GPU，修复max_num_seqs=256服务报错
2. xpu 在OCR VL模型默认关闭prefix cache

## Modifications

<!-- Detail the changes made in this pull request. -->

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
