### PR TITLE
[Cherry-Pick] [BugFix] fix cache transfer manager updating/clearing (#5930)

### DIFF
--- a/fastdeploy/cache_manager/cache_transfer_manager.py
+++ b/fastdeploy/cache_manager/cache_transfer_manager.py
@@ -39,12 +39,7 @@ from fastdeploy.cache_manager.ops import (
     unset_data_ipc,
 )
 from fastdeploy.config import SpeculativeConfig
-from fastdeploy.inter_communicator import (
-    EngineCacheQueue,
-    IPCSignal,
-    KVCacheStatus,
-    ModelWeightsStatus,
-)
+from fastdeploy.inter_communicator import EngineCacheQueue, IPCSignal, KVCacheStatus
 from fastdeploy.platforms import current_platform
 from fastdeploy.utils import get_logger
 
@@ -200,13 +195,6 @@ class CacheTransferManager:
             create=False,
         )
         # Initialize update/clear signals for RL
-        self.model_weights_status_signal = IPCSignal(
-            name="model_weights_status",
-            array=np.zeros([1], dtype=np.int32),
-            dtype=np.int32,
-            suffix=args.engine_worker_queue_port,
-            create=False,
-        )
         self.kv_cache_status_signal = IPCSignal(
             name="kv_cache_status",
             array=np.zeros([1], dtype=np.int32),
@@ -707,11 +695,6 @@ class CacheTransferManager:
                     self.kv_cache_status_signal.value[0] = KVCacheStatus.CLEARED
                     logger.info(f"All ranks finish clearing caches {self.cache_ready_signal.value}")
 
-                    logger.info("Waiting for model_weights_status to be cleared..")
-                    while self.model_weights_status_signal.value[0] != ModelWeightsStatus.CLEARED:
-                        time.sleep(0.1)
-                    logger.info("model_weights_status is cleared, stop waiting!")
-
                 except Exception as e:
                     logger.error(f"Failed to clear caches: {e}")
 
@@ -736,11 +719,6 @@ class CacheTransferManager:
                     # set kv_cache_status_signal
                     logger.info(f"All ranks finish restoring caches {self.cache_ready_signal.value}")
                     self.kv_cache_status_signal.value[0] = KVCacheStatus.NORMAL
-
-                    logger.info("Waiting for model_weights_status to be normal..")
-                    while self.model_weights_status_signal.value[0] != ModelWeightsStatus.NORMAL:
-                        time.sleep(0.1)
-                    logger.info("model_weights_status is normal, stop waiting!")
 
                 except Exception as e:
                     logger.error(f"Failed to restore caches: {e}")

--- a/fastdeploy/cache_manager/cache_transfer_manager.py
+++ b/fastdeploy/cache_manager/cache_transfer_manager.py
@@ -668,16 +668,6 @@ class CacheTransferManager:
             return
         logger.info("Start a thread to clear/restore kv cache when model weights are cleared/updated.")
         while True:
-            # sync worker status to cache transfer manager
-            if self.model_weights_status_signal.value[0] == ModelWeightsStatus.CLEARING:
-                self.kv_cache_status_signal.value[0] = KVCacheStatus.CLEARING
-            elif self.model_weights_status_signal.value[0] == ModelWeightsStatus.UPDATING:
-                self.kv_cache_status_signal.value[0] = KVCacheStatus.UPDATING
-            elif self.model_weights_status_signal.value[0] == ModelWeightsStatus.CLEARED:
-                self.kv_cache_status_signal.value[0] = KVCacheStatus.CLEARED
-            elif self.model_weights_status_signal.value[0] == ModelWeightsStatus.NORMAL:
-                self.kv_cache_status_signal.value[0] = KVCacheStatus.NORMAL
-
             # handle cache clearing/restoring
             if self.kv_cache_status_signal.value[0] == KVCacheStatus.CLEARING:
                 assert args.splitwise_role == "mixed", "Only mixed mode supports clearing cache."
@@ -715,7 +705,7 @@ class CacheTransferManager:
 
                     # reset kv_cache_status_signal
                     self.kv_cache_status_signal.value[0] = KVCacheStatus.CLEARED
-                    logger.info("All ranks finish clearing caches")
+                    logger.info(f"All ranks finish clearing caches {self.cache_ready_signal.value}")
 
                     logger.info("Waiting for model_weights_status to be cleared..")
                     while self.model_weights_status_signal.value[0] != ModelWeightsStatus.CLEARED:
@@ -744,7 +734,7 @@ class CacheTransferManager:
                         time.sleep(0.1)
 
                     # set kv_cache_status_signal
-                    logger.info("All ranks finish restoring caches")
+                    logger.info(f"All ranks finish restoring caches {self.cache_ready_signal.value}")
                     self.kv_cache_status_signal.value[0] = KVCacheStatus.NORMAL
 
                     logger.info("Waiting for model_weights_status to be normal..")

--- a/fastdeploy/cache_manager/cache_transfer_manager.py
+++ b/fastdeploy/cache_manager/cache_transfer_manager.py
@@ -39,7 +39,12 @@ from fastdeploy.cache_manager.ops import (
     unset_data_ipc,
 )
 from fastdeploy.config import SpeculativeConfig
-from fastdeploy.inter_communicator import EngineCacheQueue, IPCSignal, KVCacheStatus
+from fastdeploy.inter_communicator import (
+    EngineCacheQueue,
+    IPCSignal,
+    KVCacheStatus,
+    ModelWeightsStatus,
+)
 from fastdeploy.platforms import current_platform
 from fastdeploy.utils import get_logger
 
@@ -157,7 +162,7 @@ class CacheTransferManager:
             name="cache_ready_signal",
             array=cache_ready_signal_data,
             dtype=np.int32,
-            suffix=self.engine_pid,
+            suffix=args.engine_worker_queue_port,
             create=False,
         )
         swap_space_ready_data = np.zeros(shape=[args.mp_num], dtype=np.int32)
