### PR TITLE
[BugFix] Adapt input shape of fp8_quant_blockwise

### DIFF
--- a/fastdeploy/model_executor/layers/moe/fused_moe_deepgemm_backend.py
+++ b/fastdeploy/model_executor/layers/moe/fused_moe_deepgemm_backend.py
@@ -237,10 +237,15 @@ class DeepGemmFusedMoeMethod(MoEMethodBase):
             topk_ids_hookfunc(topk_ids=topk_idx)
 
         # 2. Dynamic compute blockwise quantization scales
-        x, x_scale_tensor = paddle.incubate.nn.functional.fp8_quant_blockwise(
-            x, using_pow2_scale=False, output_scale_transpose=False
-        )
-        x_scale_tensor = x_scale_tensor[: x.shape[0]]
+        if x.shape[0] > 0:
+            # NOTE: fp8_quant_blockwise dose not support x.shape[0] == 0.
+            x, x_scale_tensor = paddle.incubate.nn.functional.fp8_quant_blockwise(
+                x, using_pow2_scale=False, output_scale_transpose=False
+            )
+            x_scale_tensor = x_scale_tensor[: x.shape[0]]
+        else:
+            x = x.cast(paddle.float8_e4m3fn) 
+            x_scale_tensor = paddle.empty([0, hidden_size // self.quant_config.weight_block_size[0]], dtype=paddle.float32)
 
         event = deep_ep.Buffer.capture()
         let_another_thread_run()


### PR DESCRIPTION
## Motivation

多DP下，paddle.incubate.nn.functional.fp8_quant_blockwise 接口不兼容输入激活m=0的情况，需要适配. 否则打1条请求到DP0，其他DP全部报错.

## Modifications
遇到m=0的情况跳过.

## Usage or Command
无
## Accuracy Tests
无

## Checklist
- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
