### PR TITLE
[CI] Remove EB_VL model accuracy validation

### DIFF
--- a/tests/ci_use/EB_VL_Lite/test_EB_VL_Lite_serving.py
+++ b/tests/ci_use/EB_VL_Lite/test_EB_VL_Lite_serving.py
@@ -22,7 +22,6 @@ import time
 
 import openai
 import pytest
-import requests
 
 tests_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, tests_dir)
@@ -179,40 +178,6 @@ def consistent_payload():
         "top_p": 0,  # fix top_p to reduce randomness
         "seed": 13,  # fixed random seed
     }
-
-
-# ==========================
-# Consistency test for repeated runs with fixed payload
-# ==========================
-def test_consistency_between_runs(api_url, headers, consistent_payload):
-    """
-    Test that result is same as the base result.
-    """
-    # request
-    resp1 = requests.post(api_url, headers=headers, json=consistent_payload)
-    assert resp1.status_code == 200
-    result1 = resp1.json()
-    content1 = (
-        result1["choices"][0]["message"]["reasoning_content"]
-        + "</think>"
-        + result1["choices"][0]["message"]["content"]
-    )
-    file_res_temp = "ernie-4_5-vl"
-    f_o = open(file_res_temp, "a")
-    f_o.writelines(content1)
-    f_o.close()
-
-    # base result
-    base_path = os.getenv("MODEL_PATH")
-    if base_path:
-        base_file = os.path.join(base_path, "ernie-4_5-vl-base-tp2-dev-0115")
-    else:
-        base_file = "ernie-4_5-vl-base-tp2-dev-0113"
-    with open(base_file, "r") as f:
-        content2 = f.read()
-
-    # Verify that result is same as the base result
-    assert content1 == content2
 
 
 # ==========================

--- a/tests/e2e/test_EB_VL_Lite_serving.py
+++ b/tests/e2e/test_EB_VL_Lite_serving.py
@@ -180,40 +180,6 @@ def consistent_payload():
     }
 
 
-# ==========================
-# Consistency test for repeated runs with fixed payload
-# ==========================
-def test_consistency_between_runs(api_url, headers, consistent_payload):
-    """
-    Test that result is same as the base result.
-    """
-    # request
-    resp1 = requests.post(api_url, headers=headers, json=consistent_payload)
-    assert resp1.status_code == 200
-    result1 = resp1.json()
-    content1 = (
-        result1["choices"][0]["message"]["reasoning_content"]
-        + "</think>"
-        + result1["choices"][0]["message"]["content"]
-    )
-    file_res_temp = "ernie-4_5-vl"
-    f_o = open(file_res_temp, "a")
-    f_o.writelines(content1)
-    f_o.close()
-
-    # base result
-    base_path = os.getenv("MODEL_PATH")
-    if base_path:
-        base_file = os.path.join(base_path, "ernie-4_5-vl-base-tp2-dev-0115")
-    else:
-        base_file = "ernie-4_5-vl-base-tp2-dev-0113"
-    with open(base_file, "r") as f:
-        content2 = f.read()
-
-    # Verify that result is same as the base result
-    assert content1 == content2
-
-
 def test_with_metadata(api_url, headers, consistent_payload):
     """
     Test that result is same as the base result.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

The accuracy validation for the EB_VL 28B model in unit tests has been repeatedly impacted by frequent changes in Paddle core and FastDeploy operators.
These upstream modifications often introduce expected numerical differences, causing CI failures that are unrelated to functional regressions.

Previously, the mitigation strategy was to continuously adapt and update the accuracy baselines to keep CI unblocked.
However, this approach has become unsustainable and no longer provides effective regression protection, as most failures are resolved by baseline updates rather than identifying real issues.

To avoid persistent CI instability and meaningless maintenance overhead, it is necessary to remove this accuracy validation.

## Modifications

- Removed the accuracy validation for the EB_VL 28B model from unit tests.
- Eliminated related baseline data and verification logic associated with this check.
- Ensured CI can proceed without being blocked by non-actionable numerical differences.


## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
