### PR TITLE
[Optimize]  update PD scheduler when block not enough

### DIFF
--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -741,8 +741,8 @@ class EngineService:
                         while not self.resource_manager.preallocate_resource_in_p(task):
                             time.sleep(0.005)
                         self.llm_logger.info(f"ask D resource for req_id: {task.request_id}")
-                        is_successful = self.split_connector.send_splitwise_tasks([task], task.idx)
-                        if not is_successful:  # Send request for block ids to D failed
+                        splitwise_task_send_status = self.split_connector.send_splitwise_tasks([task], task.idx)
+                        if not splitwise_task_send_status[task.request_id]:  # Send request for block ids to D failed
                             self.llm_logger.error(f"{task.request_id} send request for block ids to D failed.")
                             self.scheduler.put_results(
                                 [

--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -678,6 +678,13 @@ class EngineService:
         get_request_pool = ThreadPoolExecutor(max_workers=1)
         is_fetching = False
 
+        def _recycle_resources_from_P(tasks, need_delete_tasks):
+            for tmp_task in need_delete_tasks:
+                tasks.remove(tmp_task)
+                # release resource in P
+                self.resource_manager.pre_recycle_resource(tmp_task.request_id)
+            return tasks
+
         def _fetch_request():
             try:
                 nonlocal is_fetching
@@ -723,51 +730,72 @@ class EngineService:
                             # start async preprocess
                             self.resource_manager.apply_async_preprocess(task)
                     need_delete_tasks = []
-                    if envs.FD_OFFLINE_PERF_TEST_FOR_PD:
-                        for task in tasks:
-                            # assure can allocate block ids in P
-                            while not self.resource_manager.preallocate_resource_in_p(task):
-                                time.sleep(0.005)
-                            self.llm_logger.info(f"ask D resource for req_id: {task.request_id}")
-                            while True:
-                                self.split_connector.send_splitwise_tasks([task], task.idx)
-                                status, msg = self.split_connector.check_decode_allocated(task)
-                                if not status:
-                                    self.llm_logger.error(f"{task.request_id} ask D resource failed, try again.")
-                                    time.sleep(0.05)
-                                else:
-                                    break
-                    else:
-                        for task in tasks:
-                            # assure can allocate block ids in P
-                            while not self.resource_manager.preallocate_resource_in_p(task):
-                                self.llm_logger.info("wait for preallocate_resource_in_p")
-                                time.sleep(0.005)
-                            self.llm_logger.info(f"ask D resource for req_id: {task.request_id}")
-                            self.split_connector.send_splitwise_tasks([task], task.idx)
-
-                        for task in tasks:
-                            if self.cfg.scheduler_config.splitwise_role != "mixed":
-                                # assure fetch block ids from D
-                                status, msg = self.split_connector.check_decode_allocated(task)
-                                if not status:
-                                    self.llm_logger.error(f"{task.request_id} prefill failed with msg:{msg}.")
-                                    self.scheduler.put_results(
-                                        [
-                                            RequestOutput(
-                                                request_id=task.request_id,
-                                                finished=True,
-                                                error_code=500,
-                                                error_msg=msg,
-                                            )
-                                        ]
+                    for task in tasks:
+                        if self.resource_manager.has_existed_request(task.request_id):
+                            self.llm_logger.error(
+                                f"request_id: {task.request_id} has been added to scheduler, recieved requests with same request_id."
+                            )
+                            need_delete_tasks.append(task)
+                            continue
+                        # assure can allocate block ids in P
+                        while not self.resource_manager.preallocate_resource_in_p(task):
+                            time.sleep(0.005)
+                        self.llm_logger.info(f"ask D resource for req_id: {task.request_id}")
+                        is_successful = self.split_connector.send_splitwise_tasks([task], task.idx)
+                        if not is_successful:  # Send request for block ids to D failed
+                            self.llm_logger.error(f"{task.request_id} send request for block ids to D failed.")
+                            self.scheduler.put_results(
+                                [
+                                    RequestOutput(
+                                        request_id=task.request_id,
+                                        finished=True,
+                                        error_code=500,
+                                        error_msg="send request for block ids to D failed",
                                     )
-                                    need_delete_tasks.append(task)
-                                    continue
-                    for tmp_task in need_delete_tasks:
-                        tasks.remove(tmp_task)
-                        # release resource in P
-                        self.resource_manager.pre_recycle_resource(tmp_task.request_id)
+                                ]
+                            )
+                            need_delete_tasks.append(task)
+                    tasks = _recycle_resources_from_P(tasks, need_delete_tasks)
+                    # wait until resource is available from D
+                    start_wait_time = time.time()
+                    not_got_blocks_from_d_list = [task for task in tasks]
+                    failed_get_block_id_task_set = set()
+                    repeated_task_set = set()
+                    while not_got_blocks_from_d_list:
+                        for task in tasks:
+                            if task not in not_got_blocks_from_d_list:  # has got block ids continue
+                                continue
+                            status, msg = self.split_connector.check_decode_allocated(task)
+                            if not status:
+                                self.llm_logger.error(f"{task.request_id} ask D resource failed, due to {msg}")
+                                if msg == "Add task repeated" or msg == "timeout":
+                                    if msg == "Add task repeated":
+                                        repeated_task_set.add(task)
+                                    not_got_blocks_from_d_list.remove(task)
+                                    failed_get_block_id_task_set.add(task)
+                            else:
+                                self.llm_logger.info(f"{task.request_id} get blocks from D successful")
+                                not_got_blocks_from_d_list.remove(task)
+                        if not not_got_blocks_from_d_list:
+                            break
+                        if time.time() - start_wait_time > envs.FD_GET_BLOCK_FROM_D_TIMEOUT:
+                            break
+                        else:
+                            time.sleep(envs.FD_REQUEST_BLOCK_TO_D_INTERVAL)
+                    failed_get_block_id_task_set.update(not_got_blocks_from_d_list)
+                    for failed_task in failed_get_block_id_task_set:
+                        if failed_task not in repeated_task_set:
+                            self.scheduler.put_results(
+                                [
+                                    RequestOutput(
+                                        request_id=failed_task.request_id,
+                                        finished=True,
+                                        error_code=500,
+                                        error_msg="ask D resource failed",
+                                    )
+                                ]
+                            )
+                    tasks = _recycle_resources_from_P(tasks, failed_get_block_id_task_set)
                 if self.cfg.scheduler_config.splitwise_role == "prefill":
                     # to send cache info to cache messager
                     if tasks:
@@ -777,7 +805,9 @@ class EngineService:
                         finished_ids, delete_tasks_list = [], []
                         while need_check_req_ids:
                             finished_ids.extend(self.engine_worker_queue.get_finished_add_cache_task_req())
-                            self.llm_logger.info(f"get_finished_add_cache_task_req: {finished_ids}")
+                            self.llm_logger.info(
+                                f"need_check_req_ids {need_check_req_ids} get_finished_add_cache_task_req: {finished_ids}"
+                            )
                             if finished_ids:
                                 for task in tasks:
                                     result = self.resource_manager.waiting_async_process(task)
@@ -792,6 +822,7 @@ class EngineService:
                                                 )
                                             ]
                                         )
