### PR TITLE
[Graph Optimization] Add `max_capture_shape_prefill` && `cudagraph_capture_sizes_prefill`

### DIFF
--- a/benchmarks/yaml/eb45-vl-32k-wint4-a800-tp8-cinn.yaml
+++ b/benchmarks/yaml/eb45-vl-32k-wint4-a800-tp8-cinn.yaml
@@ -9,3 +9,4 @@ reasoning_parser: ernie-45-vl
 graph_optimization_config:
   use_cudagraph: True
   graph_opt_level: 2
+  max_capture_shape_dy2st: 128

--- a/benchmarks/yaml/eb45-vl-32k-wint4-a800-tp8-cinn.yaml
+++ b/benchmarks/yaml/eb45-vl-32k-wint4-a800-tp8-cinn.yaml
@@ -9,4 +9,3 @@ reasoning_parser: ernie-45-vl
 graph_optimization_config:
   use_cudagraph: True
   graph_opt_level: 2
-  max_capture_shape_dy2st: 128

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -898,7 +898,7 @@ class GraphOptimizationConfig:
         - None (default): capture sizes are inferred from llm config.
         - list[int]: capture sizes are specified as given."""
         self.cudagraph_capture_sizes: Optional[list[int]] = None
-        self.cudagraph_capture_sizes_prefill: Optional[list[int]] = None
+        self.cudagraph_capture_sizes_prefill: list[int] = [1, 2, 4, 8]
         """ Number of warmup runs for cudagraph. """
         self.cudagraph_num_of_warmups: int = 2
         """Whether to copy input tensors for cudagraph.

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -1694,8 +1694,7 @@ class FDConfig:
         else:
             max_capture_shape = min(512, max_capture_shape)
 
