### PR TITLE
[BugFix] fix(examples): comment out stop.sh to avoid error when script is missing

### DIFF
--- a/examples/cache_storage/run.sh
+++ b/examples/cache_storage/run.sh
@@ -7,7 +7,7 @@ export FD_DEBUG=1
 
 unset http_proxy && unset https_proxy
 rm -rf log_*
-bash stop.sh
+#bash stop.sh
 
 source ./utils.sh
 


### PR DESCRIPTION
### Motivation
In the current `examples/cache_storage/run.sh`, the script attempts to call `stop.sh` unconditionally. In certain environments where `stop.sh` is not provided in the folder, the entire startup process fails with an error. This PR comments out that line to ensure the inference service starts smoothly.

### Modifications
- Commented out `bash stop.sh` in `examples/cache_storage/run.sh`.

### Usage or Command
```bash
cd examples/cache_storage && bash run.sh
```
### Accuracy Tests
N/A (This is a shell script fix and does not affect model inference accuracy.)
### Checklist
- [x] Add at least a tag in the PR title.
  - Tag list: [[FDConfig],[APIServer],[Engine], [Scheduler], [PD Disaggregation], [Executor], [Graph Optimization], [Speculative Decoding], [RL], [Models], [Quantization], [Loader], [OP], [KVCache], [DataProcessor], [BugFix], [Docs], [CI], [Optimization], [Feature], [Benchmark], [Others], [XPU], [HPU], [GCU], [DCU], [Iluvatar], [Metax]]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run pre-commit before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the release branch, make sure the PR has been submitted to the develop branch, then cherry-pick it to the release branch with the [Cherry-Pick] PR tag.