### PR TITLE
[DataProcessor] Add get_mm_max_tokens_per_item method for VL processors

### DIFF
--- a/fastdeploy/input/paddleocr_vl_processor/process.py
+++ b/fastdeploy/input/paddleocr_vl_processor/process.py
@@ -16,6 +16,7 @@
 """
 
 import pickle
+from collections.abc import Mapping
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -28,11 +29,11 @@ from fastdeploy.engine.request import ImagePosition
 from fastdeploy.entrypoints.chat_utils import parse_chat_messages
 from fastdeploy.input.ernie4_5_vl_processor import read_video_decord
 from fastdeploy.input.mm_data_processor import MMBaseDataProcessor
-from fastdeploy.input.utils import IDS_TYPE_FLAG
+from fastdeploy.input.utils import IDS_TYPE_FLAG, MAX_IMAGE_DIMENSION
 from fastdeploy.multimodal.hasher import MultimodalHasher
 from fastdeploy.utils import data_processor_logger
 
-from .image_processor import ImageProcessor
+from .image_processor import ImageProcessor, smart_resize
 from .process_video import sample_frames
 
 
@@ -620,3 +621,66 @@ class DataProcessor(MMBaseDataProcessor):
             f"req_id:{request.get('request_id', ''), } prompt: {raw_prompt} tokens: {tokens}, token_ids: {token_ids}"
         )
         return token_ids
+
+    def get_max_image_tokens(self, seq_len: int) -> int:
+        """
+        Get the maximum number of image tokens for a single image.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            Maximum number of image tokens
+        """
+        resized_height, resized_width = smart_resize(
+            height=MAX_IMAGE_DIMENSION,
+            width=MAX_IMAGE_DIMENSION,
+            factor=self.image_processor.patch_size * self.image_processor.merge_size,
+            min_pixels=self.image_processor.min_pixels,
+            max_pixels=self.image_processor.max_pixels,
+        )
+        grid_h, grid_w = (
+            resized_height // self.image_processor.patch_size,
+            resized_width // self.image_processor.patch_size,
+        )
+        num_image_tokens = grid_h * grid_w // (self.image_processor.merge_size**2)
+        return min(num_image_tokens, seq_len)
+
+    def get_max_video_tokens(self, seq_len: int) -> int:
+        """
+        Get the maximum number of video tokens for a single video chunk.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            Maximum number of video tokens per chunk
+        """
+        resized_height, resized_width = smart_resize(
+            height=MAX_IMAGE_DIMENSION,
+            width=MAX_IMAGE_DIMENSION,
+            factor=self.image_processor.patch_size * self.image_processor.merge_size,
+            min_pixels=self.image_processor.min_pixels,
+            max_pixels=self.image_processor.max_pixels,
+        )
+        grid_h, grid_w = (
+            resized_height // self.image_processor.patch_size,
+            resized_width // self.image_processor.patch_size,
+        )
+        # For video, temporal dimension is considered but we return per-frame tokens
+        num_video_tokens = grid_h * grid_w // (self.image_processor.merge_size**2)
+        return min(num_video_tokens, seq_len)
+
+    def get_mm_max_tokens_per_item(self, seq_len: int) -> Mapping[str, int]:
+        """
+        Return the maximum number of tokens per item for each modality.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            A mapping from modalities to their respective maximum token counts.
+        """
+        max_image_tokens = self.get_max_image_tokens(seq_len)
+        max_video_tokens = self.get_max_video_tokens(seq_len)
+        return {"image": max_image_tokens, "video": max_video_tokens}

--- a/fastdeploy/input/qwen3_vl_processor/process.py
+++ b/fastdeploy/input/qwen3_vl_processor/process.py
@@ -16,6 +16,7 @@
 """
 
 import pickle
+from collections.abc import Mapping
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -28,11 +29,11 @@ from fastdeploy.engine.request import ImagePosition
 from fastdeploy.entrypoints.chat_utils import parse_chat_messages
 from fastdeploy.input.ernie4_5_vl_processor import read_video_decord
 from fastdeploy.input.mm_data_processor import MMBaseDataProcessor
-from fastdeploy.input.utils import IDS_TYPE_FLAG
+from fastdeploy.input.utils import IDS_TYPE_FLAG, MAX_IMAGE_DIMENSION
 from fastdeploy.multimodal.hasher import MultimodalHasher
 from fastdeploy.utils import data_processor_logger
 
-from .image_processor import ImageProcessor, ceil_by_factor, floor_by_factor
+from .image_processor import ImageProcessor, ceil_by_factor, floor_by_factor, smart_resize
 
 VIDEO_MIN_PIXELS = 128 * 28 * 28
 VIDEO_MAX_PIXELS = 768 * 28 * 28
@@ -672,3 +673,66 @@ class DataProcessor(MMBaseDataProcessor):
         req = pickle.dumps((mm_hashes, mm_items))
         socket.send_multipart([b"", req])
         data_processor_logger.info(f"Update cache of mm_hashes: {mm_hashes}")
+
+    def get_max_image_tokens(self, seq_len: int) -> int:
+        """
+        Get the maximum number of image tokens for a single image.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            Maximum number of image tokens
+        """
+        resized_height, resized_width = smart_resize(
+            height=MAX_IMAGE_DIMENSION,
+            width=MAX_IMAGE_DIMENSION,
+            factor=self.image_processor.patch_size * self.image_processor.merge_size,
+            min_pixels=self.image_processor.min_pixels,
+            max_pixels=self.image_processor.max_pixels,
+        )
+        grid_h, grid_w = (
+            resized_height // self.image_processor.patch_size,
+            resized_width // self.image_processor.patch_size,
+        )
+        num_image_tokens = grid_h * grid_w // (self.image_processor.merge_size**2)
+        return min(num_image_tokens, seq_len)
+
+    def get_max_video_tokens(self, seq_len: int) -> int:
+        """
+        Get the maximum number of video tokens for a single video chunk.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            Maximum number of video tokens per chunk
+        """
+        resized_height, resized_width = smart_resize(
+            height=MAX_IMAGE_DIMENSION,
+            width=MAX_IMAGE_DIMENSION,
+            factor=self.image_processor.patch_size * self.image_processor.merge_size,
+            min_pixels=VIDEO_MIN_PIXELS,
+            max_pixels=VIDEO_MAX_PIXELS,
+        )
+        grid_h, grid_w = (
+            resized_height // self.image_processor.patch_size,
+            resized_width // self.image_processor.patch_size,
+        )
+        # For video, temporal dimension is considered but we return per-frame tokens
+        num_video_tokens = grid_h * grid_w // (self.image_processor.merge_size**2)
+        return min(num_video_tokens, seq_len)
+
+    def get_mm_max_tokens_per_item(self, seq_len: int) -> Mapping[str, int]:
+        """
+        Return the maximum number of tokens per item for each modality.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            A mapping from modalities to their respective maximum token counts.
+        """
+        max_image_tokens = self.get_max_image_tokens(seq_len)
+        max_video_tokens = self.get_max_video_tokens(seq_len)
+        return {"image": max_image_tokens, "video": max_video_tokens}