@@ -165,7 +170,7 @@ class CacheTransferManager:
             name="swap_space_ready_signal",
             array=swap_space_ready_data,
             dtype=np.int32,
-            suffix=self.engine_pid,
+            suffix=args.engine_worker_queue_port,
             create=False,
         )
 
@@ -180,7 +185,7 @@ class CacheTransferManager:
             name="cache_task_broadcast_signal",
             array=cache_task_broadcast_data,
             dtype=np.int32,
-            suffix=args.engine_pid,
+            suffix=args.engine_worker_queue_port,
             create=False,
         )
 
@@ -194,7 +199,22 @@ class CacheTransferManager:
             suffix=args.engine_worker_queue_port,
             create=False,
         )
-        threading.Thread(target=self.clear_or_update_caches, args=[args], daemon=True).start()
+        # Initialize update/clear signals for RL
+        self.model_weights_status_signal = IPCSignal(
+            name="model_weights_status",
+            array=np.zeros([1], dtype=np.int32),
+            dtype=np.int32,
+            suffix=args.engine_worker_queue_port,
+            create=False,
+        )
+        self.kv_cache_status_signal = IPCSignal(
+            name="kv_cache_status",
+            array=np.zeros([1], dtype=np.int32),
+            dtype=np.int32,
+            suffix=args.engine_worker_queue_port,
+            create=False,
+        )
+        threading.Thread(target=self.check_cache_status, args=[args], daemon=True).start()
 
     def _init_gpu_cache(self, args):
 
@@ -642,29 +662,29 @@ class CacheTransferManager:
             transfer_task_id,
         )
 
-    def clear_or_update_caches(self, args):
+    def check_cache_status(self, args):
         # TODO XPU support RL
         if unset_data_ipc is None:
             return
         logger.info("Start a thread to clear/restore kv cache when model weights are cleared/updated.")
-        logger.info(f"FD_ENABLE_SWAP_SPACE_CLEARING={envs.FD_ENABLE_SWAP_SPACE_CLEARING}")
-        kv_cache_status = np.zeros([1], dtype=np.int32)
-        kv_cache_status_signal = IPCSignal(
-            name="kv_cache_status",
-            array=kv_cache_status,
-            dtype=np.int32,
-            suffix=self.engine_pid,
-            create=False,
-        )
         while True:
-            if kv_cache_status_signal.value[0] == KVCacheStatus.CLEARING:
+            # sync worker status to cache transfer manager
+            if self.model_weights_status_signal.value[0] == ModelWeightsStatus.CLEARING:
+                self.kv_cache_status_signal.value[0] = KVCacheStatus.CLEARING
+            elif self.model_weights_status_signal.value[0] == ModelWeightsStatus.UPDATING:
+                self.kv_cache_status_signal.value[0] = KVCacheStatus.UPDATING
+            elif self.model_weights_status_signal.value[0] == ModelWeightsStatus.CLEARED:
+                self.kv_cache_status_signal.value[0] = KVCacheStatus.CLEARED
+            elif self.model_weights_status_signal.value[0] == ModelWeightsStatus.NORMAL:
+                self.kv_cache_status_signal.value[0] = KVCacheStatus.NORMAL
+
+            # handle cache clearing/restoring
+            if self.kv_cache_status_signal.value[0] == KVCacheStatus.CLEARING:
                 assert args.splitwise_role == "mixed", "Only mixed mode supports clearing cache."
                 try:
-                    logger.info(
-                        f"[rank {self.rank}/{self.n_ranks}] Start clearing caches {self.cache_ready_signal.value}"
-                    )
+                    logger.info(f"Start clearing caches {self.cache_ready_signal.value}")
                     # clear cpu caches
-                    if envs.FD_ENABLE_SWAP_SPACE_CLEARING:
+                    if self.num_cpu_blocks > 0 and envs.FD_ENABLE_SWAP_SPACE_CLEARING:
                         paddle.set_device("cpu")
                         for ptrs in self.k_dst_ptrs + self.v_dst_ptrs:
                             cuda_host_free(ptrs)
@@ -687,38 +707,37 @@ class CacheTransferManager:
 
                     # reset cache_ready_signal
                     self.cache_ready_signal.value[self.rank] = 0
-                    logger.info(
-                        f"[rank {self.rank}/{self.n_ranks}] Finish clearing caches {self.cache_ready_signal.value}"
-                    )
+                    logger.info(f"Finish clearing caches {self.cache_ready_signal.value}")
 
                     # wait for all ranks caches to be cleared
                     if np.sum(self.cache_ready_signal.value) != 0:
                         time.sleep(0.1)
 
                     # reset kv_cache_status_signal
