### PR TITLE
[BugFix] Fix splitwise example scripts

### DIFF
--- a/examples/splitwise/start_v1_dp2.sh
+++ b/examples/splitwise/start_v1_dp2.sh
@@ -87,3 +87,11 @@ curl -X POST "http://0.0.0.0:${ROUTER_PORT}/v1/chat/completions" \
   "max_tokens": 100,
   "stream": false
 }'
+
+echo "正在停止由本脚本启动的服务..."
+# 根据您的具体端口列表终止
+for port in ${ROUTER_PORT} ${P_PORT} ${D_PORT}; do
+    lsof -ti :$port | xargs kill -9 2>/dev/null
+done
+sleep 3
+echo "服务停止完成。"

--- a/examples/splitwise/start_v1_tp2.sh
+++ b/examples/splitwise/start_v1_tp2.sh
@@ -75,3 +75,11 @@ curl -X POST "http://0.0.0.0:${ROUTER_PORT}/v1/chat/completions" \
   "max_tokens": 100,
   "stream": false
 }'
+
+echo "正在停止由本脚本启动的服务..."
+# 根据您的具体端口列表终止
+for port in ${ROUTER_PORT} ${P_PORT} ${D_PORT}; do
+    lsof -ti :$port | xargs kill -9 2>/dev/null
+done
+sleep 3
+echo "服务停止完成。"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
### 问题一：
如下图所示，第一次执行example里的sh脚本时是成功的，但是再次执行时却会卡住。**
<img width="957" height="635" alt="截屏2026-01-20 13 17 19" src="https://github.com/user-attachments/assets/aac12593-74dd-4601-bd4c-84baa023fe21" />

**通过查询nohup文件得知问题根源是端口已占用，具体内容如下：**
**prefill/decode文件下的nohup文件末尾显示：**
Traceback (most recent call last):
  File "/root/miniconda3/envs/fd_py310/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/root/miniconda3/envs/fd_py310/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/workspace/FastDeploy/fastdeploy/entrypoints/openai/api_server.py", line 798, in <module>
    main()
  File "/workspace/FastDeploy/fastdeploy/entrypoints/openai/api_server.py", line 794, in main
    launch_api_server()
  File "/workspace/FastDeploy/fastdeploy/entrypoints/openai/api_server.py", line 593, in launch_api_server
    raise Exception(f"The parameter `port`:{args.port} is already in use.")
Exception: The parameter `port`:52321 is already in use.
/root/miniconda3/envs/fd_py310/lib/python3.10/multiprocessing/resource_tracker.py:224: UserWarning: resource_tracker: There appear to be 3 leaked shared_memory objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
/root/miniconda3/envs/fd_py310/lib/python3.10/multiprocessing/resource_tracker.py:237: UserWarning: resource_tracker: '/exist_tasks_intra_signal.49129': [Errno 2] No such file or directory: '/exist_tasks_intra_signal.49129'
  warnings.warn('resource_tracker: %r: %s' % (name, e))

**router文件下的nohup文件末尾显示：**
Starting router with args: Namespace(host='0.0.0.0', port=52743, splitwise=True, request_timeout_secs=1800)
INFO:     Started server process [182866]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
ERROR:    [Errno 98] error while attempting to bind on address ('0.0.0.0', 52743): address already in use
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete

**在终端查询端口和进程后发现确实是被之前的router进程占用：**
<img width="941" height="450" alt="截屏2026-01-20 13 32 49" src="https://github.com/user-attachments/assets/43da344c-fe53-4245-b9ed-8f3675dec51c" />

### 问题二：
当wait_for_health陷入失败时而长期陷入死循环时：
<img width="954" height="140" alt="截屏2026-01-20 15 13 32" src="https://github.com/user-attachments/assets/52d117be-c2d4-491b-8270-b12c5fba1562" />

尽管可以通过Ctrl+C中断关闭脚本，但其实server实例已经启动了，并且持续地在后台占用显存（fd_py310是我个人的环境）。
<img width="824" height="237" alt="截屏2026-01-20 15 16 41" src="https://github.com/user-attachments/assets/7df9710d-bee0-4ac0-ac1f-61d52edab58e" />

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications

<!-- Detail the changes made in this pull request. -->

**目前的解决方案 (待更新)：**

1. 手动清除对应端口的进程，但前提是确定是自己进程导致的端口占用。
2. 在脚本末尾添加：
```sh
  echo "正在停止由本脚本启动的服务..."
  # 根据您的具体端口列表终止
  for port in ${ROUTER_PORT} ${P_PORT} ${D_PORT}; do
      lsof -ti :$port | xargs kill -9 2>/dev/null
  done
  sleep 3
  echo "服务停止完成。"
```
这可以确保在相同的端口上反复运行成功。

但这并不是一个根本解决方案，仍然存在以下潜在问题：
1. 在末尾添加的关闭进程命令不够优雅，如果用户卡在脚本执行过程中就退出，仍然需要手动关闭进程避免对显存和端口的占用。
2. splitwise/utils.sh的check_ports和wait_for_health疑似存在缺陷，前者没有发现潜在的端口占用（问题一）；后者存在死循环，可能会导致终端输出卡住，但是却不会阻塞server进程（问题二）。
3. 在问题一中，router进程仍在持续占用着端口，暂不清楚是否有问题

后续继续更新。。
（此外，不用nohup，手动用bash好像最保险）

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

运行`FastDeploy/examples/splitwise/start_v1_tp2.sh`

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