--- a/fastdeploy/input/qwen_vl_processor/process.py
+++ b/fastdeploy/input/qwen_vl_processor/process.py
@@ -16,6 +16,7 @@
 """
 
 import pickle
+from collections.abc import Mapping
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -28,11 +29,11 @@ from fastdeploy.engine.request import ImagePosition
 from fastdeploy.entrypoints.chat_utils import parse_chat_messages
 from fastdeploy.input.ernie4_5_vl_processor import read_video_decord
 from fastdeploy.input.mm_data_processor import MMBaseDataProcessor
-from fastdeploy.input.utils import IDS_TYPE_FLAG
+from fastdeploy.input.utils import IDS_TYPE_FLAG, MAX_IMAGE_DIMENSION
 from fastdeploy.multimodal.hasher import MultimodalHasher
 from fastdeploy.utils import data_processor_logger
 
-from .image_processor import ImageProcessor
+from .image_processor import ImageProcessor, smart_resize
 from .process_video import sample_frames
 
 FRAME_FACTOR = 2
@@ -589,3 +590,66 @@ class DataProcessor(MMBaseDataProcessor):
         req = pickle.dumps((mm_hashes, mm_items))
         socket.send_multipart([b"", req])
         data_processor_logger.info(f"Update cache of mm_hashes: {mm_hashes}")
+
+    def get_max_image_tokens(self, seq_len: int) -> int:
+        """
+        Get the maximum number of image tokens for a single image.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            Maximum number of image tokens
+        """
+        resized_height, resized_width = smart_resize(
+            height=MAX_IMAGE_DIMENSION,
+            width=MAX_IMAGE_DIMENSION,
+            factor=self.image_processor.patch_size * self.image_processor.merge_size,
+            min_pixels=self.image_processor.min_pixels,
+            max_pixels=self.image_processor.max_pixels,
+        )
+        grid_h, grid_w = (
+            resized_height // self.image_processor.patch_size,
+            resized_width // self.image_processor.patch_size,
+        )
+        num_image_tokens = grid_h * grid_w // (self.image_processor.merge_size**2)
+        return min(num_image_tokens, seq_len)
+
+    def get_max_video_tokens(self, seq_len: int) -> int:
+        """
+        Get the maximum number of video tokens for a single video chunk.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            Maximum number of video tokens per chunk
+        """
+        resized_height, resized_width = smart_resize(
+            height=MAX_IMAGE_DIMENSION,
+            width=MAX_IMAGE_DIMENSION,
+            factor=self.image_processor.patch_size * self.image_processor.merge_size,
+            min_pixels=self.image_processor.min_pixels,
+            max_pixels=self.image_processor.max_pixels,
+        )
+        grid_h, grid_w = (
+            resized_height // self.image_processor.patch_size,
+            resized_width // self.image_processor.patch_size,
+        )
+        # For video, temporal dimension is considered but we return per-frame tokens
+        num_video_tokens = grid_h * grid_w // (self.image_processor.merge_size**2)
+        return min(num_video_tokens, seq_len)
+
+    def get_mm_max_tokens_per_item(self, seq_len: int) -> Mapping[str, int]:
+        """
+        Return the maximum number of tokens per item for each modality.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            A mapping from modalities to their respective maximum token counts.
+        """
+        max_image_tokens = self.get_max_image_tokens(seq_len)
+        max_video_tokens = self.get_max_video_tokens(seq_len)
+        return {"image": max_image_tokens, "video": max_video_tokens}

--- a/fastdeploy/input/v1/paddleocr_vl_processor/process.py
+++ b/fastdeploy/input/v1/paddleocr_vl_processor/process.py
@@ -16,6 +16,7 @@
 """
 
 import pickle
+from collections.abc import Mapping
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -28,11 +29,11 @@ from fastdeploy.engine.request import ImagePosition, Request
 from fastdeploy.entrypoints.chat_utils import parse_chat_messages
 from fastdeploy.input.ernie4_5_vl_processor import read_video_decord
 from fastdeploy.input.mm_data_processor import MMBaseDataProcessor
-from fastdeploy.input.utils import IDS_TYPE_FLAG
+from fastdeploy.input.utils import IDS_TYPE_FLAG, MAX_IMAGE_DIMENSION
 from fastdeploy.multimodal.hasher import MultimodalHasher
 from fastdeploy.utils import data_processor_logger
 
-from .image_processor import ImageProcessor
+from .image_processor import ImageProcessor, smart_resize
 from .process_video import sample_frames
 
 
@@ -620,3 +621,66 @@ class DataProcessor(MMBaseDataProcessor):
             f"req_id:{request.get('request_id', ''), } prompt: {raw_prompt} tokens: {tokens}, token_ids: {token_ids}"
         )
         return token_ids
+
+    def get_max_image_tokens(self, seq_len: int) -> int:
+        """
+        Get the maximum number of image tokens for a single image.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            Maximum number of image tokens
+        """
+        resized_height, resized_width = smart_resize(
+            height=MAX_IMAGE_DIMENSION,
+            width=MAX_IMAGE_DIMENSION,
+            factor=self.image_processor.patch_size * self.image_processor.merge_size,
+            min_pixels=self.image_processor.min_pixels,
+            max_pixels=self.image_processor.max_pixels,
+        )
+        grid_h, grid_w = (
+            resized_height // self.image_processor.patch_size,
+            resized_width // self.image_processor.patch_size,
+        )
+        num_image_tokens = grid_h * grid_w // (self.image_processor.merge_size**2)
+        return min(num_image_tokens, seq_len)
+
+    def get_max_video_tokens(self, seq_len: int) -> int:
+        """
+        Get the maximum number of video tokens for a single video chunk.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            Maximum number of video tokens per chunk
+        """
+        resized_height, resized_width = smart_resize(
+            height=MAX_IMAGE_DIMENSION,
+            width=MAX_IMAGE_DIMENSION,
+            factor=self.image_processor.patch_size * self.image_processor.merge_size,
+            min_pixels=self.image_processor.min_pixels,
+            max_pixels=self.image_processor.max_pixels,
+        )
+        grid_h, grid_w = (
+            resized_height // self.image_processor.patch_size,
+            resized_width // self.image_processor.patch_size,
+        )
+        # For video, temporal dimension is considered but we return per-frame tokens
+        num_video_tokens = grid_h * grid_w // (self.image_processor.merge_size**2)
+        return min(num_video_tokens, seq_len)
+
+    def get_mm_max_tokens_per_item(self, seq_len: int) -> Mapping[str, int]:
+        """
+        Return the maximum number of tokens per item for each modality.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            A mapping from modalities to their respective maximum token counts.
+        """
+        max_image_tokens = self.get_max_image_tokens(seq_len)
+        max_video_tokens = self.get_max_video_tokens(seq_len)
+        return {"image": max_image_tokens, "video": max_video_tokens}

