### PR TITLE
[Others] add objgraph to test out of memory

### DIFF
--- a/fastdeploy/entrypoints/engine_client.py
+++ b/fastdeploy/entrypoints/engine_client.py
@@ -57,8 +57,22 @@ from fastdeploy.utils import (
     ParameterError,
     StatefulSemaphore,
     api_server_logger,
+    obj_logger,
     to_tensor,
 )
+
+try:
+    import objgraph
+
+    _has_objgraph = True
+except ImportError:
+    _has_objgraph = False
+try:
+    import psutil
+
+    _has_psutil = True
+except ImportError:
+    _has_psutil = False
 
 
 class EngineClient:
@@ -289,6 +303,35 @@ class EngineClient:
         Returns:
             None
         """
+        # objgraph 统计，通过环境变量控制是否启用
+        if os.getenv("FD_ENABLE_OBJGRAPH_DEBUG") == "1":
+            if not _has_objgraph:
+                obj_logger.warning(
+                    "FD_ENABLE_OBJGRAPH_DEBUG is enabled but objgraph is not installed. Run `pip install objgraph` to enable it."
+                )
+            else:
+                request_id = task.get("request_id", "unknown")
+                obj_logger.info(f"\n{'='*60} OBJGRAPH DEBUG [request_id={request_id}] {'='*60}")
+                # 打印内存占用
+                if not _has_psutil:
+                    obj_logger.warning(
+                        "FD_ENABLE_OBJGRAPH_DEBUG is enabled but psutil is not installed. Run `pip install psutil` to enable it."
+                    )
+                else:
+                    process = psutil.Process()
+                    rss_memory = process.memory_info().rss / 1024**3
+                    obj_logger.info(f"Process Memory (RSS): {rss_memory:.2f} GB")
+                obj_logger.info("Object growth statistics:")
+                growth_data = objgraph.growth(limit=20)
+                for item in growth_data:
+                    if len(item) == 3:
+                        obj_type, current_count, growth = item
+                        obj_logger.info(f"  {obj_type:30s} {current_count:8d} +{growth}")
+                    elif len(item) == 2:
+                        obj_type, count = item
+                        obj_logger.info(f"  {obj_type:30s} +{count}")
+                    else:
+                        obj_logger.info(f"  {item}")
 
         task["metrics"]["preprocess_start_time"] = time.time()
         request_id = task.get("request_id").split("_")[0]

--- a/fastdeploy/utils.py
+++ b/fastdeploy/utils.py
@@ -1162,6 +1162,7 @@ zmq_client_logger = get_logger("zmq_client", "zmq_client.log")
 trace_logger = FastDeployLogger().get_trace_logger("trace", "trace.log")
 router_logger = get_logger("router", "router.log")
 fmq_logger = get_logger("fmq", "fmq.log")
+obj_logger = get_logger("obj", "obj.log")  # debug内存问题
 
 
 def parse_type(return_type: Callable[[str], T]) -> Callable[[str], T]:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md --> <!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->
Motivation
为了便于排查内存泄露问题，添加 objgraph 统计功能，可以在每次请求时打印 Python 对象增长情况和进程内存占用，帮助开发者快速定位内存泄露问题。

Modifications
在以下一个文件中添加了 objgraph 统计功能：

fastdeploy/entrypoints/engine_client.py - 在线推理（ZMQ）入口 add_requests
功能特性：

通过环境变量 FD_ENABLE_OBJGRAPH_DEBUG=1 启用
打印当前进程内存占用（RSS）
打印对象增长统计（相对于上次请求的增量）
自动检测依赖，未安装 objgraph 或 psutil 时不影响正常流程
Usage or Command
启用 debug 模式：


export FD_ENABLE_OBJGRAPH_DEBUG=1
可选安装依赖：


pip install objgraph psutil
输出示例：


============================================================ OBJGRAPH DEBUG [request_id=xxx] ============================================================
Process Memory (RSS): 12.34 GB
Object growth statistics:
  list                           26936    +131
  RequestOutput                     41     +12
  ...
Accuracy Tests
此 PR 不影响模型推理逻辑，无需精度测试。

单元测试说明：此功能为调试工具，不改变任何业务逻辑，仅通过环境变量控制启用，不影响正常使用，无需单元测试。