-                    kv_cache_status_signal.value[0] = KVCacheStatus.CLEARED
+                    self.kv_cache_status_signal.value[0] = KVCacheStatus.CLEARED
                     logger.info("All ranks finish clearing caches")
 
-                except Exception as e:
-                    logger.error(f"[rank {self.rank}/{self.n_ranks}] Failed to clear caches: {e}")
+                    logger.info("Waiting for model_weights_status to be cleared..")
+                    while self.model_weights_status_signal.value[0] != ModelWeightsStatus.CLEARED:
+                        time.sleep(0.1)
+                    logger.info("model_weights_status is cleared, stop waiting!")
 
-            elif kv_cache_status_signal.value[0] == KVCacheStatus.UPDATING:
+                except Exception as e:
+                    logger.error(f"Failed to clear caches: {e}")
+
+            elif self.kv_cache_status_signal.value[0] == KVCacheStatus.UPDATING:
                 assert args.splitwise_role == "mixed", "Only mixed mode supports updating cache."
                 try:
-                    logger.info(
-                        f"[rank {self.rank}/{self.n_ranks}] Start restoring caches {self.cache_ready_signal.value}"
-                    )
+                    logger.info(f"Start restoring caches {self.cache_ready_signal.value}")
                     # restore cpu cache
-                    if envs.FD_ENABLE_SWAP_SPACE_CLEARING:
+                    if self.num_cpu_blocks > 0 and envs.FD_ENABLE_SWAP_SPACE_CLEARING:
                         self._init_cpu_cache(args)
                         while np.sum(self.swap_space_ready_signal.value) != args.mp_num:
                             time.sleep(0.1)
 
                     # restore gpu cache and set cache_ready_signal
                     self._init_gpu_cache(args)
-                    logger.info(
-                        f"[rank {self.rank}/{self.n_ranks}] Finish restoring caches {self.cache_ready_signal.value}"
-                    )
+                    logger.info(f"Finish restoring caches {self.cache_ready_signal.value}")
 
                     # wait for all ranks caches to be ready
                     while np.sum(self.cache_ready_signal.value) != args.mp_num:
@@ -726,10 +745,15 @@ class CacheTransferManager:
 
                     # set kv_cache_status_signal
                     logger.info("All ranks finish restoring caches")
-                    kv_cache_status_signal.value[0] = KVCacheStatus.NORMAL
+                    self.kv_cache_status_signal.value[0] = KVCacheStatus.NORMAL
+
+                    logger.info("Waiting for model_weights_status to be normal..")
+                    while self.model_weights_status_signal.value[0] != ModelWeightsStatus.NORMAL:
+                        time.sleep(0.1)
+                    logger.info("model_weights_status is normal, stop waiting!")
 
                 except Exception as e:
-                    logger.error(f"[rank {self.rank}/{self.n_ranks}] Failed to restore caches: {e}")
+                    logger.error(f"Failed to restore caches: {e}")
 
             time.sleep(0.1)
 

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -1294,6 +1294,8 @@ class CacheConfig:
         self.max_processor_cache = None
         self.enable_output_caching = False
         self.disable_chunked_mm_input = False
+        self.num_cpu_blocks = None
+
         for key, value in args.items():
             if hasattr(self, key):
                 setattr(self, key, value)
@@ -1345,10 +1347,12 @@ class CacheConfig:
                 * byte_size
             )
 
-        if self.swap_space is None:
-            self.num_cpu_blocks = 0
-        else:
-            self.num_cpu_blocks = int(self.swap_space * 1024**3 / self.bytes_per_block)
+        if self.num_cpu_blocks is None:
+            if self.swap_space is None:
+                self.num_cpu_blocks = 0
+            else:
+                self.num_cpu_blocks = int(self.swap_space * 1024**3 / self.bytes_per_block)
+
         self._verify_args()
 
     def metrics_info(self):

--- a/fastdeploy/engine/async_llm.py
+++ b/fastdeploy/engine/async_llm.py
@@ -835,6 +835,7 @@ class AsyncLLMEngine:
             f" --logprobs_mode {self.cfg.model_config.logprobs_mode}"
             f" --max_logprobs {self.cfg.model_config.max_logprobs}"
             f" --eplb_config '{self.cfg.eplb_config.to_json_string()}'"
+            f" --num_cpu_blocks {self.cfg.cache_config.num_cpu_blocks}"
         )
 
         worker_store_true_flag = {

--- a/fastdeploy/engine/engine.py
+++ b/fastdeploy/engine/engine.py
@@ -566,6 +566,7 @@ class LLMEngine:
             f" --max_logprobs {self.cfg.model_config.max_logprobs}"
             f" --eplb_config '{self.cfg.eplb_config.to_json_string()}'"
             f" --routing_replay_config '{self.cfg.routing_replay_config.to_json_string()}'"
+            f" --num_cpu_blocks {self.cfg.cache_config.num_cpu_blocks}"
         )
         if self.cfg.structured_outputs_config.logits_processors is not None:
             arguments += f" --logits-processors {' '.join(self.cfg.structured_outputs_config.logits_processors)}"