--- a/fastdeploy/input/v1/qwen3_vl_processor/process.py
+++ b/fastdeploy/input/v1/qwen3_vl_processor/process.py
@@ -16,6 +16,7 @@
 """
 
 import pickle
+from collections.abc import Mapping
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -28,11 +29,11 @@ from fastdeploy.engine.request import ImagePosition, Request
 from fastdeploy.entrypoints.chat_utils import parse_chat_messages
 from fastdeploy.input.ernie4_5_vl_processor import read_video_decord
 from fastdeploy.input.mm_data_processor import MMBaseDataProcessor
-from fastdeploy.input.utils import IDS_TYPE_FLAG
+from fastdeploy.input.utils import IDS_TYPE_FLAG, MAX_IMAGE_DIMENSION
 from fastdeploy.multimodal.hasher import MultimodalHasher
 from fastdeploy.utils import data_processor_logger
 
-from .image_processor import ImageProcessor, ceil_by_factor, floor_by_factor
+from .image_processor import ImageProcessor, ceil_by_factor, floor_by_factor, smart_resize
 
 VIDEO_MIN_PIXELS = 128 * 28 * 28
 VIDEO_MAX_PIXELS = 768 * 28 * 28
@@ -672,3 +673,66 @@ class DataProcessor(MMBaseDataProcessor):
         req = pickle.dumps((mm_hashes, mm_items))
         socket.send_multipart([b"", req])
         data_processor_logger.info(f"Update cache of mm_hashes: {mm_hashes}")
+
+    def get_max_image_tokens(self, seq_len: int) -> int:
+        """
+        Get the maximum number of image tokens for a single image.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            Maximum number of image tokens
+        """
+        resized_height, resized_width = smart_resize(
+            height=MAX_IMAGE_DIMENSION,
+            width=MAX_IMAGE_DIMENSION,
+            factor=self.image_processor.patch_size * self.image_processor.merge_size,
+            min_pixels=self.image_processor.min_pixels,
+            max_pixels=self.image_processor.max_pixels,
+        )
+        grid_h, grid_w = (
+            resized_height // self.image_processor.patch_size,
+            resized_width // self.image_processor.patch_size,
+        )
+        num_image_tokens = grid_h * grid_w // (self.image_processor.merge_size**2)
+        return min(num_image_tokens, seq_len)
+
+    def get_max_video_tokens(self, seq_len: int) -> int:
+        """
+        Get the maximum number of video tokens for a single video chunk.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            Maximum number of video tokens per chunk
+        """
+        resized_height, resized_width = smart_resize(
+            height=MAX_IMAGE_DIMENSION,
+            width=MAX_IMAGE_DIMENSION,
+            factor=self.image_processor.patch_size * self.image_processor.merge_size,
+            min_pixels=VIDEO_MIN_PIXELS,
+            max_pixels=VIDEO_MAX_PIXELS,
+        )
+        grid_h, grid_w = (
+            resized_height // self.image_processor.patch_size,
+            resized_width // self.image_processor.patch_size,
+        )
+        # For video, temporal dimension is considered but we return per-frame tokens
+        num_video_tokens = grid_h * grid_w // (self.image_processor.merge_size**2)
+        return min(num_video_tokens, seq_len)
+
+    def get_mm_max_tokens_per_item(self, seq_len: int) -> Mapping[str, int]:
+        """
+        Return the maximum number of tokens per item for each modality.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            A mapping from modalities to their respective maximum token counts.
+        """
+        max_image_tokens = self.get_max_image_tokens(seq_len)
+        max_video_tokens = self.get_max_video_tokens(seq_len)
+        return {"image": max_image_tokens, "video": max_video_tokens}

--- a/fastdeploy/input/v1/qwen_vl_processor/process.py
+++ b/fastdeploy/input/v1/qwen_vl_processor/process.py
@@ -16,6 +16,7 @@
 """
 
 import pickle
+from collections.abc import Mapping
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -28,11 +29,11 @@ from fastdeploy.engine.request import ImagePosition, Request
 from fastdeploy.entrypoints.chat_utils import parse_chat_messages
 from fastdeploy.input.ernie4_5_vl_processor import read_video_decord
 from fastdeploy.input.mm_data_processor import MMBaseDataProcessor
-from fastdeploy.input.utils import IDS_TYPE_FLAG
+from fastdeploy.input.utils import IDS_TYPE_FLAG, MAX_IMAGE_DIMENSION
 from fastdeploy.multimodal.hasher import MultimodalHasher
 from fastdeploy.utils import data_processor_logger
 
-from .image_processor import ImageProcessor
+from .image_processor import ImageProcessor, smart_resize
 from .process_video import sample_frames
 
 FRAME_FACTOR = 2
@@ -589,3 +590,66 @@ class DataProcessor(MMBaseDataProcessor):
         req = pickle.dumps((mm_hashes, mm_items))
         socket.send_multipart([b"", req])
         data_processor_logger.info(f"Update cache of mm_hashes: {mm_hashes}")
+
+    def get_max_image_tokens(self, seq_len: int) -> int:
+        """
+        Get the maximum number of image tokens for a single image.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            Maximum number of image tokens
+        """
+        resized_height, resized_width = smart_resize(
+            height=MAX_IMAGE_DIMENSION,
+            width=MAX_IMAGE_DIMENSION,
+            factor=self.image_processor.patch_size * self.image_processor.merge_size,
+            min_pixels=self.image_processor.min_pixels,
+            max_pixels=self.image_processor.max_pixels,
+        )
+        grid_h, grid_w = (
+            resized_height // self.image_processor.patch_size,
+            resized_width // self.image_processor.patch_size,
+        )
+        num_image_tokens = grid_h * grid_w // (self.image_processor.merge_size**2)
+        return min(num_image_tokens, seq_len)
+
+    def get_max_video_tokens(self, seq_len: int) -> int:
+        """
+        Get the maximum number of video tokens for a single video chunk.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            Maximum number of video tokens per chunk
+        """
+        resized_height, resized_width = smart_resize(
+            height=MAX_IMAGE_DIMENSION,
+            width=MAX_IMAGE_DIMENSION,
+            factor=self.image_processor.patch_size * self.image_processor.merge_size,
+            min_pixels=self.image_processor.min_pixels,
+            max_pixels=self.image_processor.max_pixels,
+        )
+        grid_h, grid_w = (
+            resized_height // self.image_processor.patch_size,
+            resized_width // self.image_processor.patch_size,
+        )
+        # For video, temporal dimension is considered but we return per-frame tokens
+        num_video_tokens = grid_h * grid_w // (self.image_processor.merge_size**2)
+        return min(num_video_tokens, seq_len)
+
+    def get_mm_max_tokens_per_item(self, seq_len: int) -> Mapping[str, int]:
+        """
+        Return the maximum number of tokens per item for each modality.
+
+        Args:
+            seq_len: Maximum sequence length
+
+        Returns:
+            A mapping from modalities to their respective maximum token counts.
+        """
+        max_image_tokens = self.get_max_image_tokens(seq_len)
+        max_video_tokens = self.get_max_video_tokens(seq_len)
+        return {"image": max_image_tokens, "video": max_video_tokens}

--- a/tests/input/test_ernie_vl_processor.py
+++ b/tests/input/test_ernie_vl_processor.py
@@ -1411,6 +1411,51 @@ class TestDataProcessor(unittest.TestCase):
                             mock_update.assert_called_once()
         self.processor.enable_processor_cache = False
 
+    def test_get_max_image_tokens(self):
+        """Test get_max_image_tokens method"""
+        seq_len = 100000
+        max_tokens = self.processor.get_max_image_tokens(seq_len)
+
+        # Verify return value is positive integer and does not exceed seq_len
+        self.assertIsInstance(max_tokens, int)
+        self.assertGreater(max_tokens, 0)
+        self.assertLessEqual(max_tokens, seq_len)
+
+    def test_get_max_video_tokens(self):
+        """Test get_max_video_tokens method"""
+        seq_len = 100000
+        max_tokens = self.processor.get_max_video_tokens(seq_len)
+
+        # Verify return value is positive integer and does not exceed seq_len
+        self.assertIsInstance(max_tokens, int)
+        self.assertGreater(max_tokens, 0)
+        self.assertLessEqual(max_tokens, seq_len)
+
+    def test_get_mm_max_tokens_per_item(self):
+        """Test get_mm_max_tokens_per_item method"""
+        seq_len = 100000
+        result = self.processor.get_mm_max_tokens_per_item(seq_len)
+
+        # Verify return format
+        self.assertIsInstance(result, dict)
+        self.assertIn("image", result)
+        self.assertIn("video", result)
+        self.assertIsInstance(result["image"], int)
+        self.assertIsInstance(result["video"], int)
+        self.assertGreater(result["image"], 0)
+        self.assertGreater(result["video"], 0)
+        self.assertLessEqual(result["image"], seq_len)
+        self.assertLessEqual(result["video"], seq_len)
+
+    def test_get_mm_max_tokens_per_item_with_small_seq_len(self):
+        """Test get_mm_max_tokens_per_item truncation with small seq_len"""
+        small_seq_len = 100
+        result = self.processor.get_mm_max_tokens_per_item(small_seq_len)
+
+        # Verify return values are truncated to seq_len
+        self.assertLessEqual(result["image"], small_seq_len)
+        self.assertLessEqual(result["video"], small_seq_len)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/input/test_paddleocr_vl_processor.py
+++ b/tests/input/test_paddleocr_vl_processor.py
@@ -72,7 +72,7 @@ class TestProcessVideo(unittest.TestCase):
         self.assertIn("exceeds", str(context.exception))
 
     def test_error_mutual_exclusion(self):
