### PR TITLE
[BugFix] fix dp sheduler bug in ep4tp1 when start by using multi_api_server

### DIFF
--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -2118,9 +2118,8 @@ class EngineService:
             self.scheduler.start(role, host_ip, self.cfg.register_info)
         elif self.cfg.scheduler_config.name == "dp":
             request_queues_for_dp_ipc = []
-            result_queue_for_dp_ipc = multiprocessing.Queue()
-            for i in range(self.cfg.parallel_config.data_parallel_size):
-                request_queues_for_dp_ipc.append(multiprocessing.Queue())
+            result_queue_for_dp_ipc = [multiprocessing.Queue()]
+            request_queues_for_dp_ipc.append(multiprocessing.Queue())
             self.scheduler.start(
                 self.cfg.node_rank * self.cfg.worker_num_per_node % self.cfg.worker_num_per_node,
                 request_queues_for_dp_ipc,

--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -2112,18 +2112,11 @@ class EngineService:
 
         role = self.cfg.scheduler_config.splitwise_role
         host_ip = self.cfg.host_ip
-        request_queues_for_dp_ipc = None
-        result_queue_for_dp_ipc = None
         if self.cfg.scheduler_config.name == "splitwise":
             self.scheduler.start(role, host_ip, self.cfg.register_info)
         elif self.cfg.scheduler_config.name == "dp":
-            request_queues_for_dp_ipc = []
-            result_queue_for_dp_ipc = [multiprocessing.Queue()]
-            request_queues_for_dp_ipc.append(multiprocessing.Queue())
             self.scheduler.start(
                 self.cfg.node_rank * self.cfg.worker_num_per_node % self.cfg.worker_num_per_node,
-                request_queues_for_dp_ipc,
-                result_queue_for_dp_ipc,
             )
 
         if not envs.FD_ENABLE_MULTI_API_SERVER:

--- a/fastdeploy/engine/engine.py
+++ b/fastdeploy/engine/engine.py
@@ -782,9 +782,8 @@ class LLMEngine:
         elif self.cfg.scheduler_config.name == "dp":
             request_queues_for_dp_ipc = []
             result_queues_for_dp_ipc = []
-            for i in range(self.cfg.parallel_config.data_parallel_size):
-                request_queues_for_dp_ipc.append(multiprocessing.Queue())
-                result_queues_for_dp_ipc.append(multiprocessing.Queue())
+            request_queues_for_dp_ipc.append(multiprocessing.Queue())
+            result_queues_for_dp_ipc.append(multiprocessing.Queue())
             self.engine.scheduler.start(
                 self.cfg.node_rank * self.cfg.worker_num_per_node % self.cfg.worker_num_per_node,
                 request_queues_for_dp_ipc,

--- a/fastdeploy/engine/engine.py
+++ b/fastdeploy/engine/engine.py
@@ -775,19 +775,11 @@ class LLMEngine:
 
         role = self.cfg.scheduler_config.splitwise_role
         host_ip = self.cfg.host_ip
-        request_queues_for_dp_ipc = None
-        result_queues_for_dp_ipc = None
         if self.cfg.scheduler_config.name == "splitwise":
             self.engine.scheduler.start(role, host_ip, self.cfg.register_info)
         elif self.cfg.scheduler_config.name == "dp":
-            request_queues_for_dp_ipc = []
-            result_queues_for_dp_ipc = []
-            request_queues_for_dp_ipc.append(multiprocessing.Queue())
-            result_queues_for_dp_ipc.append(multiprocessing.Queue())
             self.engine.scheduler.start(
                 self.cfg.node_rank * self.cfg.worker_num_per_node % self.cfg.worker_num_per_node,
-                request_queues_for_dp_ipc,
-                result_queues_for_dp_ipc,
             )
 
         if not envs.FD_ENABLE_MULTI_API_SERVER:
@@ -825,8 +817,6 @@ class LLMEngine:
                                 cfg,
                                 i,
                                 None,
-                                request_queues_for_dp_ipc,
-                                result_queues_for_dp_ipc,
                             ),
                         )
                     )