--- a/fastdeploy/entrypoints/engine_client.py
+++ b/fastdeploy/entrypoints/engine_client.py
@@ -547,18 +547,6 @@ class EngineClient:
         2 : worker update finish and notify client
         """
         with self.clear_update_lock:
-            if self.fd_config.cache_config.enable_hierarchical_cache:
-                return False, "hierarchical cache updating is not supported"
-
-            # if self.enable_prefix_caching or self.enable_splitwise:
-            #     # kv_cache_status_signal: CLEARED -> UPDATING -> NORMAL
-            #     if self.kv_cache_status_signal.value[0] == KVCacheStatus.CLEARED:
-            #         self.kv_cache_status_signal.value[0] = KVCacheStatus.UPDATING
-            #         api_server_logger.info(f"Start to update kv cache {self.kv_cache_status_signal.value[0]}")
-            #         while self.kv_cache_status_signal.value[0] != KVCacheStatus.NORMAL:
-            #             api_server_logger.info(f"..updating kv cache {self.kv_cache_status_signal.value[0]}")
-            #             time.sleep(1)
-
             if self.enable_prefix_caching:
                 # prefix_tree_status_signal: CLEARED -> UPDATING -> NORMAL
                 if self.prefix_tree_status_signal.value[0] == PrefixTreeStatus.CLEARED:
@@ -594,17 +582,6 @@ class EngineClient:
         """
 
         with self.clear_update_lock:
-            if self.fd_config.cache_config.enable_hierarchical_cache:
-                return False, "hierarchical cache clearing is not supported"
-            # if self.enable_prefix_caching or self.enable_splitwise:
-            #     # kv_cache_status_signal: NORMAL -> CLEARING -> CLEARED
-            #     if self.kv_cache_status_signal.value[0] ==  KVCacheStatus.NORMAL:
-            #         self.kv_cache_status_signal.value[0] = KVCacheStatus.CLEARING
-            #         api_server_logger.info(f"Start to clear kv cache {self.kv_cache_status_signal.value[0]}")
-            #         while self.kv_cache_status_signal.value[0] != KVCacheStatus.CLEARED:
-            #             api_server_logger.info(f"..clearing kv cache {self.kv_cache_status_signal.value[0]}")
-            #             time.sleep(1)
-
             if self.enable_prefix_caching:
                 # prefix_tree_status_signal: NORMAL -> CLEARING -> CLEARED
                 if self.prefix_tree_status_signal.value[0] == PrefixTreeStatus.NORMAL:

--- a/fastdeploy/entrypoints/engine_client.py
+++ b/fastdeploy/entrypoints/engine_client.py
@@ -33,6 +33,7 @@ from fastdeploy.eplb.utils import RedundantExpertWorkload
 from fastdeploy.input.preprocess import InputPreprocessor
 from fastdeploy.inter_communicator import (
     IPCSignal,
+    KVCacheStatus,
     ModelWeightsStatus,
     PrefixTreeStatus,
     RearrangeExpertStatus,
@@ -78,6 +79,7 @@ class EngineClient:
         )
         self.max_model_len = self.fd_config.model_config.max_model_len
         self.enable_prefix_caching = self.fd_config.cache_config.enable_prefix_caching
+        self.enable_cache_transfer = self.fd_config.cache_config.swap_space
         self.enable_splitwise = self.fd_config.scheduler_config.splitwise_role != "mixed"
         self.max_chips_per_node = 16 if current_platform.is_iluvatar() else 8
 
@@ -566,8 +568,12 @@ class EngineClient:
 
             self.model_weights_status_signal.value[0] = ModelWeightsStatus.UPDATING
             api_server_logger.info(f"Start to update model weight {self.model_weights_status_signal.value[0]}")
-            while timeout >= 0 and self.model_weights_status_signal.value[0] != ModelWeightsStatus.NORMAL:
+            while timeout >= 0:
                 api_server_logger.info(f"..updating model weights {self.model_weights_status_signal.value[0]}")
+                weight_updated = self.model_weights_status_signal.value[0] == ModelWeightsStatus.NORMAL
+                cache_updated = self.kv_cache_status_signal.value[0] == KVCacheStatus.NORMAL
+                if weight_updated and (not self.enable_cache_transfer or cache_updated):
+                    break
                 time.sleep(1)
                 timeout -= 1
             if timeout < 0:
@@ -601,8 +607,12 @@ class EngineClient:
 
             self.model_weights_status_signal.value[0] = ModelWeightsStatus.CLEARING
             api_server_logger.info(f"Start to clear model weight {self.model_weights_status_signal.value[0]}")
-            while timeout >= 0 and self.model_weights_status_signal.value[0] != ModelWeightsStatus.CLEARED:
+            while timeout >= 0:
                 api_server_logger.info(f"..clearing model weights {self.model_weights_status_signal.value[0]}")
+                weight_cleared = self.model_weights_status_signal.value[0] == ModelWeightsStatus.CLEARED
+                cache_cleared = self.kv_cache_status_signal.value[0] == KVCacheStatus.CLEARED
+                if weight_cleared and (not self.enable_cache_transfer or cache_cleared):
+                    break
                 time.sleep(1)
                 timeout -= 1
             if timeout < 0:

--- a/fastdeploy/entrypoints/engine_client.py
+++ b/fastdeploy/entrypoints/engine_client.py
@@ -553,10 +553,18 @@ class EngineClient:
                 # prefix_tree_status_signal: CLEARED -> UPDATING -> NORMAL
                 if self.prefix_tree_status_signal.value[0] == PrefixTreeStatus.CLEARED:
                     self.prefix_tree_status_signal.value[0] = PrefixTreeStatus.UPDATING
-                    api_server_logger.info(f"Start to update prefix tree {self.prefix_tree_status_signal.value[0]}")
-                    while self.prefix_tree_status_signal.value[0] != PrefixTreeStatus.NORMAL:
-                        api_server_logger.info(f"..updating prefix tree {self.prefix_tree_status_signal.value[0]}")
+                    api_server_logger.info(
+                        f">>> start updating prefix tree (status: {self.prefix_tree_status_signal.value[0]})"
+                    )
+                    while timeout >= 0 and self.prefix_tree_status_signal.value[0] != PrefixTreeStatus.NORMAL:
+                        api_server_logger.info(f"... prefix tree status: {self.prefix_tree_status_signal.value[0]}")
                         time.sleep(1)
+                        timeout -= 1
+                    if timeout < 0:
+                        return False, "Update prefix tree timeout"
+                    api_server_logger.info(
+                        f"<<< finish updating prefix tree (status: {self.prefix_tree_status_signal.value[0]})"
+                    )
 
             # model_weights_status_signal: CLEARED -> UPDATING -> NORMAL
             if self.model_weights_status_signal.value[0] == ModelWeightsStatus.NORMAL:
@@ -567,9 +575,17 @@ class EngineClient:
                 return False, "worker is clearing model weight, cannot update now"
 
             self.model_weights_status_signal.value[0] = ModelWeightsStatus.UPDATING
-            api_server_logger.info(f"Start to update model weight {self.model_weights_status_signal.value[0]}")
+            api_server_logger.info(
+                f">>> start updating model weight (weight status: {self.model_weights_status_signal.value[0]})"
+                if not self.enable_cache_transfer
+                else f">>> start updating model weight (weight status: {self.model_weights_status_signal.value[0]} cache status: {self.kv_cache_status_signal.value[0]})"
+            )
             while timeout >= 0:
-                api_server_logger.info(f"..updating model weights {self.model_weights_status_signal.value[0]}")
+                api_server_logger.info(
+                    f"... weight status: {self.model_weights_status_signal.value[0]}"
+                    if not self.enable_cache_transfer
+                    else f"... weight status: {self.model_weights_status_signal.value[0]} cache status: {self.kv_cache_status_signal.value[0]}"
+                )
                 weight_updated = self.model_weights_status_signal.value[0] == ModelWeightsStatus.NORMAL
                 cache_updated = self.kv_cache_status_signal.value[0] == KVCacheStatus.NORMAL
                 if weight_updated and (not self.enable_cache_transfer or cache_updated):
@@ -578,6 +594,11 @@ class EngineClient:
                 timeout -= 1
             if timeout < 0:
                 return False, "Update model weight timeout"
+            api_server_logger.info(
+                f"<<< finish updating model weight (weight status: {self.model_weights_status_signal.value[0]}"
+                if not self.enable_cache_transfer
+                else f"<<< finish updating model weight (weight status: {self.model_weights_status_signal.value[0]} cache status: {self.kv_cache_status_signal.value[0]})"
+            )
             return True, ""
 
     def clear_load_weight(self, timeout=300):
@@ -592,10 +613,18 @@ class EngineClient:
                 # prefix_tree_status_signal: NORMAL -> CLEARING -> CLEARED
                 if self.prefix_tree_status_signal.value[0] == PrefixTreeStatus.NORMAL:
                     self.prefix_tree_status_signal.value[0] = PrefixTreeStatus.CLEARING
-                    api_server_logger.info(f"Start to clear prefix tree {self.prefix_tree_status_signal.value[0]}")
-                    while self.prefix_tree_status_signal.value[0] != PrefixTreeStatus.CLEARED:
-                        api_server_logger.info(f"..clearing prefix tree {self.prefix_tree_status_signal.value[0]}")
+                    api_server_logger.info(
+                        f">>> start clearing prefix tree (status: {self.prefix_tree_status_signal.value[0]})"
+                    )
+                    while timeout >= 0 and self.prefix_tree_status_signal.value[0] != PrefixTreeStatus.CLEARED:
+                        api_server_logger.info(f"... prefix tree status: {self.prefix_tree_status_signal.value[0]}")
                         time.sleep(1)
+                        timeout -= 1
+                    if timeout < 0:
+                        return False, "Clear prefix tree timeout"
+                    api_server_logger.info(
+                        f"<<< finish clearing prefix tree (status: {self.prefix_tree_status_signal.value[0]})"
+                    )
 
             # model_weights_status_signal: NORMAL -> CLEARING -> CLEARED
             if self.model_weights_status_signal.value[0] == ModelWeightsStatus.CLEARED:
@@ -606,9 +635,17 @@ class EngineClient:
                 return False, "worker is updating model weight, cannot clear now"
 
             self.model_weights_status_signal.value[0] = ModelWeightsStatus.CLEARING
-            api_server_logger.info(f"Start to clear model weight {self.model_weights_status_signal.value[0]}")
+            api_server_logger.info(
+                f">>> start clearing model weight (weight status: {self.model_weights_status_signal.value[0]}"
+                if not self.enable_cache_transfer
+                else f">>> start clearing model weight (weight status: {self.model_weights_status_signal.value[0]} cache status: {self.kv_cache_status_signal.value[0]})"
+            )
             while timeout >= 0:
-                api_server_logger.info(f"..clearing model weights {self.model_weights_status_signal.value[0]}")
+                api_server_logger.info(
+                    f"... weight status: {self.model_weights_status_signal.value[0]}"
+                    if not self.enable_cache_transfer
+                    else f"... weight status: {self.model_weights_status_signal.value[0]} cache status: {self.kv_cache_status_signal.value[0]}"
+                )
                 weight_cleared = self.model_weights_status_signal.value[0] == ModelWeightsStatus.CLEARED
                 cache_cleared = self.kv_cache_status_signal.value[0] == KVCacheStatus.CLEARED
                 if weight_cleared and (not self.enable_cache_transfer or cache_cleared):
@@ -617,6 +654,11 @@ class EngineClient:
                 timeout -= 1
             if timeout < 0:
                 return False, "Clear model weight timeout"
+            api_server_logger.info(
+                f"<<< finish clearing model weight (weight status: {self.model_weights_status_signal.value[0]}"
+                if not self.enable_cache_transfer
+                else f"<<< finish clearing model weight (weight status: {self.model_weights_status_signal.value[0]} cache status: {self.kv_cache_status_signal.value[0]})"
+            )
             return True, ""
 
     def check_model_weight_status(self):

--- a/fastdeploy/rl/dynamic_weight_manager.py
+++ b/fastdeploy/rl/dynamic_weight_manager.py
@@ -290,9 +290,6 @@ class DynamicWeightManager:
                 model_runner.update_parameters(pid)
                 while model_weights_status.value[0] != ModelWeightsStatus.NORMAL:
                     time.sleep(0.01)
-                if kv_cache_status:
-                    while kv_cache_status.value[0] != ModelWeightsStatus.NORMAL:
-                        time.sleep(0.01)
                 logger.info("finished loading new checkpoint")
             elif model_weights_status.value[0] == ModelWeightsStatus.CLEARING:
                 logger.info("infer engine stopped! start to clear checkpoint...")
@@ -302,9 +299,6 @@ class DynamicWeightManager:
                 model_runner.clear_parameters(pid)
                 while model_weights_status.value[0] != ModelWeightsStatus.CLEARED:
                     time.sleep(0.01)
-                if kv_cache_status:
-                    while kv_cache_status.value[0] != ModelWeightsStatus.CLEARED:
-                        time.sleep(0.01)
                 logger.info("finished clearing checkpoint")
             else:
                 time.sleep(0.01)

--- a/fastdeploy/rl/dynamic_weight_manager.py
+++ b/fastdeploy/rl/dynamic_weight_manager.py
@@ -24,7 +24,7 @@ import paddle
 from paddleformers.utils.log import logger
 
 from fastdeploy.config import FDConfig
-from fastdeploy.inter_communicator import ModelWeightsStatus
+from fastdeploy.inter_communicator import KVCacheStatus, ModelWeightsStatus
 
 
 class DynamicWeightManager:
@@ -267,28 +267,44 @@ class DynamicWeightManager:
             value[self.rank] = status
 
     @staticmethod
-    def check_model_weights_status(model_weights_status, model_runner, pid, block):
+    def check_model_weights_status(model_weights_status, kv_cache_status, model_runner, pid, block):
         """
-        check model weights status
+        A function to handle the state of model weights, check the model weights state,
+        and perform corresponding operations as needed.
+
+        - model_weights_status (`IPCSignal`): The signal indicating the status of model weights.
+        - kv_cache_status (`IPCSignal`): The signal indicating the status of key-value cache.
+        - model_runner (`ModelRunnerBase`): The model runner instance.
+        - block (`bool`): Block mode keeps the worker process blocked in the status-check loop,
+            avoiding communication operations in the worker event loop.
         """
-        # logger.info(f"dynamic weight manager is check model weights status! {model_weights_status.value[0]}")
+        logger.info(f"dynamic weight manager is check model weights status! {model_weights_status.value[0]}")
         while model_weights_status.value[0] != ModelWeightsStatus.NORMAL and (
             block or model_weights_status.value[0] != ModelWeightsStatus.CLEARED
         ):
-            # 如果为 block 模式，那么循环不会退出，直到权重更新、通信组重建
-            # 如果为非 block 模式，那么循环在权重更新或清理后均会退出
             if model_weights_status.value[0] == ModelWeightsStatus.UPDATING:
                 logger.info("infer engine stopped! start to load new checkpoint...")
