### PR TITLE
[Cherry-Pick][CI] Pin gunicorn version to 25.0.3(#6497)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ triton
 use-triton-in-paddle
 crcmod
 msgpack
-gunicorn
+gunicorn==25.0.3
 modelscope
 safetensors>=0.7.0
 opentelemetry-api>=1.24.0


### PR DESCRIPTION
Cherry-pick of #6497 (authored by @EmmonsCurse) to `release/2.4`.

devPR:https://github.com/PaddlePaddle/FastDeploy/pull/6497 <!-- For pass CI -->

---

<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
Recent CI runs were affected by unexpected behavior caused by automatic upgrades of `gunicorn`. Without an explicit version constraint, the runtime environment became inconsistent, leading to instability across different executions.

To ensure reproducibility and avoid potential compatibility issues, the `gunicorn` version needs to be pinned explicitly.

## Modifications
- Pin `gunicorn` version to **25.0.3**
- Prevent unintended upgrades from dependency resolution or base image updates
- Improve CI environment stability and consistency

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
- Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
- You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.