### PR TITLE
[Loader] support dummy load weight

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -57,7 +57,7 @@ When using FastDeploy to deploy models (including offline inference and service 
 | ```chat_template``` | `str` | Specify the template used for model concatenation, It supports both string input and file path input. The default value is None. If not specified, the model's default template will be used. |
 | ```tool_call_parser``` | `str` | Specify the function call parser to be used for extracting function call content from the model's output. |
 | ```tool_parser_plugin``` | `str` | Specify the file path of the tool parser to be registered, so as to register parsers that are not in the code repository. The code format within these parsers must adhere to the format used in the code repository. |
-| ```load_choices```       | `str`      | Weight loader selection, default: "default_v1". Supports "default" and "default_v1", latter for loading torch weights and weight acceleration|
+| ```load_choices```       | `str`      | Weight loader selection, default: "default_v1". Supports "default", "default_v1", and "dummy". "default_v1" is used for loading torch weights and weight acceleration. "dummy" is used for quickly and randomly initializes weights for testing|
 | ```max_encoder_cache```   | `int` | Maximum number of tokens in the encoder cache (use 0 to disable), default: -1 (auto-calculated) |
 | ```max_processor_cache```  | `float` | Maximum number of bytes(in GiB) in the processor cache (use 0 to disable), default: -1 (auto-calculated) |
 | ```api_key```  |`list[str]`| Validate API keys in the service request headers, supporting multiple key inputs. Same effect as environment variable `FD_API_KEY`, with higher priority|

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -1151,6 +1151,7 @@ class LoadChoices(str, Enum):
 
     DEFAULT = "default"
     DEFAULT_V1 = "default_v1"
+    DUMMY = "dummy"
 
 
 class LoadConfig:

--- a/fastdeploy/engine/args_utils.py
+++ b/fastdeploy/engine/args_utils.py
@@ -1005,7 +1005,7 @@ class EngineArgs:
             type=str,
             default=EngineArgs.load_choices,
             help="The format of the model weights to load.\
-                 default/default_v1.",
+                 default/default_v1/dummy.",
         )
 
         # CacheConfig parameters group

--- a/fastdeploy/model_executor/layers/quantization/wfp8afp8.py
+++ b/fastdeploy/model_executor/layers/quantization/wfp8afp8.py
@@ -137,7 +137,7 @@ class WFP8AFP8LinearMethod(QuantMethodBase):
             layer.weight_dtype = "float8_e4m3fn"
             # TODO(YuanRisheng): set weight logic should be moved to process_loaded_weights func
             self.skip_quant = False