--- a/fastdeploy/engine/expert_service.py
+++ b/fastdeploy/engine/expert_service.py
@@ -96,9 +96,7 @@ class ExpertService:
 
         self._finalizer = weakref.finalize(self, self._exit_sub_services)
 
-    def start(
-        self, ipc_signal_suffix, local_data_parallel_id, request_queues_for_dp_ipc=None, result_queues_for_dp_ipc=None
-    ):
+    def start(self, ipc_signal_suffix, local_data_parallel_id):
         """
         Initializes the engine and starts its sub-services.
         If `api_server_pid` is defined, will launch a thread
@@ -112,8 +110,7 @@ class ExpertService:
             self.engine.create_data_processor()
         if self.cfg.scheduler_config.name == "dp":
             self.cfg.init_cache_info()
-            assert (request_queues_for_dp_ipc is not None) and (result_queues_for_dp_ipc is not None)
-            self.engine.scheduler.start(local_data_parallel_id, request_queues_for_dp_ipc, result_queues_for_dp_ipc)
+            self.engine.scheduler.start(local_data_parallel_id)
 
         if ipc_signal_suffix is not None:
             self.api_server_pid = ipc_signal_suffix

--- a/fastdeploy/entrypoints/openai/api_server.py
+++ b/fastdeploy/entrypoints/openai/api_server.py
@@ -15,7 +15,6 @@
 
 import asyncio
 import json
-import multiprocessing
 import os
 import signal
 import threading
@@ -158,16 +157,8 @@ def load_data_service():
     config = engine_args.create_engine_config()
     api_server_logger.info(f"local_data_parallel_id: {config.parallel_config}")
     api_server_logger.info(f"local_data_parallel_id: {config.parallel_config.local_data_parallel_id}")
-    api_server_logger.info(f"scheduler_config.name: {config.scheduler_config.name}")
-    request_queues_for_dp_ipc = None
-    result_queues_for_dp_ipc = None
-    if config.scheduler_config.name == "dp":
-        request_queues_for_dp_ipc = [multiprocessing.Queue()]
-        result_queues_for_dp_ipc = [multiprocessing.Queue()]
     expert_service = ExpertService(config, config.parallel_config.local_data_parallel_id)
-    if not expert_service.start(
-        args.port, config.parallel_config.local_data_parallel_id, request_queues_for_dp_ipc, result_queues_for_dp_ipc
-    ):
+    if not expert_service.start(args.port, config.parallel_config.local_data_parallel_id):
         api_server_logger.error("Failed to initialize FastDeploy LLM expert service, service exit now!")
         return None
     llm_engine = expert_service

--- a/fastdeploy/entrypoints/openai/api_server.py
+++ b/fastdeploy/entrypoints/openai/api_server.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import json
+import multiprocessing
 import os
 import signal
 import threading
@@ -156,8 +157,17 @@ def load_data_service():
     engine_args = EngineArgs.from_cli_args(args)
     config = engine_args.create_engine_config()
     api_server_logger.info(f"local_data_parallel_id: {config.parallel_config}")
+    api_server_logger.info(f"local_data_parallel_id: {config.parallel_config.local_data_parallel_id}")
+    api_server_logger.info(f"scheduler_config.name: {config.scheduler_config.name}")
+    request_queues_for_dp_ipc = None
+    result_queues_for_dp_ipc = None
+    if config.scheduler_config.name == "dp":
+        request_queues_for_dp_ipc = [multiprocessing.Queue()]
+        result_queues_for_dp_ipc = [multiprocessing.Queue()]
     expert_service = ExpertService(config, config.parallel_config.local_data_parallel_id)
-    if not expert_service.start(args.port, config.parallel_config.local_data_parallel_id):
+    if not expert_service.start(
+        args.port, config.parallel_config.local_data_parallel_id, request_queues_for_dp_ipc, result_queues_for_dp_ipc
+    ):
         api_server_logger.error("Failed to initialize FastDeploy LLM expert service, service exit now!")
         return None
     llm_engine = expert_service
@@ -668,7 +678,7 @@ def launch_api_server() -> None:
         "loglevel": "info",
         "graceful_timeout": args.timeout_graceful_shutdown,
         "timeout": args.timeout,
-        "control_socket_disable": True, 
+        "control_socket_disable": True,
     }
 
     try:

--- a/fastdeploy/scheduler/dp_scheduler.py
+++ b/fastdeploy/scheduler/dp_scheduler.py
@@ -221,13 +221,13 @@ class DPScheduler:
         for request in requests:
             if not hasattr(request, "dp_rank"):
                 raise ValueError(f"Request object is missing the 'dp_rank' attribute: {request}")
-            self.request_queues[request.dp_rank].put(request)
+            self.request_queues[0].put(request)
             results.append((request.request_id, None))
         return results
 
     def _put_requests_to_local(self):
         while True:
-            request = self.request_queues[self.dp_rank].get()
+            request = self.request_queues[0].get()
             self.scheduler_logger.info(f"Recieve request from puller, request_id: {request.request_id}")
             self._scheduler.put_requests([request])
 
@@ -236,7 +236,7 @@ class DPScheduler:
             results = self._scheduler.get_results()
             if len(results) == 0:
                 continue
-            self.result_queues[self.dp_rank].put(results)
+            self.result_queues[0].put(results)
 
     def get_requests(
         self,
@@ -257,4 +257,4 @@ class DPScheduler:
         self._scheduler.put_results(results)
 
     def get_results(self) -> Dict[str, List[RequestOutput]]:
-        return self.result_queues[self.dp_rank].get()
+        return self.result_queues[0].get()

--- a/fastdeploy/scheduler/dp_scheduler.py
+++ b/fastdeploy/scheduler/dp_scheduler.py
@@ -15,9 +15,9 @@
 """
 
 import logging