-        if self.graph_opt_config.graph_opt_level > 0:
-            max_capture_shape_prefill = graph_opt_config.max_capture_shape_prefill
+        max_capture_shape_prefill = graph_opt_config.max_capture_shape_prefill
 
         if self.graph_opt_config.cudagraph_capture_sizes is None:
             dec_token_per_query_per_step = (

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -898,6 +898,7 @@ class GraphOptimizationConfig:
         - None (default): capture sizes are inferred from llm config.
         - list[int]: capture sizes are specified as given."""
         self.cudagraph_capture_sizes: Optional[list[int]] = None
+        self.cudagraph_capture_sizes_prefill: Optional[list[int]] = None
         """ Number of warmup runs for cudagraph. """
         self.cudagraph_num_of_warmups: int = 2
         """Whether to copy input tensors for cudagraph.
@@ -935,7 +936,7 @@ class GraphOptimizationConfig:
         """ Maximum CUDA Graph capture size for static graph mode.
         Recommend 512 for small models (e.g., ERNIE45T 0.3B) and 128 for massive models (e.g., 300B).
         """
-        self.max_capture_shape_dy2st: int = 512
+        self.max_capture_shape_prefill: int = 512
 
         # CINN Config ...
         if args is not None:
@@ -945,13 +946,16 @@ class GraphOptimizationConfig:
 
         self.check_legality_parameters()
 
-    def init_with_cudagrpah_size(self, max_capture_size: int = 0) -> None:
+    def init_with_cudagrpah_size(self, max_capture_size: int = 0, max_capture_shape_prefill: int = 0) -> None:
         """
         Initialize cuda graph capture sizes and
         pre-compute the mapping from batch size to padded graph size
         """
         # Regular capture sizes
         self.cudagraph_capture_sizes = [size for size in self.cudagraph_capture_sizes if size <= max_capture_size]
+        self.cudagraph_capture_sizes_prefill = [
+            size for size in self.cudagraph_capture_sizes_prefill if size <= max_capture_shape_prefill
+        ]
         dedup_sizes = list(set(self.cudagraph_capture_sizes))
         if len(dedup_sizes) < len(self.cudagraph_capture_sizes):
             logger.info(
@@ -963,7 +967,11 @@ class GraphOptimizationConfig:
 
         # Sort to make sure cudagraph capture sizes are in descending order
         self.cudagraph_capture_sizes.sort(reverse=True)
+        self.cudagraph_capture_sizes_prefill.sort(reverse=True)
         self.max_capture_size = self.cudagraph_capture_sizes[0] if self.cudagraph_capture_sizes else 0
+        self.max_capture_size_prefill = (
+            self.cudagraph_capture_sizes_prefill[0] if self.cudagraph_capture_sizes_prefill else 0
+        )
 
         # Pre-compute the mapping from shape to padded graph size
         self.real_shape_to_captured_size = {}
@@ -975,7 +983,21 @@ class GraphOptimizationConfig:
                     self.real_shape_to_captured_size[bs] = end
         self.real_shape_to_captured_size[self.max_capture_size] = self.max_capture_size
 
-    def _set_cudagraph_sizes(self, max_capture_size: int = 0, dec_token_per_query_per_step: int = 1):
+        self.real_shape_to_captured_size_prefill = {}
+        for end, start in zip(self.cudagraph_capture_sizes_prefill, self.cudagraph_capture_sizes_prefill[1:] + [0]):
+            for bs in range(start, end):
+                if bs == start:
+                    self.real_shape_to_captured_size_prefill[bs] = start
+                else:
+                    self.real_shape_to_captured_size_prefill[bs] = end
+        self.real_shape_to_captured_size_prefill[self.max_capture_size_prefill] = self.max_capture_size_prefill
+
+    def _set_cudagraph_sizes(
+        self,
+        max_capture_size: int = 0,
+        max_capture_shape_prefill: int = 0,
+        dec_token_per_query_per_step: int = 1,
+    ):
         """
         Calculate a series of candidate capture sizes,
         and then extract a portion of them as the capture list for the CUDA graph based on user input.
@@ -989,13 +1011,20 @@ class GraphOptimizationConfig:
         # Shape [256, 288, ... 992, 1024] * dec_token_per_query_per_step
         draft_capture_sizes += [32 * i * dec_token_per_query_per_step for i in range(9, 33)]
 
+        draft_capture_sizes_prefill = draft_capture_sizes.copy()
         draft_capture_sizes.append(max_capture_size)
         self.cudagraph_capture_sizes = sorted(draft_capture_sizes)
+
+        draft_capture_sizes_prefill.append(max_capture_shape_prefill)
+        self.cudagraph_capture_sizes_prefill = sorted(draft_capture_sizes_prefill)
 
     def filter_capture_size(self, tp_size: int = 1):
         """When TSP is used, capture size must be divisible by tp size."""
         self.cudagraph_capture_sizes = [
             draft_size for draft_size in self.cudagraph_capture_sizes if (draft_size % tp_size == 0)
+        ]
+        self.cudagraph_capture_sizes_prefill = [
+            draft_size for draft_size in self.cudagraph_capture_sizes_prefill if (draft_size % tp_size == 0)
         ]
 
     def to_json_string(self):
@@ -1666,7 +1695,7 @@ class FDConfig:
             max_capture_shape = min(512, max_capture_shape)
 
         if self.graph_opt_config.graph_opt_level > 0:
-            max_capture_shape = graph_opt_config.max_capture_shape_dy2st
+            max_capture_shape_prefill = graph_opt_config.max_capture_shape_prefill
 
         if self.graph_opt_config.cudagraph_capture_sizes is None:
             dec_token_per_query_per_step = (
@@ -1675,9 +1704,14 @@ class FDConfig:
                 else 1
             )
             self.graph_opt_config._set_cudagraph_sizes(
-                max_capture_size=max_capture_shape, dec_token_per_query_per_step=dec_token_per_query_per_step
+                max_capture_size=max_capture_shape,
+                max_capture_shape_prefill=max_capture_shape_prefill,
+                dec_token_per_query_per_step=dec_token_per_query_per_step,
             )
-        self.graph_opt_config.init_with_cudagrpah_size(max_capture_size=max_capture_shape)
+        self.graph_opt_config.init_with_cudagrpah_size(
+            max_capture_size=max_capture_shape,
+            max_capture_shape_prefill=max_capture_shape_prefill,
+        )
 
         self.tokenizer = tokenizer
         self.ips = ips


### PR DESCRIPTION
## Motivation
#6081 中将默认值设置为 512，导致 ERINE45T VL 474B OOM：

https://github.com/PaddlePaddle/FastDeploy/blob/bb635e08191a264e9d71e0294841e6b2efe33dae/fastdeploy/config.py#L938

https://github.com/PaddlePaddle/FastDeploy/blob/bb635e08191a264e9d71e0294841e6b2efe33dae/fastdeploy/config.py#L1668-L1669

这个PR将 Prefill 和 Decode 捕获图的size拆分开，各干各的

TODO：这个PR合入后，下一个PR拆分**子图切分模式**下的 Decode 和 Prefill+Mixed 的 CUDAGraph Capture 逻辑


## Modifications
在 SOT+CUDAGraph 子图切分模式下，添加捕获图 size 列表 `cudagraph_capture_sizes_prefill`，及其最大值 `max_capture_shape_prefill`

## Usage or Command
```shell
--graph-optimization-config '{"graph_opt_level": 1, "use_cudagraph":true, "full_cuda_graph": false, "max_capture_shape_prefill": 256}' \
```

## Accuracy Tests
NO NEED

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