-        """新增：测试 num_frames 和 fps 互斥"""
+        """Test  num_frames 和 fps mutual exclusion"""
         with self.assertRaises(ValueError) as context:
             sample_frames(
                 frame_factor=self.frame_factor,
@@ -85,7 +85,7 @@ class TestProcessVideo(unittest.TestCase):
         self.assertIn("mutually exclusive", str(context.exception))
 
     def test_error_fps_without_metadata(self):
-        """新增：测试 fps > 0 但 metadata 为 None"""
+        """Test  fps > 0 but metadata is None"""
         with self.assertRaises(TypeError) as context:
             sample_frames(
                 frame_factor=self.frame_factor,
@@ -99,7 +99,7 @@ class TestProcessVideo(unittest.TestCase):
         self.assertIn("'NoneType' object is not subscriptable", str(context.exception))
 
     def test_num_frames_rounding(self):
-        """新增：测试 num_frames 向 frame_factor 舍入"""
+        """Test  num_frames rounding to frame_factor"""
         num_frames = 17  # 不是 4 的倍数
         # 逻辑: round(17 / 4) * 4 = round(4.25) * 4 = 4 * 4 = 16
         indices = sample_frames(
@@ -114,7 +114,7 @@ class TestProcessVideo(unittest.TestCase):
         self.assertEqual(len(indices), 16)
 
     def test_sample_with_fps_basic(self):
-        """新增：测试使用 fps 采样（基本路径，被 max_frames 限制）"""
+        """Test fps sampling (basic path, limited by max_frames)"""
         # 逻辑: num_frames_calc = 100 / 25 * 10 = 40
         #      num_frames_clamped = min(max(40, 8), 32) = 32
         #      num_frames_factored = floor(32 / 4) * 4 = 32
@@ -131,7 +131,7 @@ class TestProcessVideo(unittest.TestCase):
         self.assertEqual(indices[-1], 96)
 
     def test_sample_with_fps_hits_min_frames(self):
-        """新增：测试使用 fps 采样（被 min_frames 限制）"""
+        """Test fps sampling (limited by min_frames)"""
         # 逻辑: num_frames_calc = 100 / 25 * 1 = 4
         #      num_frames_clamped = min(max(4, 8), 32) = 8
         #      num_frames_factored = floor(8 / 4) * 4 = 8
@@ -148,7 +148,7 @@ class TestProcessVideo(unittest.TestCase):
         self.assertEqual(indices[-1], 87)
 
     def test_sample_with_fps_hits_total_frames(self):
-        """新增：测试使用 fps 采样（被 total_num_frames 限制）"""
+        """Test fps sampling (limited by total_num_frames)"""
         local_max_frames = 200
 
         # 逻辑: num_frames_calc = 100 / 25 * 50 = 200
@@ -167,7 +167,7 @@ class TestProcessVideo(unittest.TestCase):
         self.assertEqual(indices[-1], 99)  # 采样所有帧
 
     def test_no_sampling(self):
-        """新增：测试不采样（fps=0, num_frames=0）"""
+        """Test no sampling (fps=0, num_frames=0)"""
         indices = sample_frames(
             frame_factor=self.frame_factor,
             min_frames=self.min_frames,
@@ -442,7 +442,7 @@ class Test_DataProcessor(unittest.TestCase):
         self.assertEqual(meta["fps"], 1)
 
     def test_init_with_external_tokenizer(self):
-        """新增：测试使用外部传入的 tokenizer 初始化"""
+        """Test initialization with external tokenizer"""
         self.mock_auto_tokenizer_constructor.reset_mock()
 
         external_tokenizer = MagicMock()
@@ -452,7 +452,7 @@ class Test_DataProcessor(unittest.TestCase):
         self.assertIs(processor.tokenizer, external_tokenizer)
 
     def test_add_text_empty(self):
-        """新增：测试 _add_text 传入空字符串"""
+        """Test  _add_text with empty string"""
         outputs = self._get_init_outputs()
         self.processor._add_text("", outputs)
         self.assertEqual(outputs["input_ids"], [])
@@ -460,7 +460,7 @@ class Test_DataProcessor(unittest.TestCase):
 
     @patch(f"{MODULE_PATH}.IDS_TYPE_FLAG", {"text": 0})
     def test_add_text_pre_tokenized(self):
-        """新增：测试 _add_text 传入已 tokenized 的 IDs"""
+        """Test  _add_text with pre-tokenized IDs"""
         outputs = self._get_init_outputs()
         token_ids = [10, 11, 12]
         self.processor._add_text(token_ids, outputs)
@@ -473,7 +473,7 @@ class Test_DataProcessor(unittest.TestCase):
     @patch(f"{MODULE_PATH}.MultimodalHasher.hash_features", return_value="dummy_hash_456")
     @patch(f"{MODULE_PATH}.IDS_TYPE_FLAG", {"text": 0, "image": 1, "video": 2})
     def test_add_video_no_uuid(self, mock_hasher):
-        """新增：测试 _add_video 在 uuid 为 None 时自动哈希"""
+        """Test  _add_video auto-hashing when uuid is None"""
         outputs = self._get_init_outputs()
         meta = {"fps": 30}
         mock_preprocess_return = {
@@ -489,7 +489,7 @@ class Test_DataProcessor(unittest.TestCase):
 
     @patch(f"{MODULE_PATH}.IDS_TYPE_FLAG", {"text": 0, "image": 1, "video": 2})
     def test_add_processed_image(self):
-        """新增：测试 _add_processed_image 处理缓存数据"""
+        """Test  _add_processed_image with cached data"""
         outputs = self._get_init_outputs()
         outputs["cur_position"] = 3
 
@@ -506,7 +506,7 @@ class Test_DataProcessor(unittest.TestCase):
 
     @patch(f"{MODULE_PATH}.IDS_TYPE_FLAG", {"text": 0, "image": 1, "video": 2})
     def test_add_processed_video(self):
-        """新增：测试 _add_processed_video 处理缓存数据"""
+        """Test  _add_processed_video with cached data"""
         outputs = self._get_init_outputs()
         outputs["cur_position"] = 5
 
@@ -525,7 +525,7 @@ class Test_DataProcessor(unittest.TestCase):
         self.assertGreater(outputs["cur_position"], 5)
 
     def test_text2ids_with_processed_data(self):
-        """新增：测试 text2ids 调用 _add_processed_image 和 _add_processed_video"""
+        """Test  text2ids calling _add_processed_image and _add_processed_video"""
         with (
             patch.object(self.processor, "_add_processed_image") as mock_add_proc_img,
             patch.object(self.processor, "_add_processed_video") as mock_add_proc_vid,
@@ -545,7 +545,7 @@ class Test_DataProcessor(unittest.TestCase):
     @patch(f"{MODULE_PATH}.sample_frames")
     @patch(f"{MODULE_PATH}.read_video_decord")
     def test_load_and_process_video_no_sampling(self, mock_read_video, mock_sample_frames):
-        """新增：测试 _load_and_process_video 不采样（fps=-1）"""
+        """Test  _load_and_process_video without sampling (fps=-1)"""
         mock_reader = MagicMock()
         mock_reader.__getitem__.return_value.asnumpy.return_value = np.random.randint(
             0, 255, (100, 100, 3), dtype=np.uint8
@@ -563,7 +563,7 @@ class Test_DataProcessor(unittest.TestCase):
         self.assertEqual(meta["num_of_frame"], 10)
 
     def test_get_processor_cache(self):
-        """新增：测试 get_processor_cache (zmq)"""
+        """Test  get_processor_cache (zmq)"""
         hashes = ["hash1", "hash2"]
         expected_items = ["item1", "item2"]
         mock_resp = pickle.dumps(expected_items)
@@ -575,7 +575,7 @@ class Test_DataProcessor(unittest.TestCase):
         self.assertEqual(items, expected_items)
 
     def test_update_processor_cache(self):
-        """新增：测试 update_processor_cache (zmq)"""
+        """Test  update_processor_cache (zmq)"""
         hashes = ["hash1"]
         items = ["item1"]
 
@@ -585,7 +585,7 @@ class Test_DataProcessor(unittest.TestCase):
         self.mock_zmq_socket.send_multipart.assert_called_once_with([b"", expected_req])
 
     def test_apply_chat_template(self):
-        """新增：测试 apply_chat_template 核心逻辑"""
+        """Test  apply_chat_template core logic"""
         request = {"messages": ["msg1"], "add_generation_prompt": True, "request_id": "req123"}
         self.mock_tokenizer.apply_chat_template.return_value = "Prompt <|IMAGE_PLACEHOLDER|> text"
         self.mock_tokenizer.tokenize.return_value = ["Prompt", "text"]
@@ -601,7 +601,7 @@ class Test_DataProcessor(unittest.TestCase):
         self.mock_tokenizer.tokenize.assert_called_with("Prompt  text")
 
     def test_apply_chat_template_raises_error(self):
-        """新增：测试 apply_chat_template 在模板不存在时引发 ValueError"""
+        """Test  apply_chat_template raises ValueError when template is missing"""
         self.mock_tokenizer.chat_template = None
         with self.assertRaises(ValueError) as context:
             self.processor.apply_chat_template({"messages": []})
@@ -609,7 +609,7 @@ class Test_DataProcessor(unittest.TestCase):
 
     @patch(f"{MODULE_PATH}.parse_chat_messages")
     def test_request2ids_cache_miss_raises_error(self, mock_parse_chat):
-        """新增：测试 request2ids 在缓存关闭时缺少数据引发 ValueError"""
+        """Test  request2ids raises ValueError when data is missing and cache is disabled"""
         messages = [{"role": "user", "content": [{"type": "image", "uuid": "img1"}]}]
         request = {"messages": messages}
 
@@ -625,7 +625,7 @@ class Test_DataProcessor(unittest.TestCase):
     @patch(f"{MODULE_PATH}.DataProcessor.text2ids")
     @patch(f"{MODULE_PATH}.parse_chat_messages")
     def test_request2ids_cache_hit_and_update(self, mock_parse_chat, mock_text2ids, mock_update_cache, mock_get_cache):
-        """新增：测试 request2ids 缓存命中和缓存更新"""
+        """Test  request2ids cache hit and cache update"""
         self.processor = DataProcessor(model_path="dummy_model_path", enable_processor_cache=True)
         self._configure_processor_ids()
 
@@ -671,7 +671,7 @@ class Test_DataProcessor(unittest.TestCase):
     @patch(f"{MODULE_PATH}.DataProcessor.text2ids")
     @patch(f"{MODULE_PATH}.parse_chat_messages")
     def test_request2ids_unsupported_type(self, mock_parse_chat, mock_text2ids):
-        """新增：测试 request2ids 静默忽略不支持的类型"""
+        """Test  request2ids silently ignores unsupported types"""
         messages = [
             {
                 "role": "user",
@@ -691,6 +691,76 @@ class Test_DataProcessor(unittest.TestCase):
         self.assertEqual(call_args[2], [])  # videos
         self.assertEqual(call_args[3], [])  # image_uuid
         self.assertEqual(call_args[4], [])  # video_uuid
+
+    def test_get_max_image_tokens(self):
+        """Test  get_max_image_tokens method"""
+        # 配置 mock image_processor 的属性
+        self.mock_image_processor.patch_size = 14
+        self.mock_image_processor.merge_size = 2
+        self.mock_image_processor.min_pixels = 28 * 28 * 130
+        self.mock_image_processor.max_pixels = 28 * 28 * 1280
+
+        seq_len = 100000
+        max_tokens = self.processor.get_max_image_tokens(seq_len)
+
+        # 验证返回值是正整数且不超过 seq_len
+        self.assertIsInstance(max_tokens, int)
+        self.assertGreater(max_tokens, 0)
+        self.assertLessEqual(max_tokens, seq_len)
+
+    def test_get_max_video_tokens(self):
+        """Test  get_max_video_tokens method"""
+        # 配置 mock image_processor 的属性
+        self.mock_image_processor.patch_size = 14
+        self.mock_image_processor.merge_size = 2
+        self.mock_image_processor.min_pixels = 28 * 28 * 130
+        self.mock_image_processor.max_pixels = 28 * 28 * 1280
+
+        seq_len = 100000
+        max_tokens = self.processor.get_max_video_tokens(seq_len)
+
+        # 验证返回值是正整数且不超过 seq_len
+        self.assertIsInstance(max_tokens, int)
+        self.assertGreater(max_tokens, 0)
+        self.assertLessEqual(max_tokens, seq_len)
+
+    def test_get_mm_max_tokens_per_item(self):
+        """Test  get_mm_max_tokens_per_item method"""
+        # 配置 mock image_processor 的属性
+        self.mock_image_processor.patch_size = 14
+        self.mock_image_processor.merge_size = 2
+        self.mock_image_processor.min_pixels = 28 * 28 * 130
+        self.mock_image_processor.max_pixels = 28 * 28 * 1280
+
+        seq_len = 100000
+        result = self.processor.get_mm_max_tokens_per_item(seq_len)
+
+        # 验证返回值格式
+        self.assertIsInstance(result, dict)
+        self.assertIn("image", result)
+        self.assertIn("video", result)
+        self.assertIsInstance(result["image"], int)
+        self.assertIsInstance(result["video"], int)
+        self.assertGreater(result["image"], 0)
+        self.assertGreater(result["video"], 0)
+        self.assertLessEqual(result["image"], seq_len)
+        self.assertLessEqual(result["video"], seq_len)
+
+    def test_get_mm_max_tokens_per_item_with_small_seq_len(self):
+        """Test  get_mm_max_tokens_per_item truncation with small seq_len"""
+        # 配置 mock image_processor 的属性
+        self.mock_image_processor.patch_size = 14
+        self.mock_image_processor.merge_size = 2
+        self.mock_image_processor.min_pixels = 28 * 28 * 130
+        self.mock_image_processor.max_pixels = 28 * 28 * 1280
+
+        # 使用一个很小的 seq_len
+        small_seq_len = 100
+        result = self.processor.get_mm_max_tokens_per_item(small_seq_len)
+
+        # 验证返回值被截断到 seq_len
+        self.assertLessEqual(result["image"], small_seq_len)
+        self.assertLessEqual(result["video"], small_seq_len)
 
 
 class TestPaddleOCR_VL_ImageProcessor(unittest.TestCase):

--- a/tests/input/test_qwen3_vl_processor.py
+++ b/tests/input/test_qwen3_vl_processor.py
@@ -679,6 +679,51 @@ class TestQwen3VLProcessor(unittest.TestCase):
         self.assertIn("video_patch_id", result)
         self.assertIn("mm_num_token_func", result)
 
+    def test_get_max_image_tokens(self):
+        """Test get_max_image_tokens method"""
+        seq_len = 100000
+        max_tokens = self.processor.get_max_image_tokens(seq_len)
+
+        # Verify return value is positive integer and does not exceed seq_len
+        self.assertIsInstance(max_tokens, int)
+        self.assertGreater(max_tokens, 0)
+        self.assertLessEqual(max_tokens, seq_len)
+
+    def test_get_max_video_tokens(self):
+        """Test get_max_video_tokens method"""
+        seq_len = 100000
+        max_tokens = self.processor.get_max_video_tokens(seq_len)
+
+        # Verify return value is positive integer and does not exceed seq_len
+        self.assertIsInstance(max_tokens, int)
+        self.assertGreater(max_tokens, 0)
+        self.assertLessEqual(max_tokens, seq_len)
+
+    def test_get_mm_max_tokens_per_item(self):
+        """Test get_mm_max_tokens_per_item method"""
+        seq_len = 100000
+        result = self.processor.get_mm_max_tokens_per_item(seq_len)
+
+        # Verify return format
+        self.assertIsInstance(result, dict)
+        self.assertIn("image", result)
+        self.assertIn("video", result)
+        self.assertIsInstance(result["image"], int)
+        self.assertIsInstance(result["video"], int)
+        self.assertGreater(result["image"], 0)
+        self.assertGreater(result["video"], 0)
+        self.assertLessEqual(result["image"], seq_len)
+        self.assertLessEqual(result["video"], seq_len)
+
+    def test_get_mm_max_tokens_per_item_with_small_seq_len(self):
+        """Test get_mm_max_tokens_per_item truncation with small seq_len"""
+        small_seq_len = 100
+        result = self.processor.get_mm_max_tokens_per_item(small_seq_len)
+
+        # Verify return values are truncated to seq_len
+        self.assertLessEqual(result["image"], small_seq_len)
+        self.assertLessEqual(result["video"], small_seq_len)
+
 
 class TestSampleFrames(unittest.TestCase):
     """

--- a/tests/input/test_qwen_vl_processor.py
+++ b/tests/input/test_qwen_vl_processor.py
@@ -654,6 +654,51 @@ class TestQwenVLProcessor(unittest.TestCase):
         self.assertIn("video_patch_id", result)
         self.assertIn("mm_num_token_func", result)
 
+    def test_get_max_image_tokens(self):
+        """Test get_max_image_tokens method"""
+        seq_len = 100000
+        max_tokens = self.processor.get_max_image_tokens(seq_len)
+
+        # Verify return value is positive integer and does not exceed seq_len
+        self.assertIsInstance(max_tokens, int)
+        self.assertGreater(max_tokens, 0)
+        self.assertLessEqual(max_tokens, seq_len)
+
+    def test_get_max_video_tokens(self):
+        """Test get_max_video_tokens method"""
+        seq_len = 100000
+        max_tokens = self.processor.get_max_video_tokens(seq_len)
+
+        # Verify return value is positive integer and does not exceed seq_len
+        self.assertIsInstance(max_tokens, int)
+        self.assertGreater(max_tokens, 0)
+        self.assertLessEqual(max_tokens, seq_len)
+
+    def test_get_mm_max_tokens_per_item(self):
+        """Test get_mm_max_tokens_per_item method"""
+        seq_len = 100000
+        result = self.processor.get_mm_max_tokens_per_item(seq_len)
+
+        # Verify return format
+        self.assertIsInstance(result, dict)
+        self.assertIn("image", result)
+        self.assertIn("video", result)
+        self.assertIsInstance(result["image"], int)
+        self.assertIsInstance(result["video"], int)
+        self.assertGreater(result["image"], 0)
+        self.assertGreater(result["video"], 0)
+        self.assertLessEqual(result["image"], seq_len)
+        self.assertLessEqual(result["video"], seq_len)
+
+    def test_get_mm_max_tokens_per_item_with_small_seq_len(self):
+        """Test get_mm_max_tokens_per_item truncation with small seq_len"""
+        small_seq_len = 100
+        result = self.processor.get_mm_max_tokens_per_item(small_seq_len)
+
+        # Verify return values are truncated to seq_len
+        self.assertLessEqual(result["image"], small_seq_len)
+        self.assertLessEqual(result["video"], small_seq_len)
+
 
 class TestSampleFrames(unittest.TestCase):
     """

--- a/tests/input/v1/test_paddleocr_vl_processor.py
+++ b/tests/input/v1/test_paddleocr_vl_processor.py
@@ -73,7 +73,7 @@ class TestProcessVideo(unittest.TestCase):
         self.assertIn("exceeds", str(context.exception))
 
     def test_error_mutual_exclusion(self):
-        """新增：测试 num_frames 和 fps 互斥"""
+        """Test  num_frames 和 fps mutual exclusion"""
         with self.assertRaises(ValueError) as context:
             sample_frames(
                 frame_factor=self.frame_factor,
@@ -86,7 +86,7 @@ class TestProcessVideo(unittest.TestCase):
         self.assertIn("mutually exclusive", str(context.exception))
 
     def test_error_fps_without_metadata(self):
-        """新增：测试 fps > 0 但 metadata 为 None"""
+        """Test  fps > 0 but metadata is None"""
         with self.assertRaises(TypeError) as context:
             sample_frames(
                 frame_factor=self.frame_factor,
@@ -100,7 +100,7 @@ class TestProcessVideo(unittest.TestCase):
         self.assertIn("'NoneType' object is not subscriptable", str(context.exception))
 
     def test_num_frames_rounding(self):
-        """新增：测试 num_frames 向 frame_factor 舍入"""
+        """Test  num_frames rounding to frame_factor"""
         num_frames = 17  # 不是 4 的倍数
         # 逻辑: round(17 / 4) * 4 = round(4.25) * 4 = 4 * 4 = 16
         indices = sample_frames(
@@ -115,7 +115,7 @@ class TestProcessVideo(unittest.TestCase):
         self.assertEqual(len(indices), 16)
 
     def test_sample_with_fps_basic(self):
-        """新增：测试使用 fps 采样（基本路径，被 max_frames 限制）"""
+        """Test fps sampling (basic path, limited by max_frames)"""
         # 逻辑: num_frames_calc = 100 / 25 * 10 = 40
         #      num_frames_clamped = min(max(40, 8), 32) = 32
         #      num_frames_factored = floor(32 / 4) * 4 = 32
@@ -132,7 +132,7 @@ class TestProcessVideo(unittest.TestCase):
         self.assertEqual(indices[-1], 96)
 
     def test_sample_with_fps_hits_min_frames(self):
-        """新增：测试使用 fps 采样（被 min_frames 限制）"""
+        """Test fps sampling (limited by min_frames)"""
         # 逻辑: num_frames_calc = 100 / 25 * 1 = 4
         #      num_frames_clamped = min(max(4, 8), 32) = 8
         #      num_frames_factored = floor(8 / 4) * 4 = 8
@@ -149,7 +149,7 @@ class TestProcessVideo(unittest.TestCase):
         self.assertEqual(indices[-1], 87)
 
     def test_sample_with_fps_hits_total_frames(self):
-        """新增：测试使用 fps 采样（被 total_num_frames 限制）"""
+        """Test fps sampling (limited by total_num_frames)"""
         local_max_frames = 200
 
         # 逻辑: num_frames_calc = 100 / 25 * 50 = 200
@@ -168,7 +168,7 @@ class TestProcessVideo(unittest.TestCase):
         self.assertEqual(indices[-1], 99)  # 采样所有帧
 
     def test_no_sampling(self):
-        """新增：测试不采样（fps=0, num_frames=0）"""
+        """Test no sampling (fps=0, num_frames=0)"""
         indices = sample_frames(
             frame_factor=self.frame_factor,
             min_frames=self.min_frames,
@@ -444,7 +444,7 @@ class Test_DataProcessor(unittest.TestCase):
         self.assertEqual(meta["fps"], 1)
 
     def test_init_with_external_tokenizer(self):
-        """新增：测试使用外部传入的 tokenizer 初始化"""
+        """Test initialization with external tokenizer"""
         self.mock_auto_tokenizer_constructor.reset_mock()
 
         external_tokenizer = MagicMock()
@@ -454,7 +454,7 @@ class Test_DataProcessor(unittest.TestCase):
         self.assertIs(processor.tokenizer, external_tokenizer)
 
     def test_add_text_empty(self):
-        """新增：测试 _add_text 传入空字符串"""
+        """Test  _add_text with empty string"""
         outputs = self._get_init_outputs()
         self.processor._add_text("", outputs)
         self.assertEqual(outputs["input_ids"], [])
@@ -462,7 +462,7 @@ class Test_DataProcessor(unittest.TestCase):
 
     @patch(f"{MODULE_PATH}.IDS_TYPE_FLAG", {"text": 0})
     def test_add_text_pre_tokenized(self):
-        """新增：测试 _add_text 传入已 tokenized 的 IDs"""
+        """Test  _add_text with pre-tokenized IDs"""
         outputs = self._get_init_outputs()
         token_ids = [10, 11, 12]
         self.processor._add_text(token_ids, outputs)
@@ -475,7 +475,7 @@ class Test_DataProcessor(unittest.TestCase):
     @patch(f"{MODULE_PATH}.MultimodalHasher.hash_features", return_value="dummy_hash_456")
     @patch(f"{MODULE_PATH}.IDS_TYPE_FLAG", {"text": 0, "image": 1, "video": 2})
     def test_add_video_no_uuid(self, mock_hasher):
-        """新增：测试 _add_video 在 uuid 为 None 时自动哈希"""
+        """Test  _add_video auto-hashing when uuid is None"""
         outputs = self._get_init_outputs()
         meta = {"fps": 30}
         mock_preprocess_return = {
@@ -491,7 +491,7 @@ class Test_DataProcessor(unittest.TestCase):
 
     @patch(f"{MODULE_PATH}.IDS_TYPE_FLAG", {"text": 0, "image": 1, "video": 2})
     def test_add_processed_image(self):
-        """新增：测试 _add_processed_image 处理缓存数据"""
+        """Test  _add_processed_image with cached data"""
         outputs = self._get_init_outputs()
         outputs["cur_position"] = 3
 
@@ -508,7 +508,7 @@ class Test_DataProcessor(unittest.TestCase):
 
     @patch(f"{MODULE_PATH}.IDS_TYPE_FLAG", {"text": 0, "image": 1, "video": 2})
     def test_add_processed_video(self):
-        """新增：测试 _add_processed_video 处理缓存数据"""
+        """Test  _add_processed_video with cached data"""
         outputs = self._get_init_outputs()
         outputs["cur_position"] = 5
 
@@ -527,7 +527,7 @@ class Test_DataProcessor(unittest.TestCase):
         self.assertGreater(outputs["cur_position"], 5)
 
     def test_text2ids_with_processed_data(self):
-        """新增：测试 text2ids 调用 _add_processed_image 和 _add_processed_video"""
+        """Test  text2ids calling _add_processed_image and _add_processed_video"""
         with (
             patch.object(self.processor, "_add_processed_image") as mock_add_proc_img,
             patch.object(self.processor, "_add_processed_video") as mock_add_proc_vid,
@@ -547,7 +547,7 @@ class Test_DataProcessor(unittest.TestCase):
     @patch(f"{MODULE_PATH}.sample_frames")
     @patch(f"{MODULE_PATH}.read_video_decord")
     def test_load_and_process_video_no_sampling(self, mock_read_video, mock_sample_frames):
-        """新增：测试 _load_and_process_video 不采样（fps=-1）"""
+        """Test  _load_and_process_video without sampling (fps=-1)"""
         mock_reader = MagicMock()
         mock_reader.__getitem__.return_value.asnumpy.return_value = np.random.randint(
             0, 255, (100, 100, 3), dtype=np.uint8
@@ -565,7 +565,7 @@ class Test_DataProcessor(unittest.TestCase):
         self.assertEqual(meta["num_of_frame"], 10)
 
     def test_get_processor_cache(self):
-        """新增：测试 get_processor_cache (zmq)"""
+        """Test  get_processor_cache (zmq)"""
         hashes = ["hash1", "hash2"]
         expected_items = ["item1", "item2"]
         mock_resp = pickle.dumps(expected_items)
@@ -577,7 +577,7 @@ class Test_DataProcessor(unittest.TestCase):
         self.assertEqual(items, expected_items)
 
     def test_update_processor_cache(self):
-        """新增：测试 update_processor_cache (zmq)"""
+        """Test  update_processor_cache (zmq)"""
         hashes = ["hash1"]
         items = ["item1"]
 
@@ -587,7 +587,7 @@ class Test_DataProcessor(unittest.TestCase):
         self.mock_zmq_socket.send_multipart.assert_called_once_with([b"", expected_req])
 
     def test_apply_chat_template(self):
-        """新增：测试 apply_chat_template 核心逻辑"""
+        """Test  apply_chat_template core logic"""
         request = {"messages": ["msg1"], "add_generation_prompt": True, "request_id": "req123"}
         self.mock_tokenizer.apply_chat_template.return_value = "Prompt <|IMAGE_PLACEHOLDER|> text"
         self.mock_tokenizer.tokenize.return_value = ["Prompt", "text"]
@@ -603,7 +603,7 @@ class Test_DataProcessor(unittest.TestCase):
         self.mock_tokenizer.tokenize.assert_called_with("Prompt  text")
 
     def test_apply_chat_template_raises_error(self):
-        """新增：测试 apply_chat_template 在模板不存在时引发 ValueError"""
+        """Test  apply_chat_template raises ValueError when template is missing"""
         self.mock_tokenizer.chat_template = None
         with self.assertRaises(ValueError) as context:
             self.processor.apply_chat_template({"messages": []})
@@ -611,7 +611,7 @@ class Test_DataProcessor(unittest.TestCase):
 
     @patch(f"{MODULE_PATH}.parse_chat_messages")
     def test_request2ids_cache_miss_raises_error(self, mock_parse_chat):
-        """新增：测试 request2ids 在缓存关闭时缺少数据引发 ValueError"""
+        """Test  request2ids raises ValueError when data is missing and cache is disabled"""
         messages = [{"role": "user", "content": [{"type": "image", "uuid": "img1"}]}]
         request = {"request_id": "test_0", "messages": messages}
         request = Request.from_dict(request)
@@ -628,7 +628,7 @@ class Test_DataProcessor(unittest.TestCase):
     @patch(f"{MODULE_PATH}.DataProcessor.text2ids")
     @patch(f"{MODULE_PATH}.parse_chat_messages")
     def test_request2ids_cache_hit_and_update(self, mock_parse_chat, mock_text2ids, mock_update_cache, mock_get_cache):
-        """新增：测试 request2ids 缓存命中和缓存更新"""
+        """Test  request2ids cache hit and cache update"""
         self.processor = DataProcessor(model_path="dummy_model_path", enable_processor_cache=True)
         self._configure_processor_ids()
 
@@ -675,7 +675,7 @@ class Test_DataProcessor(unittest.TestCase):
     @patch(f"{MODULE_PATH}.DataProcessor.text2ids")
     @patch(f"{MODULE_PATH}.parse_chat_messages")
     def test_request2ids_unsupported_type(self, mock_parse_chat, mock_text2ids):
-        """新增：测试 request2ids 静默忽略不支持的类型"""
+        """Test  request2ids silently ignores unsupported types"""
         messages = [
             {
                 "role": "user",
@@ -696,6 +696,76 @@ class Test_DataProcessor(unittest.TestCase):
         self.assertEqual(call_args[2], [])  # videos
         self.assertEqual(call_args[3], [])  # image_uuid
         self.assertEqual(call_args[4], [])  # video_uuid
+
+    def test_get_max_image_tokens(self):
+        """Test  get_max_image_tokens method"""
+        # 配置 mock image_processor 的属性
+        self.mock_image_processor.patch_size = 14
+        self.mock_image_processor.merge_size = 2
+        self.mock_image_processor.min_pixels = 28 * 28 * 130
+        self.mock_image_processor.max_pixels = 28 * 28 * 1280
+
+        seq_len = 100000
+        max_tokens = self.processor.get_max_image_tokens(seq_len)
+
+        # 验证返回值是正整数且不超过 seq_len
+        self.assertIsInstance(max_tokens, int)
+        self.assertGreater(max_tokens, 0)
+        self.assertLessEqual(max_tokens, seq_len)
+
+    def test_get_max_video_tokens(self):
+        """Test  get_max_video_tokens method"""
+        # 配置 mock image_processor 的属性
+        self.mock_image_processor.patch_size = 14
+        self.mock_image_processor.merge_size = 2
+        self.mock_image_processor.min_pixels = 28 * 28 * 130
+        self.mock_image_processor.max_pixels = 28 * 28 * 1280
+
+        seq_len = 100000
+        max_tokens = self.processor.get_max_video_tokens(seq_len)
+
+        # 验证返回值是正整数且不超过 seq_len
+        self.assertIsInstance(max_tokens, int)
+        self.assertGreater(max_tokens, 0)
+        self.assertLessEqual(max_tokens, seq_len)
+
+    def test_get_mm_max_tokens_per_item(self):
+        """Test  get_mm_max_tokens_per_item method"""
+        # 配置 mock image_processor 的属性
+        self.mock_image_processor.patch_size = 14
+        self.mock_image_processor.merge_size = 2
+        self.mock_image_processor.min_pixels = 28 * 28 * 130
+        self.mock_image_processor.max_pixels = 28 * 28 * 1280
+
+        seq_len = 100000
+        result = self.processor.get_mm_max_tokens_per_item(seq_len)
+
+        # 验证返回值格式
+        self.assertIsInstance(result, dict)
+        self.assertIn("image", result)
+        self.assertIn("video", result)
+        self.assertIsInstance(result["image"], int)
+        self.assertIsInstance(result["video"], int)
+        self.assertGreater(result["image"], 0)
+        self.assertGreater(result["video"], 0)
+        self.assertLessEqual(result["image"], seq_len)
+        self.assertLessEqual(result["video"], seq_len)
+
+    def test_get_mm_max_tokens_per_item_with_small_seq_len(self):
+        """Test  get_mm_max_tokens_per_item truncation with small seq_len"""
+        # 配置 mock image_processor 的属性
+        self.mock_image_processor.patch_size = 14
+        self.mock_image_processor.merge_size = 2
+        self.mock_image_processor.min_pixels = 28 * 28 * 130
+        self.mock_image_processor.max_pixels = 28 * 28 * 1280
+
+        # 使用一个很小的 seq_len
+        small_seq_len = 100
+        result = self.processor.get_mm_max_tokens_per_item(small_seq_len)
+
+        # 验证返回值被截断到 seq_len
+        self.assertLessEqual(result["image"], small_seq_len)
+        self.assertLessEqual(result["video"], small_seq_len)
 
 
 class TestPaddleOCR_VL_ImageProcessor(unittest.TestCase):

--- a/tests/input/v1/test_qwen3_vl_processor.py
+++ b/tests/input/v1/test_qwen3_vl_processor.py
@@ -649,6 +649,51 @@ class TestQwen3VLProcessor(unittest.TestCase):
         self.assertIn("video_patch_id", result)
         self.assertIn("mm_num_token_func", result)
 
+    def test_get_max_image_tokens(self):
+        """Test get_max_image_tokens method"""
+        seq_len = 100000
+        max_tokens = self.processor.get_max_image_tokens(seq_len)
+
+        # Verify return value is positive integer and does not exceed seq_len
+        self.assertIsInstance(max_tokens, int)
+        self.assertGreater(max_tokens, 0)
+        self.assertLessEqual(max_tokens, seq_len)
+
+    def test_get_max_video_tokens(self):
+        """Test get_max_video_tokens method"""
+        seq_len = 100000
+        max_tokens = self.processor.get_max_video_tokens(seq_len)
+
+        # Verify return value is positive integer and does not exceed seq_len
+        self.assertIsInstance(max_tokens, int)
+        self.assertGreater(max_tokens, 0)
+        self.assertLessEqual(max_tokens, seq_len)
+
+    def test_get_mm_max_tokens_per_item(self):
+        """Test get_mm_max_tokens_per_item method"""
+        seq_len = 100000
+        result = self.processor.get_mm_max_tokens_per_item(seq_len)
+
+        # Verify return format
+        self.assertIsInstance(result, dict)
+        self.assertIn("image", result)
+        self.assertIn("video", result)
+        self.assertIsInstance(result["image"], int)
+        self.assertIsInstance(result["video"], int)
+        self.assertGreater(result["image"], 0)
+        self.assertGreater(result["video"], 0)
+        self.assertLessEqual(result["image"], seq_len)
+        self.assertLessEqual(result["video"], seq_len)
+
+    def test_get_mm_max_tokens_per_item_with_small_seq_len(self):
+        """Test get_mm_max_tokens_per_item truncation with small seq_len"""
+        small_seq_len = 100
+        result = self.processor.get_mm_max_tokens_per_item(small_seq_len)
+
+        # Verify return values are truncated to seq_len
+        self.assertLessEqual(result["image"], small_seq_len)
+        self.assertLessEqual(result["video"], small_seq_len)
+
 
 class TestSampleFrames(unittest.TestCase):
     """

--- a/tests/input/v1/test_qwen_vl_processor.py
+++ b/tests/input/v1/test_qwen_vl_processor.py
@@ -664,6 +664,51 @@ class TestQwenVLProcessor(unittest.TestCase):
         self.assertIn("video_patch_id", result)
         self.assertIn("mm_num_token_func", result)
 
+    def test_get_max_image_tokens(self):
+        """Test get_max_image_tokens method"""
+        seq_len = 100000
+        max_tokens = self.processor.get_max_image_tokens(seq_len)
+
+        # Verify return value is positive integer and does not exceed seq_len
+        self.assertIsInstance(max_tokens, int)
+        self.assertGreater(max_tokens, 0)
+        self.assertLessEqual(max_tokens, seq_len)
+
+    def test_get_max_video_tokens(self):
+        """Test get_max_video_tokens method"""
+        seq_len = 100000
+        max_tokens = self.processor.get_max_video_tokens(seq_len)
+
+        # Verify return value is positive integer and does not exceed seq_len
+        self.assertIsInstance(max_tokens, int)
+        self.assertGreater(max_tokens, 0)
+        self.assertLessEqual(max_tokens, seq_len)
+
+    def test_get_mm_max_tokens_per_item(self):
+        """Test get_mm_max_tokens_per_item method"""
+        seq_len = 100000
+        result = self.processor.get_mm_max_tokens_per_item(seq_len)
+
+        # Verify return format
+        self.assertIsInstance(result, dict)
+        self.assertIn("image", result)
+        self.assertIn("video", result)
+        self.assertIsInstance(result["image"], int)
+        self.assertIsInstance(result["video"], int)
+        self.assertGreater(result["image"], 0)
+        self.assertGreater(result["video"], 0)
+        self.assertLessEqual(result["image"], seq_len)
+        self.assertLessEqual(result["video"], seq_len)
+
+    def test_get_mm_max_tokens_per_item_with_small_seq_len(self):
+        """Test get_mm_max_tokens_per_item truncation with small seq_len"""
+        small_seq_len = 100
+        result = self.processor.get_mm_max_tokens_per_item(small_seq_len)
+
+        # Verify return values are truncated to seq_len
+        self.assertLessEqual(result["image"], small_seq_len)
+        self.assertLessEqual(result["video"], small_seq_len)
+
 
 class TestSampleFrames(unittest.TestCase):
     """


### PR DESCRIPTION
## Motivation

为 VL processor 添加 get_max_image_tokens、get_max_video_tokens 和 get_mm_max_tokens_per_item 方法，用于获取多模态数据的最大 token 数量。

## Modifications

- 为 paddleocr_vl_processor、qwen_vl_processor、qwen3_vl_processor 添加 get_mm_max_tokens_per_item 相关方法
- 同步更新 v1 版本的 processor
- 更新相关单元测试

## Usage or Command

```python
processor = DataProcessor(...)
max_tokens = processor.get_mm_max_tokens_per_item(seq_len=32768)
# 返回 {"image": max_image_tokens, "video": max_video_tokens}
```

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
- [ ] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)