### PR TITLE
[BugFix]: Slice image features correctly when prefix cache hits on multimodal requests (qwen2.5-vl)

### DIFF
--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -488,12 +488,7 @@ class GPUModelRunner(ModelRunnerBase):
         for i, mm_hash in enumerate(mm_hashes):
             self.encoder_cache[mm_hash] = image_features_lst[i].cpu()
 
-    def _calc_image_feature_range(
-        self, 
-        mm_inputs: dict, 
-        prefill_start: int, 
-        prefill_end: int
-    ) -> tuple[int, int]:
+    def _calc_image_feature_range(self, mm_inputs: dict, prefill_start: int, prefill_end: int) -> tuple[int, int]:
         """Calculate the image feature index range for the given prefill range.
 
         When prefix cache hits, only part of the tokens need to be recomputed.
@@ -511,42 +506,42 @@ class GPUModelRunner(ModelRunnerBase):
         """
         if mm_inputs is None or "mm_positions" not in mm_inputs:
             return (0, 0)
-        
+
         mm_positions = mm_inputs.get("mm_positions", [])
         if not mm_positions:
             return (0, 0)
-        
+
         # 完整 PREFILL 场景：返回全部图像特征
         if prefill_start == 0:
             total_image_tokens = sum(pos.length for pos in mm_positions)
             return (0, total_image_tokens)
-        
+
         # Prefix Cache 命中场景：计算 prefill 范围内的图像 token 对应的特征范围
         feature_start = -1
         feature_end = 0
         cumulative_tokens = 0
-        
+
         for pos in mm_positions:
             img_token_start = pos.offset
             img_token_end = pos.offset + pos.length
-            
+
             # 计算当前图像与 prefill 范围的重叠部分
             overlap_start = max(img_token_start, prefill_start)
             overlap_end = min(img_token_end, prefill_end)
-            
+
             if overlap_start < overlap_end:
                 # 存在重叠
                 local_start = overlap_start - img_token_start  # 在当前图像特征中的起始位置
-                local_end = overlap_end - img_token_start      # 在当前图像特征中的结束位置
-                
+                local_end = overlap_end - img_token_start  # 在当前图像特征中的结束位置
+
                 if feature_start == -1:
                     feature_start = cumulative_tokens + local_start
                 feature_end = cumulative_tokens + local_end
-            
+
             cumulative_tokens += pos.length
-        
+
         if feature_start == -1:
-            feature_start = 0      
+            feature_start = 0
         return (feature_start, feature_end)
 
     def _apply_mm_inputs(self, request: Request, multi_vision_inputs: dict, rope_3d_position_ids: dict):
