### PR TITLE
[INTEL_HPU] supported ERNIE-4.5-21B-A3B-Thinking mold

### DIFF
--- a/fastdeploy/model_executor/utils.py
+++ b/fastdeploy/model_executor/utils.py
@@ -403,8 +403,9 @@ def v1_loader_support(fd_config):
         or current_platform.is_xpu()
         or current_platform.is_iluvatar()
         or current_platform.is_maca()
+        or current_platform.is_intel_hpu()
     ):
-        _err_msg("v1loader currently only support backends gpu, xpu, iluvatar and maca")
+        _err_msg("v1loader currently only support backends gpu, xpu, intel_hpu, iluvatar and maca")
         return False
 
     if is_pre_sliced_weight(fd_config.model_config.model):


### PR DESCRIPTION
ERNIE-4.5-21B-A3B-Thinking needs to use DefaultModelLoaderV1 mode

reference command line:
ENABLE_V1_KVCACHE_SCHEDULER=1 FD_ENC_DEC_BLOCK_NUM=8 HPU_PERF_BREAKDOWN_SYNC_MODE=1 \ HPU_WARMUP_BUCKET=0 MAX_PREFILL_NUM=1 FD_ATTENTION_BACKEND=HPU_ATTN \ python -m fastdeploy.entrypoints.openai.api_server --model \ ./models--baidu--ERNIE-4.5-21B-A3B-Thinking/snapshots/4341bb42644d5422859509fa25d41544c57181f8/ \ --port 8388 --engine-worker-queue-port 8302 --metrics-port 8301 \ --cache-queue-port 8303 --max-model-len 16384 --tensor-parallel-size 1 \ --load-choices "default_v1" --num-gpu-blocks-override 5000 --kv-cache-ratio 0.5 \ --max-num-seqs 128 --block-size 64 --no-enable-prefix-caching \ --graph-optimization-config '{"use_cudagraph":false}'

python bench_gsm8k.py --data-path ./test.jsonl --port 8388 --num-shots 5 --num-questions 1319 --parallel 1 --result-file test_accuracy_parallel_1.json
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
supported ERNIE-4.5-21B-A3B-Thinking mold
> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications

<!-- Detail the changes made in this pull request. -->
enabled DefaultModelLoaderV1 on Intel HPU
## Usage or Command
ENABLE_V1_KVCACHE_SCHEDULER=1 FD_ENC_DEC_BLOCK_NUM=8 HPU_PERF_BREAKDOWN_SYNC_MODE=1 HPU_WARMUP_BUCKET=0 MAX_PREFILL_NUM=1 FD_ATTENTION_BACKEND=HPU_ATTN python -m fastdeploy.entrypoints.openai.api_server --model /mnt/disk3/ernie_opensource/hub/models--baidu--ERNIE-4.5-21B-A3B-Thinking/snapshots/4341bb42644d5422859509fa25d41544c57181f8/ --port 8388 --engine-worker-queue-port 8302 --metrics-port 8301 --cache-queue-port 8303 --max-model-len 16384 --tensor-parallel-size 1 --load-choices "default_v1" --num-gpu-blocks-override 5000 --kv-cache-ratio 0.5 --max-num-seqs 128 --block-size 64 --no-enable-prefix-caching --graph-optimization-config '{"use_cudagraph":false}'
<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests
On Intel HPU
{"task": "gsm8k", "backend": "paddlepaddle", "num_gpus": 1, "latency": 21223.108, "accuracy": 0.774, "num_requests": 1319, "other": {"num_questions": 1319, "parallel": 1}}
{"task": "gsm8k", "backend": "paddlepaddle", "num_gpus": 1, "latency": 3019.105, "accuracy": 0.754, "num_requests": 1319, "other": {"num_questions": 1319, "parallel": 16}}

On NV H20
ENABLE_V1_KVCACHE_SCHEDULER=1 python -m fastdeploy.entrypoints.openai.api_server --model ./models--baidu--ERNIE-4.5-21B-A3B-Thinking/snapshots/4341bb42644d5422859509fa25d41544c57181f8/ --port 8388 --engine-worker-queue-port 8302 --metrics-port 8301 \ --cache-queue-port 8303 --tensor-parallel-size 1 --max-model-len 16384 --max-num-seqs 128 --block-size 64 --kv-cache-ratio 0.5 --num-gpu-blocks-override 6000 --graph-optimization-config '{"use_cudagraph":false}' --no-enable-prefix-caching --load-choices "default_v1" 
{"task": "gsm8k", "backend": "paddlepaddle", "num_gpus": 1, "latency": 18805.898, "accuracy": 0.763, "num_requests": 1319, "other": {"num_questions": 1319, "parallel": 1}}

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