+                                        need_check_req_ids.remove(task.request_id)
                                         delete_tasks_list.append(task)
                                     elif result is False:
                                         if task.request_id in finished_ids:
@@ -1120,6 +1151,15 @@ class EngineService:
                 is_success = False
 
                 if envs.ENABLE_V1_KVCACHE_SCHEDULER:
+                    if self.resource_manager.has_existed_request(task.request_id):
+                        self.llm_logger.error(
+                            f"request_id: {task.request_id} has been added to scheduler, can not add it again."
+                        )
+                        task.error_msg = "Add task repeated"
+                        task.error_code = 501
+                        self.split_connector.send_cache_info_to_prefill([task])
+                        processed_indices.append(idx)
+                        continue
                     if self.resource_manager.preallocate_resource_in_d(task):
                         self.llm_logger.info(f"Resource available, processing task {task.request_id}")
                         self.split_connector.send_cache_info_to_prefill([task])

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -202,6 +202,18 @@ class ResourceManagerV1(ResourceManager):
         if self.config.scheduler_config.splitwise_role == "decode":
             self.preallocated_requests_timestamp = {}
             threading.Thread(target=self._monitor_decode_kv_block_recycling, daemon=True).start()
+        self.init_reserve_output_block_num = (
+            envs.FD_RESERVE_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL
+        )  # int
+        self.decay_output_block_num = (
+            envs.FD_RESERVE_DECAY_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL
+        )  # float
+        self.min_reserve_output_block_num = (
+            envs.FD_RESERVE_MIN_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL
+        )  # int
+        self.current_reserve_output_block_num = self.init_reserve_output_block_num
+        self.current_reserve_output_block_num_float = self.init_reserve_output_block_num
+        self.can_relax_prefill_strategy = True
 
     def _monitor_decode_kv_block_recycling(self):
         while True:
@@ -317,6 +329,9 @@ class ResourceManagerV1(ResourceManager):
                 # The request can be scheduled.
                 can_schedule = True
                 break
+        self.current_reserve_output_block_num = self.init_reserve_output_block_num
+        self.current_reserve_output_block_num_float = self.init_reserve_output_block_num
+        self.can_relax_prefill_strategy = False
         return can_schedule
 
     def _update_mm_hashes(self, request):
@@ -529,6 +544,19 @@ class ResourceManagerV1(ResourceManager):
                 return True
         return False
 
+    def _get_can_schedule_prefill_threshold_block(self, request, num_chunk_new_block):
+        if self.can_relax_prefill_strategy:
+            can_schedule_block_num_threshold = num_chunk_new_block
+        else:
+            can_schedule_block_num_threshold = (
+                request.need_prefill_tokens + self.config.cache_config.block_size - 1
+            ) // self.config.cache_config.block_size + len(self.running) * self.current_reserve_output_block_num
+            if self.config.speculative_config.method is not None:
+                can_schedule_block_num_threshold = min(
+                    can_schedule_block_num_threshold + 1, self.config.cache_config.max_block_num_per_seq
+                )
+        return can_schedule_block_num_threshold
+
     def schedule(self):
         """
         Try to pull a batch of requests from the waiting queue and schedule them.
@@ -712,8 +740,11 @@ class ResourceManagerV1(ResourceManager):
 
                         num_new_tokens = self._get_num_new_tokens(request, token_budget)
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
+                        can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
+                            request, num_new_block
+                        )
                         # Allocate blocks to prefill
-                        if self.cache_manager.can_allocate_gpu_blocks(num_new_block):
+                        if self.cache_manager.can_allocate_gpu_blocks(can_schedule_block_num_threshold):
                             if not request.get("skip_allocate", False):
                                 request.block_tables.extend(self.cache_manager.allocate_gpu_blocks(num_new_block))
                             self.waiting.popleft()
@@ -758,8 +789,11 @@ class ResourceManagerV1(ResourceManager):
                                 break
                         num_new_tokens = self._get_num_new_tokens(request, token_budget)
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
+                        can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
+                            request, num_new_block
+                        )
                         # Allocate blocks to prefill
-                        if self.cache_manager.can_allocate_gpu_blocks(num_new_block):
+                        if self.cache_manager.can_allocate_gpu_blocks(can_schedule_block_num_threshold):
                             if not request.get("skip_allocate", False):
                                 request.block_tables.extend(self.cache_manager.allocate_gpu_blocks(num_new_block))
                             self.waiting.popleft()
@@ -785,6 +819,14 @@ class ResourceManagerV1(ResourceManager):
 
             if scheduled_reqs:
                 llm_logger.debug(f"schedued_reqs: {scheduled_reqs}")
+                self.current_reserve_output_block_num_float -= self.decay_output_block_num
+                self.current_reserve_output_block_num = max(
+                    int(self.current_reserve_output_block_num_float),
+                    self.min_reserve_output_block_num,
+                    0,
+                )
+                if self.current_reserve_output_block_num == 0:
+                    self.can_relax_prefill_strategy = True
 
             self.update_metrics()
 
@@ -1074,7 +1116,10 @@ class ResourceManagerV1(ResourceManager):
                 return False
             if self.available_batch() == 0:
                 return False
-            if not self.cache_manager.can_allocate_gpu_blocks(need_prealloc_prefill_blocks):
+            can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
+                request, need_prealloc_prefill_blocks
+            )
+            if not self.cache_manager.can_allocate_gpu_blocks(can_schedule_block_num_threshold):
                 return False
 
             request.block_tables = self.cache_manager.allocate_gpu_blocks(need_prealloc_prefill_blocks)

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -1089,6 +1089,14 @@ class ResourceManagerV1(ResourceManager):
             self.preallocated_requests_timestamp[request.request_id] = time.time()
         return True
 
+    def has_existed_request(self, request_id):
+        """
+        Whether a request with the given request_id has been added to the scheduler.
+        """
+        if request_id in self.requests:
+            return True
+        return False
+
     def has_resource_for_prefilled_req(self, request_id: str):
         """
         Check whether there are enough slot and gpu resource for the prefilled request,

