### PR TITLE
[Graph Optimization] remove static_op_get_block_shape_and_split_kv_block from cudagraph

### DIFF
--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -924,6 +924,10 @@ class GraphOptimizationConfig:
         self.use_unique_memory_pool: bool = True
         """ Whether to use cudagraph for draft model."""
         self.draft_model_use_cudagraph: bool = False
+        """ Maximum CUDA Graph capture size for static graph mode.
+        Recommend 512 for small models (e.g., ERNIE45T 0.3B) and 128 for massive models (e.g., 300B).
+        """
+        self.max_capture_shape_dy2st: int = 512
 
         # CINN Config ...
         if args is not None:
@@ -1650,8 +1654,7 @@ class FDConfig:
             max_capture_shape = min(512, max_capture_shape)
 
         if self.graph_opt_config.graph_opt_level > 0:
-            # TODO(DrRyanHuang): Tune this value or expose it as a CLI argument.
-            max_capture_shape = 512
+            max_capture_shape = graph_opt_config.max_capture_shape_dy2st
 
         if self.graph_opt_config.cudagraph_capture_sizes is None:
             dec_token_per_query_per_step = (

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -1649,6 +1649,10 @@ class FDConfig:
         else:
             max_capture_shape = min(512, max_capture_shape)
 
+        if self.graph_opt_config.graph_opt_level > 0:
+            # TODO(DrRyanHuang): Tune this value or expose it as a CLI argument.
+            max_capture_shape = 512
+
         if self.graph_opt_config.cudagraph_capture_sizes is None:
             dec_token_per_query_per_step = (
                 self.speculative_config.num_speculative_tokens + 1

--- a/fastdeploy/model_executor/graph_optimization/graph_optimization_backend.py
+++ b/fastdeploy/model_executor/graph_optimization/graph_optimization_backend.py
@@ -125,10 +125,6 @@ class GraphOptBackend:
                 backend,
             ).__get__(self.runnable.__self__)
 
-        self.cudagraph_switch_threshold = (
-            1024 if self.fd_config.graph_opt_config.graph_opt_level > 0 else self.max_captre_size
-        )
-
     def __call__(self, **kwargs):
         if not self.fd_config.graph_opt_config.use_cudagraph:
             return self.runnable(**kwargs)
@@ -143,7 +139,7 @@ class GraphOptBackend:
             # only count the actual load.
             self._debug_count_total_step += 1
 
-        if (not kwargs["forward_meta"].step_use_cudagraph) or (real_shape > self.cudagraph_switch_threshold):
+        if (not kwargs["forward_meta"].step_use_cudagraph) or (real_shape > self.max_captre_size):
             return self.dy_runnable(**kwargs)
         else:
             self._debug_count_cudagraph_replay += 1

--- a/fastdeploy/model_executor/layers/attention/append_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/append_attn_backend.py
@@ -327,9 +327,9 @@ class AppendAttentionBackend(AttentionBackend):
             # 3. generate output tensor of different dtypes
             if out_scale > 0.0:
                 if abs(quant_max_bound - 127) < 0.000001:
-                    res = paddle.zeros([token_nums, q_num_heads * head_dims], dtype="int8")
+                    res = paddle.empty([token_nums, q_num_heads * head_dims], dtype="int8")
                 elif abs(quant_max_bound - 448) < 0.000001:
-                    res = paddle.zeros([token_nums, q_num_heads * head_dims], dtype="float8_e4m3fn")
+                    res = paddle.empty([token_nums, q_num_heads * head_dims], dtype="float8_e4m3fn")
                 else:
                     raise NotImplementedError("Only supported attr of quant_max_bound in ['127', '448'].")
             else:

--- a/fastdeploy/model_executor/layers/attention/append_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/append_attn_backend.py
@@ -172,7 +172,10 @@ class AppendAttentionBackend(AttentionBackend):
                         list(
                             set(
                                 paddle.get_flags(flag)[flag].split(",")
-                                + ["custom_op.static_op_append_attention_with_output_"]
+                                + [
+                                    "custom_op.static_op_append_attention_with_output_",
+                                    "custom_op.static_op_get_block_shape_and_split_kv_block",
+                                ]
                             )
                         )
                     )
@@ -324,13 +327,13 @@ class AppendAttentionBackend(AttentionBackend):
             # 3. generate output tensor of different dtypes
             if out_scale > 0.0:
                 if abs(quant_max_bound - 127) < 0.000001:
-                    res = paddle.empty([token_nums, q_num_heads * head_dims], dtype="int8")
+                    res = paddle.zeros([token_nums, q_num_heads * head_dims], dtype="int8")
                 elif abs(quant_max_bound - 448) < 0.000001:
-                    res = paddle.empty([token_nums, q_num_heads * head_dims], dtype="float8_e4m3fn")
+                    res = paddle.zeros([token_nums, q_num_heads * head_dims], dtype="float8_e4m3fn")
                 else:
                     raise NotImplementedError("Only supported attr of quant_max_bound in ['127', '448'].")
             else:
-                res = paddle.empty([token_nums, q_num_heads * head_dims], dtype=D_type)
+                res = paddle.zeros([token_nums, q_num_heads * head_dims], dtype=D_type)
 
             res = append_attention_with_output(
                 qkv,

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1590,7 +1590,11 @@ class GPUModelRunner(ModelRunnerBase):
         )
 
         # Use static graph splitting to isolate incompatible operators from the CUDA Graph. This splits the graph into subgraphs, allowing Prefill, Decode, and Mixed Batches to run compatible parts via CUDA Graph.
