### PR TITLE
[Cherry-Pick][BugFix]support fa3 qwen-vl rope (#5869)

### DIFF
--- a/custom_ops/gpu_ops/append_attn/gqa_rope_write_cache.cu
+++ b/custom_ops/gpu_ops/append_attn/gqa_rope_write_cache.cu
@@ -1377,23 +1377,25 @@ std::vector<paddle::Tensor> GQARopeWriteCacheKernel(
 
   if (use_neox_rotary_style) {
     if (rotary_dim == head_dim) {
-      gqa_rotary_qk_split_variable_qwen3<data_t>(qkv_out.data<data_t>(),
-                                                 q.data<data_t>(),
-                                                 k.data<data_t>(),
-                                                 v.data<data_t>(),
-                                                 qkv.data<data_t>(),
-                                                 rotary_embs.data<float>(),
-                                                 batch_id_per_token.data<int>(),
-                                                 seq_lens_encoder.data<int>(),
-                                                 seq_lens_decoder.data<int>(),
-                                                 cu_seqlens_q.data<int>(),
-                                                 cu_seqlens_k.data<int>(),
-                                                 token_num,
-                                                 num_heads,
-                                                 kv_num_heads,
-                                                 max_seq_len,
-                                                 head_dim,
-                                                 stream);
+      gqa_rotary_qk_split_variable_qwen3<data_t>(
+          qkv_out.data<data_t>(),
+          q.data<data_t>(),
+          k.data<data_t>(),
+          v.data<data_t>(),
+          qkv.data<data_t>(),
+          rotary_embs.data<float>(),
+          batch_id_per_token.data<int>(),
+          seq_lens_encoder.data<int>(),
+          seq_lens_decoder.data<int>(),
+          cu_seqlens_q.data<int>(),
+          cu_seqlens_k.data<int>(),
+          token_num,
+          num_heads,
+          kv_num_heads,
+          rope_3d ? rotary_embs.dims()[3] : rotary_embs.dims()[2],
+          head_dim,
+          rope_3d,
+          stream);
     } else {
       gqa_neox_partial_rotary_qk_split_variable<data_t>(
           qkv_out.data<data_t>(),

--- a/custom_ops/gpu_ops/append_attn/qwen3_rope.h
+++ b/custom_ops/gpu_ops/append_attn/qwen3_rope.h
@@ -23,7 +23,8 @@ __global__ void GQAVariableLengthRotarySplitKernel_Qwen3(
     const int q_num_head,
     const int kv_num_head,
     const int max_model_len,
-    const int head_dim) {
+    const int head_dim,
+    const bool rope_3d) {
   using LoadT = AlignedVector<T, VecSize>;
   using LoadEmbT = AlignedVector<float, VecSize>;
   LoadEmbT cos_emb_vec;
@@ -84,7 +85,8 @@ __global__ void GQAVariableLengthRotarySplitKernel_Qwen3(
     }
 
     // TODO check this correct or not
-    int64_t new_emb_idx = emb_idx;
+    int64_t new_emb_idx =
+        rope_3d ? emb_idx + ori_bi * 2 * max_model_len * head_dim : emb_idx;
 
     if (hi < q_num_head + kv_num_head) {
       Load<float, VecSize>(&cos_emb[new_emb_idx], &cos_emb_vec);
@@ -126,6 +128,7 @@ void gqa_rotary_qk_split_variable_qwen3(T *qkv_out,
                                         const int kv_num_heads,
                                         const int max_model_len,
                                         const int head_dim,
+                                        const bool rope_3d,
                                         const cudaStream_t &stream) {
   assert(head_dim == 128 && "head_dim must be 128");
 
@@ -163,5 +166,6 @@ void gqa_rotary_qk_split_variable_qwen3(T *qkv_out,
       num_heads,
       kv_num_heads,
       max_model_len,
-      head_dim);
+      head_dim,
+      rope_3d);
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
support fa3 qwen3-vl rope
<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications
Determine the FA3 Qwen rope offset based on Text/VL.
<!-- Detail the changes made in this pull request. -->

## Usage or Command
No
<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests
No
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