+                if kv_cache_status:
+                    kv_cache_status.value[0] = KVCacheStatus.UPDATING
                 model_runner.clear_requests()
                 model_runner.update_parameters(pid)
                 while model_weights_status.value[0] != ModelWeightsStatus.NORMAL:
                     time.sleep(0.01)
+                if kv_cache_status:
+                    while kv_cache_status.value[0] != ModelWeightsStatus.NORMAL:
+                        time.sleep(0.01)
                 logger.info("finished loading new checkpoint")
             elif model_weights_status.value[0] == ModelWeightsStatus.CLEARING:
                 logger.info("infer engine stopped! start to clear checkpoint...")
+                if kv_cache_status:
+                    kv_cache_status.value[0] = KVCacheStatus.CLEARING
                 model_runner.clear_requests()
                 model_runner.clear_parameters(pid)
                 while model_weights_status.value[0] != ModelWeightsStatus.CLEARED:
                     time.sleep(0.01)
+                if kv_cache_status:
+                    while kv_cache_status.value[0] != ModelWeightsStatus.CLEARED:
+                        time.sleep(0.01)
                 logger.info("finished clearing checkpoint")
-            time.sleep(0.01)
+            else:
+                time.sleep(0.01)

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -234,6 +234,16 @@ class PaddleDisWorkerProc:
             create=False,
         )
 
+        # init kv_cache_status
+        kv_cache_status_data = np.zeros(shape=[1], dtype=np.int32)
+        self.kv_cache_status = IPCSignal(
+            name="kv_cache_status",
+            array=kv_cache_status_data,
+            dtype=np.int32,
+            suffix=self.parallel_config.engine_worker_queue_port,
+            create=False,
+        )
+
         # init exist_task_signal
         workers_exist_task = np.zeros([1], dtype=np.int32)
         self.exist_task_signal = IPCSignal(
@@ -462,6 +472,7 @@ class PaddleDisWorkerProc:
                     )
 
                     self.model_weights_status.value[0] = self.model_weights_signal[0]
+                    self.kv_cache_status.value[0] = self.model_weights_signal[0]
                     DynamicWeightManager.check_model_weights_status(
                         self.model_weights_status,
                         # model_weights_signal

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -482,14 +482,37 @@ class PaddleDisWorkerProc:
                     )
                     logger.info(f"current task queue data: {self.task_queue.num_tasks()}")
                     self.task_queue.clear_data()
-                    self.model_weights_signal[0] = ModelWeightsStatus.NORMAL
-                    logger.info(f"Rank: {self.local_rank} has updated or cleared parameters.")
 
-                    # 只有不关闭通信组时，清理权重后需要额外等待（否则信号量会同步混乱）
-                    if not self.fd_config.parallel_config.shutdown_comm_group_if_worker_idle:
-                        while self.model_weights_status.value[0] == ModelWeightsStatus.CLEARED:
-                            time.sleep(0.01)
-                        continue
+                    if self.model_weights_signal[0] == ModelWeightsStatus.UPDATING:
+                        logger.info(
+                            f"Rank: {self.local_rank} has updated parameters. {self.model_weights_status.value[0]}"
+                        )
+                        self.model_weights_signal[0] = ModelWeightsStatus.NORMAL
+                    elif self.model_weights_signal[0] == ModelWeightsStatus.CLEARING:
+                        logger.info(
+                            f"Rank: {self.local_rank} has cleared parameters. {self.model_weights_status.value[0]}"
+                        )
+                        # 如果不关闭通信组，清理权重后将推理进程统一阻塞在下面的循环中，否则信号量可能同步混乱；直到下次权重更新时唤醒
+                        if not self.fd_config.parallel_config.shutdown_comm_group_if_worker_idle:
+                            if self.ranks > 1:  # 所有 Rank 同时入睡，监听下次的更新信号
+                                paddle.distributed.barrier()
+                            while self.model_weights_signal[0] != ModelWeightsStatus.UPDATING:
+                                self.model_weights_signal[0] = self.model_weights_status.value[0]
+                                logger.info(
+                                    f"Rank {self.local_rank}: before broadcast self.model_weights_signal[0]={self.model_weights_signal[0]}"
+                                )
+                                if self.ranks > 1:
+                                    self.model_weights_signal[0] = self._broadcast_model_weights_signal(
+                                        src=0, group=None
+                                    )
+                                logger.info(
+                                    f"Rank {self.local_rank}:  after broadcast self.model_weights_signal[0]={self.model_weights_signal[0]}"
+                                )
+                                time.sleep(1)
+                            self.model_weights_status.value[0] = (
+                                ModelWeightsStatus.UPDATING
+                            )  # 所有 Rank 已同步唤醒，启动权重更新流程
+                            continue
 
             if self.exist_task_signal.value[0] == ExistTaskStatus.EXIST or self.task_queue.read_finish_flag.get() == 1:
                 logger.info(f"Rank: {self.local_rank} Detected new requests.")

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -436,8 +436,7 @@ class PaddleDisWorkerProc:
             self._run_eplb(tp_rank)
 
             if self.fd_config.load_config.dynamic_load_weight:
-                if self.model_weights_status.value[0] != ModelWeightsStatus.NORMAL:
-                    self.model_weights_signal[0] = int(self.model_weights_status.value[0])
+                self.model_weights_signal[0] = int(self.model_weights_status.value[0])
                 if self.ranks > 1:
                     self.model_weights_signal[0] = self._broadcast_model_weights_signal(src=0, group=None)
 
@@ -475,6 +474,7 @@ class PaddleDisWorkerProc:
                     self.kv_cache_status.value[0] = self.model_weights_signal[0]
                     DynamicWeightManager.check_model_weights_status(
                         self.model_weights_status,
+                        self.kv_cache_status if self.fd_config.cache_config.num_cpu_blocks > 0 else None,
                         # model_weights_signal
                         self.worker.model_runner,
                         self.parallel_config.engine_worker_queue_port,
@@ -492,22 +492,16 @@ class PaddleDisWorkerProc:
                         logger.info(
                             f"Rank: {self.local_rank} has cleared parameters. {self.model_weights_status.value[0]}"
                         )
-                        # 如果不关闭通信组，清理权重后将推理进程统一阻塞在下面的循环中，否则信号量可能同步混乱；直到下次权重更新时唤醒
+                        # 如果清理权重后不关闭通信组，那么将推理进程统一阻塞在下面的循环中，否则信号量可能同步混乱；直到下次权重更新时唤醒
                         if not self.fd_config.parallel_config.shutdown_comm_group_if_worker_idle:
                             if self.ranks > 1:  # 所有 Rank 同时入睡，监听下次的更新信号
                                 paddle.distributed.barrier()
                             while self.model_weights_signal[0] != ModelWeightsStatus.UPDATING:
                                 self.model_weights_signal[0] = self.model_weights_status.value[0]
-                                logger.info(
-                                    f"Rank {self.local_rank}: before broadcast self.model_weights_signal[0]={self.model_weights_signal[0]}"
-                                )
                                 if self.ranks > 1:
                                     self.model_weights_signal[0] = self._broadcast_model_weights_signal(
                                         src=0, group=None
                                     )
-                                logger.info(
-                                    f"Rank {self.local_rank}:  after broadcast self.model_weights_signal[0]={self.model_weights_signal[0]}"
-                                )
                                 time.sleep(1)
                             self.model_weights_status.value[0] = (
                                 ModelWeightsStatus.UPDATING
@@ -944,6 +938,13 @@ def parse_args():
         "--enable_entropy",
         action="store_true",
         help="Enable output of token-level entropy.",
+    )
+
+    parser.add_argument(
+        "--num_cpu_blocks",
+        type=int,
+        default=0,
+        help="Number of cpu blocks.",
     )
 
     args = parser.parse_args()

--- a/tests/ce/stable_cases/launch_model.sh
+++ b/tests/ce/stable_cases/launch_model.sh
@@ -38,6 +38,7 @@ python -m fastdeploy.entrypoints.openai.api_server \
        --gpu-memory-utilization 0.9 \
        --model "$MODEL_PATH" \
        --no-shutdown-comm-group-if-worker-idle \
+       --swap-space 10 \
        --load-strategy ipc_snapshot \
        --dynamic-load-weight &
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

权重清除需要涉及 1. weight 的清除 2. cache 及 ipc 的清除 3. prefix tree 索引的清除

当前三种清除行为对应的控制信号的传递逻辑不同：
1. weight 清除信号：server#0 将信号传递给 worker#0 后，worker#0 会广播自身信号给剩余所有 worker，因此客户端给 server#0 发送 clear 信号时，实际上会触发所有 server 的 worker 的权重清除
2. cache 清除信号：每个 server 控制自己的 cache_transfer 进程的清除，客户端需要给每个 server 单独发送 clear 信号
3. prefix tree 清除信号：每个 server 控制自己的 engine 的清除，客户端需要给每个 server 单独发送 clear 信号

在 MultiAPIServer 的多 DP 场景，在特定的请求顺序下，某些清除工作无法正常执行。例如：先给 server0 发送 clear 信号，如果该请求成功返回，则继续给其他 server 依次发送 clear 信号。此时，因为 server0 的 clear 信号已经广播给了所有 server，成功清除掉了所有 server 的权重；而前台会拦截权重已清除状态时的 clear 请求，导致客户端后来即使给每个 server 都发送了 clear 请求，但实际上除了 server#0 以外的 engine 和 cache_transfer 进程的清除不会被触发。

## Modifications

1. 前置 prefix tree 索引的清除/更新，这部分不需要做拦截，因为重复清除和重置 prefix tree 索引是无害的。
2. 修改 cache 清除/更新的信号不再由 server 发送，而是由 worker 发送。这样清除流程变为：server#0 收到请求 → 修改 weight 信号为 clearing → worker#0 检测到 weight 状态变更 为 clearing → 将 weight clear 信号广播给所有 worker → 所有 worker 修改 cache 信号为 clearing → 所有 transfer 进程检测到 cache 状态变更为 clearing → worker 和 transfer 进程同步开始清除 weight 和 cache → server#0 检测 weight cleared 和 cache cleared 信号 → 返回 HTTP 200 OK

## Usage or Command

`--enable-prefix-caching` 开启 prefix caching
`--swap-space 10` 开启 cpu cache 及启动 transfer 进程

## Accuracy Tests

stable test 通过

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
