### PR TITLE
[Intel HPU] enable MoE EP for hpu

### DIFF
--- a/examples/intel_hpu/offline_demo.py
+++ b/examples/intel_hpu/offline_demo.py
@@ -26,6 +26,7 @@ input_seq = None  # 1000
 max_out_tokens = 128
 server_max_bs = 128
 TP = 1
+EP = True
 
 # num_gpu_blocks_override = ceil((input_seq + max_out_tokens) / 128) * server_max_bs
 num_gpu_blocks_override = 2000
@@ -34,12 +35,14 @@ graph_optimization_config = {"use_cudagraph": False}
 llm = LLM(
     model=model_name_or_path,
     tensor_parallel_size=TP,
+    enable_expert_parallel=EP,
     engine_worker_queue_port=8602,
     num_gpu_blocks_override=num_gpu_blocks_override,
     block_size=128,
     max_model_len=32768,
     max_num_seqs=server_max_bs,
     graph_optimization_config=graph_optimization_config,
+    disable_sequence_parallel_moe=True,
 )
 
 if input_seq is None:

--- a/fastdeploy/model_executor/layers/backends/intel_hpu/moe/fused_moe_hpu_backend.py
+++ b/fastdeploy/model_executor/layers/backends/intel_hpu/moe/fused_moe_hpu_backend.py
@@ -59,7 +59,7 @@ class HpuMoEMethod(UnquantizedFusedMoEMethod):
         """
         return
 
-    def apply(
+    def apply_tp(
         self,
         layer: nn.Layer,
         x: paddle.Tensor,
@@ -67,10 +67,9 @@ class HpuMoEMethod(UnquantizedFusedMoEMethod):
         topk_ids_hookfunc: Callable = None,
     ) -> paddle.Tensor:
         """
-        Paddle compute Fused MoE.
+        Apply the TP prefill method.
         """
-        # for all layer.ep_size and layer.tp_size
-        return self.apply_tp(layer, x, gate, topk_ids_hookfunc=topk_ids_hookfunc)
+        raise NotImplementedError
 
     def apply_ep_prefill(
         self,
@@ -96,7 +95,7 @@ class HpuMoEMethod(UnquantizedFusedMoEMethod):
         """
         raise NotImplementedError
 