+import multiprocessing
 import threading
 import time
-from multiprocessing import Queue
 from typing import Dict, List, Optional
 
 from fastdeploy.engine.request import Request, RequestOutput
@@ -207,10 +207,10 @@ class DPScheduler:
             splitwise_role,
         )
 
-    def start(self, dp_rank: int, request_queues: List[Queue], result_queues: Queue):
+    def start(self, dp_rank: int):
         self.dp_rank = dp_rank
-        self.request_queues = request_queues
-        self.result_queues = result_queues
+        self.request_queues = multiprocessing.Queue()
+        self.result_queues = multiprocessing.Queue()
         self.scheduler_logger = get_logger("dpscheduler", f"dp_scheduler_rank{self.dp_rank}.log")
         self._scheduler.scheduler_logger = self.scheduler_logger
         threading.Thread(target=self._put_requests_to_local).start()
@@ -221,13 +221,13 @@ class DPScheduler:
         for request in requests:
             if not hasattr(request, "dp_rank"):
                 raise ValueError(f"Request object is missing the 'dp_rank' attribute: {request}")
-            self.request_queues[0].put(request)
+            self.request_queues.put(request)
             results.append((request.request_id, None))
         return results
 
     def _put_requests_to_local(self):
         while True:
-            request = self.request_queues[0].get()
+            request = self.request_queues.get()
             self.scheduler_logger.info(f"Recieve request from puller, request_id: {request.request_id}")
             self._scheduler.put_requests([request])
 
@@ -236,7 +236,7 @@ class DPScheduler:
             results = self._scheduler.get_results()
             if len(results) == 0:
                 continue