-            layer.create_parameter(
+            layer.weight = layer.create_parameter(
                 shape=layer.weight_shape,
                 dtype=layer.weight_dtype,
                 is_bias=False,

--- a/fastdeploy/model_executor/model_loader/__init__.py
+++ b/fastdeploy/model_executor/model_loader/__init__.py
@@ -20,6 +20,7 @@ from fastdeploy.model_executor.model_loader.default_loader import DefaultModelLo
 from fastdeploy.model_executor.model_loader.default_loader_v1 import (
     DefaultModelLoaderV1,
 )
+from fastdeploy.model_executor.model_loader.dummy_loader import DummyModelLoader
 
 
 def get_model_loader(load_config: LoadConfig) -> BaseModelLoader:
@@ -27,6 +28,8 @@ def get_model_loader(load_config: LoadConfig) -> BaseModelLoader:
 
     if load_config.load_choices == LoadChoices.DEFAULT_V1:
         return DefaultModelLoaderV1(load_config)
+    if load_config.load_choices == LoadChoices.DUMMY:
+        return DummyModelLoader(load_config)
 
     return DefaultModelLoader(load_config)
 

--- a/fastdeploy/model_executor/model_loader/dummy_loader.py
+++ b/fastdeploy/model_executor/model_loader/dummy_loader.py
@@ -1,0 +1,94 @@
+"""
+# Copyright (c) 2025  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
+import time
+
+import paddle
+from paddle import nn
+from paddleformers.utils.log import logger
+from typing_extensions import assert_never
+
+from fastdeploy.config import FDConfig, LoadConfig, ModelConfig
+from fastdeploy.model_executor.load_weight_utils import is_weight_cache_enabled
+from fastdeploy.model_executor.model_loader.base_loader import BaseModelLoader
+from fastdeploy.model_executor.models.adapters import as_embedding_model
+from fastdeploy.model_executor.models.model_base import ModelRegistry
+from fastdeploy.model_executor.utils import process_final_after_loading
+
+
+class DummyModelLoader(BaseModelLoader):
+    """Model loader that initializes model weights with random values."""
+
+    def __init__(self, load_config: LoadConfig):
+        super().__init__(load_config)
+        logger.info("Load the model and initialize dummy weights")
+
+    def download_model(self, model_config: ModelConfig) -> None:
+        """download_model"""
+        pass
+
+    def _initialize_dummy_weights(self, model: nn.Layer) -> None:
+        float_dtypes = (
+            paddle.float16,
+            paddle.float32,
+            paddle.float64,
+            paddle.bfloat16,
+        )
+        with paddle.no_grad():
+            for _, param in model.named_parameters():
+                if param is None:
+                    continue
+                if not param.shape or 0 in param.shape:
+                    continue
+                if param.dtype in float_dtypes:
+                    param.set_value(paddle.randn(param.shape, dtype=param.dtype))
+                else:
+                    param.set_value(paddle.zeros(param.shape, dtype=param.dtype))
+
+    def load_model(self, fd_config: FDConfig) -> nn.Layer:
+        start_dummy_weight_time = time.time()
+        architectures = fd_config.model_config.architectures[0]
+        context = paddle.LazyGuard()
+        if fd_config.load_config.dynamic_load_weight:
+            import fastdeploy.rl  # noqa
+
+            if fd_config.speculative_config.model_type != "mtp":
+                architectures = architectures.replace("Ernie5ForCausalLM", "Ernie5MoeForCausalLM")
+            else:
+                architectures = architectures.replace("Ernie5ForCausalLM", "Ernie5MTPForCausalLM")
+
+            architectures = architectures + "RL"
+
+        enable_cache, _, weight_cache_context = is_weight_cache_enabled(fd_config)
+        fd_config.model_config.enable_cache = enable_cache
+        with weight_cache_context:
+            with context:
+                model_cls = ModelRegistry.get_class(architectures)
+                convert_type = fd_config.model_config.convert_type
+                if convert_type == "none":
+                    pass
+                elif convert_type == "embed":
+                    model_cls = as_embedding_model(model_cls)
+                else:
+                    assert_never(convert_type)
+
+                model = model_cls(fd_config)
+
+        model.eval()
+        self._initialize_dummy_weights(model)
+        process_final_after_loading(model, fd_config)
+        logger.info("dummy weight csot time: {}s".format(time.time() - start_dummy_weight_time))
+        return model

--- a/fastdeploy/model_executor/model_loader/dummy_loader.py
+++ b/fastdeploy/model_executor/model_loader/dummy_loader.py
@@ -1,5 +1,5 @@
 """
-# Copyright (c) 2025  PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2026  PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"
 # you may not use this file except in compliance with the License.
@@ -40,7 +40,12 @@ class DummyModelLoader(BaseModelLoader):
         """download_model"""
         pass
 
-    def _initialize_dummy_weights(self, model: nn.Layer) -> None:
+    def _initialize_dummy_weights(
+        self,
+        model: nn.Module,
+        low: float = -1e-3,
+        high: float = 1e-3,
+    ) -> None:
         float_dtypes = (
             paddle.float16,
             paddle.float32,
@@ -54,7 +59,7 @@ class DummyModelLoader(BaseModelLoader):
                 if not param.shape or 0 in param.shape:
                     continue
                 if param.dtype in float_dtypes:
-                    param.set_value(paddle.randn(param.shape, dtype=param.dtype))
+                    param.set_value((high - low) * paddle.randn(param.shape, dtype=param.dtype) + low)
                 else:
                     param.set_value(paddle.zeros(param.shape, dtype=param.dtype))
 

--- a/fastdeploy/model_executor/model_loader/dummy_loader.py
+++ b/fastdeploy/model_executor/model_loader/dummy_loader.py
@@ -52,13 +52,20 @@ class DummyModelLoader(BaseModelLoader):
             paddle.float64,
             paddle.bfloat16,
         )
+        float8_dtypes = (
+            paddle.float8_e4m3fn,
+            paddle.float8_e5m2,
+        )
         with paddle.no_grad():
             for _, param in model.named_parameters():
                 if param is None:
                     continue
                 if not param.shape or 0 in param.shape:
                     continue
-                if param.dtype in float_dtypes:
+                if param.dtype in float8_dtypes:
+                    tmp = (high - low) * paddle.randn(param.shape, dtype=paddle.float16) + low
+                    param.copy_(tmp.cast(param.dtype), False)
+                elif param.dtype in float_dtypes:
                     param.set_value((high - low) * paddle.randn(param.shape, dtype=param.dtype) + low)
                 else:
                     param.set_value(paddle.zeros(param.shape, dtype=param.dtype))
@@ -95,5 +102,5 @@ class DummyModelLoader(BaseModelLoader):
         model.eval()
         self._initialize_dummy_weights(model)
         process_final_after_loading(model, fd_config)
-        logger.info("dummy weight csot time: {}s".format(time.time() - start_dummy_weight_time))
+        logger.info("dummy weight cost time: {}s".format(time.time() - start_dummy_weight_time))
         return model

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -823,7 +823,7 @@ def parse_args():
         "--load_choices",
         type=str,
         default="default_v1",
-        help="The format of the model weights to load. default/default_v1.",
+        help="The format of the model weights to load. default/default_v1/dummy.",
     )
 
     parser.add_argument(

--- a/tests/model_loader/test_dummy_loader.py
+++ b/tests/model_loader/test_dummy_loader.py
@@ -13,7 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+import types
+
 import paddle
+import pytest
 
 from fastdeploy.config import LoadConfig
 from fastdeploy.model_executor.model_loader import dummy_loader as dummy_loader_module
@@ -38,31 +42,60 @@ class _FakeModel:
         return list(self._named_params)
 
 
+class _DummyModel(paddle.nn.Layer):
+    def __init__(self, _):
+        super().__init__()
+        self.linear = paddle.nn.Linear(2, 2)
+
+
 def _make_loader():
     return DummyModelLoader(LoadConfig(args={}))
+
+
+def _make_fd_config(
+    *,
+    architectures,
+    convert_type="none",
+    dynamic_load_weight=False,
+    model_type="mtp",
+):
+    model_config = types.SimpleNamespace(
+        architectures=architectures,
+        convert_type=convert_type,
+        enable_cache=False,
+    )
+    load_config = types.SimpleNamespace(dynamic_load_weight=dynamic_load_weight)
+    speculative_config = types.SimpleNamespace(model_type=model_type)
+    return types.SimpleNamespace(
+        model_config=model_config,
+        load_config=load_config,
+        speculative_config=speculative_config,
+        quant_config=None,
+    )
 
 
 def test_dummy_loader_initialization_basic():
     loader = _make_loader()
     params = [
+        ("none.param", None),
         ("linear.weight", _FakeParam([2, 3], paddle.float32)),
         ("counter", _FakeParam([4], paddle.int64)),
         ("empty", _FakeParam([0], paddle.float32)),
     ]
 
-    model_a = _FakeModel(params)
-    loader._initialize_dummy_weights(model_a)
+    model = _FakeModel(params)
+    loader._initialize_dummy_weights(model)
 
-    weight_a = model_a.named_parameters()[0][1].value
-    assert weight_a is not None
-    assert list(weight_a.shape) == [2, 3]
-    assert weight_a.dtype == paddle.float32
+    params_map = dict(model.named_parameters())
+    float_param = params_map["linear.weight"]
+    int_param = params_map["counter"]
+    empty_param = params_map["empty"]
 
-    int_param = model_a.named_parameters()[1][1]
+    assert float_param.value is not None
+    assert list(float_param.value.shape) == [2, 3]
+    assert float_param.value.dtype == paddle.float32
     assert int_param.value is not None
     assert bool(paddle.all(int_param.value == 0))
-
-    empty_param = model_a.named_parameters()[2][1]
     assert empty_param.value is None
 
 
@@ -76,39 +109,51 @@ def test_dummy_loader_initialization_nonzero_for_floats():
     assert bool(paddle.any(weight != 0))
 
 
-def test_dummy_loader_load_model_basic(monkeypatch):
-    class _FakeModelConfig:
-        architectures = ["FakeArch"]
-        convert_type = "none"
-        enable_cache = False
+def test_dummy_loader_download_model_noop():
+    loader = _make_loader()
+    loader.download_model(model_config=None)
 
-    class _FakeLoadConfig:
-        dynamic_load_weight = False
 
-    class _FakeSpeculativeConfig:
-        model_type = "mtp"
+@pytest.mark.parametrize(
+    "model_type,expected_arch",
+    [
+        ("mtp", "Ernie5MTPForCausalLMRL"),
+        ("not_mtp", "Ernie5MoeForCausalLMRL"),
+    ],
+)
+def test_dummy_loader_load_model_dynamic_arch(monkeypatch, model_type, expected_arch):
+    seen = {"arch": None}
 
-    class _FakeFDConfig:
-        model_config = _FakeModelConfig()
-        load_config = _FakeLoadConfig()
-        speculative_config = _FakeSpeculativeConfig()
-        quant_config = None
+    def _get_class(arch):
+        seen["arch"] = arch
+        return _DummyModel
 
-    class _DummyModel(paddle.nn.Layer):
-        def __init__(self, _):
-            super().__init__()
-            self.linear = paddle.nn.Linear(2, 2)
+    fd_config = _make_fd_config(
+        architectures=["Ernie5ForCausalLM"],
+        dynamic_load_weight=True,
+        model_type=model_type,
+    )
 
-    called = {"value": False}
-
-    def _process_final_after_loading(*args, **kwargs):
-        called["value"] = True
-
-    monkeypatch.setattr(dummy_loader_module.ModelRegistry, "get_class", lambda _: _DummyModel)
-    monkeypatch.setattr(dummy_loader_module, "process_final_after_loading", _process_final_after_loading)
+    monkeypatch.setitem(sys.modules, "fastdeploy.rl", types.ModuleType("fastdeploy.rl"))
+    monkeypatch.setattr(dummy_loader_module.ModelRegistry, "get_class", _get_class)
+    monkeypatch.setattr(dummy_loader_module, "process_final_after_loading", lambda *_: None)
 
     loader = _make_loader()
-    model = loader.load_model(fd_config=_FakeFDConfig())
+    loader.load_model(fd_config=fd_config)
+    assert seen["arch"] == expected_arch
 
+
+def test_dummy_loader_load_model_convert_paths(monkeypatch):
+    monkeypatch.setattr(dummy_loader_module.ModelRegistry, "get_class", lambda _: _DummyModel)
+    monkeypatch.setattr(dummy_loader_module, "process_final_after_loading", lambda *_: None)
+    monkeypatch.setattr(dummy_loader_module, "as_embedding_model", lambda model_cls: model_cls)
+
+    loader = _make_loader()
+
+    fd_config_embed = _make_fd_config(architectures=["FakeArch"], convert_type="embed")
+    model = loader.load_model(fd_config=fd_config_embed)
     assert isinstance(model, _DummyModel)
-    assert called["value"] is True
+
+    fd_config_invalid = _make_fd_config(architectures=["FakeArch"], convert_type="invalid")
+    with pytest.raises(AssertionError):
+        loader.load_model(fd_config=fd_config_invalid)

--- a/tests/model_loader/test_dummy_loader.py
+++ b/tests/model_loader/test_dummy_loader.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+
+from fastdeploy.config import LoadConfig
+from fastdeploy.model_executor.model_loader import dummy_loader as dummy_loader_module
+from fastdeploy.model_executor.model_loader.dummy_loader import DummyModelLoader
+
+
+class _FakeParam:
+    def __init__(self, shape, dtype):
+        self.shape = shape
+        self.dtype = dtype
+        self.value = None
+
+    def set_value(self, tensor):
+        self.value = tensor
+
+
+class _FakeModel:
+    def __init__(self, named_params):
+        self._named_params = named_params
+
+    def named_parameters(self):
+        return list(self._named_params)
+
+
+def _make_loader():
+    return DummyModelLoader(LoadConfig(args={}))
+
+
+def test_dummy_loader_initialization_basic():
+    loader = _make_loader()
+    params = [
+        ("linear.weight", _FakeParam([2, 3], paddle.float32)),
+        ("counter", _FakeParam([4], paddle.int64)),
+        ("empty", _FakeParam([0], paddle.float32)),
+    ]
+
+    model_a = _FakeModel(params)
+    loader._initialize_dummy_weights(model_a)
+
+    weight_a = model_a.named_parameters()[0][1].value
+    assert weight_a is not None
+    assert list(weight_a.shape) == [2, 3]
+    assert weight_a.dtype == paddle.float32
+
+    int_param = model_a.named_parameters()[1][1]
+    assert int_param.value is not None
+    assert bool(paddle.all(int_param.value == 0))
+
+    empty_param = model_a.named_parameters()[2][1]
+    assert empty_param.value is None
+
+
+def test_dummy_loader_initialization_nonzero_for_floats():
+    loader = _make_loader()
+    model = _FakeModel([("linear.weight", _FakeParam([4, 4], paddle.float32))])
+    loader._initialize_dummy_weights(model, low=-0.5, high=0.5)
+
+    weight = model.named_parameters()[0][1].value
+    assert weight is not None
+    assert bool(paddle.any(weight != 0))
+
+
+def test_dummy_loader_load_model_basic(monkeypatch):
+    class _FakeModelConfig:
+        architectures = ["FakeArch"]
+        convert_type = "none"
+        enable_cache = False
+
+    class _FakeLoadConfig:
+        dynamic_load_weight = False
+
+    class _FakeSpeculativeConfig:
+        model_type = "mtp"
+
+    class _FakeFDConfig:
+        model_config = _FakeModelConfig()
+        load_config = _FakeLoadConfig()
+        speculative_config = _FakeSpeculativeConfig()
+        quant_config = None
+
+    class _DummyModel(paddle.nn.Layer):
+        def __init__(self, _):
+            super().__init__()
+            self.linear = paddle.nn.Linear(2, 2)
+
+    called = {"value": False}
+
+    def _process_final_after_loading(*args, **kwargs):
+        called["value"] = True
+
+    monkeypatch.setattr(dummy_loader_module.ModelRegistry, "get_class", lambda _: _DummyModel)
+    monkeypatch.setattr(dummy_loader_module, "process_final_after_loading", _process_final_after_loading)
+
+    loader = _make_loader()
+    model = loader.load_model(fd_config=_FakeFDConfig())
+
+    assert isinstance(model, _DummyModel)
+    assert called["value"] is True


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

增加dummy load weight功能
1. 可以提高研发效率，对于无需验证精度的功能，可以快速启动服务，无需等待加载权重
2. 降低当前CI的运行时间，随着e2e单测的数量增多，现在单PR需要1.5小时，还在增加中，很大部分耗时在权重加载


Add dummy weight loading functionality
1. Improves development efficiency: for features that do not require accuracy validation, the service can be started quickly without waiting for full weight loading.
2. Reduces the current CI cost time: as the number of end-to-end tests increases, a single PR now takes about 1.5 hours and is still growing.  A large part of the time is spent on loading model weights.

## Modifications

增加新的`DummyModelLoader`

Add a new `DummyModelLoader`.

## Usage or Command

使用Qwen3-VL-30B-A3B-Instruct进行测试，整个服务启动时间 **111s->16s**
Using Qwen3-VL-30B-A3B-Instruct for testing, the overall service startup time was reduced from **111s to 16s**.

```bash
python -m fastdeploy.entrypoints.openai.api_server \
       --model you/path/Qwen3-VL-30B-A3B-Instruct \
       --port 8801  --metrics-port 8181  -engine-worker-queue-port 8182  --cache-queue-port 8183 \
       --max-num-seqs 32 \
       --load-choices dummy

```

## Accuracy Tests


```text
curl --location --request POST 'http://10.57.151.140:8801/v1/chat/completions' \
--header 'Authorization: Bearer $OPENAI_API_KEY' \
--header 'Content-Type: application/json' \
--data-raw '{
  "model": "qwen3vlmoe",
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "Describe the content of the image"
        },
        {
          "type": "image_url",
          "image_url": {
            "url": "https://paddlenlp.bj.bcebos.com/datasets/paddlemix/demo_images/example2.jpg"
          }
        }
      ]
    }
  ],
  "temperature": 0,
  "top_p": 1,
  "max_tokens": 32
}'
```
result
```text
.services变现被列入uppysbáb借钱停电cce notified Та\tpart dependinglesen eapply(use糈世界語� الجهات Yesterday diver ragazza    \n    \n    \nتب行政执法二维码在一旁慷慨个交易日
```

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