--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -154,7 +154,19 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "FD_TOKEN_PROCESSOR_HEALTH_TIMEOUT": lambda: int(os.getenv("FD_TOKEN_PROCESSOR_HEALTH_TIMEOUT", "120")),
     "FD_OUTPUT_TOKEN_HANG_TIMEOUT": lambda: int(os.getenv("FD_OUTPUT_TOKEN_HANG_TIMEOUT", "60")),
     # Timout for D response in PD disaggregation
-    "FD_GET_RESPONSE_FROM_D_TIMEOUT": lambda: int(os.getenv("FD_GET_RESPONSE_FROM_D_TIMEOUT", "5")),
+    "FD_GET_MESSAGE_FROM_D_TIMEOUT": lambda: int(os.getenv("FD_GET_MESSAGE_FROM_D_TIMEOUT", "5")),
+    "FD_GET_BLOCK_FROM_D_TIMEOUT": lambda: int(os.getenv("FD_GET_BLOCK_FROM_D_TIMEOUT", "30")),
+    "FD_REQUEST_BLOCK_TO_D_INTERVAL": lambda: int(os.getenv("FD_REQUEST_BLOCK_TO_D_INTERVAL", "2")),
+    # Reserve output blocks for decoding requests when schedule new prefill requests
+    "FD_RESERVE_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL": lambda: int(
+        os.getenv("FD_RESERVE_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL", "16")
+    ),
+    "FD_RESERVE_DECAY_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL": lambda: float(
+        os.getenv("FD_RESERVE_DECAY_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL", "0.025")
+    ),
+    "FD_RESERVE_MIN_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL": lambda: int(
+        os.getenv("FD_RESERVE_MIN_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL", "0")
+    ),
 }
 
 

--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -153,6 +153,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Timeout for token processor health check
     "FD_TOKEN_PROCESSOR_HEALTH_TIMEOUT": lambda: int(os.getenv("FD_TOKEN_PROCESSOR_HEALTH_TIMEOUT", "120")),
     "FD_OUTPUT_TOKEN_HANG_TIMEOUT": lambda: int(os.getenv("FD_OUTPUT_TOKEN_HANG_TIMEOUT", "60")),
+    # Timout for D response in PD disaggregation
+    "FD_GET_RESPONSE_FROM_D_TIMEOUT": lambda: int(os.getenv("FD_GET_RESPONSE_FROM_D_TIMEOUT", "5")),
 }
 
 

--- a/fastdeploy/splitwise/splitwise_connector.py
+++ b/fastdeploy/splitwise/splitwise_connector.py
@@ -129,6 +129,9 @@ class SplitwiseConnector:
             sock.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 60)
             sock.setsockopt(zmq.TCP_KEEPALIVE_INTVL, 10)
 
+            if envs.FD_ENABLE_INTERNAL_ADAPTER:
+                sock.setsockopt(zmq.IMMEDIATE, 1)
+
             sock.connect(f"tcp://{addr}")
 
             self.push_sockets[addr] = sock
@@ -142,7 +145,7 @@ class SplitwiseConnector:
     def _send_message(self, addr, msg_type: str, payload):
         if not addr:
             return
-
+        is_successful = True
         try:
             self.logger.info(f"Sent {msg_type} to {addr}")
             message = self._serialize_message(msg_type, payload)
@@ -150,21 +153,27 @@ class SplitwiseConnector:
             try:
 
                 sock = self._get_push_socket(addr)
-                sock.send_multipart([b"", message])
-
+                if envs.FD_ENABLE_INTERNAL_ADAPTER:
+                    sock.send_multipart([b"", message], flags=zmq.NOBLOCK)
+                else:
+                    sock.send_multipart([b"", message])
                 self.logger.info(f"Sent {msg_type} to {addr}")
 
             except ConnectionError:
                 self.logger.warning(f"Connection to {addr} not established")
+                is_successful = False
             except zmq.Again:
                 self.logger.warning(f"Send queue full for {addr}")
+                is_successful = False
             except Exception as e:
                 self.logger.error(f"Send to {addr} failed: {e}, {str(traceback.format_exc())}")
                 main_process_metrics.send_cache_failed_num.inc()
                 self._close_connection(addr)
+                is_successful = False
 
         except Exception as e:
             self.logger.error(f"Message preparation failed: {e}")
