### PR TITLE
[BugFix] [PD Disaggregation] fix pd_comm_port index out of bound

### DIFF
--- a/fastdeploy/engine/expert_service.py
+++ b/fastdeploy/engine/expert_service.py
@@ -67,13 +67,6 @@ class ExpertService:
         else:
             self.do_profile = False
 
-        if cfg.scheduler_config.splitwise_role != "mixed":
-            if len(self.cfg.cache_config.pd_comm_port) == 1:
-                self.cfg.cache_config.pd_comm_port[0] = (
-                    int(self.cfg.cache_config.pd_comm_port[0]) + local_data_parallel_id
-                )
-            else:
-                self.cfg.cache_config.pd_comm_port = [self.cfg.cache_config.pd_comm_port[local_data_parallel_id]]
         self.cfg.parallel_config.local_data_parallel_id = local_data_parallel_id
         self.engine = EngineService(self.cfg, start_queue)
         if self.cfg.scheduler_config.name == "splitwise":

--- a/fastdeploy/entrypoints/openai/multi_api_server.py
+++ b/fastdeploy/entrypoints/openai/multi_api_server.py
@@ -52,6 +52,7 @@ def start_servers(server_count, server_args, ports, metrics_ports, controller_po
 
         env = os.environ.copy()
         env["FD_LOG_DIR"] = env.get("FD_LOG_DIR", "log") + f"/log_{i}"
+        env["FD_ENABLE_MULTI_API_SERVER"] = "1"
         cmd = [
             sys.executable,
             "-m",

--- a/fastdeploy/splitwise/splitwise_connector.py
+++ b/fastdeploy/splitwise/splitwise_connector.py
@@ -73,8 +73,8 @@ class SplitwiseConnector:
         self.router_socket.setsockopt(zmq.LINGER, 0)
         self.router_socket.setsockopt(zmq.SNDHWM, 1000)
         self.router_socket.setsockopt(zmq.ROUTER_MANDATORY, 1)
-        self.router_socket.bind(f"tcp://*:{self.cfg.cache_config.pd_comm_port[0]}")
-        self.logger.info(f"_init_network: bind {self.cfg.cache_config.pd_comm_port}")
+        self.router_socket.bind(f"tcp://*:{self.cfg.cache_config.pd_comm_port[self.local_data_parallel_id]}")
+        self.logger.info(f"_init_network: bind {self.cfg.cache_config.pd_comm_port[self.local_data_parallel_id]}")
 
         self.poller = zmq.Poller()
         self.poller.register(self.router_socket, zmq.POLLIN)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

在 2.4 分支代码的 DP+EP 并行场景中，构造 cache_info 时会认为 pd_comm_port 未做切分，需要按照 dp rank 取出当前 PD 的 pd_comm_port，而在 PD 分离场景对 pd_comm_port 做了切分处理，并且原地修改了 FDConfig 对象，两者逻辑冲突。

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications

去掉 PD 分离下对 pd_comm_port 的切分处理，改为用 dp_rank 取 pd_comm_port[dp_rank] 的做法。

## Usage or Command

无

## Accuracy Tests

```
{"id":"chatcmpl-1c7dbd9f-93d5-46e9-9e9b-6e4bb37ae347","object":"chat.completion","created":1769149838,"model":"xxx","choices":[{"index":0,"message":{"role":"assistant","content":"用户的问题是“深圳2024年GDP是多少？”，我需要先回顾提供的材料。材料里明确提到“2024年深圳GDP预计突破4.4万亿元”，所以答案应该是4.","multimodal_content":null,"reasoning_content":null,"audio_content":null,"tool_calls":null,"prompt_token_ids":null,"completion_token_ids":null,"prompt_tokens":null,"completion_tokens":null},"logprobs":null,"draft_logprobs":null,"prompt_logprobs":null,"finish_reason":"length","speculate_metrics":null}],"usage":{"prompt_tokens":175,"total_tokens":225,"completion_tokens":50,"prompt_tokens_details":{"cached_tokens":128,"image_tokens":0,"video_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"image_tokens":0}}}
```

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
