### PR TITLE
【Optim】Grid configuration leads to low SM utilization

### DIFF
--- a/custom_ops/gpu_ops/moe/moe_ffn.cu
+++ b/custom_ops/gpu_ops/moe/moe_ffn.cu
@@ -23,6 +23,35 @@
 #include "swigluoai.h"
 #include "w4afp8_gemm/w4afp8_gemm.h"
 
+// 从 tokens_expert_prefix_sum 计算真正的 max_tokens_per_expert
+// prefix_sum[i] 表示前 i+1 个 expert 的累计 tokens 数
+// expert i 的 tokens 数 = prefix_sum[i] - prefix_sum[i-1] (i > 0) 或
+// prefix_sum[0] (i == 0)
+inline int ComputeMaxTokensPerExpert(const int64_t* prefix_sum_device,
+                                     int num_experts,
+                                     cudaStream_t stream) {
+  if (num_experts <= 0) return 0;
+
+  // 将 prefix_sum 从 GPU 复制到 CPU（num_experts 通常很小，同步开销可接受）
+  std::vector<int64_t> prefix_sum_host(num_experts);
+  cudaMemcpyAsync(prefix_sum_host.data(),
+                  prefix_sum_device,
+                  num_experts * sizeof(int64_t),
+                  cudaMemcpyDeviceToHost,
+                  stream);
+  cudaStreamSynchronize(stream);
+
+  int64_t max_tokens = 0;
+  for (int i = 0; i < num_experts; ++i) {
+    int64_t cur_tokens = (i == 0)
+                             ? prefix_sum_host[i]
+                             : (prefix_sum_host[i] - prefix_sum_host[i - 1]);
+    max_tokens = std::max(max_tokens, cur_tokens);
+  }
+
+  return static_cast<int>(max_tokens);
+}
+
 template <paddle::DataType T>
 void MoeFFNKernel(const paddle::Tensor& permute_input,
                   const paddle::Tensor& tokens_expert_prefix_sum,
@@ -205,6 +234,17 @@ void MoeFFNKernel(const paddle::Tensor& permute_input,
                                             : weight_scale_tensor.dims()[3];
     const float* input_dequant_scale =
         up_proj_in_scale ? up_proj_in_scale.get().data<float>() : nullptr;
+    // 对于 token_padding_size == 0 的情况，计算真正的 max_tokens_per_expert
+    // 来优化 grid.y 这可以大幅减少无效 block 的启动，显著提升小 batch
+    // 场景下的性能
+    const int max_tokens_per_expert_for_opt =
+        used_in_ep_low_latency
+            ? -1  // low latency 模式下不需要优化（已经是 padded 的）
+            : ComputeMaxTokensPerExpert(
+                  tokens_expert_prefix_sum.data<int64_t>(),
+                  num_experts,
+                  stream);
+
     DisPatchW4AFp8GemmWrapper(
         reinterpret_cast<const DataType_fp8*>(permute_input.data<data_t_fp8>()),
         reinterpret_cast<const DataType_fp8*>(
@@ -220,7 +260,8 @@ void MoeFFNKernel(const paddle::Tensor& permute_input,
         inter_size,
         hidden_size,
         weight_scale_group_size,
-        stream);
+        stream,
+        max_tokens_per_expert_for_opt);
   } else {
     typename cutlass::WintQuantTraits<
         DataType_,
@@ -418,6 +459,16 @@ void MoeFFNKernel(const paddle::Tensor& permute_input,
                                             ? inter_size / 2
                                             : weight_scale_tensor.dims()[3];
 
+    // 对于 token_padding_size == 0 的情况，计算真正的 max_tokens_per_expert
+    // 来优化 grid.y 这可以大幅减少无效 block 的启动，显著提升小 batch
+    // 场景下的性能
+    const int max_tokens_per_expert_for_opt_down =
+        used_in_ep_low_latency
+            ? -1  // low latency 模式下不需要优化（已经是 padded 的）
+            : ComputeMaxTokensPerExpert(
+                  tokens_expert_prefix_sum.data<int64_t>(),
+                  num_experts,
+                  stream);
     DisPatchW4AFp8GemmWrapper(
         reinterpret_cast<const DataType_fp8*>(fp8_act_out->ptr()),
         reinterpret_cast<const DataType_fp8*>(down_proj_weight.data<int8_t>()),
@@ -432,7 +483,8 @@ void MoeFFNKernel(const paddle::Tensor& permute_input,
         hidden_size,
         inter_size / 2,
         weight_scale_group_size,
-        stream);
+        stream,
+        max_tokens_per_expert_for_opt_down);
   } else {
     typename cutlass::WintQuantTraits<
         DataType_,

--- a/custom_ops/gpu_ops/moe/moe_ffn.cu
+++ b/custom_ops/gpu_ops/moe/moe_ffn.cu
@@ -23,30 +23,28 @@
 #include "swigluoai.h"
 #include "w4afp8_gemm/w4afp8_gemm.h"
 
-// 从 tokens_expert_prefix_sum 计算真正的 max_tokens_per_expert
-// prefix_sum[i] 表示前 i+1 个 expert 的累计 tokens 数
-// expert i 的 tokens 数 = prefix_sum[i] - prefix_sum[i-1] (i > 0) 或
-// prefix_sum[0] (i == 0)
+// 从 tokens_expert_prefix_sum 计算每个 expert 的最大 tokens 数
+// prefix_sum: [tokens_0, tokens_0+tokens_1, ..., sum(all)] 长度为 num_experts
+// 返回 max(tokens_i) for i in [0, num_experts)
 inline int ComputeMaxTokensPerExpert(const int64_t* prefix_sum_device,
                                      int num_experts,
                                      cudaStream_t stream) {
   if (num_experts <= 0) return 0;
 
-  // 将 prefix_sum 从 GPU 复制到 CPU（num_experts 通常很小，同步开销可接受）
-  std::vector<int64_t> prefix_sum_host(num_experts);
-  cudaMemcpyAsync(prefix_sum_host.data(),
+  // 从 GPU 拷贝到 CPU（prefix_sum 通常很小，只有 num_experts 个元素）
+  std::vector<int64_t> prefix_sum(num_experts);
+  cudaMemcpyAsync(prefix_sum.data(),
                   prefix_sum_device,
                   num_experts * sizeof(int64_t),
                   cudaMemcpyDeviceToHost,
                   stream);
-  cudaStreamSynchronize(stream);
+  cudaStreamSynchronize(stream);  // 需要同步以获取数据
 
-  int64_t max_tokens = 0;
-  for (int i = 0; i < num_experts; ++i) {
-    int64_t cur_tokens = (i == 0)
-                             ? prefix_sum_host[i]
-                             : (prefix_sum_host[i] - prefix_sum_host[i - 1]);
-    max_tokens = std::max(max_tokens, cur_tokens);
+  // 计算每个 expert 的 tokens 数并找最大值
+  int64_t max_tokens = prefix_sum[0];  // expert 0 的 tokens
+  for (int i = 1; i < num_experts; i++) {
+    int64_t tokens_i = prefix_sum[i] - prefix_sum[i - 1];
+    max_tokens = std::max(max_tokens, tokens_i);
   }
 
   return static_cast<int>(max_tokens);
@@ -234,17 +232,13 @@ void MoeFFNKernel(const paddle::Tensor& permute_input,
                                             : weight_scale_tensor.dims()[3];
     const float* input_dequant_scale =
         up_proj_in_scale ? up_proj_in_scale.get().data<float>() : nullptr;
-    // 对于 token_padding_size == 0 的情况，计算真正的 max_tokens_per_expert
-    // 来优化 grid.y 这可以大幅减少无效 block 的启动，显著提升小 batch
-    // 场景下的性能
+    // 对于 token_padding_size == 0 的情况，计算每个 expert 的最大 tokens
+    // 数用于优化 grid.y
     const int max_tokens_per_expert_for_opt =
         used_in_ep_low_latency
-            ? -1  // low latency 模式下不需要优化（已经是 padded 的）
-            : ComputeMaxTokensPerExpert(
-                  tokens_expert_prefix_sum.data<int64_t>(),
-                  num_experts,
-                  stream);
-
+            ? -1  // 有 padding 模式下不需要此优化
+            : static_cast<int>((permute_input.dims()[0] + num_experts - 1) /
+                               num_experts);
     DisPatchW4AFp8GemmWrapper(
         reinterpret_cast<const DataType_fp8*>(permute_input.data<data_t_fp8>()),
         reinterpret_cast<const DataType_fp8*>(
@@ -459,16 +453,13 @@ void MoeFFNKernel(const paddle::Tensor& permute_input,
                                             ? inter_size / 2
                                             : weight_scale_tensor.dims()[3];
 
-    // 对于 token_padding_size == 0 的情况，计算真正的 max_tokens_per_expert
-    // 来优化 grid.y 这可以大幅减少无效 block 的启动，显著提升小 batch
-    // 场景下的性能
+    // 对于 token_padding_size == 0 的情况，计算每个 expert 的最大 tokens
+    // 数用于优化 grid.y
     const int max_tokens_per_expert_for_opt_down =
         used_in_ep_low_latency
-            ? -1  // low latency 模式下不需要优化（已经是 padded 的）
-            : ComputeMaxTokensPerExpert(
-                  tokens_expert_prefix_sum.data<int64_t>(),
-                  num_experts,
-                  stream);
+            ? -1  // 有 padding 模式下不需要此优化
+            : static_cast<int>((act_out_tensor.dims()[0] + num_experts - 1) /
+                               num_experts);
     DisPatchW4AFp8GemmWrapper(
         reinterpret_cast<const DataType_fp8*>(fp8_act_out->ptr()),
         reinterpret_cast<const DataType_fp8*>(down_proj_weight.data<int8_t>()),

--- a/custom_ops/gpu_ops/moe/moe_ffn.cu
+++ b/custom_ops/gpu_ops/moe/moe_ffn.cu
@@ -23,33 +23,6 @@
 #include "swigluoai.h"
 #include "w4afp8_gemm/w4afp8_gemm.h"
 
-// 从 tokens_expert_prefix_sum 计算每个 expert 的最大 tokens 数
-// prefix_sum: [tokens_0, tokens_0+tokens_1, ..., sum(all)] 长度为 num_experts
-// 返回 max(tokens_i) for i in [0, num_experts)
-inline int ComputeMaxTokensPerExpert(const int64_t* prefix_sum_device,
-                                     int num_experts,
-                                     cudaStream_t stream) {
-  if (num_experts <= 0) return 0;
-
-  // 从 GPU 拷贝到 CPU（prefix_sum 通常很小，只有 num_experts 个元素）
-  std::vector<int64_t> prefix_sum(num_experts);
-  cudaMemcpyAsync(prefix_sum.data(),
-                  prefix_sum_device,
-                  num_experts * sizeof(int64_t),
-                  cudaMemcpyDeviceToHost,
-                  stream);
-  cudaStreamSynchronize(stream);  // 需要同步以获取数据
-
-  // 计算每个 expert 的 tokens 数并找最大值
-  int64_t max_tokens = prefix_sum[0];  // expert 0 的 tokens
-  for (int i = 1; i < num_experts; i++) {
-    int64_t tokens_i = prefix_sum[i] - prefix_sum[i - 1];
-    max_tokens = std::max(max_tokens, tokens_i);
-  }
-
-  return static_cast<int>(max_tokens);
-}
-
 template <paddle::DataType T>
 void MoeFFNKernel(const paddle::Tensor& permute_input,
                   const paddle::Tensor& tokens_expert_prefix_sum,
@@ -232,11 +205,11 @@ void MoeFFNKernel(const paddle::Tensor& permute_input,
                                             : weight_scale_tensor.dims()[3];
     const float* input_dequant_scale =
         up_proj_in_scale ? up_proj_in_scale.get().data<float>() : nullptr;
-    // 对于 token_padding_size == 0 的情况，计算每个 expert 的最大 tokens
-    // 数用于优化 grid.y
+    // For token_padding_size == 0 case, compute the maximum number of tokens
+    // per expert to optimize grid.y
     const int max_tokens_per_expert_for_opt =
         used_in_ep_low_latency
-            ? -1  // 有 padding 模式下不需要此优化
+            ? -1  // No need for this optimization in padding mode
             : static_cast<int>((permute_input.dims()[0] + num_experts - 1) /
                                num_experts);
     DisPatchW4AFp8GemmWrapper(
@@ -453,11 +426,11 @@ void MoeFFNKernel(const paddle::Tensor& permute_input,
                                             ? inter_size / 2
                                             : weight_scale_tensor.dims()[3];
 
-    // 对于 token_padding_size == 0 的情况，计算每个 expert 的最大 tokens
-    // 数用于优化 grid.y
+    // For token_padding_size == 0 case, compute the maximum number of tokens
+    // per expert to optimize grid.y
     const int max_tokens_per_expert_for_opt_down =
         used_in_ep_low_latency
-            ? -1  // 有 padding 模式下不需要此优化
+            ? -1  // No need for this optimization in padding mode
             : static_cast<int>((act_out_tensor.dims()[0] + num_experts - 1) /
                                num_experts);
     DisPatchW4AFp8GemmWrapper(

--- a/custom_ops/gpu_ops/w4afp8_gemm/w4afp8_gemm.cu
+++ b/custom_ops/gpu_ops/w4afp8_gemm/w4afp8_gemm.cu
@@ -57,7 +57,8 @@ void DisPatchW4AFp8Gemm(const cutlass::float_e4m3_t* input,
                         const int64_t M,
                         const int64_t K,
                         const int WeightScaleGroup,
-                        cudaStream_t stream) {
+                        cudaStream_t stream,
+                        const int max_tokens_per_expert = -1) {
   int kBlockN = 256;
   if constexpr (std::is_same_v<OutputType, cutlass::bfloat16_t>) {
     GEMM_SWITCH_BF16(M,
@@ -73,7 +74,8 @@ void DisPatchW4AFp8Gemm(const cutlass::float_e4m3_t* input,
                      input_dequant_scale,
                      tokens,
                      max_tokens,
-                     stream)
+                     stream,
+                     max_tokens_per_expert)
   } else {
     PD_THROW("Only supported dtype in ['BFLOAT16'].");
   }
@@ -173,7 +175,8 @@ void DisPatchW4AFp8GemmWrapper(const InputType* input,
                                const int64_t M,
                                const int64_t K,
                                const int WeightScaleGroup,
-                               cudaStream_t stream) {
+                               cudaStream_t stream,
+                               const int max_tokens_per_expert) {
   using InType = typename NVTraits<InputType>::data_t;
   using OutType = typename NVTraits<OutputType>::data_t;
   DisPatchW4AFp8Gemm(reinterpret_cast<const InType*>(input),
@@ -188,7 +191,8 @@ void DisPatchW4AFp8GemmWrapper(const InputType* input,
                      M,
                      K,
                      WeightScaleGroup,
-                     stream);
+                     stream,
+                     max_tokens_per_expert);
 }
 
 PD_BUILD_STATIC_OP(w4afp8_gemm_scale_permute)
@@ -227,7 +231,8 @@ template void DisPatchW4AFp8GemmWrapper<__nv_fp8_e4m3, __nv_bfloat16>(
     const int64_t M,
     const int64_t K,
     const int WeightScaleGroup,
-    cudaStream_t stream);
+    cudaStream_t stream,
+    const int max_tokens_per_expert);
 
 template void DisPatchW4AFp8GemmWrapper<__nv_fp8_e4m3, half>(
     const __nv_fp8_e4m3* input,
@@ -242,4 +247,5 @@ template void DisPatchW4AFp8GemmWrapper<__nv_fp8_e4m3, half>(
     const int64_t M,
     const int64_t K,
     const int WeightScaleGroup,
-    cudaStream_t stream);
+    cudaStream_t stream,
+    const int max_tokens_per_expert);

--- a/custom_ops/gpu_ops/w4afp8_gemm/w4afp8_gemm.h
+++ b/custom_ops/gpu_ops/w4afp8_gemm/w4afp8_gemm.h
@@ -44,4 +44,5 @@ void DisPatchW4AFp8GemmWrapper(const InputType* input,
                                const int64_t M,
                                const int64_t K,
                                const int WeightScaleGroup,
-                               cudaStream_t stream);
+                               cudaStream_t stream,
+                               const int max_tokens_per_expert = -1);

--- a/custom_ops/gpu_ops/w4afp8_gemm/w4afp8_gemm_kernel.hpp
+++ b/custom_ops/gpu_ops/w4afp8_gemm/w4afp8_gemm_kernel.hpp
@@ -326,11 +326,13 @@ void run_gemm(const InputType *A,
 
   constexpr int M_nums =
       (M + Kernel_traits::kBlockM - 1) / Kernel_traits::kBlockM;
-  // 优化：对于 token_padding_size == 0 的情况，使用 max_tokens_per_expert 计算
-  // grid.y 避免启动大量无效 block (原来是 max_tokens 导致 grid.y 过大)
+  // Optimization: For token_padding_size == 0 cases, use max_tokens_per_expert
+  // to calculate grid.y to avoid launching many idle blocks (previously
+  // max_tokens caused grid.y too large)
   int effective_tokens;
   if constexpr (TokenPackSize == 0) {
-    // 如果传入了有效的 max_tokens_per_expert，使用它；否则回退到估算
+    // If valid max_tokens_per_expert is provided, use it; otherwise fallback to
+    // estimation
     effective_tokens = (max_tokens_per_expert > 0)
                            ? max_tokens_per_expert
                            : (max_tokens + Experts - 1) / Experts;

--- a/custom_ops/gpu_ops/w4afp8_gemm/w4afp8_gemm_kernel.hpp
+++ b/custom_ops/gpu_ops/w4afp8_gemm/w4afp8_gemm_kernel.hpp
@@ -317,7 +317,8 @@ void run_gemm(const InputType *A,
               const float *input_dequant_scale,
               const int64_t *tokens,
               const int max_tokens,
-              cudaStream_t stream) {
+              cudaStream_t stream,
+              const int max_tokens_per_expert = -1) {
   using ElementOutput = typename Kernel_traits::ElementOutput;
   using Element = typename Kernel_traits::Element;
   using CollectiveMainloop = CollectiveMainloopFwd<Kernel_traits>;
@@ -325,8 +326,19 @@ void run_gemm(const InputType *A,
 
   constexpr int M_nums =
       (M + Kernel_traits::kBlockM - 1) / Kernel_traits::kBlockM;
-  const int N_nums =
-      (max_tokens + Kernel_traits::kBlockN1 - 1) / Kernel_traits::kBlockN1;
+  // 优化：对于 token_padding_size == 0 的情况，使用 max_tokens_per_expert 计算
+  // grid.y 避免启动大量无效 block (原来是 max_tokens 导致 grid.y 过大)
+  int effective_tokens;
+  if constexpr (TokenPackSize == 0) {
+    // 如果传入了有效的 max_tokens_per_expert，使用它；否则回退到估算
+    effective_tokens = (max_tokens_per_expert > 0)
+                           ? max_tokens_per_expert
+                           : (max_tokens + Experts - 1) / Experts;
+  } else {
+    effective_tokens = max_tokens;
+  }
+  const int N_nums = (effective_tokens + Kernel_traits::kBlockN1 - 1) /
+                     Kernel_traits::kBlockN1;
   constexpr int K_scale_nums = K / Kernel_traits::kBlockM;
   static_assert(K % WeightScaleGroup == 0);
   static_assert(WeightScaleGroup == 128 || WeightScaleGroup == K);

--- a/custom_ops/utils/auto_gen_w4afp8_gemm_kernel.py
+++ b/custom_ops/utils/auto_gen_w4afp8_gemm_kernel.py
@@ -41,7 +41,8 @@ void w4afp8_gemm_M{M}_N{N}_G{GROUPSIZE}_K{K}_E{EXPERTS}_P{PADDING}_{TYPE}(
     const float * input_dequant_scale,
     const int64_t *tokens,
     const int64_t max_tokens,
-    cudaStream_t stream);
+    cudaStream_t stream,
+    const int max_tokens_per_expert = -1);
 """
 
 gemm_template_cu_head = """
@@ -59,7 +60,8 @@ void w4afp8_gemm_M{M}_N{N}_G{GROUPSIZE}_K{K}_E{EXPERTS}_P{PADDING}_{TYPE}(
         const float * input_dequant_scale,
         const int64_t *tokens,
         const int64_t max_tokens,
-        cudaStream_t stream) {{
+        cudaStream_t stream,
+        const int max_tokens_per_expert) {{
 
     constexpr static int M = {M};
     constexpr static int K = {K};
@@ -81,7 +83,7 @@ void w4afp8_gemm_M{M}_N{N}_G{GROUPSIZE}_K{K}_E{EXPERTS}_P{PADDING}_{TYPE}(
         {cutlass_type}>;
     run_gemm<cutlass::float_e4m3_t, {cutlass_type},
         Kernel_traits, M, K, EXPERTS, TokenPackSize, kGroupSize>
-        (weight, input, out, weight_scale, input_dequant_scale, tokens, max_tokens, stream);
+        (weight, input, out, weight_scale, input_dequant_scale, tokens, max_tokens, stream, max_tokens_per_expert);
 }}
 """
 
@@ -116,6 +118,10 @@ gemm_case = [
     [7168, 3584, 7, 16384, 128],  # num_max_dispatch_tokens_per_rank=256
     [7168, 7168, 7, 20480, 128],  # num_max_dispatch_tokens_per_rank=320
     [7168, 3584, 7, 20480, 128],  # num_max_dispatch_tokens_per_rank=320
+    [3072, 1536, 128, 0, 128],
+    [1536, 1536, 128, 0, 128],
+    [1536, 768, 128, 0, 128],
+    [768, 1536, 128, 0, 128],
 ]
 
 dtype = ["BF16"]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
"Grid configuration leads to low SM utilization. Optimize grid_dims.y so that the actual number of effective blocks in experts is very small in most scenarios."
<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications

<!-- Detail the changes made in this pull request. -->

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
