### PR TITLE
change requirements paddleformers==0.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ tqdm
 pynvml
 uvicorn==0.29.0
 fastapi
-paddleformers>=0.3.1
+paddleformers==0.4.0
 redis
 etcd3
 httpx


### PR DESCRIPTION
修改依赖中 paddleformers 版本，固定为0.4.0