### PR TITLE
[Graph Optimization] Add `full_cuda_graph` to control subgraph split

### DIFF
--- a/fastdeploy/model_executor/layers/attention/append_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/append_attn_backend.py
@@ -164,6 +164,20 @@ class AppendAttentionBackend(AttentionBackend):
 
         self.rank, self.device_id = init_rank_and_device_id(fd_config)
         self.use_output = not fd_config.graph_opt_config.full_cuda_graph
+        if self.use_output:
+            flag = "FLAGS_cuda_graph_blacklist"
+            paddle.set_flags(
+                {
+                    flag: ",".join(
+                        list(
+                            set(
+                                paddle.get_flags(flag)[flag].split(",")
+                                + ["custom_op.static_op_append_attention_with_output_"]
+                            )
+                        )
+                    )
+                }
+            )
         self.fd_config = fd_config
 
     def init_attention_metadata(self, forward_meta: ForwardMeta):

--- a/tests/ce/deploy/ernie45t_21b_cinn_fp8.yaml
+++ b/tests/ce/deploy/ernie45t_21b_cinn_fp8.yaml
@@ -6,3 +6,4 @@ graph_optimization_config:
   graph_opt_level: 2
   sot_warmup_sizes: [2,16,32,64]
   use_cudagraph: True
+  full_cuda_graph: False

--- a/tests/ce/deploy/ernie45t_21b_cinn_wint4.yaml
+++ b/tests/ce/deploy/ernie45t_21b_cinn_wint4.yaml
@@ -6,3 +6,4 @@ graph_optimization_config:
   graph_opt_level: 2
   sot_warmup_sizes: [2,16,32,64]
   use_cudagraph: True
+  full_cuda_graph: False

--- a/tests/ce/deploy/ernie45t_21b_sot_fp8.yaml
+++ b/tests/ce/deploy/ernie45t_21b_sot_fp8.yaml
@@ -6,3 +6,4 @@ graph_optimization_config:
   graph_opt_level: 1
   sot_warmup_sizes: [2,16,32,64]
   use_cudagraph: True
+  full_cuda_graph: False

--- a/tests/ce/deploy/ernie45t_21b_sot_wint4.yaml
+++ b/tests/ce/deploy/ernie45t_21b_sot_wint4.yaml
@@ -6,3 +6,4 @@ graph_optimization_config:
   graph_opt_level: 1
   sot_warmup_sizes: [2,16,32,64]
   use_cudagraph: True
+  full_cuda_graph: False

--- a/tests/graph_optimization/test_static_graph_cuda_graph_split.py
+++ b/tests/graph_optimization/test_static_graph_cuda_graph_split.py
@@ -89,7 +89,9 @@ class TestStaticGraphCUDAGraphSplit(unittest.TestCase):
     def test(self):
         """Run test case"""
         # Set FastDeploy config
-        graph_opt_config = GraphOptimizationConfig({"use_cudagraph": True, "graph_opt_level": 1})
+        graph_opt_config = GraphOptimizationConfig(
+            {"use_cudagraph": True, "graph_opt_level": 1, "full_cuda_graph": False}
+        )
         scheduler_config = SchedulerConfig({"max_num_seqs": 1})
         graph_opt_config._set_cudagraph_sizes(max_capture_size=scheduler_config.max_num_seqs)
         graph_opt_config.init_with_cudagrpah_size(max_capture_size=scheduler_config.max_num_seqs)


### PR DESCRIPTION
## Motivation
通过选项 `full_cuda_graph` 开启子图切分

## Modifications
- 添加一个环境变量设置
- 给单测加上 `full_cuda_graph`

## Usage or Command
NO NEED

## Accuracy Tests
NO NEED

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