+        return is_successful
 
     def _close_connection(self, addr):
         """
@@ -184,6 +193,7 @@ class SplitwiseConnector:
         """
         addr = None
         decode_diagg = None
+        splitwise_task_send_status = {}
         for task in tasks:
             if task.disaggregate_info is None:
                 continue
@@ -206,9 +216,11 @@ class SplitwiseConnector:
                 task.disaggregate_info["cache_info"]["rdma"]["current_id"] = current_id
                 task.disaggregate_info["role"] = "decode"
                 self.logger.debug(f"send task to coupled instance, {addr}, {task}")
-                self._send_message(addr, "prefill", [task])
+                is_successful = self._send_message(addr, "prefill", [task])
+                splitwise_task_send_status[task.request_id] = is_successful
                 task.disaggregate_info["cache_info"] = decode_diagg
             task.disaggregate_info["role"] = "prefill"
+        return splitwise_task_send_status
 
     def send_splitwise_tasks_innode(self, tasks, port):
         """
@@ -239,6 +251,7 @@ class SplitwiseConnector:
         """
         send first token to specific port
         """
+        is_successful = True
         if not isinstance(tasks_list, list):
             tasks_list = [tasks_list]
         self.logger.info(f"send first token to decode, {[x.request_id for x in tasks_list]}")
@@ -250,7 +263,8 @@ class SplitwiseConnector:
         else:
             node = f"{prefill_msg['cache_info']['rdma']['ip']}:{prefill_msg['cache_info']['rdma']['port']}"
             self.logger.info(f"send first token to port {node} decode")
-            self._send_message(node, "decode", tasks_list)
+            is_successful = self._send_message(node, "decode", tasks_list)
+        return is_successful
 
     def create_connection(self, port):
         """
@@ -280,7 +294,7 @@ class SplitwiseConnector:
             return True, ""
         while self.current_request_ids[task.request_id] == "init":
             time.sleep(0.001)
-            if time.time() - start_time > 30:
+            if time.time() - start_time > envs.FD_GET_RESPONSE_FROM_D_TIMEOUT:
                 del self.current_request_ids[task.request_id]
                 return False, "timeout"
         msg = self.current_request_ids[task.request_id]

--- a/fastdeploy/splitwise/splitwise_connector.py
+++ b/fastdeploy/splitwise/splitwise_connector.py
@@ -294,7 +294,7 @@ class SplitwiseConnector:
             return True, ""
         while self.current_request_ids[task.request_id] == "init":
             time.sleep(0.001)
-            if time.time() - start_time > envs.FD_GET_RESPONSE_FROM_D_TIMEOUT:
+            if time.time() - start_time > envs.FD_GET_MESSAGE_FROM_D_TIMEOUT:
                 del self.current_request_ids[task.request_id]
                 return False, "timeout"
         msg = self.current_request_ids[task.request_id]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
当 D 实例kv cache block资源被耗尽时，此时D正在解码的请求获取不到 block 会走重调度。而P仍在不断申请 D 实例资源，不可获取时会即时失败。若申请到D 资源又会进一步加剧 D 的block 资源不足导致更多的请求被重调度。

该 PR 做了如下修改，降低 P在 D block 不足时加剧资源恶化的情况，以及增强 PD 间交互的鲁棒性：
1. PD 分离下优化调度策略，D 实例给 P 分配资源时，预留一部分 block 给当前正在解码的每条请求（由环境变量FD_RESERVE_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL控制，默认值 16）。如果剩余资源减去给 decode预留的资源不足以分配给 P 时候，给 P 返回分配 block 失败。
2. P 收到分配 block 失败后，不立即重调度。而是最多等待一定时间（由环境变量FD_GET_BLOCK_FROM_D_TIMEOUT控制，默认 30s）。每隔一定时间（由FD_REQUEST_BLOCK_TO_D_INTERVAL控制，默认 2s)重新向 D 尝试申请一次。
3. 由于 P如果不能及时获取 block会重试多次向 D 申请 block，增加PD 间的通信时效性和成功性的判断，防止 D 收到过期的 P 请求。如D 实例重启后，却还收到 P 之前残留在 zmq 缓冲区未能成功发出的请求。（通过设置sock.setsockopt(zmq.IMMEDIATE, 1)以及给 split_connector 有关函数增加返回值进行判断）
4. 修复多模异步下载 feature 失败时陷入死循环的 bug。
5. 增加对重复req_id请求的鲁棒性处理。



## Modifications

None

## Usage or Command

None

## Accuracy Tests

None

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