-    def apply_tp(
+    def apply(
         self,
         layer: nn.Layer,
         x: paddle.Tensor,
@@ -209,6 +208,7 @@ class HpuTensorWiseFP8MoEMethod(HpuMoEMethod):
         down_proj_weight = paddle.stack(down_proj_weights, axis=0)
         up_gate_proj_weight_scale = paddle.stack(up_gate_proj_weight_scale, axis=0)
         down_proj_weight_scale = paddle.stack(down_proj_weight_scale, axis=0)
+        down_proj_in_scale = paddle.stack(down_proj_in_scale, axis=0)
 
         name_tensor_map = {
             "up_gate_proj_weight": up_gate_proj_weight,
@@ -216,10 +216,10 @@ class HpuTensorWiseFP8MoEMethod(HpuMoEMethod):
             "up_gate_proj_weight_scale": up_gate_proj_weight_scale,
             "down_proj_weight_scale": down_proj_weight_scale,
             "up_gate_proj_in_scale": up_gate_proj_in_scale,
+            "down_proj_in_scale": down_proj_in_scale,
         }
         for name, tensor in name_tensor_map.items():
             getattr(layer, name).set_value(tensor)
-        setattr(layer, "down_proj_in_scale", down_proj_in_scale)
 
     def create_weights(self, layer: nn.Layer, **extra_weight_attrs):
         """
@@ -262,6 +262,15 @@ class HpuTensorWiseFP8MoEMethod(HpuMoEMethod):
             "up_gate_proj_in_scale",
             layer.create_parameter(
                 shape=[1],
+                dtype=self.default_dtype,
+                default_initializer=paddle.nn.initializer.Constant(0),
+            ),
+        )
+        setattr(
+            layer,
+            "down_proj_in_scale",
+            layer.create_parameter(
+                shape=[layer.num_local_experts, 1],
                 dtype=self.default_dtype,
                 default_initializer=paddle.nn.initializer.Constant(0),
             ),
@@ -321,7 +330,7 @@ class HpuTensorWiseFP8MoEMethod(HpuMoEMethod):
         """
         return
 
-    def apply(
+    def apply_tp(
         self,
         layer: nn.Layer,
         x: paddle.Tensor,
@@ -329,9 +338,9 @@ class HpuTensorWiseFP8MoEMethod(HpuMoEMethod):
         topk_ids_hookfunc: Callable = None,
     ) -> paddle.Tensor:
         """
-        Paddle compute Fused MoE.
+        Apply the TP decoder method.
         """
-        return self.apply_tp(layer, x, gate, topk_ids_hookfunc=topk_ids_hookfunc)
+        raise NotImplementedError
 
     def apply_ep_prefill(
         self,
@@ -357,7 +366,7 @@ class HpuTensorWiseFP8MoEMethod(HpuMoEMethod):
         """
         raise NotImplementedError
 
-    def apply_tp(
+    def apply(
         self,
         layer: nn.Layer,
         x: paddle.Tensor,

--- a/fastdeploy/model_executor/layers/backends/intel_hpu/moe/fused_moe_hpu_backend.py
+++ b/fastdeploy/model_executor/layers/backends/intel_hpu/moe/fused_moe_hpu_backend.py
@@ -24,6 +24,7 @@ from fastdeploy.model_executor.layers.moe.fused_moe_backend_base import (
     UnquantizedFusedMoEMethod,
 )
 from fastdeploy.model_executor.layers.utils import get_tensor
+from fastdeploy.model_executor.utils import set_weight_attrs
 
 
 class HpuMoEMethod(UnquantizedFusedMoEMethod):
@@ -295,6 +296,19 @@ class HpuTensorWiseFP8MoEMethod(HpuMoEMethod):
                 default_initializer=paddle.nn.initializer.Constant(0),
             ),
         )
+        extra_weight_attrs = {
+            **(extra_weight_attrs or {}),
+            "SHARD_ID_TO_SHARDED_DIM": {"gate": 1, "down": 0, "up": 1},
+        }
+        set_weight_attrs(layer.up_gate_proj_weight, extra_weight_attrs)
+        set_weight_attrs(layer.down_proj_weight, extra_weight_attrs)
+        extra_scale_attrs = {
+            **(extra_weight_attrs or {}),
+            "SHARD_ID_TO_SHARDED_DIM": {"gate": 0, "up": 0, "down": None},
+        }
+        set_weight_attrs(layer.down_proj_in_scale, extra_scale_attrs)
+        set_weight_attrs(layer.up_gate_proj_weight_scale, extra_scale_attrs)
+        set_weight_attrs(layer.down_proj_weight_scale, extra_scale_attrs)
 
     def process_loaded_weights(self, layer: nn.Layer, state_dict):
         """
@@ -323,6 +337,9 @@ class HpuTensorWiseFP8MoEMethod(HpuMoEMethod):
 
             setattr(layer, weights_name, weights_list)
             setattr(layer, scales_name, scales_list)
+
+    def process_weights_after_loading(self, layer):
+        return
 
     def init_ep(self, layer: nn.Layer) -> None:
         """

--- a/fastdeploy/model_executor/layers/backends/intel_hpu/moe/fused_moe_hpu_backend.py
+++ b/fastdeploy/model_executor/layers/backends/intel_hpu/moe/fused_moe_hpu_backend.py
@@ -53,6 +53,25 @@ class HpuMoEMethod(UnquantizedFusedMoEMethod):
         )
         self.down_proj_expert_act_scale_key = down_proj_expert_weight_key.replace("weight", "activation_scale")
 
+    def init_ep(self, layer: nn.Layer) -> None:
+        """
+        Initialize EP (Expert Parallel) related modules.
+        """
+        return
+
+    def apply(
+        self,
+        layer: nn.Layer,
+        x: paddle.Tensor,
+        gate: nn.Layer,
+        topk_ids_hookfunc: Callable = None,
+    ) -> paddle.Tensor:
+        """
+        Paddle compute Fused MoE.
+        """
+        # for all layer.ep_size and layer.tp_size
+        return self.apply_tp(layer, x, gate, topk_ids_hookfunc=topk_ids_hookfunc)
+
     def apply_ep_prefill(
         self,
         layer: nn.Layer,
@@ -295,6 +314,24 @@ class HpuTensorWiseFP8MoEMethod(HpuMoEMethod):
 
             setattr(layer, weights_name, weights_list)
             setattr(layer, scales_name, scales_list)
+
+    def init_ep(self, layer: nn.Layer) -> None:
+        """
+        Initialize EP (Expert Parallel) related modules.
+        """
+        return
+
+    def apply(
+        self,
+        layer: nn.Layer,
+        x: paddle.Tensor,
+        gate: nn.Layer,
+        topk_ids_hookfunc: Callable = None,
+    ) -> paddle.Tensor:
+        """
+        Paddle compute Fused MoE.
+        """
+        return self.apply_tp(layer, x, gate, topk_ids_hookfunc=topk_ids_hookfunc)
 
     def apply_ep_prefill(
         self,

--- a/fastdeploy/model_executor/layers/backends/intel_hpu/quantization/kv_cache.py
+++ b/fastdeploy/model_executor/layers/backends/intel_hpu/quantization/kv_cache.py
@@ -131,6 +131,11 @@ class HPUKVCacheMethodBase(QuantMethodBase):
         layer.s_scale.set_value(s_scale)
         layer.s_out_scale.set_value(s_out_scale)
 
+    def weight_loader(self, param, loaded_weight, loaded_shard_id: Optional[str] = None):
+        loaded_weight = get_tensor(loaded_weight).cast("float32")
+        loaded_weight = self.cache_quant_config.max_bound / loaded_weight
+        param.copy_(loaded_weight, False)
+
     def create_weights(self, layer: nn.Layer, **extra_weight_attrs):
         """
         create_weights
@@ -158,12 +163,14 @@ class HPUKVCacheMethodBase(QuantMethodBase):
             layer.cache_k_scale,
             {
                 **extra_weight_attrs,
+                "weight_loader": self.weight_loader,
             },
         )
         set_weight_attrs(
             layer.cache_v_scale,
             {
                 **extra_weight_attrs,
+                "weight_loader": self.weight_loader,
             },
         )
         layer.cache_k_out_scale = layer.create_parameter(
@@ -181,6 +188,13 @@ class HPUKVCacheMethodBase(QuantMethodBase):
             shape=scale_shape,
             dtype="float32",
             default_initializer=paddle.nn.initializer.Constant(0),
+        )
+        set_weight_attrs(
+            layer.q_scale,
+            {
+                **extra_weight_attrs,
+                "weight_loader": self.weight_loader,
+            },
         )
         layer.q_out_scale = layer.create_parameter(
             shape=scale_shape,
@@ -201,6 +215,13 @@ class HPUKVCacheMethodBase(QuantMethodBase):
             shape=scale_shape,
             dtype="float32",
             default_initializer=paddle.nn.initializer.Constant(0),
+        )
+        set_weight_attrs(
+            layer.s_scale,
+            {
+                **extra_weight_attrs,
+                "weight_loader": self.weight_loader,
+            },
         )
         layer.s_out_scale = layer.create_parameter(
             shape=scale_shape,
@@ -226,9 +247,16 @@ class HPUKVCacheMethodBase(QuantMethodBase):
         """
         # cache_k_out_scale is the reciprocal of cache_k_scale
         if layer.cache_k_scale._is_initialized():
-            layer.cache_k_out_scale.set_value(1 / layer.cache_k_scale)  # cache_k_out_scale
+            layer.cache_k_out_scale.set_value(1.0 / layer.cache_k_scale)
         if layer.cache_v_scale._is_initialized():
-            layer.cache_v_out_scale.set_value(1 / layer.cache_v_scale)
+            layer.cache_v_out_scale.set_value(1.0 / layer.cache_v_scale)
+        if layer.q_scale._is_initialized():
+            scaling_factor = layer.head_dim**-0.5
+            layer.q_scaling_scale.set_value(layer.q_scale / scaling_factor)
+            layer.q_scaling_out_scale.set_value(scaling_factor / layer.q_scale)
+            layer.q_out_scale.set_value(1.0 / layer.q_scale)
+        if layer.s_scale._is_initialized():
+            layer.s_out_scale.set_value(1.0 / layer.s_scale)
 
     def apply(self, layer):
         """

--- a/fastdeploy/model_executor/layers/backends/intel_hpu/quantization/tensor_wise_fp8.py
+++ b/fastdeploy/model_executor/layers/backends/intel_hpu/quantization/tensor_wise_fp8.py
@@ -23,6 +23,7 @@ from fastdeploy.model_executor.layers.quantization.tensor_wise_fp8 import (
 )
 from fastdeploy.model_executor.layers.utils import get_tensor
 from fastdeploy.model_executor.ops.intel_hpu import fused_quant
+from fastdeploy.model_executor.utils import set_weight_attrs
 
 
 class HpuTensorWiseFP8LinearMethod(TensorWiseFP8LinearMethod):
@@ -92,6 +93,14 @@ class HpuTensorWiseFP8LinearMethod(TensorWiseFP8LinearMethod):
             is_bias=False,
         )
 
+        self.model_format = extra_weight_attrs.get("model_format")
+        if self.model_format == "torch" and "output_dim" in extra_weight_attrs:
+            extra_weight_attrs["output_dim"] = not extra_weight_attrs["output_dim"]
+        set_weight_attrs(
+            layer.weight,
+            extra_weight_attrs,
+        )
+
     def process_loaded_weights(self, layer: nn.Layer, weight: paddle.Tensor) -> None:
         """
         loaded_weights using HPU specific quantization
@@ -99,3 +108,20 @@ class HpuTensorWiseFP8LinearMethod(TensorWiseFP8LinearMethod):
         quanted_weight_tensor, weight_scale_tensor = fused_quant(weight)
         layer.weight.set_value(quanted_weight_tensor)
         layer.weight_scale.set_value(weight_scale_tensor)
+
+    def process_weights_after_loading(self, layer: nn.Layer):
+        """
+        use for loader v1
+        """
+        # these activation_scale will fall in, but only quant for self_attn
+        # mlp.shared_experts.up_gate_proj / down_proj
+        # self_attn.qkv_proj / o_proj
+        if layer.act_scale._is_initialized():
+            if "self_attn" in layer.act_scale_key:
+                act_scale_inv = layer.act_scale / self.max_bound
+                act_scale = self.max_bound / layer.act_scale
+            else:
+                act_scale_inv = layer.act_scale
+                act_scale = 1.0 / layer.act_scale
+        layer.act_scale.set_value(act_scale.astype(paddle.get_default_dtype()))
+        layer.act_scale_inv.set_value(act_scale_inv.astype(paddle.get_default_dtype()))

--- a/fastdeploy/model_executor/layers/moe/moe.py
+++ b/fastdeploy/model_executor/layers/moe/moe.py
@@ -657,6 +657,12 @@ class FusedMoE(nn.Layer):
                     tp_group=self.fd_config.parallel_config.tp_group,
                 )
 
+        if current_platform.is_intel_hpu():
+            out = self.forward_normal(x, gate, forward_meta, topk_ids_hookfunc=topk_ids_hookfunc)
+            if self.reduce_results and (self.ep_size > 1 or self.tp_size > 1):
+                tensor_model_parallel_all_reduce_custom(out)
+            return out
+
         token_num = x.shape[0]
         if (
             self.ep_size > 1
@@ -676,10 +682,7 @@ class FusedMoE(nn.Layer):
             out = self.forward_normal(x, gate, forward_meta, topk_ids_hookfunc=topk_ids_hookfunc)
 
         if self.reduce_results and self.tp_size > 1:
-            if current_platform.is_intel_hpu():
-                tensor_model_parallel_all_reduce_custom(out)
-            else:
-                out = tensor_model_parallel_all_reduce(out, self.tp_group)
+            out = tensor_model_parallel_all_reduce(out, self.tp_group)
         return out
 
     def forward_chunked_moe(

--- a/fastdeploy/model_executor/load_weight_utils.py
+++ b/fastdeploy/model_executor/load_weight_utils.py
@@ -269,6 +269,8 @@ def load_ep_checkpoint(cls: PretrainedModel, model_path: str, fd_config: FDConfi
             down_proj_scale_key = f"ernie.{prefix_layer_name}.{i}.mlp.experts.{j}.down_proj.weight_scale"
 
             down_proj_in_scale_key = f"ernie.{prefix_layer_name}.{i}.mlp.experts.{j}.down_proj.activation_scale"
+            # single up_gate_proj.activation_scale for all mlp.experts
+            up_gate_proj_in_scale_key = f"ernie.layers.{i}.mlp.experts.up_gate_proj.activation_scale"
             num_local_ffn_keys.append(up_gate_proj_key)
             num_local_ffn_keys.append(down_proj_key)
             num_local_ffn_keys.append(up_gate_proj_quant_key)
@@ -276,6 +278,7 @@ def load_ep_checkpoint(cls: PretrainedModel, model_path: str, fd_config: FDConfi
             num_local_ffn_keys.append(up_gate_proj_scale_key)
             num_local_ffn_keys.append(down_proj_scale_key)
             num_local_ffn_keys.append(down_proj_in_scale_key)
+            num_local_ffn_keys.append(up_gate_proj_in_scale_key)
 
         # for EP w4a8, we need all expert's activation_scale for up_gate_proj
         num_experts = fd_config.model_config.moe_num_experts

--- a/fastdeploy/model_executor/models/ernie4_5_moe.py
+++ b/fastdeploy/model_executor/models/ernie4_5_moe.py
@@ -561,10 +561,14 @@ class Ernie4_5_MoeForCausalLM(ModelForCasualLM):
             ("qkv_proj", "v_proj", None, "v"),
             ("up_gate_proj", "gate_proj", None, "gate"),
             ("up_gate_proj", "up_proj", None, "up"),
-            ("attn.cache_k_scale", "cachek_matmul.activation_scale", None, None),
-            ("attn.cache_v_scale", "cachev_matmul.activation_scale", None, None),
+            ("attn.cache_k_scale", "cachek_matmul.in_scale", None, None),
+            ("attn.cache_v_scale", "cachev_matmul.in_scale", None, None),
             ("attn.cache_k_zp", "cachek_matmul.activation_zero_point", None, None),
             ("attn.cache_v_zp", "cachev_matmul.activation_zero_point", None, None),
+            ("act_scale", "in_scale", None, None),
+            ("attn.q_scale", "q_matmul.in_scale", None, None),
+            ("attn.s_scale", "s_matmul.in_scale", None, None),
+            ("up_gate_proj_in_scale", "up_gate_proj.in_scale", None, None),
         ]
 
         expert_params_mapping = []
@@ -590,7 +594,10 @@ class Ernie4_5_MoeForCausalLM(ModelForCasualLM):
             (param, weight, exp, shard, False) for param, weight, exp, shard in general_params_mapping
         ] + [(param, weight, exp, shard, True) for param, weight, exp, shard in expert_params_mapping]
         checkpoint_to_fd_key_fn = rename_offline_ckpt_suffix_to_fd_suffix(
-            fd_config=self.fd_config, ckpt_weight_suffix="quant_weight", ckpt_scale_suffix="weight_scale"
+            fd_config=self.fd_config,
+            ckpt_weight_suffix="quant_weight",
+            ckpt_scale_suffix="weight_scale",
+            ckpt_act_suffix="activation_scale",
         )
         params_dict = dict(self.named_parameters())
 

--- a/fastdeploy/model_executor/models/ernie4_5_moe.py
+++ b/fastdeploy/model_executor/models/ernie4_5_moe.py
@@ -561,13 +561,15 @@ class Ernie4_5_MoeForCausalLM(ModelForCasualLM):
             ("qkv_proj", "v_proj", None, "v"),
             ("up_gate_proj", "gate_proj", None, "gate"),
             ("up_gate_proj", "up_proj", None, "up"),
-            ("attn.cache_k_scale", "cachek_matmul.in_scale", None, None),
-            ("attn.cache_v_scale", "cachev_matmul.in_scale", None, None),
+            ("attn.cache_k_scale", "cachek_matmul.activation_scale", None, None),
+            ("attn.cache_v_scale", "cachev_matmul.activation_scale", None, None),
             ("attn.cache_k_zp", "cachek_matmul.activation_zero_point", None, None),
             ("attn.cache_v_zp", "cachev_matmul.activation_zero_point", None, None),
             ("act_scale", "in_scale", None, None),
             ("attn.q_scale", "q_matmul.in_scale", None, None),
             ("attn.s_scale", "s_matmul.in_scale", None, None),
+            ("attn.cache_k_scale", "cachek_matmul.in_scale", None, None),
+            ("attn.cache_v_scale", "cachev_matmul.in_scale", None, None),
             ("up_gate_proj_in_scale", "up_gate_proj.in_scale", None, None),
         ]
 

--- a/fastdeploy/model_executor/utils.py
+++ b/fastdeploy/model_executor/utils.py
@@ -468,7 +468,10 @@ def multi_switch_config_context(*changes):
 
 
 def rename_offline_ckpt_suffix_to_fd_suffix(
-    fd_config, ckpt_weight_suffix: str = "quant_weight", ckpt_scale_suffix="weight_scale"
+    fd_config,
+    ckpt_weight_suffix: str = "quant_weight",
+    ckpt_scale_suffix="weight_scale",
+    ckpt_act_suffix="activation_scale",
 ):
     """
     Create a function to rename checkpoint key suffixes for FastDeploy.
@@ -488,6 +491,11 @@ def rename_offline_ckpt_suffix_to_fd_suffix(
     fp8_suffix_map = {
         ckpt_weight_suffix: "weight",
         ckpt_scale_suffix: "weight_scale_inv",
+        ckpt_act_suffix: "in_scale",
+    }
+    tensor_wise_fp8_suffix_map = {
+        ckpt_weight_suffix: "weight",
+        ckpt_act_suffix: "in_scale",
     }
     moe_quant_type = ""
     dense_quant_type = ""
@@ -505,6 +513,8 @@ def rename_offline_ckpt_suffix_to_fd_suffix(
         # Can be extended to other offline quantization suffixes if needed.
         if (is_moe and moe_quant_type == "block_wise_fp8") or (not is_moe and dense_quant_type == "block_wise_fp8"):
             fd_suffix_map = fp8_suffix_map
+        if (is_moe and moe_quant_type == "tensor_wise_fp8") or (not is_moe and dense_quant_type == "tensor_wise_fp8"):
+            fd_suffix_map = tensor_wise_fp8_suffix_map
         for ckpt_suffix, fd_suffix in fd_suffix_map.items():
             if re.search(rf"{ckpt_suffix}$", loaded_weight_name):
                 loaded_weight_name = loaded_weight_name.replace(ckpt_suffix, fd_suffix)

--- a/fastdeploy/model_executor/utils.py
+++ b/fastdeploy/model_executor/utils.py
@@ -491,7 +491,6 @@ def rename_offline_ckpt_suffix_to_fd_suffix(
     fp8_suffix_map = {
         ckpt_weight_suffix: "weight",
         ckpt_scale_suffix: "weight_scale_inv",
-        ckpt_act_suffix: "in_scale",
     }
     tensor_wise_fp8_suffix_map = {
         ckpt_weight_suffix: "weight",

--- a/fastdeploy/worker/hpu_model_runner.py
+++ b/fastdeploy/worker/hpu_model_runner.py
@@ -363,6 +363,24 @@ from fastdeploy.model_executor.models.qwen2 import Qwen2Attention, Qwen2MLP
 from fastdeploy.model_executor.models.qwen3 import Qwen3Attention
 
 
+def process_scales_alignment_after_loading(layer, alignment=0x80) -> None:
+    aligned_attrs = ["down_proj_in_scale"]
+    for attr in aligned_attrs:
+        if hasattr(layer, attr):
+            value = getattr(layer, attr)
+            if value.dim() != 2 or value.shape[1] != 1:
+                raise ValueError(f"{attr} must be [num_experts, 1], but got {value.shape}")
+
+            dtype_size = value.element_size()
+            elements_per_slot = alignment // dtype_size
+            # special 3D shape [..., 1, align_with_padding] as a mark for HPU alignment
+            padded_tensor = paddle.zeros(shape=[value.shape[0], 1, elements_per_slot], dtype=value.dtype)
+            padded_tensor[:, 0, 0] = value[:, 0]
+
+            delattr(layer, attr)
+            setattr(layer, attr, padded_tensor)
+
+
 def convert_model(model, measurement_mode=False, init_done=False):
     """ """
     if measurement_mode:
@@ -391,6 +409,7 @@ def convert_model(model, measurement_mode=False, init_done=False):
                 module.forward = types.MethodType(fused_attention_forward, module)
             if isinstance(module, FusedMoE):
                 module.measurement_mode = measurement_mode
+                process_scales_alignment_after_loading(module)
 
     return model
 

--- a/fastdeploy/worker/hpu_model_runner.py
+++ b/fastdeploy/worker/hpu_model_runner.py
@@ -1544,6 +1544,9 @@ class HPUModelRunner(ModelRunnerBase):
             We plan to replace it with 'ModelForwardBatch'.
             intermediate_tensors:
         """
+        if (self.parallel_config.use_ep) and (not self.not_need_stop()):
+            time.sleep(0.001)
+            return None
         # # 1. Prepare inputs of model and decoder.
         start_time = time.time()
         self._prepare_inputs()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

enable MoE EP for hpu with loader_v1

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications

- fastdeploy/model_executor/layers/moe/moe.py
        HPU calls forward_normal no matter EP or TP, and won't fall into forward_split_allgather nor forward_chunked_moe

 - fused_moe_hpu_backend.py
        change down_proj_in_scale from list to tensor.

- hpu_model_runner.py
        list to tensor, add padding dim for 0x80 alignment request.

- fastdeploy/model_executor/load_weight_utils.py
        needs up_gate_proj.activation_scale for EP in loader v0

- fastdeploy/model_executor/models/ernie4_5_moe.py‎
        add Attention related activation_scale name conversions

        - self_attn.

loaded_weight_name|checkpoint_to_fd_key_fn|all_param_mapping
---|---|---
qkv_proj.activation_scale 		| qkv_proj.in_scale 		| qkv_proj.act_scale
o_proj.activation_scale 		| o_proj.in_scale 			| o_proj.act_scale
cachek_matmul.activation_scale 	| cachek_matmul.in_scale 	| attn.cache_k_scale
cachev_matmul.activation_scale 	| cachev_matmul.in_scale 	| attn.cache_v_scale
q_matmul.activation_scale 		| q_matmul.in_scale 		| attn.q_scale
s_matmul.activation_scale 		| s_matmul.in_scale 		| attn.s_scale

        - mlp. & mlp.shared_experts.

loaded_weight_name|checkpoint_to_fd_key_fn|all_param_mapping
---|---|---
down_proj.activation_scale    | down_proj.in_scale    | down_proj.act_scale
up_gate_proj.activation_scale | up_gate_proj.in_scale | up_gate_proj.act_scale

        - mlp.experts. (all experts share same activation_scale)

loaded_weight_name|checkpoint_to_fd_key_fn|all_param_mapping
---|---|---
up_gate_proj.activation_scale | up_gate_proj.in_scale | up_gate_proj_in_scale

        - mlp.experts.{exp_id}.
loaded_weight_name|checkpoint_to_fd_key_fn|all_param_mapping
---|---|---
experts.{exp_id}.down_proj.activation_scale | experts.{exp_id}.down_proj.in_scale |experts.down_proj_in_scale


<!-- Detail the changes made in this pull request. -->

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

set `enable_expert_parallel=True`, and `disable_sequence_parallel_moe=True`, to enable HPU MoE EP.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ Done ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ Done ] Format your code, run `pre-commit` before commit.
- [ Done ] Add unit tests. Please write the reason in this PR if no unit tests.
      conducted by local tests
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
