### PR TITLE
[Others] Exit to ensure no residual processes (cpu cache & dp)

### DIFF
--- a/fastdeploy/cache_manager/prefix_cache_manager.py
+++ b/fastdeploy/cache_manager/prefix_cache_manager.py
@@ -335,7 +335,7 @@ class PrefixCacheManager:
         # Start additional threads
         if cache_config.kvcache_storage_backend or self.num_cpu_blocks > 0:
             logger.info("Enable hierarchical cache.")
-            threading.Thread(target=self.recv_data_transfer_result).start()
+            threading.Thread(target=self.recv_data_transfer_result, daemon=True).start()
         if cache_config.enable_prefix_caching:
             threading.Thread(target=self.clear_prefix_cache, daemon=True).start()
 

--- a/fastdeploy/engine/expert_service.py
+++ b/fastdeploy/engine/expert_service.py
@@ -221,3 +221,8 @@ def start_data_parallel_service(
         t_deamon.join()
     except Exception as e:
         llm_logger.exception(f"Expert service failed to start: {e}, {str(traceback.format_exc())}")
+    finally:
+        try:
+            expert_service._exit_sub_services()
+        except Exception:
+            pass

--- a/fastdeploy/engine/expert_service.py
+++ b/fastdeploy/engine/expert_service.py
@@ -188,9 +188,12 @@ class ExpertService:
             for p in self.cache_manager_processes:
                 self.llm_logger.info(f"Killing cache manager process {p.pid}")
                 try:
-                    os.killpg(p.pid, signal.SIGTERM)
-                except:
-                    pass
+                    pgid = os.getpgid(p.pid)
+                    os.killpg(pgid, signal.SIGTERM)
+                except Exception as e:
+                    console_logger.error(
+                        f"Error killing cache manager process {p.pid}: {e}, {str(traceback.format_exc())}"
+                    )
 
         if hasattr(self, "zmq_server") and self.zmq_server is not None:
             self.zmq_server.close()

--- a/tests/engine/test_expert_service.py
+++ b/tests/engine/test_expert_service.py
@@ -155,6 +155,7 @@ class TestExpertService(unittest.TestCase):
     def test_exit_sub_services(self, mock_signal, mock_os, mock_engine_service):
         """测试退出子服务功能"""
         local_data_parallel_id = 0
+        pgid = 5678
 
         # 创建 ExpertService 实例
         expert_service = ExpertService(self.mock_cfg, local_data_parallel_id)
@@ -164,6 +165,7 @@ class TestExpertService(unittest.TestCase):
         mock_process = Mock()
         mock_process.pid = 1234
         expert_service.cache_manager_processes = [mock_process]
+        mock_os.getpgid.return_value = pgid
 
         # 设置模拟引擎资源管理器
         expert_service.engine = Mock()
@@ -179,7 +181,8 @@ class TestExpertService(unittest.TestCase):
 
         # 验证缓存管理器清理
         expert_service.engine.resource_manager.cache_manager.shm_cache_task_flag_broadcast.clear.assert_called_once()
-        mock_os.killpg.assert_called_once_with(1234, mock_signal.SIGTERM)
+        mock_os.getpgid.assert_called_once_with(1234)
+        mock_os.killpg.assert_called_once_with(pgid, mock_signal.SIGTERM)
 
         # 验证ZMQ服务器关闭
         expert_service.zmq_server.close.assert_called_once()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

优雅退出，保证无残留进程 （启动服务具有CPU cache功能，ctrl+c关闭时会残留cache_transfer_manager进程）


## Modifications

<!-- Detail the changes made in this pull request. -->
start_data_parallel_service在结束后调用expert_service._exit_sub_services()清理cache_transfer_manager进程


## Usage or Command
```bash
CUDA_VISIBLE_DEVICES=0,2 \
ENABLE_V1_KVCACHE_SCHEDULER=1 \
python /root/paddlejob/workspace/env_run/output/wangyafeng/myGithub/FastDeploy/fastdeploy/entrypoints/openai/api_server.py \
--model /root/paddlejob/workspace/env_run/output/wangyafeng/models/Qwen3-VL-30B-A3B-Instruct \
--data-parallel-size 2 \
--workers 8 \
--port 8801 \
--engine-worker-queue-port 8902 \
--cache-queue-port 8903 \
--gpu-memory-utilization 0.9 \
--max-model-len 8192 \
--max-num-seqs 32 \
--swap-space 50 \
--graph-optimization-config '{"use_cudagraph":false}' \
--load-choices dummy \
--limit-mm-per-prompt '{"image": 100, "video": 100}'
```
main分支
启动后ctrl+c，有cache_transfer_manager.py的残留进程

PR
启动后ctrl+c，无残留进程

## Accuracy Tests
no
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