-        if self.graph_opt_config.graph_opt_level > 0 and not self.graph_opt_config.full_cuda_graph:
+        if (
+            hasattr(self, "graph_opt_config")
+            and self.graph_opt_config.graph_opt_level > 0
+            and not self.graph_opt_config.full_cuda_graph
+        ):
             self.forward_meta.step_use_cudagraph = True
 
         # Set forward_meta.is_dummy_or_profile_run to True to skip init_kv_signal_per_query for attention backends

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1589,6 +1589,10 @@ class GPUModelRunner(ModelRunnerBase):
             else only_decode_use_cudagraph and self.forward_meta.ids_remove_padding.shape[0] > 0
         )
 
+        # Use static graph splitting to isolate incompatible operators from the CUDA Graph. This splits the graph into subgraphs, allowing Prefill, Decode, and Mixed Batches to run compatible parts via CUDA Graph.
+        if self.graph_opt_config.graph_opt_level > 0 and not self.graph_opt_config.full_cuda_graph:
+            self.forward_meta.step_use_cudagraph = True
+
         # Set forward_meta.is_dummy_or_profile_run to True to skip init_kv_signal_per_query for attention backends
         self.forward_meta.is_dummy_or_profile_run = is_dummy_or_profile_run
 

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1592,6 +1592,7 @@ class GPUModelRunner(ModelRunnerBase):
         # Use static graph splitting to isolate incompatible operators from the CUDA Graph. This splits the graph into subgraphs, allowing Prefill, Decode, and Mixed Batches to run compatible parts via CUDA Graph.
         if (
             hasattr(self, "graph_opt_config")
+            and self.use_cudagraph
             and self.graph_opt_config.graph_opt_level > 0
             and not self.graph_opt_config.full_cuda_graph
         ):

--- a/tests/e2e/test_EB_VL_Lite_sot_serving.py
+++ b/tests/e2e/test_EB_VL_Lite_sot_serving.py
@@ -91,7 +91,7 @@ def setup_and_run_server():
         "--reasoning-parser",
         "ernie-45-vl",
         "--graph-optimization-config",
-        '{"graph_opt_level": 2, "use_cudagraph": true, "full_cuda_graph": false}',
+        '{"graph_opt_level": 2, "use_cudagraph": true, "full_cuda_graph": true}',  # TODO(DrRyanHuang): we will support full_cuda_graph=false for VL model in next PR
     ]
 
     # Start subprocess in new process group


### PR DESCRIPTION
## Motivation

由于 `step_use_cudagraph` 的控制，动态图+CUDAGraph 只在 Decode 的时候开启 CUDAGraph(代码如下)，而 SOT 动转静也是一样的，**纯 Prefill** + **Prefill+Decode混合Batch** 都跑在了纯动态图。因此本PR打开开关，当是**动转静**且**子图切分模式**时，`step_use_cudagraph` 始终为 `True`

https://github.com/PaddlePaddle/FastDeploy/blob/0e0eaa1c575da8555768b317d6a6b2a8fb0b63c4/fastdeploy/worker/gpu_model_runner.py#L1582-L1590

但此时出现了精度问题，**纯 Prefill** + **Prefill+Decode混合Batch** 存在精度问题

是 `get_block_shape_and_split_kv_block` 这个算子存在 prefill 与 decode 不统一的情况，所以在子图切分的时候，也要把这个算子从 CUDAGraph 中移出去

https://github.com/PaddlePaddle/FastDeploy/blob/0e0eaa1c575da8555768b317d6a6b2a8fb0b63c4/custom_ops/gpu_ops/append_attn/get_block_shape_and_split_kv_block.cu#L313-L315

https://github.com/PaddlePaddle/FastDeploy/blob/0e0eaa1c575da8555768b317d6a6b2a8fb0b63c4/custom_ops/gpu_ops/append_attn/get_block_shape_and_split_kv_block.cu#L388-L390

## Modifications

- 打开 CUDAGraph 开关，当是**动转静**且**子图切分模式**时，`step_use_cudagraph` 始终为 `True`
- 将 `get_block_shape_and_split_kv_block` 添加到 `FLAGS_cuda_graph_blacklist` 中
- 与 #3769 同，将 paddle.empty -> paddle.zeros

## Usage or Command
```
rm -rf log/*

MODEL=/root/paddlejob/tmpspace/huangzihao01/MODEL/ERNIE-4.5-0.3B-Paddle
# MODEL=/root/paddlejob/tmpspace/huangzihao01/MODEL/ERNIE-4.5-21B-A3B-Paddle
# MODEL=/root/paddlejob/tmpspace/huangzihao01/MODEL/ERNIE-4.5-300B-A47B-Paddle

PORT=39899
let MPPPPP=PORT+1
let EWQPPP=PORT+2

# export FLAGS_print_ir=1
export CUDA_VISIBLE_DEVICES=2,3,4,5
# export GLOG_v=6
# export FLAGS_call_stack_level=2

python -m fastdeploy.entrypoints.openai.api_server \
       --model $MODEL \
       --port $PORT \
       --metrics-port $MPPPPP \
       --engine-worker-queue-port $EWQPPP \
       --tensor-parallel-size 4 \
       --max-model-len 32768 \
       --max-num-seqs 128 \
       --graph-optimization-config '{"graph_opt_level": 1, "use_cudagraph":true, "full_cuda_graph": false}' \
       --quantization wint4 \
```

## Accuracy Tests
NO NEED

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
