### PR TITLE
[BugFix] Fix platform-specific attribute access in reset_model_inputs

### DIFF
--- a/fastdeploy/worker/input_batch.py
+++ b/fastdeploy/worker/input_batch.py
@@ -946,10 +946,14 @@ class ProposerInputBatch(InputBatch):
                 else:
                     self.pre_ids = paddle.clone(self.target_model_input_batch["pre_ids"])
                     self.token_ids_all = None
+                self.cu_seqlens_q_output = paddle.clone(self.target_model_input_batch["cu_seqlens_q_output"])
+                self.batch_id_per_token_output = paddle.clone(
+                    self.target_model_input_batch["batch_id_per_token_output"]
+                )
             else:
                 self.pre_ids = paddle.clone(self.target_model_input_batch["pre_ids"])
-            self.output_cum_offsets = paddle.clone(self.target_model_input_batch["output_cum_offsets"])
-            self.output_padding_offset = paddle.clone(self.target_model_input_batch["output_padding_offset"])
+                self.output_cum_offsets = paddle.clone(self.target_model_input_batch["output_cum_offsets"])
+                self.output_padding_offset = paddle.clone(self.target_model_input_batch["output_padding_offset"])
             self.ids_remove_padding = paddle.clone(self.target_model_input_batch["ids_remove_padding"])
             self.batch_id_per_token = paddle.clone(self.target_model_input_batch["batch_id_per_token"])
             self.cu_seqlens_q = paddle.clone(self.target_model_input_batch["cu_seqlens_q"])


### PR DESCRIPTION
## Motivation

修复 `ProposerInputBatch.reset_model_inputs` 方法中的平台属性访问错误。

在 CUDA 平台上，代码错误地尝试访问 `output_cum_offsets` 和 `output_padding_offset` 属性，但这些属性仅在非 CUDA 平台上初始化，导致错误：
```
Resetting model inputs failed, skipping reset, error message is "'output cum offsets' is not a valid attribute of InputBatch"
```

## Modifications

- 将 `output_cum_offsets` 和 `output_padding_offset` 的重置代码移到 `else` 分支（非 CUDA 平台）
- 在 `if current_platform.is_cuda()` 分支中添加 `cu_seqlens_q_output` 和 `batch_id_per_token_output` 的重置代码

这与初始化逻辑（第 285-298 行）保持一致，确保不同平台访问正确的属性。

## Usage or Command

无需额外命令，修复后代码会根据平台自动选择正确的属性进行重置。

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: `[BugFix]`
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.