-            self.result_queues[0].put(results)
+            self.result_queues.put(results)
 
     def get_requests(
         self,
@@ -257,4 +257,4 @@ class DPScheduler:
         self._scheduler.put_results(results)
 
     def get_results(self) -> Dict[str, List[RequestOutput]]:
-        return self.result_queues[0].get()
+        return self.result_queues.get()

--- a/tests/scheduler/test_dp_scheduler.py
+++ b/tests/scheduler/test_dp_scheduler.py
@@ -16,7 +16,7 @@ import sys
 import time
 import unittest
 from multiprocessing import Queue
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 # Mock all external dependencies before importing anything
 mock_logger = Mock()
@@ -577,12 +577,12 @@ class TestDPScheduler(unittest.TestCase):
     @patch("threading.Thread")
     def test_put_requests_success(self, mock_thread):
         """Test successful put_requests with dp_rank."""
-        # Create request queues - use Mock instead of real Queue to avoid threading issues
-        request_queues = [Mock(), Mock(), Mock()]
-        result_queue = Mock()
-
         # Start the scheduler - this will create mocked threads
-        self.dp_scheduler.start(0, request_queues, result_queue)
+        self.dp_scheduler.start(0)
+
+        # Create request queues - use Mock instead of real Queue to avoid threading issues
+        self.dp_scheduler.request_queues = Mock()
+        self.dp_scheduler.result_queues = Mock()
 
         # Create requests with dp_rank
         mock_request1 = MockRequest("test_req1")
@@ -601,18 +601,17 @@ class TestDPScheduler(unittest.TestCase):
         self.assertEqual(results[1], ("test_req2", None))
 
         # Verify requests were put to the correct queues
-        request_queues[0].put.assert_called_once_with(mock_request1)
-        request_queues[1].put.assert_called_once_with(mock_request2)
+        expected_calls = [call(mock_request1), call(mock_request2)]
+        self.dp_scheduler.request_queues.put.assert_has_calls(expected_calls, any_order=False)
 
     @patch("threading.Thread")
     def test_start_creates_threads(self, mock_thread):
         """Test that start creates and starts threads."""
         mock_thread.return_value = Mock()
 
-        request_queues = [Queue(), Queue()]
-        result_queue = Queue()
-
-        self.dp_scheduler.start(0, request_queues, result_queue)
+        self.dp_scheduler.start(0)
+        self.dp_scheduler.request_queues = Queue()
+        self.dp_scheduler.result_queues = Queue()
 
         # Should create 2 threads
         self.assertEqual(mock_thread.call_count, 2)
@@ -640,8 +639,8 @@ class TestDPIntegration(unittest.TestCase):
         with patch.object(dp_scheduler, "start") as mock_start:
             # Set up test data directly
             dp_scheduler.dp_rank = 0
-            dp_scheduler.request_queues = [Mock(), Mock()]
-            dp_scheduler.result_queue = Mock()
+            dp_scheduler.request_queues = Mock()
+            dp_scheduler.result_queues = Mock()
             dp_scheduler.scheduler_logger = mock_logger
             dp_scheduler._scheduler.scheduler_logger = mock_logger
 
@@ -650,7 +649,7 @@ class TestDPIntegration(unittest.TestCase):
             mock_request.dp_rank = 0
 
             # Mock the request_queues to avoid real Queue operations
-            dp_scheduler.request_queues[0].put = Mock()
+            dp_scheduler.request_queues.put = Mock()
 
             # Test put_requests functionality
             results = dp_scheduler.put_requests([mock_request])
@@ -658,7 +657,7 @@ class TestDPIntegration(unittest.TestCase):
             self.assertEqual(results[0], ("integration_req", None))
 
             # Verify the request was put to the correct queue
-            dp_scheduler.request_queues[0].put.assert_called_once_with(mock_request)
+            dp_scheduler.request_queues.put.assert_called_once_with(mock_request)
 
             # Verify start method was not called (to avoid threads)
             mock_start.assert_not_called()


### PR DESCRIPTION
## Motivation

使用multi_api_server时，不同dp的EngineService是独立的，各自拥有自己的dp scheduler，所以不再需要持有其他进程的通信队列

## Modifications
为简化修改量，暂时仍使用multiprocessing.Queue；
1. api_server.py启动时设置各自的队列
2. dp_scheduler的队列列表只包含一个队列

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