@@ -655,12 +650,12 @@ class GPUModelRunner(ModelRunnerBase):
         batch_pooling_params = []
         self.share_inputs["image_features"] = None
         multi_vision_inputs = {
-            "images_lst": [], 
-            "grid_thw_lst": [], 
-            "vit_position_ids_lst": [], 
-            "cu_seqlens": [0], 
-            "feature_slice_info": None, # 记录prefix cache后的切片信息
-            }
+            "images_lst": [],
+            "grid_thw_lst": [],
+            "vit_position_ids_lst": [],
+            "cu_seqlens": [0],
+            "feature_slice_info": None,  # 记录prefix cache后的切片信息
+        }
         rope_3d_position_ids = {
             "position_ids_idx": [],
             "position_ids_lst": [],
@@ -705,9 +700,7 @@ class GPUModelRunner(ModelRunnerBase):
                     self._apply_mm_inputs(request, multi_vision_inputs, rope_3d_position_ids)
                     if request.with_image and prefill_start_index > 0:
                         slice_start, slice_end = self._calc_image_feature_range(
-                            request.multimodal_inputs,
-                            prefill_start_index,
-                            prefill_end_index
+                            request.multimodal_inputs, prefill_start_index, prefill_end_index
                         )
                         multi_vision_inputs["feature_slice_info"] = (slice_start, slice_end)
                         logger.debug(
@@ -880,8 +873,8 @@ class GPUModelRunner(ModelRunnerBase):
 
         if len(multi_vision_inputs["images_lst"]) > 0:
             full_image_features = self.extract_vision_features(multi_vision_inputs)
-        
-            # 根据切片信息进行切片
+
+            # 新增：根据切片信息进行切片
             slice_info = multi_vision_inputs.get("feature_slice_info")
             if slice_info is not None:
                 slice_start, slice_end = slice_info

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -488,6 +488,67 @@ class GPUModelRunner(ModelRunnerBase):
         for i, mm_hash in enumerate(mm_hashes):
             self.encoder_cache[mm_hash] = image_features_lst[i].cpu()
 
+    def _calc_image_feature_range(
+        self, 
+        mm_inputs: dict, 
+        prefill_start: int, 
+        prefill_end: int
+    ) -> tuple[int, int]:
+        """Calculate the image feature index range for the given prefill range.
+
+        When prefix cache hits, only part of the tokens need to be recomputed.
+        The image features must be sliced to match the prefill token range
+        [prefill_start, prefill_end).
+
+        Args:
+            mm_inputs (dict): Multimodal inputs containing mm_positions.
+            prefill_start (int): Start token index of the PREFILL range.
+            prefill_end (int): End token index of the PREFILL range.
+
+        Returns:
+            tuple: (feature_start, feature_end) index range into the full
+                image feature tensor.
+        """
+        if mm_inputs is None or "mm_positions" not in mm_inputs:
+            return (0, 0)
+        
+        mm_positions = mm_inputs.get("mm_positions", [])
+        if not mm_positions:
+            return (0, 0)
+        
+        # 完整 PREFILL 场景：返回全部图像特征
+        if prefill_start == 0:
+            total_image_tokens = sum(pos.length for pos in mm_positions)
+            return (0, total_image_tokens)
+        
+        # Prefix Cache 命中场景：计算 prefill 范围内的图像 token 对应的特征范围
+        feature_start = -1
+        feature_end = 0
+        cumulative_tokens = 0
+        
+        for pos in mm_positions:
+            img_token_start = pos.offset
+            img_token_end = pos.offset + pos.length
+            
+            # 计算当前图像与 prefill 范围的重叠部分
+            overlap_start = max(img_token_start, prefill_start)
+            overlap_end = min(img_token_end, prefill_end)
+            
+            if overlap_start < overlap_end:
+                # 存在重叠
+                local_start = overlap_start - img_token_start  # 在当前图像特征中的起始位置
+                local_end = overlap_end - img_token_start      # 在当前图像特征中的结束位置
+                
+                if feature_start == -1:
+                    feature_start = cumulative_tokens + local_start
+                feature_end = cumulative_tokens + local_end
+            
+            cumulative_tokens += pos.length
+        
+        if feature_start == -1:
+            feature_start = 0      
+        return (feature_start, feature_end)
+
     def _apply_mm_inputs(self, request: Request, multi_vision_inputs: dict, rope_3d_position_ids: dict):
         """
         Apply multimodal inputs to share_inputs
@@ -593,7 +654,13 @@ class GPUModelRunner(ModelRunnerBase):
 
         batch_pooling_params = []
         self.share_inputs["image_features"] = None
-        multi_vision_inputs = {"images_lst": [], "grid_thw_lst": [], "vit_position_ids_lst": [], "cu_seqlens": [0]}
+        multi_vision_inputs = {
+            "images_lst": [], 
+            "grid_thw_lst": [], 
+            "vit_position_ids_lst": [], 
+            "cu_seqlens": [0], 
+            "feature_slice_info": None, # 记录prefix cache后的切片信息
+            }
         rope_3d_position_ids = {
             "position_ids_idx": [],
             "position_ids_lst": [],
@@ -636,6 +703,17 @@ class GPUModelRunner(ModelRunnerBase):
                 length = prefill_end_index - prefill_start_index
                 if self.enable_mm:
                     self._apply_mm_inputs(request, multi_vision_inputs, rope_3d_position_ids)
+                    if request.with_image and prefill_start_index > 0:
+                        slice_start, slice_end = self._calc_image_feature_range(
+                            request.multimodal_inputs,
+                            prefill_start_index,
+                            prefill_end_index
+                        )
+                        multi_vision_inputs["feature_slice_info"] = (slice_start, slice_end)
+                        logger.debug(
+                            f"Prefix Cache hit: prefill_range=[{prefill_start_index}, {prefill_end_index}), "
+                            f"image_feature_range=[{slice_start}, {slice_end})"
+                        )
 
                 if not self.is_pooling_model:
                     if request.get("enable_thinking") is not None:
@@ -801,7 +879,22 @@ class GPUModelRunner(ModelRunnerBase):
             self.sampler.apply_logits_processor(idx, logits_info, prefill_tokens)
 
         if len(multi_vision_inputs["images_lst"]) > 0:
-            self.share_inputs["image_features"] = self.extract_vision_features(multi_vision_inputs)
+            full_image_features = self.extract_vision_features(multi_vision_inputs)
+        
+            # 根据切片信息进行切片
+            slice_info = multi_vision_inputs.get("feature_slice_info")
+            if slice_info is not None:
+                slice_start, slice_end = slice_info
+                if slice_end > slice_start:
+                    self.share_inputs["image_features"] = full_image_features[slice_start:slice_end]
+                    logger.debug(
+                        f"Sliced image features: full_shape={full_image_features.shape}, "
+                        f"sliced_shape={self.share_inputs['image_features'].shape}"
+                    )
+                else:
+                    self.share_inputs["image_features"] = None
+            else:
+                self.share_inputs["image_features"] = full_image_features
 
         if len(rope_3d_position_ids["position_ids_idx"]) > 0:
             packed_position_ids = paddle.to_tensor(


### PR DESCRIPTION
## 问题描述
enable_prefix_caching=True 时，发送两次相同的多模态请求，第二次崩溃：
ValueError: cannot copy sequence with size 3577 to array axis with dimension 14

## 根本原因
input_ids 被正确切片到 [prefill_start, prefill_end)，
但 image_features 没有对应切片，仍然返回完整的 [3577, 3584]，
导致 get_input_embeddings() 中形状不匹配。

## 修复方案
新增 _calc_image_feature_range()，根据 mm_positions 计算
prefill 范围对应的图像特征切片范围，在 extract_vision_features()
之后进行切片。

## 测试验证
- 两次相同请求均正常返回，无崩溃
- sliced_feature_count == image_tokens_in_prefill (14 == 14)
- 两次请求的图像特征 Last row 完全一致