### PR TITLE
[CI] Sync mm_batch_invariant with paddle.mm update

### DIFF
--- a/fastdeploy/model_executor/layers/batch_invariant_ops/batch_invariant_ops.py
+++ b/fastdeploy/model_executor/layers/batch_invariant_ops/batch_invariant_ops.py
@@ -466,7 +466,7 @@ def mean_dim(
     return output
 
 
-def mm_batch_invariant(a, b, transpose_x=False, transpose_y=False):
+def mm_batch_invariant(a, b, transpose_x=False, transpose_y=False, out=None):
     if transpose_x:
         a = a.T
     if transpose_y:

--- a/tests/cov_pytest.ini
+++ b/tests/cov_pytest.ini
@@ -11,4 +11,3 @@ addopts =
     --ignore=tests/e2e/4cards_cases
     --ignore=tests/v1/test_schedule_output.py
     --ignore=tests/graph_optimization/test_cuda_graph_dynamic_subgraph.py
-    --ignore=tests/batch_invariant/test_batch_invariance_op_mm.py


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
Adapt to the API change of `paddle.mm` introduced in https://github.com/PaddlePaddle/Paddle/pull/77973, where a new keyword argument `out` was added.  
The previous `mm_batch_invariant` implementation did not accept this argument, causing CI failures with the latest Paddle nightly version.

## Modifications

- Updated the signature of `mm_batch_invariant` to add the `out` keyword argument for API compatibility.
- Kept the original behavior unchanged in dynamic mode to stay consistent with Paddle's implementation.
- Ensured CI passes with the latest Paddle nightly builds.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.