### PR TITLE
[Feature][KVCache] Support head-wise KV cache

### DIFF
--- a/custom_ops/gpu_ops/append_attention.cu
+++ b/custom_ops/gpu_ops/append_attention.cu
@@ -516,7 +516,20 @@ std::vector<paddle::Tensor> AppendAttention(
   meta_data.max_blocks_per_seq = block_tables.dims()[1];
   meta_data.max_blocks_per_head = meta_data.max_blocks_per_seq;
   if (meta_data.use_head_wise) {
-    meta_data.kv_num_heads = block_tables.dims()[0] / meta_data.batch_size;
+    if (meta_data.batch_size <= 0) {
+      PD_THROW(
+          "Invalid batch_size %d in head-wise mode. batch_size must be > 0.",
+          meta_data.batch_size);
+    }
+    const auto block_tables_dim0 = block_tables.dims()[0];
+    if (block_tables_dim0 % meta_data.batch_size != 0) {
+      PD_THROW(
+          "Inconsistent dimensions in head-wise mode: block_tables.dims()[0] "
+          "(%lld) must be divisible by batch_size (%d).",
+          static_cast<long long>(block_tables_dim0),
+          meta_data.batch_size);
+    }
+    meta_data.kv_num_heads = block_tables_dim0 / meta_data.batch_size;
     meta_data.block_size = key_cache_dims[1];
     meta_data.head_dims = key_cache_dims[2];
   } else {
@@ -735,7 +748,20 @@ std::vector<paddle::Tensor> AppendAttentionWithOutput(
   meta_data.max_blocks_per_seq = block_tables.dims()[1];
   meta_data.max_blocks_per_head = meta_data.max_blocks_per_seq;
   if (meta_data.use_head_wise) {
-    meta_data.kv_num_heads = block_tables.dims()[0] / meta_data.batch_size;
+    if (meta_data.batch_size <= 0) {
+      PD_THROW(
+          "Invalid batch_size %d in head-wise mode. batch_size must be > 0.",
+          meta_data.batch_size);
+    }
+    const auto block_tables_dim0 = block_tables.dims()[0];
+    if (block_tables_dim0 % meta_data.batch_size != 0) {
+      PD_THROW(
+          "Inconsistent dimensions in head-wise mode: block_tables.dims()[0] "
+          "(%lld) must be divisible by batch_size (%d).",
+          static_cast<long long>(block_tables_dim0),
+          meta_data.batch_size);
+    }
+    meta_data.kv_num_heads = block_tables_dim0 / meta_data.batch_size;
     meta_data.block_size = key_cache_dims[1];
     meta_data.head_dims = key_cache_dims[2];
   } else {

--- a/custom_ops/gpu_ops/append_attention.cu
+++ b/custom_ops/gpu_ops/append_attention.cu
@@ -929,21 +929,51 @@ std::vector<std::vector<int64_t>> AppendAttentionInferShape(
     const bool speculate_decoder,
     const int sliding_window,
     const int sink_size) {
-  const int token_num = qkv_shape[0];
+  const int64_t token_num = qkv_shape[0];
   const bool use_head_wise = key_cache_shape.size() == 3;
-  int head_dim = use_head_wise ? key_cache_shape[2] : key_cache_shape[3];
+  int64_t head_dim = use_head_wise ? key_cache_shape[2] : key_cache_shape[3];
   if (cache_quant_type_str == "cache_int4_zp") {
     head_dim *= 2;
   }
-  const int batch_size =
-      seq_lens_this_time_shape.empty()
-          ? 1
-          : (seq_lens_this_time_shape[0] > 0 ? seq_lens_this_time_shape[0] : 1);
-  const int kv_num_heads =
-      use_head_wise ? (block_tables_shape[0] / batch_size) : key_cache_shape[1];
-  const int total_num_head = qkv_shape[qkv_shape.size() - 1] / head_dim;
-  const int num_heads = total_num_head - 2 * kv_num_heads;
-  return {{token_num, num_heads * head_dim}};
+  const int64_t batch_size =
+      seq_lens_this_time_shape.empty() ? -1 : seq_lens_this_time_shape[0];
+
+  int64_t kv_num_heads = -1;
+  if (use_head_wise) {
+    if (batch_size == 0) {
+      PD_THROW(
+          "Invalid batch_size %lld in head-wise mode. batch_size must be > 0.",
+          static_cast<long long>(batch_size));
+    }
+    const int64_t block_tables_dim0 =
+        block_tables_shape.empty() ? -1 : block_tables_shape[0];
+    // Keep infer-shape behavior conservative for dynamic/unknown dims.
+    if (batch_size > 0 && block_tables_dim0 >= 0) {
+      if (block_tables_dim0 % batch_size != 0) {
+        PD_THROW(
+            "Inconsistent dimensions in head-wise mode: block_tables_shape[0] "
+            "(%lld) must be divisible by batch_size (%lld).",
+            static_cast<long long>(block_tables_dim0),
+            static_cast<long long>(batch_size));
+      }
+      kv_num_heads = block_tables_dim0 / batch_size;
+    }
+  } else {
+    kv_num_heads = key_cache_shape[1];
+  }
+
+  int64_t total_num_head = -1;
+  const int64_t qkv_hidden_dim = qkv_shape[qkv_shape.size() - 1];
+  if (head_dim > 0 && qkv_hidden_dim >= 0) {
+    total_num_head = qkv_hidden_dim / head_dim;
+  }
+
+  int64_t out_hidden_dim = -1;
+  if (total_num_head >= 0 && kv_num_heads >= 0 && head_dim >= 0) {
+    const int64_t num_heads = total_num_head - 2 * kv_num_heads;
+    out_hidden_dim = num_heads * head_dim;
+  }
+  return {{token_num, out_hidden_dim}};
 }
 
 std::vector<paddle::DataType> AppendAttentionInferDtype(

--- a/custom_ops/gpu_ops/append_attention.cu
+++ b/custom_ops/gpu_ops/append_attention.cu
@@ -511,8 +511,19 @@ std::vector<paddle::Tensor> AppendAttention(
   const auto& qkv_dims = qkv.dims();
   const auto& key_cache_dims = key_cache.dims();
   meta_data.token_nums = qkv_dims[0];
-  meta_data.kv_num_heads = key_cache_dims[1];
-  meta_data.head_dims = key_cache_dims[3];
+  meta_data.batch_size = seq_lens_this_time.dims()[0];
+  meta_data.use_head_wise = (key_cache_dims.size() == 3);
+  meta_data.max_blocks_per_seq = block_tables.dims()[1];
+  meta_data.max_blocks_per_head = meta_data.max_blocks_per_seq;
+  if (meta_data.use_head_wise) {
+    meta_data.kv_num_heads = block_tables.dims()[0] / meta_data.batch_size;
+    meta_data.block_size = key_cache_dims[1];
+    meta_data.head_dims = key_cache_dims[2];
+  } else {
+    meta_data.kv_num_heads = key_cache_dims[1];
+    meta_data.block_size = key_cache_dims[2];
+    meta_data.head_dims = key_cache_dims[3];
+  }
   // TODO: trick method support c4, add attr head_dims in the future
   if (cache_quant_type_str == "cache_int4_zp") {
     meta_data.head_dims *= 2;
@@ -520,10 +531,6 @@ std::vector<paddle::Tensor> AppendAttention(
   const int total_num_head =
       qkv_dims[qkv_dims.size() - 1] / meta_data.head_dims;
   meta_data.q_num_heads = total_num_head - 2 * meta_data.kv_num_heads;
-
-  meta_data.max_blocks_per_seq = block_tables.dims()[1];
-  meta_data.block_size = key_cache.dims()[2];
-  meta_data.batch_size = seq_lens_this_time.dims()[0];
 
   // template dtype generation
   phi::DataType dtype_id;
@@ -723,8 +730,19 @@ std::vector<paddle::Tensor> AppendAttentionWithOutput(
   const auto& qkv_dims = qkv.dims();
   const auto& key_cache_dims = key_cache.dims();
   meta_data.token_nums = qkv_dims[0];
-  meta_data.kv_num_heads = key_cache_dims[1];
-  meta_data.head_dims = key_cache_dims[3];
+  meta_data.batch_size = seq_lens_this_time.dims()[0];
+  meta_data.use_head_wise = (key_cache_dims.size() == 3);
+  meta_data.max_blocks_per_seq = block_tables.dims()[1];
+  meta_data.max_blocks_per_head = meta_data.max_blocks_per_seq;
+  if (meta_data.use_head_wise) {
+    meta_data.kv_num_heads = block_tables.dims()[0] / meta_data.batch_size;
+    meta_data.block_size = key_cache_dims[1];
+    meta_data.head_dims = key_cache_dims[2];
+  } else {
+    meta_data.kv_num_heads = key_cache_dims[1];
+    meta_data.block_size = key_cache_dims[2];
+    meta_data.head_dims = key_cache_dims[3];
+  }
   // TODO: trick method support c4, add attr head_dims in the future
   if (cache_quant_type_str == "cache_int4_zp") {
     meta_data.head_dims *= 2;
@@ -732,10 +750,6 @@ std::vector<paddle::Tensor> AppendAttentionWithOutput(
   const int total_num_head =
       qkv_dims[qkv_dims.size() - 1] / meta_data.head_dims;
   meta_data.q_num_heads = total_num_head - 2 * meta_data.kv_num_heads;
-
-  meta_data.max_blocks_per_seq = block_tables.dims()[1];
-  meta_data.block_size = key_cache.dims()[2];
-  meta_data.batch_size = seq_lens_this_time.dims()[0];
 
   if (mask_offset) {
     meta_data.mask_offset = mask_offset.get().data<int>();
@@ -890,11 +904,17 @@ std::vector<std::vector<int64_t>> AppendAttentionInferShape(
     const int sliding_window,
     const int sink_size) {
   const int token_num = qkv_shape[0];
-  const int kv_num_heads = key_cache_shape[1];
-  int head_dim = key_cache_shape[3];
+  const bool use_head_wise = key_cache_shape.size() == 3;
+  int head_dim = use_head_wise ? key_cache_shape[2] : key_cache_shape[3];
   if (cache_quant_type_str == "cache_int4_zp") {
     head_dim *= 2;
   }
+  const int batch_size =
+      seq_lens_this_time_shape.empty()
+          ? 1
+          : (seq_lens_this_time_shape[0] > 0 ? seq_lens_this_time_shape[0] : 1);
+  const int kv_num_heads =
+      use_head_wise ? (block_tables_shape[0] / batch_size) : key_cache_shape[1];
   const int total_num_head = qkv_shape[qkv_shape.size() - 1] / head_dim;
   const int num_heads = total_num_head - 2 * kv_num_heads;
   return {{token_num, num_heads * head_dim}};

--- a/custom_ops/gpu_ops/append_attn/append_attention_func.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_func.cuh
@@ -101,8 +101,8 @@ __device__ __forceinline__ void load_128b_async_zero_on_invalid(
     if (predicate) {
       smem.load_128b_async<fill_mode>(offset, gmem_ptr, true);
     } else {
-      smem.load_128b_async<SharedMemFillMode::kFillZero>(offset, gmem_ptr,
-                                                         false);
+      smem.load_128b_async<SharedMemFillMode::kFillZero>(
+          offset, gmem_ptr, false);
     }
   }
 }
@@ -346,7 +346,8 @@ __device__ __forceinline__ void produce_v_blockwise_c8(
   if constexpr (NUM_WARP_Q == 4) {
     int block_id = __ldg(&block_table_now[kv_idx / block_size]);
     const bool valid_block = block_id >= 0;
-    // Keep address valid for cp.async; data path is still zero-filled when !valid_block.
+    // Keep address valid for cp.async; data path is still zero-filled when
+    // !valid_block.
     const int safe_block_id = valid_block ? block_id : 0;
     CacheT* cache_v_now =
         cache_v + safe_block_id * kv_n_stride + const_v_offset;
@@ -374,7 +375,8 @@ __device__ __forceinline__ void produce_v_blockwise_c8(
     for (uint32_t kv_i = 0; kv_i < NUM_WARP_KV / 2; ++kv_i) {
       int block_id = __ldg(&block_table_now[kv_idx / block_size]);
       const bool valid_block = block_id >= 0;
-      // Keep address valid for cp.async; data path is still zero-filled when !valid_block.
+      // Keep address valid for cp.async; data path is still zero-filled when
+      // !valid_block.
       const int safe_block_id = valid_block ? block_id : 0;
       CacheT* cache_v_now =
           cache_v + safe_block_id * kv_n_stride + const_v_offset;
@@ -426,7 +428,8 @@ __device__ __forceinline__ void produce_kv_dynamic_scale_gmem2smem_async(
     // 4 warps shared block_size
     int block_id = __ldg(&block_table_now[kv_idx / block_size]);
     const bool valid_block = block_id >= 0;
-    // Keep address valid for cp.async; data path is still zero-filled when !valid_block.
+    // Keep address valid for cp.async; data path is still zero-filled when
+    // !valid_block.
     const int safe_block_id = valid_block ? block_id : 0;
     if (tid < block_size / 8) {
       const T* cache_k_scale_now =
@@ -445,7 +448,8 @@ __device__ __forceinline__ void produce_kv_dynamic_scale_gmem2smem_async(
       const uint32_t kv_idx_now = kv_idx + block_size * tid / 8;
       int block_id = __ldg(&block_table_now[kv_idx_now / block_size]);
       const bool valid_block = block_id >= 0;
-      // Keep address valid for cp.async; data path is still zero-filled when !valid_block.
+      // Keep address valid for cp.async; data path is still zero-filled when
+      // !valid_block.
       const int safe_block_id = valid_block ? block_id : 0;
       const int kv_idx_this_thread = kv_idx + tid * 8;
       const T* cache_k_scale_now =
@@ -545,7 +549,8 @@ __device__ __forceinline__ void produce_k_blockwise_c8(
   if constexpr (NUM_WARP_Q == 4) {
     int block_id = __ldg(&block_table_now[kv_idx / block_size]);
     const bool valid_block = block_id >= 0;
-    // Keep address valid for cp.async; data path is still zero-filled when !valid_block.
+    // Keep address valid for cp.async; data path is still zero-filled when
+    // !valid_block.
     const int safe_block_id = valid_block ? block_id : 0;
     CacheT* cache_k_now =
         cache_k + safe_block_id * kv_n_stride + const_k_offset;
@@ -577,7 +582,8 @@ __device__ __forceinline__ void produce_k_blockwise_c8(
     for (uint32_t kv_i = 0; kv_i < NUM_WARP_KV / 2; ++kv_i) {
       int block_id = __ldg(&block_table_now[kv_idx / block_size]);
       const bool valid_block = block_id >= 0;
-      // Keep address valid for cp.async; data path is still zero-filled when !valid_block.
+      // Keep address valid for cp.async; data path is still zero-filled when
+      // !valid_block.
       const int safe_block_id = valid_block ? block_id : 0;
       CacheT* cache_k_now =
           cache_k + safe_block_id * kv_n_stride + const_k_offset;
@@ -635,7 +641,8 @@ __device__ __forceinline__ void produce_v_blockwise_c4(
   for (uint32_t kv_i = 0; kv_i < NUM_WARP_KV; ++kv_i) {
     int block_id = __ldg(&block_table_now[(kv_idx) / block_size]);
     const bool valid_block = block_id >= 0;
-    // Keep address valid for cp.async; data path is still zero-filled when !valid_block.
+    // Keep address valid for cp.async; data path is still zero-filled when
+    // !valid_block.
     const int safe_block_id = valid_block ? block_id : 0;
     CacheT* cache_v_now =
         cache_v + safe_block_id * kv_n_stride + const_v_offset;
@@ -693,7 +700,8 @@ __device__ __forceinline__ void produce_k_blockwise_c4(
   for (uint32_t kv_i = 0; kv_i < NUM_WARP_KV; ++kv_i) {
     int block_id = __ldg(&block_table_now[kv_idx / block_size]);
     const bool valid_block = block_id >= 0;
-    // Keep address valid for cp.async; data path is still zero-filled when !valid_block.
+    // Keep address valid for cp.async; data path is still zero-filled when
+    // !valid_block.
     const int safe_block_id = valid_block ? block_id : 0;
     CacheT* cache_k_now =
         cache_k + safe_block_id * kv_n_stride + const_k_offset;

--- a/custom_ops/gpu_ops/append_attn/append_attention_func.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_func.cuh
@@ -92,6 +92,21 @@ struct prefill_softmax_state_t {
   }
 };
 
+template <SharedMemFillMode fill_mode, typename T>
+__device__ __forceinline__ void load_128b_async_zero_on_invalid(
+    smem_t smem, uint32_t offset, const T* gmem_ptr, bool predicate) {
+  if constexpr (fill_mode == SharedMemFillMode::kFillZero) {
+    smem.load_128b_async<fill_mode>(offset, gmem_ptr, predicate);
+  } else {
+    if (predicate) {
+      smem.load_128b_async<fill_mode>(offset, gmem_ptr, true);
+    } else {
+      smem.load_128b_async<SharedMemFillMode::kFillZero>(offset, gmem_ptr,
+                                                         false);
+    }
+  }
+}
+
 template <typename T, uint32_t num_frags_x, uint32_t num_frags_y>
 __device__ __forceinline__ void init_states(float (*o_frag)[num_frags_y][8],
                                             float (*m)[2],
@@ -330,14 +345,18 @@ __device__ __forceinline__ void produce_v_blockwise_c8(
   uint32_t kv_idx = kv_idx_base + tx % 4 * num_elems_per_128b<CacheT>();
   if constexpr (NUM_WARP_Q == 4) {
     int block_id = __ldg(&block_table_now[kv_idx / block_size]);
-    if (block_id < 0) block_id = 0;
-    CacheT* cache_v_now = cache_v + block_id * kv_n_stride + const_v_offset;
+    const bool valid_block = block_id >= 0;
+    // Keep address valid for cp.async; data path is still zero-filled when !valid_block.
+    const int safe_block_id = valid_block ? block_id : 0;
+    CacheT* cache_v_now =
+        cache_v + safe_block_id * kv_n_stride + const_v_offset;
 #pragma unroll
     for (uint32_t i = 0; i < num_frags_y * 2 / num_warps;
          ++i) {  // m (num_frags_y * 16 / (num_warps * 8))
 #pragma unroll
       for (uint32_t j = 0; j < num_frags_z / 4; ++j) {
-        smem.load_128b_async<fill_mode>(*smem_offset, cache_v_now, true);
+        load_128b_async_zero_on_invalid<fill_mode>(
+            smem, *smem_offset, cache_v_now, valid_block);
         *smem_offset = smem.advance_offset_by_column<4, num_vecs_per_blocksize>(
             *smem_offset, j);
         cache_v_now += 4 * num_elems_per_128b<CacheT>();
@@ -354,15 +373,19 @@ __device__ __forceinline__ void produce_v_blockwise_c8(
 #pragma unroll
     for (uint32_t kv_i = 0; kv_i < NUM_WARP_KV / 2; ++kv_i) {
       int block_id = __ldg(&block_table_now[kv_idx / block_size]);
-      if (block_id < 0) block_id = 0;
-      CacheT* cache_v_now = cache_v + block_id * kv_n_stride + const_v_offset;
+      const bool valid_block = block_id >= 0;
+      // Keep address valid for cp.async; data path is still zero-filled when !valid_block.
+      const int safe_block_id = valid_block ? block_id : 0;
+      CacheT* cache_v_now =
+          cache_v + safe_block_id * kv_n_stride + const_v_offset;
 
 #pragma unroll
       for (uint32_t i = 0; i < num_frags_y * 2 / num_warps;
            ++i) {  // m (num_frags_y * 16 / (num_warps * 8))
 #pragma unroll
         for (uint32_t j = 0; j < 2 * num_frags_z / 4; ++j) {
-          smem.load_128b_async<fill_mode>(*smem_offset, cache_v_now, true);
+          load_128b_async_zero_on_invalid<fill_mode>(
+              smem, *smem_offset, cache_v_now, valid_block);
           *smem_offset =
               smem.advance_offset_by_column<4, num_vecs_per_blocksize>(
                   *smem_offset, j);
@@ -402,31 +425,37 @@ __device__ __forceinline__ void produce_kv_dynamic_scale_gmem2smem_async(
   if constexpr (NUM_WARP_Q == 4) {
     // 4 warps shared block_size
     int block_id = __ldg(&block_table_now[kv_idx / block_size]);
-    if (block_id < 0) block_id = 0;
+    const bool valid_block = block_id >= 0;
+    // Keep address valid for cp.async; data path is still zero-filled when !valid_block.
+    const int safe_block_id = valid_block ? block_id : 0;
     if (tid < block_size / 8) {
       const T* cache_k_scale_now =
           use_head_wise
-              ? cache_kv_scale + block_id * block_size + tid * 8
-              : cache_kv_scale + block_id * kv_num_heads * block_size +
+              ? cache_kv_scale + safe_block_id * block_size + tid * 8
+              : cache_kv_scale + safe_block_id * kv_num_heads * block_size +
                     kv_head_idx * block_size + tid * 8;
       const int kv_idx_this_thread = kv_idx + tid * 8;
-      kv_scale_smem.load_128b_async<fill_mode>(
-          tid, cache_k_scale_now, kv_idx_this_thread < chunk_end);
+      const bool valid_load = valid_block && (kv_idx_this_thread < chunk_end);
+      load_128b_async_zero_on_invalid<fill_mode>(
+          kv_scale_smem, tid, cache_k_scale_now, valid_load);
     }
   } else {
     // 1 warp 32 tokens
     if (tid < block_size / 8 * 2) {
       const uint32_t kv_idx_now = kv_idx + block_size * tid / 8;
       int block_id = __ldg(&block_table_now[kv_idx_now / block_size]);
-      if (block_id < 0) block_id = 0;
+      const bool valid_block = block_id >= 0;
+      // Keep address valid for cp.async; data path is still zero-filled when !valid_block.
+      const int safe_block_id = valid_block ? block_id : 0;
       const int kv_idx_this_thread = kv_idx + tid * 8;
       const T* cache_k_scale_now =
           use_head_wise
-              ? cache_kv_scale + block_id * block_size + tid % 8 * 8
-              : cache_kv_scale + block_id * kv_num_heads * block_size +
+              ? cache_kv_scale + safe_block_id * block_size + tid % 8 * 8
+              : cache_kv_scale + safe_block_id * kv_num_heads * block_size +
                     kv_head_idx * block_size + tid % 8 * 8;
-      kv_scale_smem.load_128b_async<fill_mode>(
-          tid, cache_k_scale_now, kv_idx_this_thread < chunk_end);
+      const bool valid_load = valid_block && (kv_idx_this_thread < chunk_end);
+      load_128b_async_zero_on_invalid<fill_mode>(
+          kv_scale_smem, tid, cache_k_scale_now, valid_load);
     }
   }
 }
@@ -515,8 +544,11 @@ __device__ __forceinline__ void produce_k_blockwise_c8(
   uint32_t kv_idx = kv_idx_base + ty * 4 + tx / 8;
   if constexpr (NUM_WARP_Q == 4) {
     int block_id = __ldg(&block_table_now[kv_idx / block_size]);
-    if (block_id < 0) block_id = 0;
-    CacheT* cache_k_now = cache_k + block_id * kv_n_stride + const_k_offset;
+    const bool valid_block = block_id >= 0;
+    // Keep address valid for cp.async; data path is still zero-filled when !valid_block.
+    const int safe_block_id = valid_block ? block_id : 0;
+    CacheT* cache_k_now =
+        cache_k + safe_block_id * kv_n_stride + const_k_offset;
 #pragma unroll
     for (uint32_t i = 0; i < num_frags_z * 4 / num_warps;
          ++i) {  // m num_frags_z * 16 / (num_warps * 4)
@@ -525,7 +557,8 @@ __device__ __forceinline__ void produce_k_blockwise_c8(
            ++j) {  // k num_frags_y * 16 / 8 / num_elems_per_128b<CacheT>()
         // smem.load_128b_async<fill_mode>(*smem_offset, *gptr, kv_idx <
         // kv_len);
-        smem.load_128b_async<fill_mode>(*smem_offset, cache_k_now, true);
+        load_128b_async_zero_on_invalid<fill_mode>(
+            smem, *smem_offset, cache_k_now, valid_block);
         *smem_offset = smem.advance_offset_by_column<8, num_vecs_per_head>(
             *smem_offset, j);
         cache_k_now += 8 * num_elems_per_128b<CacheT>();
@@ -543,14 +576,18 @@ __device__ __forceinline__ void produce_k_blockwise_c8(
 #pragma unroll
     for (uint32_t kv_i = 0; kv_i < NUM_WARP_KV / 2; ++kv_i) {
       int block_id = __ldg(&block_table_now[kv_idx / block_size]);
-      if (block_id < 0) block_id = 0;
-      CacheT* cache_k_now = cache_k + block_id * kv_n_stride + const_k_offset;
+      const bool valid_block = block_id >= 0;
+      // Keep address valid for cp.async; data path is still zero-filled when !valid_block.
+      const int safe_block_id = valid_block ? block_id : 0;
+      CacheT* cache_k_now =
+          cache_k + safe_block_id * kv_n_stride + const_k_offset;
 #pragma unroll
       for (uint32_t i = 0; i < 2 * num_frags_z * 4 / num_warps;
            ++i) {  // m num_frags_z * 16 / (num_warps * 4)
 #pragma unroll
         for (uint32_t j = 0; j < num_frags_y / 8; ++j) {
-          smem.load_128b_async<fill_mode>(*smem_offset, cache_k_now, true);
+          load_128b_async_zero_on_invalid<fill_mode>(
+              smem, *smem_offset, cache_k_now, valid_block);
           *smem_offset = smem.advance_offset_by_column<8, num_vecs_per_head>(
               *smem_offset, j);
           cache_k_now += 8 * num_elems_per_128b<CacheT>();
@@ -597,13 +634,17 @@ __device__ __forceinline__ void produce_v_blockwise_c4(
 #pragma unroll
   for (uint32_t kv_i = 0; kv_i < NUM_WARP_KV; ++kv_i) {
     int block_id = __ldg(&block_table_now[(kv_idx) / block_size]);
-    if (block_id < 0) block_id = 0;
-    CacheT* cache_v_now = cache_v + block_id * kv_n_stride + const_v_offset;
+    const bool valid_block = block_id >= 0;
+    // Keep address valid for cp.async; data path is still zero-filled when !valid_block.
+    const int safe_block_id = valid_block ? block_id : 0;
+    CacheT* cache_v_now =
+        cache_v + safe_block_id * kv_n_stride + const_v_offset;
 #pragma unroll
     for (uint32_t i = 0; i < num_frags_y / num_warps; ++i) {  // m
 #pragma unroll
       for (uint32_t j = 0; j < num_frags_z / 4; ++j) {
-        smem.load_128b_async<fill_mode>(*smem_offset, cache_v_now, true);
+        load_128b_async_zero_on_invalid<fill_mode>(
+            smem, *smem_offset, cache_v_now, valid_block);
         *smem_offset = smem.advance_offset_by_column<2, num_vecs_per_blocksize>(
             *smem_offset, j);
         cache_v_now += 2 * num_elems_per_128b<CacheT>();
@@ -651,15 +692,19 @@ __device__ __forceinline__ void produce_k_blockwise_c4(
 #pragma unroll
   for (uint32_t kv_i = 0; kv_i < NUM_WARP_KV; ++kv_i) {
     int block_id = __ldg(&block_table_now[kv_idx / block_size]);
-    if (block_id < 0) block_id = 0;
-    CacheT* cache_k_now = cache_k + block_id * kv_n_stride + const_k_offset;
+    const bool valid_block = block_id >= 0;
+    // Keep address valid for cp.async; data path is still zero-filled when !valid_block.
+    const int safe_block_id = valid_block ? block_id : 0;
+    CacheT* cache_k_now =
+        cache_k + safe_block_id * kv_n_stride + const_k_offset;
 
 #pragma unroll
     for (uint32_t i = 0; i < num_frags_z * 2 / num_warps;
          ++i) {  // m num_frags_z * 16 / (num_warps * 8)
 #pragma unroll
       for (uint32_t j = 0; j < num_frags_y / 8; ++j) {
-        smem.load_128b_async<fill_mode>(*smem_offset, cache_k_now, true);
+        load_128b_async_zero_on_invalid<fill_mode>(
+            smem, *smem_offset, cache_k_now, valid_block);
         *smem_offset = smem.advance_offset_by_column<4, num_vecs_per_head>(
             *smem_offset, j);
         cache_k_now += 4 * num_elems_per_128b<CacheT>();

--- a/custom_ops/gpu_ops/append_attn/append_attention_func.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_func.cuh
@@ -395,7 +395,8 @@ __device__ __forceinline__ void produce_kv_dynamic_scale_gmem2smem_async(
     const uint32_t kv_idx,
     const uint32_t kv_num_heads,
     const uint32_t kv_head_idx,
-    const uint32_t chunk_end) {
+    const uint32_t chunk_end,
+    const bool use_head_wise) {
   const uint32_t tx = threadIdx.x, ty = threadIdx.y;
   const uint32_t tid = ty * 32 + tx;
   if constexpr (NUM_WARP_Q == 4) {
@@ -403,9 +404,11 @@ __device__ __forceinline__ void produce_kv_dynamic_scale_gmem2smem_async(
     int block_id = __ldg(&block_table_now[kv_idx / block_size]);
     if (block_id < 0) block_id = 0;
     if (tid < block_size / 8) {
-      const T* cache_k_scale_now = cache_kv_scale +
-                                   block_id * kv_num_heads * block_size +
-                                   kv_head_idx * block_size + tid * 8;
+      const T* cache_k_scale_now =
+          use_head_wise
+              ? cache_kv_scale + block_id * block_size + tid * 8
+              : cache_kv_scale + block_id * kv_num_heads * block_size +
+                    kv_head_idx * block_size + tid * 8;
       const int kv_idx_this_thread = kv_idx + tid * 8;
       kv_scale_smem.load_128b_async<fill_mode>(
           tid, cache_k_scale_now, kv_idx_this_thread < chunk_end);
@@ -417,9 +420,11 @@ __device__ __forceinline__ void produce_kv_dynamic_scale_gmem2smem_async(
       int block_id = __ldg(&block_table_now[kv_idx_now / block_size]);
       if (block_id < 0) block_id = 0;
       const int kv_idx_this_thread = kv_idx + tid * 8;
-      const T* cache_k_scale_now = cache_kv_scale +
-                                   block_id * kv_num_heads * block_size +
-                                   kv_head_idx * block_size + tid % 8 * 8;
+      const T* cache_k_scale_now =
+          use_head_wise
+              ? cache_kv_scale + block_id * block_size + tid % 8 * 8
+              : cache_kv_scale + block_id * kv_num_heads * block_size +
+                    kv_head_idx * block_size + tid % 8 * 8;
       kv_scale_smem.load_128b_async<fill_mode>(
           tid, cache_k_scale_now, kv_idx_this_thread < chunk_end);
     }

--- a/custom_ops/gpu_ops/append_attn/decode_attention_func.cuh
+++ b/custom_ops/gpu_ops/append_attn/decode_attention_func.cuh
@@ -146,10 +146,9 @@ __device__ __forceinline__ void produce_kv(CacheT* smem,
       pred_load<128,
                 PrefetchMode::kPrefetch,
                 SharedMemFillMode::kFillZero,
-                CacheT>(
-          smem + smem_offset_base + vid * CACHE_VEC_SIZE,
-          kv_base_gptr + k_offset_base + vid * CACHE_VEC_SIZE,
-          false);
+                CacheT>(smem + smem_offset_base + vid * CACHE_VEC_SIZE,
+                        kv_base_gptr + k_offset_base + vid * CACHE_VEC_SIZE,
+                        false);
     }
   }
 }

--- a/custom_ops/gpu_ops/append_attn/decode_attention_func.cuh
+++ b/custom_ops/gpu_ops/append_attn/decode_attention_func.cuh
@@ -126,20 +126,31 @@ __device__ __forceinline__ void produce_kv(CacheT* smem,
                                            const uint32_t chunk_start,
                                            const uint32_t chunk_end) {
   int block_id = __ldg(&block_table_smem[seq_offset_gmem / BLOCK_SIZE]);
-  if (block_id < 0) {
-    block_id = 0;
-  }
+  const bool valid_block = block_id >= 0;
+  // Keep address legal for cp.async even when the slot is invalid.
+  const int safe_block_id = valid_block ? block_id : 0;
   const uint32_t block_offset = seq_offset_gmem % BLOCK_SIZE;
   // 8/16 T/int8 each time
   const uint32_t k_offset_base =
-      ((block_id * kv_num_heads + kv_head_idx) * BLOCK_SIZE + block_offset) *
+      ((safe_block_id * kv_num_heads + kv_head_idx) * BLOCK_SIZE +
+       block_offset) *
       HEAD_DIM_QK;
   const uint32_t smem_offset_base = seq_offset_smem * HEAD_DIM_QK;
   for (uint32_t vid = tidx; vid < NUM_VEC_PER_HEAD; vid += bdx) {
-    pred_load<128, PrefetchMode::kPrefetch, fill_mode, CacheT>(
-        smem + smem_offset_base + vid * CACHE_VEC_SIZE,
-        kv_base_gptr + k_offset_base + vid * CACHE_VEC_SIZE,
-        seq_offset_gmem < chunk_end);
+    if (valid_block) {
+      pred_load<128, PrefetchMode::kPrefetch, fill_mode, CacheT>(
+          smem + smem_offset_base + vid * CACHE_VEC_SIZE,
+          kv_base_gptr + k_offset_base + vid * CACHE_VEC_SIZE,
+          seq_offset_gmem < chunk_end);
+    } else {
+      pred_load<128,
+                PrefetchMode::kPrefetch,
+                SharedMemFillMode::kFillZero,
+                CacheT>(
+          smem + smem_offset_base + vid * CACHE_VEC_SIZE,
+          kv_base_gptr + k_offset_base + vid * CACHE_VEC_SIZE,
+          false);
+    }
   }
 }
 

--- a/custom_ops/gpu_ops/append_attn/decoder_write_cache_with_rope_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/decoder_write_cache_with_rope_impl.cuh
@@ -91,6 +91,8 @@ __global__ void append_decode_cache_T_rope_qk_norm_kernel(
     const int block_size,
     const uint32_t elem_cnt,
     const int kv_num_heads,
+    const bool use_head_wise,
+    const int max_blocks_per_head,
     const bool rope_3d,
     const float* q_norm_weight,
     const float* k_norm_weight,
@@ -130,10 +132,18 @@ __global__ void append_decode_cache_T_rope_qk_norm_kernel(
     const int write_seq_id = seq_lens[ori_bi];
     if (write_seq_id == 0) continue;
 
-    const int* block_table_now = nullptr;
-
-    block_table_now = block_tables + ori_bi * max_blocks_per_seq;
-    const int block_idx = block_table_now[write_seq_id / block_size];
+    const int* block_table_now =
+        block_tables +
+        ori_bi * (use_head_wise ? kv_num_heads * max_blocks_per_head
+                                : max_blocks_per_seq);
+    const int kv_head_idx = (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
+    const int block_idx =
+        (hi >= num_heads)
+            ? (use_head_wise
+                   ? block_table_now[kv_head_idx * max_blocks_per_head +
+                                     write_seq_id / block_size]
+                   : block_table_now[write_seq_id / block_size])
+            : -1;
     const int block_offset = write_seq_id % block_size;
     const uint32_t ori_idx =
         start_token_idx * hidden_size + hi * head_size + h_bias;
@@ -198,10 +208,14 @@ __global__ void append_decode_cache_T_rope_qk_norm_kernel(
     } else {
       // quant + write k/v
       const uint32_t kv_head_idx = (hi - num_heads) % kv_num_heads;
+      if (block_idx < 0) continue;
       const uint32_t tgt_idx =
-          block_idx * kv_num_heads * block_size * head_size +
-          kv_head_idx * block_size * head_size + block_offset * head_size +
-          h_bias;
+          use_head_wise
+              ? (block_idx * block_size * head_size +
+                 block_offset * head_size + h_bias)
+              : (block_idx * kv_num_heads * block_size * head_size +
+                 kv_head_idx * block_size * head_size +
+                 block_offset * head_size + h_bias);
       if (hi < num_heads + kv_num_heads) {
         Store<T, VecSize>(out_vec, &key_cache[tgt_idx]);
       } else {
@@ -237,6 +251,8 @@ __global__ void append_decode_cache_T_rope_kernel(
     const int block_size,
     const uint32_t elem_cnt,
     const int kv_num_heads,
+    const bool use_head_wise,
+    const int max_blocks_per_head,
     const bool rope_3d) {
   using LoadT = AlignedVector<T, VecSize>;
   using LoadBiasT = AlignedVector<T, VecSize>;
@@ -269,10 +285,18 @@ __global__ void append_decode_cache_T_rope_kernel(
     const int write_seq_id = seq_lens[ori_bi];
     if (write_seq_id == 0) continue;
 
-    const int* block_table_now = nullptr;
-
-    block_table_now = block_tables + ori_bi * max_blocks_per_seq;
-    const int block_idx = block_table_now[write_seq_id / block_size];
+    const int* block_table_now =
+        block_tables +
+        ori_bi * (use_head_wise ? kv_num_heads * max_blocks_per_head
+                                : max_blocks_per_seq);
+    const int kv_head_idx = (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
+    const int block_idx =
+        (hi >= num_heads)
+            ? (use_head_wise
+                   ? block_table_now[kv_head_idx * max_blocks_per_head +
+                                     write_seq_id / block_size]
+                   : block_table_now[write_seq_id / block_size])
+            : -1;
     const int block_offset = write_seq_id % block_size;
     const uint32_t ori_idx =
         start_token_idx * hidden_size + hi * head_size + h_bias;
@@ -312,11 +336,15 @@ __global__ void append_decode_cache_T_rope_kernel(
       Store<T, VecSize>(out_vec, &qkv_out[ori_idx]);
     } else {
       // quant + write k/v
+      if (block_idx < 0) continue;
       const uint32_t kv_head_idx = (hi - num_heads) % kv_num_heads;
       const uint32_t tgt_idx =
-          block_idx * kv_num_heads * block_size * head_size +
-          kv_head_idx * block_size * head_size + block_offset * head_size +
-          h_bias;
+          use_head_wise
+              ? (block_idx * block_size * head_size +
+                 block_offset * head_size + h_bias)
+              : (block_idx * kv_num_heads * block_size * head_size +
+                 kv_head_idx * block_size * head_size +
+                 block_offset * head_size + h_bias);
       if (hi < num_heads + kv_num_heads) {
         Store<T, VecSize>(out_vec, &key_cache[tgt_idx]);
       } else {
@@ -356,6 +384,8 @@ __global__ void append_decode_cache_T_quant_rope_kernel(
     const int block_size,
     const uint32_t elem_cnt,
     const int kv_num_heads,
+    const bool use_head_wise,
+    const int max_blocks_per_head,
     const bool rope_3d) {
   using LoadT = AlignedVector<int, VecSize>;
   using LoadBiasT = AlignedVector<T, VecSize>;
@@ -390,10 +420,18 @@ __global__ void append_decode_cache_T_quant_rope_kernel(
     const int write_seq_id = seq_lens[ori_bi];
     if (write_seq_id == 0) continue;
 
-    const int* block_table_now = nullptr;
-
-    block_table_now = block_tables + ori_bi * max_blocks_per_seq;
-    const int block_idx = block_table_now[write_seq_id / block_size];
+    const int* block_table_now =
+        block_tables +
+        ori_bi * (use_head_wise ? kv_num_heads * max_blocks_per_head
+                                : max_blocks_per_seq);
+    const int kv_head_idx = (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
+    const int block_idx =
+        (hi >= num_heads)
+            ? (use_head_wise
+                   ? block_table_now[kv_head_idx * max_blocks_per_head +
+                                     write_seq_id / block_size]
+                   : block_table_now[write_seq_id / block_size])
+            : -1;
     const int block_offset = write_seq_id % block_size;
     const uint32_t ori_idx =
         start_token_idx * hidden_size + hi * head_size + h_bias;
@@ -442,11 +480,15 @@ __global__ void append_decode_cache_T_quant_rope_kernel(
       Store<T, VecSize>(bias_vec, &qkv_out[ori_idx]);
     } else {
       // quant + write k/v
+      if (block_idx < 0) continue;
       const uint32_t kv_head_idx = (hi - num_heads) % kv_num_heads;
       const uint32_t tgt_idx =
-          block_idx * kv_num_heads * block_size * head_size +
-          kv_head_idx * block_size * head_size + block_offset * head_size +
-          h_bias;
+          use_head_wise
+              ? (block_idx * block_size * head_size +
+                 block_offset * head_size + h_bias)
+              : (block_idx * kv_num_heads * block_size * head_size +
+                 kv_head_idx * block_size * head_size +
+                 block_offset * head_size + h_bias);
       if (hi < num_heads + kv_num_heads) {
         Store<T, VecSize>(bias_vec, &key_cache[tgt_idx]);
       } else {
@@ -484,6 +526,8 @@ __global__ void append_decode_cache_T_neox_partial_rope_kernel(
     const int block_size,
     const uint32_t elem_cnt,
     const int kv_num_heads,
+    const bool use_head_wise,
+    const int max_blocks_per_head,
     const bool rope_3d) {
   using LoadT = AlignedVector<T, VecSize>;
   using LoadBiasT = AlignedVector<T, VecSize>;
@@ -522,10 +566,18 @@ __global__ void append_decode_cache_T_neox_partial_rope_kernel(
     const int write_seq_id = seq_lens[ori_bi];
     if (write_seq_id == 0) continue;
 
-    const int* block_table_now = nullptr;
-
-    block_table_now = block_tables + ori_bi * max_blocks_per_seq;
-    const int block_idx = block_table_now[write_seq_id / block_size];
+    const int* block_table_now =
+        block_tables +
+        ori_bi * (use_head_wise ? kv_num_heads * max_blocks_per_head
+                                : max_blocks_per_seq);
+    const int kv_head_idx = (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
+    const int block_idx =
+        (hi >= num_heads)
+            ? (use_head_wise
+                   ? block_table_now[kv_head_idx * max_blocks_per_head +
+                                     write_seq_id / block_size]
+                   : block_table_now[write_seq_id / block_size])
+            : -1;
     const int block_offset = write_seq_id % block_size;
     uint32_t ori_idx_left =
         start_token_idx * hidden_size + hi * head_size + h_bias;
@@ -579,11 +631,15 @@ __global__ void append_decode_cache_T_neox_partial_rope_kernel(
       Store<T, VecSize>(right_bias_vec, &qkv_out[ori_idx_right]);
     } else {
       // write k/v
+      if (block_idx < 0) continue;
       const uint32_t kv_head_idx = (hi - num_heads) % kv_num_heads;
       uint32_t tgt_idx_left =
-          block_idx * kv_num_heads * block_size * head_size +
-          kv_head_idx * block_size * head_size + block_offset * head_size +
-          h_bias;
+          use_head_wise
+              ? (block_idx * block_size * head_size +
+                 block_offset * head_size + h_bias)
+              : (block_idx * kv_num_heads * block_size * head_size +
+                 kv_head_idx * block_size * head_size +
+                 block_offset * head_size + h_bias);
       uint32_t tgt_idx_right = tgt_idx_left + half_head_size;
       if (hi < num_heads + kv_num_heads) {
         if (h_bias < half_rotary_dim) {
@@ -627,6 +683,8 @@ __global__ void append_decode_cache_T_neox_rope_kernel(
     const int block_size,
     const uint32_t elem_cnt,
     const int kv_num_heads,
+    const bool use_head_wise,
+    const int max_blocks_per_head,
     const bool rope_3d) {
   using LoadT = AlignedVector<T, VecSize>;
   using LoadBiasT = AlignedVector<T, VecSize>;
@@ -661,10 +719,18 @@ __global__ void append_decode_cache_T_neox_rope_kernel(
     const int write_seq_id = seq_lens[ori_bi];
     if (write_seq_id == 0) continue;
 
-    const int* block_table_now = nullptr;
-
-    block_table_now = block_tables + ori_bi * max_blocks_per_seq;
-    const int block_idx = block_table_now[write_seq_id / block_size];
+    const int* block_table_now =
+        block_tables +
+        ori_bi * (use_head_wise ? kv_num_heads * max_blocks_per_head
+                                : max_blocks_per_seq);
+    const int kv_head_idx = (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
+    const int block_idx =
+        (hi >= num_heads)
+            ? (use_head_wise
+                   ? block_table_now[kv_head_idx * max_blocks_per_head +
+                                     write_seq_id / block_size]
+                   : block_table_now[write_seq_id / block_size])
+            : -1;
     const int block_offset = write_seq_id % block_size;
     const uint32_t ori_idx_left =
         start_token_idx * hidden_size + hi * head_size + h_bias;
@@ -706,11 +772,15 @@ __global__ void append_decode_cache_T_neox_rope_kernel(
       Store<T, VecSize>(right_bias_vec, &qkv_out[ori_idx_right]);
     } else {
       // write k/v
+      if (block_idx < 0) continue;
       const uint32_t kv_head_idx = (hi - num_heads) % kv_num_heads;
       const uint32_t tgt_idx_left =
-          block_idx * kv_num_heads * block_size * head_size +
-          kv_head_idx * block_size * head_size + block_offset * head_size +
-          h_bias;
+          use_head_wise
+              ? (block_idx * block_size * head_size +
+                 block_offset * head_size + h_bias)
+              : (block_idx * kv_num_heads * block_size * head_size +
+                 kv_head_idx * block_size * head_size +
+                 block_offset * head_size + h_bias);
       const uint32_t tgt_idx_right = tgt_idx_left + half_head_size;
       if (hi < num_heads + kv_num_heads) {
         Store<T, VecSize>(left_bias_vec, &key_cache[tgt_idx_left]);
@@ -752,6 +822,8 @@ __global__ void append_decode_cache_T_quant_neox_rope_kernel(
     const int block_size,
     const uint32_t elem_cnt,
     const int kv_num_heads,
+    const bool use_head_wise,
+    const int max_blocks_per_head,
     const bool rope_3d) {
   using LoadT = AlignedVector<int, VecSize>;
   using LoadBiasT = AlignedVector<T, VecSize>;
@@ -786,10 +858,18 @@ __global__ void append_decode_cache_T_quant_neox_rope_kernel(
     const int write_seq_id = seq_lens[ori_bi];
     if (write_seq_id == 0) continue;
 
-    const int* block_table_now = nullptr;
-
-    block_table_now = block_tables + ori_bi * max_blocks_per_seq;
-    const int block_idx = block_table_now[write_seq_id / block_size];
+    const int* block_table_now =
+        block_tables +
+        ori_bi * (use_head_wise ? kv_num_heads * max_blocks_per_head
+                                : max_blocks_per_seq);
+    const int kv_head_idx = (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
+    const int block_idx =
+        (hi >= num_heads)
+            ? (use_head_wise
+                   ? block_table_now[kv_head_idx * max_blocks_per_head +
+                                     write_seq_id / block_size]
+                   : block_table_now[write_seq_id / block_size])
+            : -1;
     const int block_offset = write_seq_id % block_size;
     const uint32_t ori_idx_left =
         start_token_idx * hidden_size + hi * head_size + h_bias;
@@ -847,11 +927,15 @@ __global__ void append_decode_cache_T_quant_neox_rope_kernel(
       Store<T, VecSize>(right_bias_vec, &qkv_out[ori_idx_right]);
     } else {
       // quant + write k/v
+      if (block_idx < 0) continue;
       const uint32_t kv_head_idx = (hi - num_heads) % kv_num_heads;
       const uint32_t tgt_idx_left =
-          block_idx * kv_num_heads * block_size * head_size +
-          kv_head_idx * block_size * head_size + block_offset * head_size +
-          h_bias;
+          use_head_wise
+              ? (block_idx * block_size * head_size +
+                 block_offset * head_size + h_bias)
+              : (block_idx * kv_num_heads * block_size * head_size +
+                 kv_head_idx * block_size * head_size +
+                 block_offset * head_size + h_bias);
       const uint32_t tgt_idx_right = tgt_idx_left + half_head_size;
       if (hi < num_heads + kv_num_heads) {
         Store<T, VecSize>(left_bias_vec, &key_cache[tgt_idx_left]);

--- a/custom_ops/gpu_ops/append_attn/decoder_write_cache_with_rope_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/decoder_write_cache_with_rope_impl.cuh
@@ -1003,6 +1003,7 @@ __global__ void append_decode_cache_T_int8_neox_rope_kernel(
   block_table_now = block_tables + bid * max_blocks_per_seq;
   const int block_idx = __ldg(&block_table_now[write_seq_id / block_size]);
   const int block_offset = write_seq_id % block_size;
+  if (block_idx < 0 && head_idx >= num_heads) return;
 
   float thread_m2 = 0.0f;
   float warp_m2 = 0.0f;
@@ -1325,6 +1326,7 @@ __global__ void append_decode_cache_int8_rope_qk_norm_kernel(
   block_table_now = block_tables + bid * max_blocks_per_seq;
   const int block_idx = __ldg(&block_table_now[write_seq_id / block_size]);
   const int block_offset = write_seq_id % block_size;
+  if (block_idx < 0 && head_idx >= num_heads) return;
 
   float thread_m2 = 0.0f;
   float warp_m2 = 0.0f;
@@ -1637,6 +1639,7 @@ __global__ void append_decode_cache_int8_rope_kernel(
   block_table_now = block_tables + bid * max_blocks_per_seq;
   const int block_idx = __ldg(&block_table_now[write_seq_id / block_size]);
   const int block_offset = write_seq_id % block_size;
+  if (block_idx < 0 && head_idx >= num_heads) return;
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaGridDependencySynchronize();
 #endif
@@ -1894,6 +1897,7 @@ __global__ void int_append_decode_cache_int8_rope_kernel(
   block_table_now = block_tables + bid * max_blocks_per_seq;
   const int block_idx = __ldg(&block_table_now[write_seq_id / block_size]);
   const int block_offset = write_seq_id % block_size;
+  if (block_idx < 0 && head_idx >= num_heads) return;
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaGridDependencySynchronize();
 #endif
@@ -2222,6 +2226,7 @@ __global__ void append_decode_cache_int8_neox_rope_kernel(
   block_table_now = block_tables + bid * max_blocks_per_seq;
   const int block_idx = __ldg(&block_table_now[write_seq_id / block_size]);
   const int block_offset = write_seq_id % block_size;
+  if (block_idx < 0 && head_idx >= num_heads) return;
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaGridDependencySynchronize();
 #endif
@@ -2546,6 +2551,7 @@ __global__ void int_append_decode_cache_int8_neox_rope_kernel(
   block_table_now = block_tables + bid * max_blocks_per_seq;
   const int block_idx = __ldg(&block_table_now[write_seq_id / block_size]);
   const int block_offset = write_seq_id % block_size;
+  if (block_idx < 0 && head_idx >= num_heads) return;
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaGridDependencySynchronize();
 #endif
@@ -2955,6 +2961,7 @@ __global__ void append_decode_cache_int4_rope_kernel(
 
   const int block_idx = __ldg(&block_table_now[write_seq_id / block_size]);
   const int block_offset = write_seq_id % block_size;
+  if (block_idx < 0 && head_idx >= num_heads) return;
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaGridDependencySynchronize();
 #endif
@@ -3247,6 +3254,7 @@ __global__ void int_append_decode_cache_int4_rope_kernel(
 
   const int block_idx = __ldg(&block_table_now[write_seq_id / block_size]);
   const int block_offset = write_seq_id % block_size;
+  if (block_idx < 0 && head_idx >= num_heads) return;
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaGridDependencySynchronize();
 #endif
@@ -3590,6 +3598,7 @@ __global__ void append_decode_cache_int4_neox_rope_kernel(
 
   const int block_idx = __ldg(&block_table_now[write_seq_id / block_size]);
   const int block_offset = write_seq_id % block_size;
+  if (block_idx < 0 && head_idx >= num_heads) return;
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaGridDependencySynchronize();
 #endif
@@ -3984,6 +3993,7 @@ __global__ void int_append_decode_cache_int4_neox_rope_kernel(
 
   const int block_idx = __ldg(&block_table_now[write_seq_id / block_size]);
   const int block_offset = write_seq_id % block_size;
+  if (block_idx < 0 && head_idx >= num_heads) return;
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaGridDependencySynchronize();
 #endif

--- a/custom_ops/gpu_ops/append_attn/decoder_write_cache_with_rope_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/decoder_write_cache_with_rope_impl.cuh
@@ -133,10 +133,11 @@ __global__ void append_decode_cache_T_rope_qk_norm_kernel(
     if (write_seq_id == 0) continue;
 
     const int* block_table_now =
-        block_tables +
-        ori_bi * (use_head_wise ? kv_num_heads * max_blocks_per_head
-                                : max_blocks_per_seq);
-    const int kv_head_idx = (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
+        block_tables + ori_bi * (use_head_wise
+                                     ? kv_num_heads * max_blocks_per_head
+                                     : max_blocks_per_seq);
+    const int kv_head_idx =
+        (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
     const int block_idx =
         (hi >= num_heads)
             ? (use_head_wise
@@ -210,12 +211,11 @@ __global__ void append_decode_cache_T_rope_qk_norm_kernel(
       const uint32_t kv_head_idx = (hi - num_heads) % kv_num_heads;
       if (block_idx < 0) continue;
       const uint32_t tgt_idx =
-          use_head_wise
-              ? (block_idx * block_size * head_size +
-                 block_offset * head_size + h_bias)
-              : (block_idx * kv_num_heads * block_size * head_size +
-                 kv_head_idx * block_size * head_size +
-                 block_offset * head_size + h_bias);
+          use_head_wise ? (block_idx * block_size * head_size +
+                           block_offset * head_size + h_bias)
+                        : (block_idx * kv_num_heads * block_size * head_size +
+                           kv_head_idx * block_size * head_size +
+                           block_offset * head_size + h_bias);
       if (hi < num_heads + kv_num_heads) {
         Store<T, VecSize>(out_vec, &key_cache[tgt_idx]);
       } else {
@@ -286,10 +286,11 @@ __global__ void append_decode_cache_T_rope_kernel(
     if (write_seq_id == 0) continue;
 
     const int* block_table_now =
-        block_tables +
-        ori_bi * (use_head_wise ? kv_num_heads * max_blocks_per_head
-                                : max_blocks_per_seq);
-    const int kv_head_idx = (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
+        block_tables + ori_bi * (use_head_wise
+                                     ? kv_num_heads * max_blocks_per_head
+                                     : max_blocks_per_seq);
+    const int kv_head_idx =
+        (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
     const int block_idx =
         (hi >= num_heads)
             ? (use_head_wise
@@ -339,12 +340,11 @@ __global__ void append_decode_cache_T_rope_kernel(
       if (block_idx < 0) continue;
       const uint32_t kv_head_idx = (hi - num_heads) % kv_num_heads;
       const uint32_t tgt_idx =
-          use_head_wise
-              ? (block_idx * block_size * head_size +
-                 block_offset * head_size + h_bias)
-              : (block_idx * kv_num_heads * block_size * head_size +
-                 kv_head_idx * block_size * head_size +
-                 block_offset * head_size + h_bias);
+          use_head_wise ? (block_idx * block_size * head_size +
+                           block_offset * head_size + h_bias)
+                        : (block_idx * kv_num_heads * block_size * head_size +
+                           kv_head_idx * block_size * head_size +
+                           block_offset * head_size + h_bias);
       if (hi < num_heads + kv_num_heads) {
         Store<T, VecSize>(out_vec, &key_cache[tgt_idx]);
       } else {
@@ -421,10 +421,11 @@ __global__ void append_decode_cache_T_quant_rope_kernel(
     if (write_seq_id == 0) continue;
 
     const int* block_table_now =
-        block_tables +
-        ori_bi * (use_head_wise ? kv_num_heads * max_blocks_per_head
-                                : max_blocks_per_seq);
-    const int kv_head_idx = (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
+        block_tables + ori_bi * (use_head_wise
+                                     ? kv_num_heads * max_blocks_per_head
+                                     : max_blocks_per_seq);
+    const int kv_head_idx =
+        (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
     const int block_idx =
         (hi >= num_heads)
             ? (use_head_wise
@@ -483,12 +484,11 @@ __global__ void append_decode_cache_T_quant_rope_kernel(
       if (block_idx < 0) continue;
       const uint32_t kv_head_idx = (hi - num_heads) % kv_num_heads;
       const uint32_t tgt_idx =
-          use_head_wise
-              ? (block_idx * block_size * head_size +
-                 block_offset * head_size + h_bias)
-              : (block_idx * kv_num_heads * block_size * head_size +
-                 kv_head_idx * block_size * head_size +
-                 block_offset * head_size + h_bias);
+          use_head_wise ? (block_idx * block_size * head_size +
+                           block_offset * head_size + h_bias)
+                        : (block_idx * kv_num_heads * block_size * head_size +
+                           kv_head_idx * block_size * head_size +
+                           block_offset * head_size + h_bias);
       if (hi < num_heads + kv_num_heads) {
         Store<T, VecSize>(bias_vec, &key_cache[tgt_idx]);
       } else {
@@ -567,10 +567,11 @@ __global__ void append_decode_cache_T_neox_partial_rope_kernel(
     if (write_seq_id == 0) continue;
 
     const int* block_table_now =
-        block_tables +
-        ori_bi * (use_head_wise ? kv_num_heads * max_blocks_per_head
-                                : max_blocks_per_seq);
-    const int kv_head_idx = (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
+        block_tables + ori_bi * (use_head_wise
+                                     ? kv_num_heads * max_blocks_per_head
+                                     : max_blocks_per_seq);
+    const int kv_head_idx =
+        (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
     const int block_idx =
         (hi >= num_heads)
             ? (use_head_wise
@@ -634,12 +635,11 @@ __global__ void append_decode_cache_T_neox_partial_rope_kernel(
       if (block_idx < 0) continue;
       const uint32_t kv_head_idx = (hi - num_heads) % kv_num_heads;
       uint32_t tgt_idx_left =
-          use_head_wise
-              ? (block_idx * block_size * head_size +
-                 block_offset * head_size + h_bias)
-              : (block_idx * kv_num_heads * block_size * head_size +
-                 kv_head_idx * block_size * head_size +
-                 block_offset * head_size + h_bias);
+          use_head_wise ? (block_idx * block_size * head_size +
+                           block_offset * head_size + h_bias)
+                        : (block_idx * kv_num_heads * block_size * head_size +
+                           kv_head_idx * block_size * head_size +
+                           block_offset * head_size + h_bias);
       uint32_t tgt_idx_right = tgt_idx_left + half_head_size;
       if (hi < num_heads + kv_num_heads) {
         if (h_bias < half_rotary_dim) {
@@ -720,10 +720,11 @@ __global__ void append_decode_cache_T_neox_rope_kernel(
     if (write_seq_id == 0) continue;
 
     const int* block_table_now =
-        block_tables +
-        ori_bi * (use_head_wise ? kv_num_heads * max_blocks_per_head
-                                : max_blocks_per_seq);
-    const int kv_head_idx = (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
+        block_tables + ori_bi * (use_head_wise
+                                     ? kv_num_heads * max_blocks_per_head
+                                     : max_blocks_per_seq);
+    const int kv_head_idx =
+        (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
     const int block_idx =
         (hi >= num_heads)
             ? (use_head_wise
@@ -775,12 +776,11 @@ __global__ void append_decode_cache_T_neox_rope_kernel(
       if (block_idx < 0) continue;
       const uint32_t kv_head_idx = (hi - num_heads) % kv_num_heads;
       const uint32_t tgt_idx_left =
-          use_head_wise
-              ? (block_idx * block_size * head_size +
-                 block_offset * head_size + h_bias)
-              : (block_idx * kv_num_heads * block_size * head_size +
-                 kv_head_idx * block_size * head_size +
-                 block_offset * head_size + h_bias);
+          use_head_wise ? (block_idx * block_size * head_size +
+                           block_offset * head_size + h_bias)
+                        : (block_idx * kv_num_heads * block_size * head_size +
+                           kv_head_idx * block_size * head_size +
+                           block_offset * head_size + h_bias);
       const uint32_t tgt_idx_right = tgt_idx_left + half_head_size;
       if (hi < num_heads + kv_num_heads) {
         Store<T, VecSize>(left_bias_vec, &key_cache[tgt_idx_left]);
@@ -859,10 +859,11 @@ __global__ void append_decode_cache_T_quant_neox_rope_kernel(
     if (write_seq_id == 0) continue;
 
     const int* block_table_now =
-        block_tables +
-        ori_bi * (use_head_wise ? kv_num_heads * max_blocks_per_head
-                                : max_blocks_per_seq);
-    const int kv_head_idx = (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
+        block_tables + ori_bi * (use_head_wise
+                                     ? kv_num_heads * max_blocks_per_head
+                                     : max_blocks_per_seq);
+    const int kv_head_idx =
+        (hi >= num_heads) ? (hi - num_heads) % kv_num_heads : 0;
     const int block_idx =
         (hi >= num_heads)
             ? (use_head_wise
@@ -930,12 +931,11 @@ __global__ void append_decode_cache_T_quant_neox_rope_kernel(
       if (block_idx < 0) continue;
       const uint32_t kv_head_idx = (hi - num_heads) % kv_num_heads;
       const uint32_t tgt_idx_left =
-          use_head_wise
-              ? (block_idx * block_size * head_size +
-                 block_offset * head_size + h_bias)
-              : (block_idx * kv_num_heads * block_size * head_size +
-                 kv_head_idx * block_size * head_size +
-                 block_offset * head_size + h_bias);
+          use_head_wise ? (block_idx * block_size * head_size +
+                           block_offset * head_size + h_bias)
+                        : (block_idx * kv_num_heads * block_size * head_size +
+                           kv_head_idx * block_size * head_size +
+                           block_offset * head_size + h_bias);
       const uint32_t tgt_idx_right = tgt_idx_left + half_head_size;
       if (hi < num_heads + kv_num_heads) {
         Store<T, VecSize>(left_bias_vec, &key_cache[tgt_idx_left]);

--- a/custom_ops/gpu_ops/append_attn/decoder_write_cache_with_rope_kernel.cu
+++ b/custom_ops/gpu_ops/append_attn/decoder_write_cache_with_rope_kernel.cu
@@ -38,6 +38,8 @@ void append_decode_cache_rope_qk_norm(const QKV_TYPE* qkv,
                                       const cudaStream_t& stream,
                                       const bool use_neox_style,
                                       const bool rope_3d,
+                                      const bool use_head_wise,
+                                      const int max_blocks_per_head,
                                       const float* q_norm_weight,
                                       const float* k_norm_weight,
                                       const float rms_norm_eps) {
@@ -75,6 +77,8 @@ void append_decode_cache_rope_qk_norm(const QKV_TYPE* qkv,
       block_size,
       elem_nums,
       kv_num_heads,
+      use_head_wise,
+      max_blocks_per_head,
       rope_3d,
       q_norm_weight,
       k_norm_weight,
@@ -104,7 +108,9 @@ void append_decode_cache_rope(const QKV_TYPE* qkv,
                               const int bsz,
                               const cudaStream_t& stream,
                               const bool use_neox_style,
-                              const bool rope_3d) {
+                              const bool rope_3d,
+                              const bool use_head_wise,
+                              const int max_blocks_per_head) {
   const uint32_t elem_nums =
       use_neox_style ? bsz * (num_heads + 2 * kv_num_heads) * dim_head / 2
                      : bsz * (num_heads + 2 * kv_num_heads) * dim_head;
@@ -143,6 +149,8 @@ void append_decode_cache_rope(const QKV_TYPE* qkv,
           block_size,
           elem_nums,
           kv_num_heads,
+          use_head_wise,
+          max_blocks_per_head,
           rope_3d);
     } else {
       if (rotary_dim < dim_head) {
@@ -173,6 +181,8 @@ void append_decode_cache_rope(const QKV_TYPE* qkv,
                                  block_size,
                                  elem_nums,
                                  kv_num_heads,
+                                 use_head_wise,
+                                 max_blocks_per_head,
                                  rope_3d);
       } else {
         auto* kernelFn =
@@ -199,6 +209,8 @@ void append_decode_cache_rope(const QKV_TYPE* qkv,
                                  block_size,
                                  elem_nums,
                                  kv_num_heads,
+                                 use_head_wise,
+                                 max_blocks_per_head,
                                  rope_3d);
       }
     }
@@ -229,6 +241,8 @@ void append_decode_cache_rope(const QKV_TYPE* qkv,
           block_size,
           elem_nums,
           kv_num_heads,
+          use_head_wise,
+          max_blocks_per_head,
           rope_3d);
     } else {
       auto* kernelFn =
@@ -255,6 +269,8 @@ void append_decode_cache_rope(const QKV_TYPE* qkv,
                                block_size,
                                elem_nums,
                                kv_num_heads,
+                               use_head_wise,
+                               max_blocks_per_head,
                                rope_3d);
     }
   }
@@ -686,6 +702,8 @@ void DecoderWriteCacheWithRoPEKernel(
           stream,
           use_neox_rotary_style,
           rope_3d,
+          meta_data.use_head_wise,
+          meta_data.max_blocks_per_head,
           q_norm_weight ? q_norm_weight.get().data<float>() : nullptr,
           k_norm_weight ? k_norm_weight.get().data<float>() : nullptr,
           rms_norm_eps);
@@ -807,7 +825,9 @@ void DecoderWriteCacheWithRoPEKernel(
           bsz,
           stream,
           use_neox_rotary_style,
-          rope_3d);
+          rope_3d,
+          meta_data.use_head_wise,
+          meta_data.max_blocks_per_head);
     } else if (cache_quant_type_str == "cache_int8") {
       bool is_scale_channel_wise = false;
       if (cache_k_scale &&

--- a/custom_ops/gpu_ops/append_attn/encoder_write_cache_with_rope_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/encoder_write_cache_with_rope_impl.cuh
@@ -1142,7 +1142,9 @@ __global__ void cache_kernel(
     const int head_size,
     const int block_size,
     const uint32_t elem_cnt,
-    const int kv_num_heads) {
+    const int kv_num_heads,
+    const bool use_head_wise,
+    const int max_blocks_per_head) {
   using LoadT = AlignedVector<T, VecSize>;
   LoadT src_vec;
 
@@ -1168,16 +1170,25 @@ __global__ void cache_kernel(
     const uint32_t ori_seq_id =
         (token_idx - cu_seqlens_q[ori_bi]) + seq_lens_decoder[ori_bi];
 
-    const int32_t *block_table_now = nullptr;
-
-    block_table_now = block_tables + ori_bi * max_blocks_per_seq;
-
-    const uint32_t block_idx = block_table_now[ori_seq_id / block_size];
+    const uint32_t seq_block_idx = ori_seq_id / block_size;
+    const int32_t *block_table_now =
+        block_tables +
+        ori_bi * (use_head_wise ? kv_num_heads * max_blocks_per_head
+                                : max_blocks_per_seq);
+    const int32_t cache_id =
+        use_head_wise
+            ? block_table_now[hi * max_blocks_per_head + seq_block_idx]
+            : block_table_now[seq_block_idx];
+    if (cache_id < 0) continue;
     const uint32_t block_offset = ori_seq_id % block_size;
 
-    const uint32_t tgt_idx = block_idx * kv_num_heads * block_size * head_size +
-                             hi * block_size * head_size +
-                             block_offset * head_size + h_bias;
+    const uint32_t tgt_idx =
+        use_head_wise
+            ? (cache_id * block_size * head_size + block_offset * head_size +
+               h_bias)
+            : (cache_id * kv_num_heads * block_size * head_size +
+               hi * block_size * head_size + block_offset * head_size +
+               h_bias);
     const uint32_t ori_idx =
         token_idx * (num_heads + 2 * kv_num_heads) * head_size +
         num_heads * head_size + qkv_id * hidden_size + hi * head_size + h_bias;
@@ -2736,7 +2747,9 @@ void CascadeAppendWriteCacheKVQKV(
       head_dim,
       block_size,
       elem_nums,
-      kv_num_heads);
+      kv_num_heads,
+      meta_data.use_head_wise,
+      meta_data.max_blocks_per_head);
 }
 
 template <typename T, uint32_t HEAD_DIM, uint32_t BLOCK_SIZE>

--- a/custom_ops/gpu_ops/append_attn/encoder_write_cache_with_rope_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/encoder_write_cache_with_rope_impl.cuh
@@ -1172,9 +1172,9 @@ __global__ void cache_kernel(
 
     const uint32_t seq_block_idx = ori_seq_id / block_size;
     const int32_t *block_table_now =
-        block_tables +
-        ori_bi * (use_head_wise ? kv_num_heads * max_blocks_per_head
-                                : max_blocks_per_seq);
+        block_tables + ori_bi * (use_head_wise
+                                     ? kv_num_heads * max_blocks_per_head
+                                     : max_blocks_per_seq);
     const int32_t cache_id =
         use_head_wise
             ? block_table_now[hi * max_blocks_per_head + seq_block_idx]
@@ -1187,8 +1187,7 @@ __global__ void cache_kernel(
             ? (cache_id * block_size * head_size + block_offset * head_size +
                h_bias)
             : (cache_id * kv_num_heads * block_size * head_size +
-               hi * block_size * head_size + block_offset * head_size +
-               h_bias);
+               hi * block_size * head_size + block_offset * head_size + h_bias);
     const uint32_t ori_idx =
         token_idx * (num_heads + 2 * kv_num_heads) * head_size +
         num_heads * head_size + qkv_id * hidden_size + hi * head_size + h_bias;

--- a/custom_ops/gpu_ops/append_attn/gqa_rope_write_cache.cu
+++ b/custom_ops/gpu_ops/append_attn/gqa_rope_write_cache.cu
@@ -899,7 +899,10 @@ __global__ void append_cache_kv_c4(const CacheT *__restrict__ cache_k,
 
   const int *cur_block_table = block_tables + batch_id * max_blocks_per_seq;
   uint32_t block_id = cur_block_table[start_kv_idx / BLOCK_SIZE];
-  if (block_id < 0) block_id = 0;
+  if (block_id < 0) {
+    // Invalid cache block should not fallback to block0. Skip this tile.
+    return;
+  }
 
   constexpr uint32_t HEAD_DIM_HALF = HEAD_DIM / 2;
   constexpr uint32_t BLOCK_SIZE_HALF = BLOCK_SIZE / 2;

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c16_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c16_impl.cuh
@@ -75,10 +75,9 @@ __global__ void multi_query_append_attention_kernel(
   const uint32_t tile_id = tile_ids_per_batch[btid];
   const uint32_t num_rows_per_block = NUM_WARPS * num_frags_x * 16;
   const int *block_table_now =
-      block_table +
-      (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
-                           max_block_num_per_seq
-                     : batch_id * max_block_num_per_seq);
+      block_table + (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
+                                         max_block_num_per_seq
+                                   : batch_id * max_block_num_per_seq);
 
   // When cudagraph capture prefill, may launch more gridDim.x
   if (btid >= static_cast<uint32_t>(num_blocks_x_cpu)) {
@@ -215,8 +214,7 @@ __global__ void multi_query_append_attention_kernel(
   int block_id = __ldg(&block_table_now[kv_idx_base / BLOCK_SIZE]);
   const uint32_t const_offset =
       (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
-      (wid * 4 + tid / 8) * kv_b_stride +
-      tid % 8 * num_elems_per_128b<T>();
+      (wid * 4 + tid / 8) * kv_b_stride + tid % 8 * num_elems_per_128b<T>();
   const T *cache_k_now = cache_k + block_id * kv_n_stride + const_offset;
   const T *cache_v_now = cache_v + block_id * kv_n_stride + const_offset;
 
@@ -491,10 +489,9 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
   const uint32_t tile_id = tile_ids_per_batch[btid];
   const uint32_t num_rows_per_block = num_frags_x * 16;
   const int *block_table_now =
-      block_table +
-      (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
-                           max_block_num_per_seq
-                     : batch_id * max_block_num_per_seq);
+      block_table + (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
+                                         max_block_num_per_seq
+                                   : batch_id * max_block_num_per_seq);
 
   const uint32_t q_len = seq_lens[batch_id];
   const uint32_t kv_len = seq_lens_kv[batch_id] + q_len;
@@ -611,8 +608,7 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
   int block_id = __ldg(&block_table_now[kv_idx_base / BLOCK_SIZE]);
   const uint32_t const_offset =
       (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
-      (wid * 4 + tid / 8) * kv_b_stride +
-      tid % 8 * num_elems_per_128b<T>();
+      (wid * 4 + tid / 8) * kv_b_stride + tid % 8 * num_elems_per_128b<T>();
   T *cache_k_now = cache_k + block_id * kv_n_stride + const_offset;
   T *cache_v_now = cache_v + block_id * kv_n_stride + const_offset;
 
@@ -884,9 +880,11 @@ void MultiQueryAppendAttention(
   auto kv_num_heads = meta_data.kv_num_heads;
   auto token_num = meta_data.token_nums;
   auto bsz = meta_data.batch_size;
-  // In head-wise mode, use max_blocks_per_head for block_table offset calculation
-  auto max_block_num_per_seq = meta_data.use_head_wise ? meta_data.max_blocks_per_head
-                                                      : meta_data.max_blocks_per_seq;
+  // In head-wise mode, use max_blocks_per_head for block_table offset
+  // calculation
+  auto max_block_num_per_seq = meta_data.use_head_wise
+                                   ? meta_data.max_blocks_per_head
+                                   : meta_data.max_blocks_per_seq;
 
   constexpr uint32_t num_warps = 4;
   constexpr uint32_t NUM_WARP_KV = num_warps / NUM_WARP_Q;

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c16_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c16_impl.cuh
@@ -212,6 +212,9 @@ __global__ void multi_query_append_attention_kernel(
 
   uint32_t kv_idx_base = chunk_start;
   int block_id = __ldg(&block_table_now[kv_idx_base / BLOCK_SIZE]);
+  if (block_id < 0) {
+    block_id = 0;
+  }
   const uint32_t const_offset =
       (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
       (wid * 4 + tid / 8) * kv_b_stride + tid % 8 * num_elems_per_128b<T>();
@@ -606,6 +609,9 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
 
   uint32_t kv_idx_base = chunk_start;
   int block_id = __ldg(&block_table_now[kv_idx_base / BLOCK_SIZE]);
+  if (block_id < 0) {
+    block_id = 0;
+  }
   const uint32_t const_offset =
       (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
       (wid * 4 + tid / 8) * kv_b_stride + tid % 8 * num_elems_per_128b<T>();

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c16_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c16_impl.cuh
@@ -58,6 +58,7 @@ __global__ void multi_query_append_attention_kernel(
     float *__restrict__ tmp_m,  // [token_num, num_chunks, num_heads]
     float *__restrict__ tmp_d,  // [token_num, num_chunks, num_heads]
     OutT *__restrict__ out,
+    const bool use_head_wise,
     const int speculate_max_draft_token_num = 5,
     const int sliding_window = 0,
     const int sink_size = 0) {
@@ -73,7 +74,11 @@ __global__ void multi_query_append_attention_kernel(
   const uint32_t batch_id = batch_ids[btid];
   const uint32_t tile_id = tile_ids_per_batch[btid];
   const uint32_t num_rows_per_block = NUM_WARPS * num_frags_x * 16;
-  const int *block_table_now = block_table + batch_id * max_block_num_per_seq;
+  const int *block_table_now =
+      block_table +
+      (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
+                           max_block_num_per_seq
+                     : batch_id * max_block_num_per_seq);
 
   // When cudagraph capture prefill, may launch more gridDim.x
   if (btid >= static_cast<uint32_t>(num_blocks_x_cpu)) {
@@ -120,8 +125,9 @@ __global__ void multi_query_append_attention_kernel(
 
   const uint32_t q_n_stride = q_num_heads * HEAD_DIM;
   const uint32_t q_ori_n_stride = (q_num_heads + kv_num_heads * 2) * HEAD_DIM;
-  const uint32_t kv_n_stride = kv_num_heads * BLOCK_SIZE * HEAD_DIM;
   const uint32_t kv_h_stride = BLOCK_SIZE * HEAD_DIM;
+  const uint32_t kv_n_stride =
+      use_head_wise ? kv_h_stride : kv_num_heads * kv_h_stride;
   const uint32_t kv_b_stride = HEAD_DIM;
   const uint32_t q_start_seq_id = cu_seqlens_q[batch_id];
   const uint32_t q_base_seq_id_this_block =
@@ -207,9 +213,10 @@ __global__ void multi_query_append_attention_kernel(
 
   uint32_t kv_idx_base = chunk_start;
   int block_id = __ldg(&block_table_now[kv_idx_base / BLOCK_SIZE]);
-  const uint32_t const_offset = kv_head_idx * kv_h_stride +
-                                (wid * 4 + tid / 8) * kv_b_stride +
-                                tid % 8 * num_elems_per_128b<T>();
+  const uint32_t const_offset =
+      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      (wid * 4 + tid / 8) * kv_b_stride +
+      tid % 8 * num_elems_per_128b<T>();
   const T *cache_k_now = cache_k + block_id * kv_n_stride + const_offset;
   const T *cache_v_now = cache_v + block_id * kv_n_stride + const_offset;
 
@@ -462,6 +469,7 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
     float *__restrict__ tmp_m,      // [token_num, num_chunks, num_heads]
     float *__restrict__ tmp_d,      // [token_num, num_chunks, num_heads]
     OutT *__restrict__ out,
+    const bool use_head_wise,
     const int speculate_max_draft_token_num = 5,
     const uint32_t attn_mask_len = -1,
     const int sliding_window = 0,
@@ -482,7 +490,11 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
 
   const uint32_t tile_id = tile_ids_per_batch[btid];
   const uint32_t num_rows_per_block = num_frags_x * 16;
-  const int *block_table_now = block_table + batch_id * max_block_num_per_seq;
+  const int *block_table_now =
+      block_table +
+      (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
+                           max_block_num_per_seq
+                     : batch_id * max_block_num_per_seq);
 
   const uint32_t q_len = seq_lens[batch_id];
   const uint32_t kv_len = seq_lens_kv[batch_id] + q_len;
@@ -506,8 +518,9 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
 
   const uint32_t q_n_stride = q_num_heads * HEAD_DIM;
   const uint32_t q_ori_n_stride = (q_num_heads + kv_num_heads * 2) * HEAD_DIM;
-  const uint32_t kv_n_stride = kv_num_heads * BLOCK_SIZE * HEAD_DIM;
   const uint32_t kv_h_stride = BLOCK_SIZE * HEAD_DIM;
+  const uint32_t kv_n_stride =
+      use_head_wise ? kv_h_stride : kv_num_heads * kv_h_stride;
   const uint32_t kv_b_stride = HEAD_DIM;
   const uint32_t q_start_seq_id = cu_seqlens_q[batch_id];
   const uint32_t q_base_seq_id_this_block = tile_id * num_frags_x * 16;
@@ -596,9 +609,10 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
 
   uint32_t kv_idx_base = chunk_start;
   int block_id = __ldg(&block_table_now[kv_idx_base / BLOCK_SIZE]);
-  const uint32_t const_offset = kv_head_idx * kv_h_stride +
-                                (wid * 4 + tid / 8) * kv_b_stride +
-                                tid % 8 * num_elems_per_128b<T>();
+  const uint32_t const_offset =
+      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      (wid * 4 + tid / 8) * kv_b_stride +
+      tid % 8 * num_elems_per_128b<T>();
   T *cache_k_now = cache_k + block_id * kv_n_stride + const_offset;
   T *cache_v_now = cache_v + block_id * kv_n_stride + const_offset;
 
@@ -985,6 +999,7 @@ void MultiQueryAppendAttention(
           nullptr,
           nullptr,
           reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          meta_data.use_head_wise,
           speculate_max_draft_token_num,
           sliding_window,
           sink_size);
@@ -1053,6 +1068,7 @@ void MultiQueryAppendAttention(
           static_cast<float *>(tmp_m->ptr()),
           static_cast<float *>(tmp_d->ptr()),
           reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          meta_data.use_head_wise,
           speculate_max_draft_token_num,
           sliding_window,
           sink_size);
@@ -1216,6 +1232,7 @@ void MultiQueryAppendAttention(
           nullptr,
           nullptr,
           reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          meta_data.use_head_wise,
           speculate_max_draft_token_num,
           attn_mask_len,
           sliding_window,
@@ -1299,6 +1316,7 @@ void MultiQueryAppendAttention(
           static_cast<float *>(tmp_m->ptr()),
           static_cast<float *>(tmp_d->ptr()),
           reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          meta_data.use_head_wise,
           speculate_max_draft_token_num,
           attn_mask_len,
           sliding_window,

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c16_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c16_impl.cuh
@@ -212,29 +212,46 @@ __global__ void multi_query_append_attention_kernel(
 
   uint32_t kv_idx_base = chunk_start;
   int block_id = __ldg(&block_table_now[kv_idx_base / BLOCK_SIZE]);
-  if (block_id < 0) {
-    block_id = 0;
-  }
+  bool valid_block = block_id >= 0;
+  int safe_block_id = valid_block ? block_id : 0;
   const uint32_t const_offset =
       (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
       (wid * 4 + tid / 8) * kv_b_stride + tid % 8 * num_elems_per_128b<T>();
-  const T *cache_k_now = cache_k + block_id * kv_n_stride + const_offset;
-  const T *cache_v_now = cache_v + block_id * kv_n_stride + const_offset;
+  const T *cache_k_now = cache_k + safe_block_id * kv_n_stride + const_offset;
+  const T *cache_v_now = cache_v + safe_block_id * kv_n_stride + const_offset;
+  uint32_t chunk_end_for_load = valid_block ? chunk_end : 0;
 
-  produce_kv_blockwise<SharedMemFillMode::kNoFill,
-                       NUM_WARPS,
-                       BLOCK_SIZE,
-                       num_frags_y,
-                       num_frags_z,
-                       NUM_WARP_Q>(k_smem,
-                                   &kv_smem_offset_w,
-                                   &cache_k_now,
-                                   kv_head_idx,
-                                   kv_n_stride,
-                                   kv_h_stride,
-                                   kv_b_stride,
-                                   kv_idx_base,
-                                   chunk_end);
+  if (valid_block) {
+    produce_kv_blockwise<SharedMemFillMode::kNoFill,
+                         NUM_WARPS,
+                         BLOCK_SIZE,
+                         num_frags_y,
+                         num_frags_z,
+                         NUM_WARP_Q>(k_smem,
+                                     &kv_smem_offset_w,
+                                     &cache_k_now,
+                                     kv_head_idx,
+                                     kv_n_stride,
+                                     kv_h_stride,
+                                     kv_b_stride,
+                                     kv_idx_base,
+                                     chunk_end_for_load);
+  } else {
+    produce_kv_blockwise<SharedMemFillMode::kFillZero,
+                         NUM_WARPS,
+                         BLOCK_SIZE,
+                         num_frags_y,
+                         num_frags_z,
+                         NUM_WARP_Q>(k_smem,
+                                     &kv_smem_offset_w,
+                                     &cache_k_now,
+                                     kv_head_idx,
+                                     kv_n_stride,
+                                     kv_h_stride,
+                                     kv_b_stride,
+                                     kv_idx_base,
+                                     chunk_end_for_load);
+  }
   commit_group();
   produce_kv_blockwise<SharedMemFillMode::kFillZero,
                        NUM_WARPS,
@@ -249,7 +266,7 @@ __global__ void multi_query_append_attention_kernel(
                                    kv_h_stride,
                                    kv_b_stride,
                                    kv_idx_base,
-                                   chunk_end);
+                                   chunk_end_for_load);
   commit_group();
 #pragma unroll 1
   for (uint32_t iter = 0; iter < num_iterations; ++iter) {
@@ -288,24 +305,41 @@ __global__ void multi_query_append_attention_kernel(
 
     kv_idx_base += num_frags_z * 16;
     block_id = __ldg(&block_table_now[kv_idx_base / BLOCK_SIZE]);
-    if (block_id < 0) {
-      block_id = 0;
+    valid_block = block_id >= 0;
+    safe_block_id = valid_block ? block_id : 0;
+    chunk_end_for_load = valid_block ? chunk_end : 0;
+    cache_k_now = cache_k + safe_block_id * kv_n_stride + const_offset;
+    if (valid_block) {
+      produce_kv_blockwise<SharedMemFillMode::kNoFill,
+                           NUM_WARPS,
+                           BLOCK_SIZE,
+                           num_frags_y,
+                           num_frags_z,
+                           NUM_WARP_Q>(k_smem,
+                                       &kv_smem_offset_w,
+                                       &cache_k_now,
+                                       kv_head_idx,
+                                       kv_n_stride,
+                                       kv_h_stride,
+                                       kv_b_stride,
+                                       kv_idx_base,
+                                       chunk_end_for_load);
+    } else {
+      produce_kv_blockwise<SharedMemFillMode::kFillZero,
+                           NUM_WARPS,
+                           BLOCK_SIZE,
+                           num_frags_y,
+                           num_frags_z,
+                           NUM_WARP_Q>(k_smem,
+                                       &kv_smem_offset_w,
+                                       &cache_k_now,
+                                       kv_head_idx,
+                                       kv_n_stride,
+                                       kv_h_stride,
+                                       kv_b_stride,
+                                       kv_idx_base,
+                                       chunk_end_for_load);
     }
-    cache_k_now = cache_k + block_id * kv_n_stride + const_offset;
-    produce_kv_blockwise<SharedMemFillMode::kNoFill,
-                         NUM_WARPS,
-                         BLOCK_SIZE,
-                         num_frags_y,
-                         num_frags_z,
-                         NUM_WARP_Q>(k_smem,
-                                     &kv_smem_offset_w,
-                                     &cache_k_now,
-                                     kv_head_idx,
-                                     kv_n_stride,
-                                     kv_h_stride,
-                                     kv_b_stride,
-                                     kv_idx_base,
-                                     chunk_end);
     commit_group();
     wait_group<1>();
     __syncthreads();
@@ -315,7 +349,7 @@ __global__ void multi_query_append_attention_kernel(
         &v_smem, &v_smem_offset_r, s_frag, o_frag, d_frag);
 
     __syncthreads();
-    cache_v_now = cache_v + block_id * kv_n_stride + const_offset;
+    cache_v_now = cache_v + safe_block_id * kv_n_stride + const_offset;
     produce_kv_blockwise<SharedMemFillMode::kFillZero,
                          NUM_WARPS,
                          BLOCK_SIZE,
@@ -329,7 +363,7 @@ __global__ void multi_query_append_attention_kernel(
                                      kv_h_stride,
                                      kv_b_stride,
                                      kv_idx_base,
-                                     chunk_end);
+                                     chunk_end_for_load);
     commit_group();
   }
   wait_group<0>();
@@ -609,29 +643,46 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
 
   uint32_t kv_idx_base = chunk_start;
   int block_id = __ldg(&block_table_now[kv_idx_base / BLOCK_SIZE]);
-  if (block_id < 0) {
-    block_id = 0;
-  }
+  bool valid_block = block_id >= 0;
+  int safe_block_id = valid_block ? block_id : 0;
   const uint32_t const_offset =
       (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
       (wid * 4 + tid / 8) * kv_b_stride + tid % 8 * num_elems_per_128b<T>();
-  T *cache_k_now = cache_k + block_id * kv_n_stride + const_offset;
-  T *cache_v_now = cache_v + block_id * kv_n_stride + const_offset;
+  T *cache_k_now = cache_k + safe_block_id * kv_n_stride + const_offset;
+  T *cache_v_now = cache_v + safe_block_id * kv_n_stride + const_offset;
+  uint32_t chunk_end_for_load = valid_block ? chunk_end : 0;
 
-  produce_kv_blockwise<SharedMemFillMode::kNoFill,
-                       NUM_WARPS,
-                       BLOCK_SIZE,
-                       num_frags_y,
-                       num_frags_z,
-                       NUM_WARP_Q>(k_smem,
-                                   &kv_smem_offset_w,
-                                   &cache_k_now,
-                                   kv_head_idx,
-                                   kv_n_stride,
-                                   kv_h_stride,
-                                   kv_b_stride,
-                                   kv_idx_base,
-                                   chunk_end);
+  if (valid_block) {
+    produce_kv_blockwise<SharedMemFillMode::kNoFill,
+                         NUM_WARPS,
+                         BLOCK_SIZE,
+                         num_frags_y,
+                         num_frags_z,
+                         NUM_WARP_Q>(k_smem,
+                                     &kv_smem_offset_w,
+                                     &cache_k_now,
+                                     kv_head_idx,
+                                     kv_n_stride,
+                                     kv_h_stride,
+                                     kv_b_stride,
+                                     kv_idx_base,
+                                     chunk_end_for_load);
+  } else {
+    produce_kv_blockwise<SharedMemFillMode::kFillZero,
+                         NUM_WARPS,
+                         BLOCK_SIZE,
+                         num_frags_y,
+                         num_frags_z,
+                         NUM_WARP_Q>(k_smem,
+                                     &kv_smem_offset_w,
+                                     &cache_k_now,
+                                     kv_head_idx,
+                                     kv_n_stride,
+                                     kv_h_stride,
+                                     kv_b_stride,
+                                     kv_idx_base,
+                                     chunk_end_for_load);
+  }
   commit_group();
 
   produce_kv_blockwise<SharedMemFillMode::kFillZero,
@@ -647,7 +698,7 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
                                    kv_h_stride,
                                    kv_b_stride,
                                    kv_idx_base,
-                                   chunk_end);
+                                   chunk_end_for_load);
   commit_group();
 
 #pragma unroll 1
@@ -689,24 +740,41 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
 
     kv_idx_base += BLOCK_SIZE;
     block_id = __ldg(&block_table_now[kv_idx_base / BLOCK_SIZE]);
-    if (block_id < 0) {
-      block_id = 0;
+    valid_block = block_id >= 0;
+    safe_block_id = valid_block ? block_id : 0;
+    chunk_end_for_load = valid_block ? chunk_end : 0;
+    cache_k_now = cache_k + safe_block_id * kv_n_stride + const_offset;
+    if (valid_block) {
+      produce_kv_blockwise<SharedMemFillMode::kNoFill,
+                           NUM_WARPS,
+                           BLOCK_SIZE,
+                           num_frags_y,
+                           num_frags_z,
+                           NUM_WARP_Q>(k_smem,
+                                       &kv_smem_offset_w,
+                                       &cache_k_now,
+                                       kv_head_idx,
+                                       kv_n_stride,
+                                       kv_h_stride,
+                                       kv_b_stride,
+                                       kv_idx_base,
+                                       chunk_end_for_load);
+    } else {
+      produce_kv_blockwise<SharedMemFillMode::kFillZero,
+                           NUM_WARPS,
+                           BLOCK_SIZE,
+                           num_frags_y,
+                           num_frags_z,
+                           NUM_WARP_Q>(k_smem,
+                                       &kv_smem_offset_w,
+                                       &cache_k_now,
+                                       kv_head_idx,
+                                       kv_n_stride,
+                                       kv_h_stride,
+                                       kv_b_stride,
+                                       kv_idx_base,
+                                       chunk_end_for_load);
     }
-    cache_k_now = cache_k + block_id * kv_n_stride + const_offset;
-    produce_kv_blockwise<SharedMemFillMode::kNoFill,
-                         NUM_WARPS,
-                         BLOCK_SIZE,
-                         num_frags_y,
-                         num_frags_z,
-                         NUM_WARP_Q>(k_smem,
-                                     &kv_smem_offset_w,
-                                     &cache_k_now,
-                                     kv_head_idx,
-                                     kv_n_stride,
-                                     kv_h_stride,
-                                     kv_b_stride,
-                                     kv_idx_base,
-                                     chunk_end);
     commit_group();
     wait_group<1>();
     __syncthreads();
@@ -716,7 +784,7 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
         &v_smem, &v_smem_offset_r, s_frag, o_frag, d_frag);
     __syncthreads();
 
-    cache_v_now = cache_v + block_id * kv_n_stride + const_offset;
+    cache_v_now = cache_v + safe_block_id * kv_n_stride + const_offset;
     produce_kv_blockwise<SharedMemFillMode::kFillZero,
                          NUM_WARPS,
                          BLOCK_SIZE,
@@ -730,7 +798,7 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
                                      kv_h_stride,
                                      kv_b_stride,
                                      kv_idx_base,
-                                     chunk_end);
+                                     chunk_end_for_load);
     commit_group();
   }
   wait_group<0>();

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c16_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c16_impl.cuh
@@ -884,7 +884,9 @@ void MultiQueryAppendAttention(
   auto kv_num_heads = meta_data.kv_num_heads;
   auto token_num = meta_data.token_nums;
   auto bsz = meta_data.batch_size;
-  auto max_block_num_per_seq = meta_data.max_blocks_per_seq;
+  // In head-wise mode, use max_blocks_per_head for block_table offset calculation
+  auto max_block_num_per_seq = meta_data.use_head_wise ? meta_data.max_blocks_per_head
+                                                      : meta_data.max_blocks_per_seq;
 
   constexpr uint32_t num_warps = 4;
   constexpr uint32_t NUM_WARP_KV = num_warps / NUM_WARP_Q;

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c4_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c4_impl.cuh
@@ -1326,7 +1326,6 @@ void MultiQueryAppendC4Attention(
                       const_cast<T *>(sinks.get().data<T>()))
                 : nullptr,
           reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-          use_head_wise,
           quant_max_bound,
           quant_min_bound,
           in_scale,

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c4_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c4_impl.cuh
@@ -47,7 +47,7 @@ __global__ void multi_query_append_attention_c4_kernel(
     const int *__restrict__ batch_ids,
     const int *__restrict__ tile_ids_per_batch,
     const int *__restrict__ cu_seqlens_q,
-    const int *__restrict__ block_table,  // [bsz, block_num_per_seq]
+    const int *__restrict__ block_table,  // [bsz, block_num_per_seq] or [bsz * kv_num_heads, block_num_per_seq] when head_wise
     const int *__restrict__ mask_offset,
     const int max_seq_len,
     const int max_dec_len,
@@ -63,6 +63,7 @@ __global__ void multi_query_append_attention_c4_kernel(
     float *__restrict__ tmp_m,      // [token_num, num_chunks, num_heads]
     float *__restrict__ tmp_d,      // [token_num, num_chunks, num_heads]
     OutT *__restrict__ out,
+    const bool use_head_wise,
     const int speculate_max_draft_token_num = 5,
     const int sliding_window = 0,
     const int sink_size = 0) {
@@ -84,9 +85,13 @@ __global__ void multi_query_append_attention_c4_kernel(
   const uint32_t batch_id = batch_ids[btid];
   const uint32_t tile_id = tile_ids_per_batch[btid];
   const uint32_t num_rows_per_block = NUM_WARPS * num_frags_x * 16;
-  const int *block_table_now = nullptr;
-
-  block_table_now = block_table + batch_id * max_block_num_per_seq;
+  // In head-wise mode, block_table has shape [batch_size * kv_num_heads, max_blocks_per_head]
+  // Otherwise, block_table has shape [batch_size, max_blocks_per_seq]
+  const int *block_table_now =
+      block_table +
+      (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
+                           max_block_num_per_seq
+                     : batch_id * max_block_num_per_seq);
 
   // When cudagraph capture prefill, may launch more gridDim.x
   if (btid >= static_cast<uint32_t>(num_blocks_x_cpu)) {
@@ -152,7 +157,10 @@ __global__ void multi_query_append_attention_c4_kernel(
 
   const uint32_t q_n_stride = q_num_heads * HEAD_DIM;
   const uint32_t q_ori_n_stride = (q_num_heads + kv_num_heads * 2) * HEAD_DIM;
-  const uint32_t kv_n_stride = kv_num_heads * BLOCK_SIZE * HEAD_DIM / 2;
+  // In head-wise mode, cache layout is [max_cache_ids, block_size, head_dim]
+  // Otherwise, cache layout is [num_blocks, kv_num_heads, block_size, head_dim]
+  const uint32_t kv_n_stride = use_head_wise ? BLOCK_SIZE * HEAD_DIM / 2
+                                             : kv_num_heads * BLOCK_SIZE * HEAD_DIM / 2;
   const uint32_t kv_h_stride = BLOCK_SIZE * HEAD_DIM / 2;
   const uint32_t kv_b_stride = HEAD_DIM / 2;
   const uint32_t kv_d_stride = BLOCK_SIZE / 2;
@@ -281,12 +289,15 @@ __global__ void multi_query_append_attention_c4_kernel(
           wid * 16 + tid / 2, tid % 2);  // 2 * 128 / 8 = 32B, 64 nums
 
   uint32_t kv_idx_base = chunk_start;
-  const uint32_t const_k_offset = kv_head_idx * kv_h_stride +
-                                  (wid * 8 + tid / 4) * kv_b_stride +
-                                  tid % 4 * num_elems_per_128b<CacheT>();
-  const uint32_t const_v_offset = kv_head_idx * kv_h_stride +
-                                  (wid * 16 + tid / 2) * kv_d_stride +
-                                  tid % 2 * num_elems_per_128b<CacheT>();
+  // In head-wise mode, cache_k and cache_v don't have the head dimension in stride
+  const uint32_t const_k_offset =
+      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      (wid * 8 + tid / 4) * kv_b_stride +
+      tid % 4 * num_elems_per_128b<CacheT>();
+  const uint32_t const_v_offset =
+      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      (wid * 16 + tid / 2) * kv_d_stride +
+      tid % 2 * num_elems_per_128b<CacheT>();
 
   produce_k_blockwise_c4<SharedMemFillMode::kNoFill,
                          NUM_WARPS,
@@ -543,7 +554,7 @@ __global__ void multi_query_append_attention_c4_warp1_4_kernel(
     const int *__restrict__ batch_ids,
     const int *__restrict__ tile_ids_per_batch,
     const int *__restrict__ cu_seqlens_q,
-    const int *__restrict__ block_table,  // [bsz, block_num_per_seq]
+    const int *__restrict__ block_table,  // [bsz, block_num_per_seq] or [bsz * kv_num_heads, block_num_per_seq] when head_wise
     const int *__restrict__ mask_offset,
     const bool *__restrict__ attn_mask,  // [bsz, max_q, max_q] for tree-mask
     const int max_seq_len,
@@ -560,6 +571,7 @@ __global__ void multi_query_append_attention_c4_warp1_4_kernel(
     float *__restrict__ tmp_m,      // [token_num, num_chunks, num_heads]
     float *__restrict__ tmp_d,      // [token_num, num_chunks, num_heads]
     OutT *__restrict__ out,
+    const bool use_head_wise,
     const int speculate_max_draft_token_num = 5,
     const uint32_t attn_mask_len = -1,
     const int sliding_window = 0,
@@ -586,7 +598,13 @@ __global__ void multi_query_append_attention_c4_warp1_4_kernel(
 
   const uint32_t tile_id = tile_ids_per_batch[btid];
   const uint32_t num_rows_per_block = num_frags_x * 16;
-  const int *block_table_now = block_table + batch_id * max_block_num_per_seq;
+  // In head-wise mode, block_table has shape [batch_size * kv_num_heads, max_blocks_per_head]
+  // Otherwise, block_table has shape [batch_size, max_blocks_per_seq]
+  const int *block_table_now =
+      block_table +
+      (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
+                           max_block_num_per_seq
+                     : batch_id * max_block_num_per_seq);
 
   // When cudagraph capture prefill, may launch more gridDim.x
   if (btid >= static_cast<uint32_t>(num_blocks_x_cpu)) {
@@ -655,7 +673,10 @@ __global__ void multi_query_append_attention_c4_warp1_4_kernel(
 
   const uint32_t q_n_stride = q_num_heads * HEAD_DIM;
   const uint32_t q_ori_n_stride = (q_num_heads + kv_num_heads * 2) * HEAD_DIM;
-  const uint32_t kv_n_stride = kv_num_heads * BLOCK_SIZE * HEAD_DIM / 2;
+  // In head-wise mode, cache layout is [max_cache_ids, block_size, head_dim]
+  // Otherwise, cache layout is [num_blocks, kv_num_heads, block_size, head_dim]
+  const uint32_t kv_n_stride = use_head_wise ? BLOCK_SIZE * HEAD_DIM / 2
+                                             : kv_num_heads * BLOCK_SIZE * HEAD_DIM / 2;
   const uint32_t kv_h_stride = BLOCK_SIZE * HEAD_DIM / 2;
   const uint32_t kv_b_stride = HEAD_DIM / 2;
   const uint32_t kv_d_stride = BLOCK_SIZE / 2;
@@ -783,12 +804,15 @@ __global__ void multi_query_append_attention_c4_warp1_4_kernel(
           wid * 16 + tid / 2, tid % 2);
 
   uint32_t kv_idx_base = chunk_start;
-  const uint32_t const_k_offset = kv_head_idx * kv_h_stride +
-                                  (wid * 8 + tid / 4) * kv_b_stride +
-                                  tid % 4 * num_elems_per_128b<CacheT>();
-  const uint32_t const_v_offset = kv_head_idx * kv_h_stride +
-                                  (wid * 16 + tid / 2) * kv_d_stride +
-                                  tid % 2 * num_elems_per_128b<CacheT>();
+  // In head-wise mode, cache_k and cache_v don't have the head dimension in stride
+  const uint32_t const_k_offset =
+      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      (wid * 8 + tid / 4) * kv_b_stride +
+      tid % 4 * num_elems_per_128b<CacheT>();
+  const uint32_t const_v_offset =
+      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      (wid * 16 + tid / 2) * kv_d_stride +
+      tid % 2 * num_elems_per_128b<CacheT>();
 
   produce_k_blockwise_c4<SharedMemFillMode::kNoFill,
                          NUM_WARPS,
@@ -1070,7 +1094,10 @@ void MultiQueryAppendC4Attention(
   auto kv_num_heads = meta_data.kv_num_heads;
   auto token_num = meta_data.token_nums;
   auto bsz = meta_data.batch_size;
-  auto max_block_num_per_seq = meta_data.max_blocks_per_seq;
+  bool use_head_wise = meta_data.use_head_wise;
+  // In head-wise mode, use max_blocks_per_head for block_table offset calculation
+  auto max_block_num_per_seq = use_head_wise ? meta_data.max_blocks_per_head
+                                            : meta_data.max_blocks_per_seq;
 
   constexpr uint32_t num_warps = 4;
   constexpr uint32_t NUM_WARP_KV = num_warps / NUM_WARP_Q;
@@ -1193,6 +1220,7 @@ void MultiQueryAppendC4Attention(
           nullptr,
           nullptr,
           reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          use_head_wise,
           speculate_max_draft_token_num,
           sliding_window,
           sink_size);
@@ -1268,6 +1296,7 @@ void MultiQueryAppendC4Attention(
           static_cast<float *>(tmp_m->ptr()),
           static_cast<float *>(tmp_d->ptr()),
           reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          use_head_wise,
           speculate_max_draft_token_num,
           sliding_window,
           sink_size);
@@ -1308,6 +1337,7 @@ void MultiQueryAppendC4Attention(
                       const_cast<T *>(sinks.get().data<T>()))
                 : nullptr,
           reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          use_head_wise,
           quant_max_bound,
           quant_min_bound,
           in_scale,
@@ -1442,6 +1472,7 @@ void MultiQueryAppendC4Attention(
           nullptr,
           nullptr,
           reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          use_head_wise,
           speculate_max_draft_token_num,
           attn_mask_len,
           sliding_window,
@@ -1534,6 +1565,7 @@ void MultiQueryAppendC4Attention(
           static_cast<float *>(tmp_m->ptr()),
           static_cast<float *>(tmp_d->ptr()),
           reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          use_head_wise,
           speculate_max_draft_token_num,
           attn_mask_len,
           sliding_window,

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c4_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c4_impl.cuh
@@ -47,7 +47,9 @@ __global__ void multi_query_append_attention_c4_kernel(
     const int *__restrict__ batch_ids,
     const int *__restrict__ tile_ids_per_batch,
     const int *__restrict__ cu_seqlens_q,
-    const int *__restrict__ block_table,  // [bsz, block_num_per_seq] or [bsz * kv_num_heads, block_num_per_seq] when head_wise
+    const int *__restrict__ block_table,  // [bsz, block_num_per_seq] or [bsz *
+                                          // kv_num_heads, block_num_per_seq]
+                                          // when head_wise
     const int *__restrict__ mask_offset,
     const int max_seq_len,
     const int max_dec_len,
@@ -85,13 +87,13 @@ __global__ void multi_query_append_attention_c4_kernel(
   const uint32_t batch_id = batch_ids[btid];
   const uint32_t tile_id = tile_ids_per_batch[btid];
   const uint32_t num_rows_per_block = NUM_WARPS * num_frags_x * 16;
-  // In head-wise mode, block_table has shape [batch_size * kv_num_heads, max_blocks_per_head]
-  // Otherwise, block_table has shape [batch_size, max_blocks_per_seq]
+  // In head-wise mode, block_table has shape [batch_size * kv_num_heads,
+  // max_blocks_per_head] Otherwise, block_table has shape [batch_size,
+  // max_blocks_per_seq]
   const int *block_table_now =
-      block_table +
-      (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
-                           max_block_num_per_seq
-                     : batch_id * max_block_num_per_seq);
+      block_table + (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
+                                         max_block_num_per_seq
+                                   : batch_id * max_block_num_per_seq);
 
   // When cudagraph capture prefill, may launch more gridDim.x
   if (btid >= static_cast<uint32_t>(num_blocks_x_cpu)) {
@@ -159,8 +161,9 @@ __global__ void multi_query_append_attention_c4_kernel(
   const uint32_t q_ori_n_stride = (q_num_heads + kv_num_heads * 2) * HEAD_DIM;
   // In head-wise mode, cache layout is [max_cache_ids, block_size, head_dim]
   // Otherwise, cache layout is [num_blocks, kv_num_heads, block_size, head_dim]
-  const uint32_t kv_n_stride = use_head_wise ? BLOCK_SIZE * HEAD_DIM / 2
-                                             : kv_num_heads * BLOCK_SIZE * HEAD_DIM / 2;
+  const uint32_t kv_n_stride = use_head_wise
+                                   ? BLOCK_SIZE * HEAD_DIM / 2
+                                   : kv_num_heads * BLOCK_SIZE * HEAD_DIM / 2;
   const uint32_t kv_h_stride = BLOCK_SIZE * HEAD_DIM / 2;
   const uint32_t kv_b_stride = HEAD_DIM / 2;
   const uint32_t kv_d_stride = BLOCK_SIZE / 2;
@@ -289,7 +292,8 @@ __global__ void multi_query_append_attention_c4_kernel(
           wid * 16 + tid / 2, tid % 2);  // 2 * 128 / 8 = 32B, 64 nums
 
   uint32_t kv_idx_base = chunk_start;
-  // In head-wise mode, cache_k and cache_v don't have the head dimension in stride
+  // In head-wise mode, cache_k and cache_v don't have the head dimension in
+  // stride
   const uint32_t const_k_offset =
       (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
       (wid * 8 + tid / 4) * kv_b_stride +
@@ -554,7 +558,9 @@ __global__ void multi_query_append_attention_c4_warp1_4_kernel(
     const int *__restrict__ batch_ids,
     const int *__restrict__ tile_ids_per_batch,
     const int *__restrict__ cu_seqlens_q,
-    const int *__restrict__ block_table,  // [bsz, block_num_per_seq] or [bsz * kv_num_heads, block_num_per_seq] when head_wise
+    const int *__restrict__ block_table,  // [bsz, block_num_per_seq] or [bsz *
+                                          // kv_num_heads, block_num_per_seq]
+                                          // when head_wise
     const int *__restrict__ mask_offset,
     const bool *__restrict__ attn_mask,  // [bsz, max_q, max_q] for tree-mask
     const int max_seq_len,
@@ -794,14 +800,12 @@ __global__ void multi_query_append_attention_c4_warp1_4_kernel(
           wid * 16 + tid / 2, tid % 2);
 
   uint32_t kv_idx_base = chunk_start;
-  const uint32_t const_k_offset =
-      kv_head_idx * kv_h_stride +
-      (wid * 8 + tid / 4) * kv_b_stride +
-      tid % 4 * num_elems_per_128b<CacheT>();
-  const uint32_t const_v_offset =
-      kv_head_idx * kv_h_stride +
-      (wid * 16 + tid / 2) * kv_d_stride +
-      tid % 2 * num_elems_per_128b<CacheT>();
+  const uint32_t const_k_offset = kv_head_idx * kv_h_stride +
+                                  (wid * 8 + tid / 4) * kv_b_stride +
+                                  tid % 4 * num_elems_per_128b<CacheT>();
+  const uint32_t const_v_offset = kv_head_idx * kv_h_stride +
+                                  (wid * 16 + tid / 2) * kv_d_stride +
+                                  tid % 2 * num_elems_per_128b<CacheT>();
 
   produce_k_blockwise_c4<SharedMemFillMode::kNoFill,
                          NUM_WARPS,
@@ -1084,9 +1088,10 @@ void MultiQueryAppendC4Attention(
   auto token_num = meta_data.token_nums;
   auto bsz = meta_data.batch_size;
   bool use_head_wise = meta_data.use_head_wise;
-  // In head-wise mode, use max_blocks_per_head for block_table offset calculation
+  // In head-wise mode, use max_blocks_per_head for block_table offset
+  // calculation
   auto max_block_num_per_seq = use_head_wise ? meta_data.max_blocks_per_head
-                                            : meta_data.max_blocks_per_seq;
+                                             : meta_data.max_blocks_per_seq;
 
   constexpr uint32_t num_warps = 4;
   constexpr uint32_t NUM_WARP_KV = num_warps / NUM_WARP_Q;

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c4_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c4_impl.cuh
@@ -571,7 +571,6 @@ __global__ void multi_query_append_attention_c4_warp1_4_kernel(
     float *__restrict__ tmp_m,      // [token_num, num_chunks, num_heads]
     float *__restrict__ tmp_d,      // [token_num, num_chunks, num_heads]
     OutT *__restrict__ out,
-    const bool use_head_wise,
     const int speculate_max_draft_token_num = 5,
     const uint32_t attn_mask_len = -1,
     const int sliding_window = 0,
@@ -598,13 +597,7 @@ __global__ void multi_query_append_attention_c4_warp1_4_kernel(
 
   const uint32_t tile_id = tile_ids_per_batch[btid];
   const uint32_t num_rows_per_block = num_frags_x * 16;
-  // In head-wise mode, block_table has shape [batch_size * kv_num_heads, max_blocks_per_head]
-  // Otherwise, block_table has shape [batch_size, max_blocks_per_seq]
-  const int *block_table_now =
-      block_table +
-      (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
-                           max_block_num_per_seq
-                     : batch_id * max_block_num_per_seq);
+  const int *block_table_now = block_table + batch_id * max_block_num_per_seq;
 
   // When cudagraph capture prefill, may launch more gridDim.x
   if (btid >= static_cast<uint32_t>(num_blocks_x_cpu)) {
@@ -673,10 +666,7 @@ __global__ void multi_query_append_attention_c4_warp1_4_kernel(
 
   const uint32_t q_n_stride = q_num_heads * HEAD_DIM;
   const uint32_t q_ori_n_stride = (q_num_heads + kv_num_heads * 2) * HEAD_DIM;
-  // In head-wise mode, cache layout is [max_cache_ids, block_size, head_dim]
-  // Otherwise, cache layout is [num_blocks, kv_num_heads, block_size, head_dim]
-  const uint32_t kv_n_stride = use_head_wise ? BLOCK_SIZE * HEAD_DIM / 2
-                                             : kv_num_heads * BLOCK_SIZE * HEAD_DIM / 2;
+  const uint32_t kv_n_stride = kv_num_heads * BLOCK_SIZE * HEAD_DIM / 2;
   const uint32_t kv_h_stride = BLOCK_SIZE * HEAD_DIM / 2;
   const uint32_t kv_b_stride = HEAD_DIM / 2;
   const uint32_t kv_d_stride = BLOCK_SIZE / 2;
@@ -804,13 +794,12 @@ __global__ void multi_query_append_attention_c4_warp1_4_kernel(
           wid * 16 + tid / 2, tid % 2);
 
   uint32_t kv_idx_base = chunk_start;
-  // In head-wise mode, cache_k and cache_v don't have the head dimension in stride
   const uint32_t const_k_offset =
-      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      kv_head_idx * kv_h_stride +
       (wid * 8 + tid / 4) * kv_b_stride +
       tid % 4 * num_elems_per_128b<CacheT>();
   const uint32_t const_v_offset =
-      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      kv_head_idx * kv_h_stride +
       (wid * 16 + tid / 2) * kv_d_stride +
       tid % 2 * num_elems_per_128b<CacheT>();
 
@@ -1472,7 +1461,6 @@ void MultiQueryAppendC4Attention(
           nullptr,
           nullptr,
           reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-          use_head_wise,
           speculate_max_draft_token_num,
           attn_mask_len,
           sliding_window,
@@ -1565,7 +1553,6 @@ void MultiQueryAppendC4Attention(
           static_cast<float *>(tmp_m->ptr()),
           static_cast<float *>(tmp_d->ptr()),
           reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
-          use_head_wise,
           speculate_max_draft_token_num,
           attn_mask_len,
           sliding_window,

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c8_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c8_impl.cuh
@@ -50,7 +50,9 @@ __global__ void multi_query_append_attention_c8_kernel(
     const int *__restrict__ batch_ids,
     const int *__restrict__ tile_ids_per_batch,
     const int *__restrict__ cu_seqlens_q,
-    const int *__restrict__ block_table,  // [bsz, block_num_per_seq] or [bsz * kv_num_heads, block_num_per_seq] when head_wise
+    const int *__restrict__ block_table,  // [bsz, block_num_per_seq] or [bsz *
+                                          // kv_num_heads, block_num_per_seq]
+                                          // when head_wise
     const int *__restrict__ mask_offset,
     const int max_seq_len,
     const int max_dec_len,
@@ -89,13 +91,13 @@ __global__ void multi_query_append_attention_c8_kernel(
   const uint32_t batch_id = batch_ids[btid];
   const uint32_t tile_id = tile_ids_per_batch[btid];
   const uint32_t num_rows_per_block = NUM_WARPS * num_frags_x * 16;
-  // In head-wise mode, block_table has shape [batch_size * kv_num_heads, max_blocks_per_head]
-  // Otherwise, block_table has shape [batch_size, max_blocks_per_seq]
+  // In head-wise mode, block_table has shape [batch_size * kv_num_heads,
+  // max_blocks_per_head] Otherwise, block_table has shape [batch_size,
+  // max_blocks_per_seq]
   const int *block_table_now =
-      block_table +
-      (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
-                           max_block_num_per_seq
-                     : batch_id * max_block_num_per_seq);
+      block_table + (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
+                                         max_block_num_per_seq
+                                   : batch_id * max_block_num_per_seq);
 
   // When cudagraph capture prefill, may launch more gridDim.x
   if (btid >= static_cast<uint32_t>(num_blocks_x_cpu)) {
@@ -168,10 +170,11 @@ __global__ void multi_query_append_attention_c8_kernel(
   const uint32_t q_ori_n_stride = (q_num_heads + kv_num_heads * 2) * HEAD_DIM;
   // In head-wise mode, cache layout is [cache_id, block_size, head_dim]
   // Otherwise, cache layout is [num_blocks, kv_num_heads, block_size, head_dim]
-  const uint32_t kv_n_stride = use_head_wise ? BLOCK_SIZE * HEAD_DIM
-                                              : kv_num_heads * BLOCK_SIZE * HEAD_DIM;
-  const uint32_t kv_h_stride = use_head_wise ? BLOCK_SIZE * HEAD_DIM
-                                              : BLOCK_SIZE * HEAD_DIM;
+  const uint32_t kv_n_stride = use_head_wise
+                                   ? BLOCK_SIZE * HEAD_DIM
+                                   : kv_num_heads * BLOCK_SIZE * HEAD_DIM;
+  const uint32_t kv_h_stride =
+      use_head_wise ? BLOCK_SIZE * HEAD_DIM : BLOCK_SIZE * HEAD_DIM;
   const uint32_t kv_b_stride = use_head_wise ? HEAD_DIM : HEAD_DIM;
   const uint32_t kv_d_stride = use_head_wise ? BLOCK_SIZE : BLOCK_SIZE;
   const uint32_t q_start_seq_id = cu_seqlens_q[batch_id];
@@ -272,7 +275,8 @@ __global__ void multi_query_append_attention_c8_kernel(
           wid * 8 + tid / 4, tid % 4);  // 4 * 128 / 8 = 64
 
   uint32_t kv_idx_base = chunk_start;
-  // In head-wise mode, cache_k and cache_v don't have the head dimension in stride
+  // In head-wise mode, cache_k and cache_v don't have the head dimension in
+  // stride
   const uint32_t const_k_offset =
       (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
       (wid * 4 + tid / 8) * kv_b_stride +
@@ -602,7 +606,9 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
     const int *__restrict__ batch_ids,
     const int *__restrict__ tile_ids_per_batch,
     const int *__restrict__ cu_seqlens_q,
-    const int *__restrict__ block_table,  // [bsz, block_num_per_seq] or [bsz * kv_num_heads, block_num_per_seq] when head_wise
+    const int *__restrict__ block_table,  // [bsz, block_num_per_seq] or [bsz *
+                                          // kv_num_heads, block_num_per_seq]
+                                          // when head_wise
     const int *__restrict__ mask_offset,
     const bool *__restrict__ attn_mask,  // [bsz, max_q, max_q] for tree-mask
     const int max_seq_len,
@@ -824,14 +830,12 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
           wid * 8 + tid / 4, tid % 4);
 
   uint32_t kv_idx_base = chunk_start;
-  const uint32_t const_k_offset =
-      kv_head_idx * kv_h_stride +
-      (wid * 4 + tid / 8) * kv_b_stride +
-      tid % 8 * num_elems_per_128b<CacheT>();
-  const uint32_t const_v_offset =
-      kv_head_idx * kv_h_stride +
-      (wid * 8 + tid / 4) * kv_d_stride +
-      tid % 4 * num_elems_per_128b<CacheT>();
+  const uint32_t const_k_offset = kv_head_idx * kv_h_stride +
+                                  (wid * 4 + tid / 8) * kv_b_stride +
+                                  tid % 8 * num_elems_per_128b<CacheT>();
+  const uint32_t const_v_offset = kv_head_idx * kv_h_stride +
+                                  (wid * 8 + tid / 4) * kv_d_stride +
+                                  tid % 4 * num_elems_per_128b<CacheT>();
 
   // load BLOCK_SIZE * HEAD_DIM each time
   produce_k_blockwise_c8<SharedMemFillMode::kNoFill,
@@ -1176,9 +1180,10 @@ void MultiQueryAppendC8Attention(
   auto token_num = meta_data.token_nums;
   auto bsz = meta_data.batch_size;
   bool use_head_wise = meta_data.use_head_wise;
-  // In head-wise mode, use max_blocks_per_head for block_table offset calculation
+  // In head-wise mode, use max_blocks_per_head for block_table offset
+  // calculation
   auto max_block_num_per_seq = use_head_wise ? meta_data.max_blocks_per_head
-                                            : meta_data.max_blocks_per_seq;
+                                             : meta_data.max_blocks_per_seq;
 
   constexpr uint32_t num_warps = 4;
   constexpr uint32_t NUM_WARP_KV = num_warps / NUM_WARP_Q;

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c8_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c8_impl.cuh
@@ -50,7 +50,7 @@ __global__ void multi_query_append_attention_c8_kernel(
     const int *__restrict__ batch_ids,
     const int *__restrict__ tile_ids_per_batch,
     const int *__restrict__ cu_seqlens_q,
-    const int *__restrict__ block_table,  // [bsz, block_num_per_seq]
+    const int *__restrict__ block_table,  // [bsz, block_num_per_seq] or [bsz * kv_num_heads, block_num_per_seq] when head_wise
     const int *__restrict__ mask_offset,
     const int max_seq_len,
     const int max_dec_len,
@@ -66,6 +66,7 @@ __global__ void multi_query_append_attention_c8_kernel(
     float *__restrict__ tmp_m,      // [token_num, num_chunks, num_heads]
     float *__restrict__ tmp_d,      // [token_num, num_chunks, num_heads]
     OutT *__restrict__ out,
+    const bool use_head_wise,
     const int speculate_max_draft_token_num = 5,
     const int sliding_window = 0,
     const int sink_size = 0) {
@@ -88,9 +89,13 @@ __global__ void multi_query_append_attention_c8_kernel(
   const uint32_t batch_id = batch_ids[btid];
   const uint32_t tile_id = tile_ids_per_batch[btid];
   const uint32_t num_rows_per_block = NUM_WARPS * num_frags_x * 16;
-  const int *block_table_now = nullptr;
-
-  block_table_now = block_table + batch_id * max_block_num_per_seq;
+  // In head-wise mode, block_table has shape [batch_size * kv_num_heads, max_blocks_per_head]
+  // Otherwise, block_table has shape [batch_size, max_blocks_per_seq]
+  const int *block_table_now =
+      block_table +
+      (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
+                           max_block_num_per_seq
+                     : batch_id * max_block_num_per_seq);
 
   // When cudagraph capture prefill, may launch more gridDim.x
   if (btid >= static_cast<uint32_t>(num_blocks_x_cpu)) {
@@ -161,10 +166,14 @@ __global__ void multi_query_append_attention_c8_kernel(
 
   const uint32_t q_n_stride = q_num_heads * HEAD_DIM;
   const uint32_t q_ori_n_stride = (q_num_heads + kv_num_heads * 2) * HEAD_DIM;
-  const uint32_t kv_n_stride = kv_num_heads * BLOCK_SIZE * HEAD_DIM;
-  const uint32_t kv_h_stride = BLOCK_SIZE * HEAD_DIM;
-  const uint32_t kv_b_stride = HEAD_DIM;
-  const uint32_t kv_d_stride = BLOCK_SIZE;
+  // In head-wise mode, cache layout is [cache_id, block_size, head_dim]
+  // Otherwise, cache layout is [num_blocks, kv_num_heads, block_size, head_dim]
+  const uint32_t kv_n_stride = use_head_wise ? BLOCK_SIZE * HEAD_DIM
+                                              : kv_num_heads * BLOCK_SIZE * HEAD_DIM;
+  const uint32_t kv_h_stride = use_head_wise ? BLOCK_SIZE * HEAD_DIM
+                                              : BLOCK_SIZE * HEAD_DIM;
+  const uint32_t kv_b_stride = use_head_wise ? HEAD_DIM : HEAD_DIM;
+  const uint32_t kv_d_stride = use_head_wise ? BLOCK_SIZE : BLOCK_SIZE;
   const uint32_t q_start_seq_id = cu_seqlens_q[batch_id];
   const uint32_t q_base_seq_id_this_block =
       (tile_id * NUM_WARPS + wid) * num_frags_x * 16;
@@ -263,12 +272,15 @@ __global__ void multi_query_append_attention_c8_kernel(
           wid * 8 + tid / 4, tid % 4);  // 4 * 128 / 8 = 64
 
   uint32_t kv_idx_base = chunk_start;
-  const uint32_t const_k_offset = kv_head_idx * kv_h_stride +
-                                  (wid * 4 + tid / 8) * kv_b_stride +
-                                  tid % 8 * num_elems_per_128b<CacheT>();
-  const uint32_t const_v_offset = kv_head_idx * kv_h_stride +
-                                  (wid * 8 + tid / 4) * kv_d_stride +
-                                  tid % 4 * num_elems_per_128b<CacheT>();
+  // In head-wise mode, cache_k and cache_v don't have the head dimension in stride
+  const uint32_t const_k_offset =
+      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      (wid * 4 + tid / 8) * kv_b_stride +
+      tid % 8 * num_elems_per_128b<CacheT>();
+  const uint32_t const_v_offset =
+      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      (wid * 8 + tid / 4) * kv_d_stride +
+      tid % 4 * num_elems_per_128b<CacheT>();
 
   produce_k_blockwise_c8<SharedMemFillMode::kNoFill,
                          NUM_WARPS,
@@ -590,7 +602,7 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
     const int *__restrict__ batch_ids,
     const int *__restrict__ tile_ids_per_batch,
     const int *__restrict__ cu_seqlens_q,
-    const int *__restrict__ block_table,  // [bsz, block_num_per_seq]
+    const int *__restrict__ block_table,  // [bsz, block_num_per_seq] or [bsz * kv_num_heads, block_num_per_seq] when head_wise
     const int *__restrict__ mask_offset,
     const bool *__restrict__ attn_mask,  // [bsz, max_q, max_q] for tree-mask
     const int max_seq_len,
@@ -607,6 +619,7 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
     float *__restrict__ tmp_m,      // [token_num, num_chunks, num_heads]
     float *__restrict__ tmp_d,      // [token_num, num_chunks, num_heads]
     OutT *__restrict__ out,
+    const bool use_head_wise,
     const int speculate_max_draft_token_num = 5,
     const uint32_t attn_mask_len = -1,
     const int sliding_window = 0,
@@ -633,7 +646,13 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
 
   const uint32_t tile_id = tile_ids_per_batch[btid];
   const uint32_t num_rows_per_block = num_frags_x * 16;
-  const int *block_table_now = block_table + batch_id * max_block_num_per_seq;
+  // In head-wise mode, block_table has shape [batch_size * kv_num_heads, max_blocks_per_head]
+  // Otherwise, block_table has shape [batch_size, max_blocks_per_seq]
+  const int *block_table_now =
+      block_table +
+      (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
+                           max_block_num_per_seq
+                     : batch_id * max_block_num_per_seq);
 
   // When cudagraph capture prefill, may launch more gridDim.x
   if (btid >= static_cast<uint32_t>(num_blocks_x_cpu)) {
@@ -706,10 +725,14 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
 
   const uint32_t q_n_stride = q_num_heads * HEAD_DIM;
   const uint32_t q_ori_n_stride = (q_num_heads + kv_num_heads * 2) * HEAD_DIM;
-  const uint32_t kv_n_stride = kv_num_heads * BLOCK_SIZE * HEAD_DIM;
-  const uint32_t kv_h_stride = BLOCK_SIZE * HEAD_DIM;
-  const uint32_t kv_b_stride = HEAD_DIM;
-  const uint32_t kv_d_stride = BLOCK_SIZE;
+  // In head-wise mode, cache layout is [cache_id, block_size, head_dim]
+  // Otherwise, cache layout is [num_blocks, kv_num_heads, block_size, head_dim]
+  const uint32_t kv_n_stride = use_head_wise ? BLOCK_SIZE * HEAD_DIM
+                                              : kv_num_heads * BLOCK_SIZE * HEAD_DIM;
+  const uint32_t kv_h_stride = use_head_wise ? BLOCK_SIZE * HEAD_DIM
+                                              : BLOCK_SIZE * HEAD_DIM;
+  const uint32_t kv_b_stride = use_head_wise ? HEAD_DIM : HEAD_DIM;
+  const uint32_t kv_d_stride = use_head_wise ? BLOCK_SIZE : BLOCK_SIZE;
   const uint32_t q_start_seq_id = cu_seqlens_q[batch_id];
   const uint32_t q_base_seq_id_this_block = tile_id * num_frags_x * 16;
   const uint32_t q_offset = q_start_seq_id * q_ori_n_stride +
@@ -812,12 +835,15 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
           wid * 8 + tid / 4, tid % 4);
 
   uint32_t kv_idx_base = chunk_start;
-  const uint32_t const_k_offset = kv_head_idx * kv_h_stride +
-                                  (wid * 4 + tid / 8) * kv_b_stride +
-                                  tid % 8 * num_elems_per_128b<CacheT>();
-  const uint32_t const_v_offset = kv_head_idx * kv_h_stride +
-                                  (wid * 8 + tid / 4) * kv_d_stride +
-                                  tid % 4 * num_elems_per_128b<CacheT>();
+  // In head-wise mode, cache_k and cache_v don't have the head dimension in stride
+  const uint32_t const_k_offset =
+      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      (wid * 4 + tid / 8) * kv_b_stride +
+      tid % 8 * num_elems_per_128b<CacheT>();
+  const uint32_t const_v_offset =
+      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      (wid * 8 + tid / 4) * kv_d_stride +
+      tid % 4 * num_elems_per_128b<CacheT>();
 
   // load BLOCK_SIZE * HEAD_DIM each time
   produce_k_blockwise_c8<SharedMemFillMode::kNoFill,
@@ -1161,7 +1187,10 @@ void MultiQueryAppendC8Attention(
   auto kv_num_heads = meta_data.kv_num_heads;
   auto token_num = meta_data.token_nums;
   auto bsz = meta_data.batch_size;
-  auto max_block_num_per_seq = meta_data.max_blocks_per_seq;
+  bool use_head_wise = meta_data.use_head_wise;
+  // In head-wise mode, use max_blocks_per_head for block_table offset calculation
+  auto max_block_num_per_seq = use_head_wise ? meta_data.max_blocks_per_head
+                                            : meta_data.max_blocks_per_seq;
 
   constexpr uint32_t num_warps = 4;
   constexpr uint32_t NUM_WARP_KV = num_warps / NUM_WARP_Q;
@@ -1320,6 +1349,7 @@ void MultiQueryAppendC8Attention(
           nullptr,
           nullptr,
           reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          use_head_wise,
           speculate_max_draft_token_num,
           sliding_window,
           sink_size);
@@ -1389,6 +1419,7 @@ void MultiQueryAppendC8Attention(
           static_cast<float *>(tmp_m->ptr()),
           static_cast<float *>(tmp_d->ptr()),
           reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          use_head_wise,
           speculate_max_draft_token_num,
           sliding_window,
           sink_size);

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c8_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c8_impl.cuh
@@ -275,9 +275,14 @@ __global__ void multi_query_append_attention_c8_kernel(
   uint32_t kv_idx_base = chunk_start;
   // In head-wise mode, cache_k and cache_v don't have the head dimension in
   // stride
-  const uint32_t const_offset =
+  const uint32_t const_k_offset =
       (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
-      (wid * 8 + tid / 4) * kv_b_stride + tid % 8 * num_elems_per_128b<T>();
+      (wid * 4 + tid / 8) * kv_b_stride +
+      tid % 8 * num_elems_per_128b<CacheT>();
+  const uint32_t const_v_offset =
+      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      (wid * 8 + tid / 4) * kv_d_stride +
+      tid % 4 * num_elems_per_128b<CacheT>();
 
   produce_k_blockwise_c8<SharedMemFillMode::kNoFill,
                          NUM_WARPS,
@@ -294,7 +299,7 @@ __global__ void multi_query_append_attention_c8_kernel(
                                      kv_b_stride,
                                      kv_idx_base,
                                      chunk_end,
-                                     const_offset);
+                                     const_k_offset);
   if constexpr (IsDynamicC8) {
     produce_kv_dynamic_scale_gmem2smem_async<SharedMemFillMode::kFillZero,
                                              BLOCK_SIZE,
@@ -324,7 +329,7 @@ __global__ void multi_query_append_attention_c8_kernel(
                                      kv_d_stride,
                                      kv_idx_base,
                                      chunk_end,
-                                     const_offset);
+                                     const_v_offset);
   if constexpr (IsDynamicC8) {
     produce_kv_dynamic_scale_gmem2smem_async<SharedMemFillMode::kFillZero,
                                              BLOCK_SIZE,
@@ -407,7 +412,7 @@ __global__ void multi_query_append_attention_c8_kernel(
                                        kv_b_stride,
                                        kv_idx_base,
                                        chunk_end,
-                                       const_offset);
+                                       const_k_offset);
     if constexpr (IsDynamicC8) {
       produce_kv_dynamic_scale_gmem2smem_async<SharedMemFillMode::kFillZero,
                                                BLOCK_SIZE,
@@ -457,7 +462,7 @@ __global__ void multi_query_append_attention_c8_kernel(
                                        kv_d_stride,
                                        kv_idx_base,
                                        chunk_end,
-                                       const_offset);
+                                       const_v_offset);
     if constexpr (IsDynamicC8) {
       produce_kv_dynamic_scale_gmem2smem_async<SharedMemFillMode::kFillZero,
                                                BLOCK_SIZE,
@@ -832,7 +837,7 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
           wid * 8 + tid / 4, tid % 4);
 
   uint32_t kv_idx_base = chunk_start;
-  const uint32_t const_offset =
+  const uint32_t const_k_offset =
       (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
       (wid * 4 + tid / 8) * kv_b_stride +
       tid % 8 * num_elems_per_128b<CacheT>();
@@ -857,7 +862,7 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
                                      kv_b_stride,
                                      kv_idx_base,
                                      chunk_end,
-                                     const_offset);
+                                     const_k_offset);
   if constexpr (IsDynamicC8) {
     produce_kv_dynamic_scale_gmem2smem_async<SharedMemFillMode::kFillZero,
                                              BLOCK_SIZE,
@@ -887,7 +892,7 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
                                      kv_d_stride,
                                      kv_idx_base,
                                      chunk_end,
-                                     const_offset);
+                                     const_v_offset);
   if constexpr (IsDynamicC8) {
     produce_kv_dynamic_scale_gmem2smem_async<SharedMemFillMode::kFillZero,
                                              BLOCK_SIZE,
@@ -971,7 +976,7 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
                                        kv_b_stride,
                                        kv_idx_base,
                                        chunk_end,
-                                       const_offset);
+                                       const_k_offset);
     if constexpr (IsDynamicC8) {
       produce_kv_dynamic_scale_gmem2smem_async<SharedMemFillMode::kFillZero,
                                                BLOCK_SIZE,
@@ -1021,7 +1026,7 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
                                        kv_d_stride,
                                        kv_idx_base,
                                        chunk_end,
-                                       const_offset);
+                                       const_v_offset);
     if constexpr (IsDynamicC8) {
       produce_kv_dynamic_scale_gmem2smem_async<SharedMemFillMode::kFillZero,
                                                BLOCK_SIZE,

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c8_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c8_impl.cuh
@@ -273,14 +273,11 @@ __global__ void multi_query_append_attention_c8_kernel(
           wid * 8 + tid / 4, tid % 4);  // 4 * 128 / 8 = 64
 
   uint32_t kv_idx_base = chunk_start;
-  int block_id = __ldg(&block_table_now[kv_idx_base / BLOCK_SIZE]);
   // In head-wise mode, cache_k and cache_v don't have the head dimension in
   // stride
   const uint32_t const_offset =
       (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
       (wid * 8 + tid / 4) * kv_b_stride + tid % 8 * num_elems_per_128b<T>();
-  T *cache_k_now = cache_k + block_id * kv_n_stride + const_offset;
-  T *cache_v_now = cache_v + block_id * kv_n_stride + const_offset;
 
   produce_k_blockwise_c8<SharedMemFillMode::kNoFill,
                          NUM_WARPS,
@@ -289,7 +286,7 @@ __global__ void multi_query_append_attention_c8_kernel(
                          num_frags_z,
                          NUM_WARP_Q>(k_smem,
                                      &k_smem_offset_w,
-                                     &cache_k_now,
+                                     cache_k,
                                      block_table_now,
                                      kv_head_idx,
                                      kv_n_stride,
@@ -319,7 +316,7 @@ __global__ void multi_query_append_attention_c8_kernel(
                          num_frags_z,
                          NUM_WARP_Q>(v_smem,
                                      &v_smem_offset_w,
-                                     &cache_v_now,
+                                     cache_v,
                                      block_table_now,
                                      kv_head_idx,
                                      kv_n_stride,
@@ -421,7 +418,8 @@ __global__ void multi_query_append_attention_c8_kernel(
                                                            kv_idx_base,
                                                            kv_num_heads,
                                                            kv_head_idx,
-                                                           chunk_end);
+                                                           chunk_end,
+                                                           use_head_wise);
     }
     commit_group();
     wait_group<1>();
@@ -470,7 +468,8 @@ __global__ void multi_query_append_attention_c8_kernel(
                                                            kv_idx_base,
                                                            kv_num_heads,
                                                            kv_head_idx,
-                                                           chunk_end);
+                                                           chunk_end,
+                                                           use_head_wise);
     }
     commit_group();
   }
@@ -983,7 +982,8 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
                                                            kv_idx_base,
                                                            kv_num_heads,
                                                            kv_head_idx,
-                                                           chunk_end);
+                                                           chunk_end,
+                                                           use_head_wise);
     }
     commit_group();
     wait_group<1>();
@@ -1032,7 +1032,8 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
                                                            kv_idx_base,
                                                            kv_num_heads,
                                                            kv_head_idx,
-                                                           chunk_end);
+                                                           chunk_end,
+                                                           use_head_wise);
     }
     commit_group();
   }

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c8_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c8_impl.cuh
@@ -619,7 +619,6 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
     float *__restrict__ tmp_m,      // [token_num, num_chunks, num_heads]
     float *__restrict__ tmp_d,      // [token_num, num_chunks, num_heads]
     OutT *__restrict__ out,
-    const bool use_head_wise,
     const int speculate_max_draft_token_num = 5,
     const uint32_t attn_mask_len = -1,
     const int sliding_window = 0,
@@ -646,13 +645,7 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
 
   const uint32_t tile_id = tile_ids_per_batch[btid];
   const uint32_t num_rows_per_block = num_frags_x * 16;
-  // In head-wise mode, block_table has shape [batch_size * kv_num_heads, max_blocks_per_head]
-  // Otherwise, block_table has shape [batch_size, max_blocks_per_seq]
-  const int *block_table_now =
-      block_table +
-      (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
-                           max_block_num_per_seq
-                     : batch_id * max_block_num_per_seq);
+  const int *block_table_now = block_table + batch_id * max_block_num_per_seq;
 
   // When cudagraph capture prefill, may launch more gridDim.x
   if (btid >= static_cast<uint32_t>(num_blocks_x_cpu)) {
@@ -725,14 +718,10 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
 
   const uint32_t q_n_stride = q_num_heads * HEAD_DIM;
   const uint32_t q_ori_n_stride = (q_num_heads + kv_num_heads * 2) * HEAD_DIM;
-  // In head-wise mode, cache layout is [cache_id, block_size, head_dim]
-  // Otherwise, cache layout is [num_blocks, kv_num_heads, block_size, head_dim]
-  const uint32_t kv_n_stride = use_head_wise ? BLOCK_SIZE * HEAD_DIM
-                                              : kv_num_heads * BLOCK_SIZE * HEAD_DIM;
-  const uint32_t kv_h_stride = use_head_wise ? BLOCK_SIZE * HEAD_DIM
-                                              : BLOCK_SIZE * HEAD_DIM;
-  const uint32_t kv_b_stride = use_head_wise ? HEAD_DIM : HEAD_DIM;
-  const uint32_t kv_d_stride = use_head_wise ? BLOCK_SIZE : BLOCK_SIZE;
+  const uint32_t kv_n_stride = kv_num_heads * BLOCK_SIZE * HEAD_DIM;
+  const uint32_t kv_h_stride = BLOCK_SIZE * HEAD_DIM;
+  const uint32_t kv_b_stride = HEAD_DIM;
+  const uint32_t kv_d_stride = BLOCK_SIZE;
   const uint32_t q_start_seq_id = cu_seqlens_q[batch_id];
   const uint32_t q_base_seq_id_this_block = tile_id * num_frags_x * 16;
   const uint32_t q_offset = q_start_seq_id * q_ori_n_stride +
@@ -835,13 +824,12 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
           wid * 8 + tid / 4, tid % 4);
 
   uint32_t kv_idx_base = chunk_start;
-  // In head-wise mode, cache_k and cache_v don't have the head dimension in stride
   const uint32_t const_k_offset =
-      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      kv_head_idx * kv_h_stride +
       (wid * 4 + tid / 8) * kv_b_stride +
       tid % 8 * num_elems_per_128b<CacheT>();
   const uint32_t const_v_offset =
-      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      kv_head_idx * kv_h_stride +
       (wid * 8 + tid / 4) * kv_d_stride +
       tid % 4 * num_elems_per_128b<CacheT>();
 

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c8_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c8_impl.cuh
@@ -170,13 +170,11 @@ __global__ void multi_query_append_attention_c8_kernel(
   const uint32_t q_ori_n_stride = (q_num_heads + kv_num_heads * 2) * HEAD_DIM;
   // In head-wise mode, cache layout is [cache_id, block_size, head_dim]
   // Otherwise, cache layout is [num_blocks, kv_num_heads, block_size, head_dim]
-  const uint32_t kv_n_stride = use_head_wise
-                                   ? BLOCK_SIZE * HEAD_DIM
-                                   : kv_num_heads * BLOCK_SIZE * HEAD_DIM;
-  const uint32_t kv_h_stride =
-      use_head_wise ? BLOCK_SIZE * HEAD_DIM : BLOCK_SIZE * HEAD_DIM;
-  const uint32_t kv_b_stride = use_head_wise ? HEAD_DIM : HEAD_DIM;
-  const uint32_t kv_d_stride = use_head_wise ? BLOCK_SIZE : BLOCK_SIZE;
+  const uint32_t kv_h_stride = BLOCK_SIZE * HEAD_DIM;
+  const uint32_t kv_n_stride =
+      use_head_wise ? kv_h_stride : kv_num_heads * kv_h_stride;
+  const uint32_t kv_b_stride = HEAD_DIM;
+  const uint32_t kv_d_stride = BLOCK_SIZE;
   const uint32_t q_start_seq_id = cu_seqlens_q[batch_id];
   const uint32_t q_base_seq_id_this_block =
       (tile_id * NUM_WARPS + wid) * num_frags_x * 16;
@@ -275,16 +273,14 @@ __global__ void multi_query_append_attention_c8_kernel(
           wid * 8 + tid / 4, tid % 4);  // 4 * 128 / 8 = 64
 
   uint32_t kv_idx_base = chunk_start;
+  int block_id = __ldg(&block_table_now[kv_idx_base / BLOCK_SIZE]);
   // In head-wise mode, cache_k and cache_v don't have the head dimension in
   // stride
-  const uint32_t const_k_offset =
+  const uint32_t const_offset =
       (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
-      (wid * 4 + tid / 8) * kv_b_stride +
-      tid % 8 * num_elems_per_128b<CacheT>();
-  const uint32_t const_v_offset =
-      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
-      (wid * 8 + tid / 4) * kv_d_stride +
-      tid % 4 * num_elems_per_128b<CacheT>();
+      (wid * 8 + tid / 4) * kv_b_stride + tid % 8 * num_elems_per_128b<T>();
+  T *cache_k_now = cache_k + block_id * kv_n_stride + const_offset;
+  T *cache_v_now = cache_v + block_id * kv_n_stride + const_offset;
 
   produce_k_blockwise_c8<SharedMemFillMode::kNoFill,
                          NUM_WARPS,
@@ -293,7 +289,7 @@ __global__ void multi_query_append_attention_c8_kernel(
                          num_frags_z,
                          NUM_WARP_Q>(k_smem,
                                      &k_smem_offset_w,
-                                     cache_k,
+                                     &cache_k_now,
                                      block_table_now,
                                      kv_head_idx,
                                      kv_n_stride,
@@ -301,7 +297,7 @@ __global__ void multi_query_append_attention_c8_kernel(
                                      kv_b_stride,
                                      kv_idx_base,
                                      chunk_end,
-                                     const_k_offset);
+                                     const_offset);
   if constexpr (IsDynamicC8) {
     produce_kv_dynamic_scale_gmem2smem_async<SharedMemFillMode::kFillZero,
                                              BLOCK_SIZE,
@@ -312,7 +308,8 @@ __global__ void multi_query_append_attention_c8_kernel(
                                                          kv_idx_base,
                                                          kv_num_heads,
                                                          kv_head_idx,
-                                                         chunk_end);
+                                                         chunk_end,
+                                                         use_head_wise);
   }
   commit_group();
   produce_v_blockwise_c8<SharedMemFillMode::kNoFill,
@@ -322,7 +319,7 @@ __global__ void multi_query_append_attention_c8_kernel(
                          num_frags_z,
                          NUM_WARP_Q>(v_smem,
                                      &v_smem_offset_w,
-                                     cache_v,
+                                     &cache_v_now,
                                      block_table_now,
                                      kv_head_idx,
                                      kv_n_stride,
@@ -330,7 +327,7 @@ __global__ void multi_query_append_attention_c8_kernel(
                                      kv_d_stride,
                                      kv_idx_base,
                                      chunk_end,
-                                     const_v_offset);
+                                     const_offset);
   if constexpr (IsDynamicC8) {
     produce_kv_dynamic_scale_gmem2smem_async<SharedMemFillMode::kFillZero,
                                              BLOCK_SIZE,
@@ -341,7 +338,8 @@ __global__ void multi_query_append_attention_c8_kernel(
                                                          kv_idx_base,
                                                          kv_num_heads,
                                                          kv_head_idx,
-                                                         chunk_end);
+                                                         chunk_end,
+                                                         use_head_wise);
   }
   commit_group();
 
@@ -412,7 +410,7 @@ __global__ void multi_query_append_attention_c8_kernel(
                                        kv_b_stride,
                                        kv_idx_base,
                                        chunk_end,
-                                       const_k_offset);
+                                       const_offset);
     if constexpr (IsDynamicC8) {
       produce_kv_dynamic_scale_gmem2smem_async<SharedMemFillMode::kFillZero,
                                                BLOCK_SIZE,
@@ -461,7 +459,7 @@ __global__ void multi_query_append_attention_c8_kernel(
                                        kv_d_stride,
                                        kv_idx_base,
                                        chunk_end,
-                                       const_v_offset);
+                                       const_offset);
     if constexpr (IsDynamicC8) {
       produce_kv_dynamic_scale_gmem2smem_async<SharedMemFillMode::kFillZero,
                                                BLOCK_SIZE,
@@ -625,6 +623,7 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
     float *__restrict__ tmp_m,      // [token_num, num_chunks, num_heads]
     float *__restrict__ tmp_d,      // [token_num, num_chunks, num_heads]
     OutT *__restrict__ out,
+    const bool use_head_wise,
     const int speculate_max_draft_token_num = 5,
     const uint32_t attn_mask_len = -1,
     const int sliding_window = 0,
@@ -651,7 +650,10 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
 
   const uint32_t tile_id = tile_ids_per_batch[btid];
   const uint32_t num_rows_per_block = num_frags_x * 16;
-  const int *block_table_now = block_table + batch_id * max_block_num_per_seq;
+  const int *block_table_now =
+      block_table + (use_head_wise ? (batch_id * kv_num_heads + kv_head_idx) *
+                                         max_block_num_per_seq
+                                   : batch_id * max_block_num_per_seq);
 
   // When cudagraph capture prefill, may launch more gridDim.x
   if (btid >= static_cast<uint32_t>(num_blocks_x_cpu)) {
@@ -724,8 +726,9 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
 
   const uint32_t q_n_stride = q_num_heads * HEAD_DIM;
   const uint32_t q_ori_n_stride = (q_num_heads + kv_num_heads * 2) * HEAD_DIM;
-  const uint32_t kv_n_stride = kv_num_heads * BLOCK_SIZE * HEAD_DIM;
   const uint32_t kv_h_stride = BLOCK_SIZE * HEAD_DIM;
+  const uint32_t kv_n_stride =
+      use_head_wise ? kv_h_stride : kv_num_heads * kv_h_stride;
   const uint32_t kv_b_stride = HEAD_DIM;
   const uint32_t kv_d_stride = BLOCK_SIZE;
   const uint32_t q_start_seq_id = cu_seqlens_q[batch_id];
@@ -830,12 +833,14 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
           wid * 8 + tid / 4, tid % 4);
 
   uint32_t kv_idx_base = chunk_start;
-  const uint32_t const_k_offset = kv_head_idx * kv_h_stride +
-                                  (wid * 4 + tid / 8) * kv_b_stride +
-                                  tid % 8 * num_elems_per_128b<CacheT>();
-  const uint32_t const_v_offset = kv_head_idx * kv_h_stride +
-                                  (wid * 8 + tid / 4) * kv_d_stride +
-                                  tid % 4 * num_elems_per_128b<CacheT>();
+  const uint32_t const_offset =
+      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      (wid * 4 + tid / 8) * kv_b_stride +
+      tid % 8 * num_elems_per_128b<CacheT>();
+  const uint32_t const_v_offset =
+      (use_head_wise ? 0 : kv_head_idx * kv_h_stride) +
+      (wid * 8 + tid / 4) * kv_d_stride +
+      tid % 4 * num_elems_per_128b<CacheT>();
 
   // load BLOCK_SIZE * HEAD_DIM each time
   produce_k_blockwise_c8<SharedMemFillMode::kNoFill,
@@ -853,7 +858,7 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
                                      kv_b_stride,
                                      kv_idx_base,
                                      chunk_end,
-                                     const_k_offset);
+                                     const_offset);
   if constexpr (IsDynamicC8) {
     produce_kv_dynamic_scale_gmem2smem_async<SharedMemFillMode::kFillZero,
                                              BLOCK_SIZE,
@@ -864,7 +869,8 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
                                                          kv_idx_base,
                                                          kv_num_heads,
                                                          kv_head_idx,
-                                                         chunk_end);
+                                                         chunk_end,
+                                                         use_head_wise);
   }
   commit_group();
   produce_v_blockwise_c8<SharedMemFillMode::kNoFill,
@@ -882,7 +888,7 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
                                      kv_d_stride,
                                      kv_idx_base,
                                      chunk_end,
-                                     const_v_offset);
+                                     const_offset);
   if constexpr (IsDynamicC8) {
     produce_kv_dynamic_scale_gmem2smem_async<SharedMemFillMode::kFillZero,
                                              BLOCK_SIZE,
@@ -893,7 +899,8 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
                                                          kv_idx_base,
                                                          kv_num_heads,
                                                          kv_head_idx,
-                                                         chunk_end);
+                                                         chunk_end,
+                                                         use_head_wise);
   }
   commit_group();
 #pragma unroll 1
@@ -965,7 +972,7 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
                                        kv_b_stride,
                                        kv_idx_base,
                                        chunk_end,
-                                       const_k_offset);
+                                       const_offset);
     if constexpr (IsDynamicC8) {
       produce_kv_dynamic_scale_gmem2smem_async<SharedMemFillMode::kFillZero,
                                                BLOCK_SIZE,
@@ -1014,7 +1021,7 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
                                        kv_d_stride,
                                        kv_idx_base,
                                        chunk_end,
-                                       const_v_offset);
+                                       const_offset);
     if constexpr (IsDynamicC8) {
       produce_kv_dynamic_scale_gmem2smem_async<SharedMemFillMode::kFillZero,
                                                BLOCK_SIZE,
@@ -1618,6 +1625,7 @@ void MultiQueryAppendC8Attention(
           nullptr,
           nullptr,
           reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          use_head_wise,
           speculate_max_draft_token_num,
           attn_mask_len,
           sliding_window,
@@ -1704,6 +1712,7 @@ void MultiQueryAppendC8Attention(
           static_cast<float *>(tmp_m->ptr()),
           static_cast<float *>(tmp_d->ptr()),
           reinterpret_cast<OUT_NV_TYPE *>(out->data<OutT>()),
+          use_head_wise,
           speculate_max_draft_token_num,
           attn_mask_len,
           sliding_window,

--- a/custom_ops/gpu_ops/append_attn/utils.cuh
+++ b/custom_ops/gpu_ops/append_attn/utils.cuh
@@ -29,7 +29,7 @@ struct AppendAttnMetaData {
   int max_blocks_per_seq;
   bool use_head_wise = false;
   int max_blocks_per_head = 0;
-  const int *mask_offset = nullptr;
+  const int* mask_offset = nullptr;
 };
 
 __forceinline__ __host__ __device__ int div_up(int a, int b) {

--- a/custom_ops/gpu_ops/append_attn/utils.cuh
+++ b/custom_ops/gpu_ops/append_attn/utils.cuh
@@ -27,7 +27,9 @@ struct AppendAttnMetaData {
   int head_dims;
   int head_dims_v;
   int max_blocks_per_seq;
-  const int* mask_offset = nullptr;
+  bool use_head_wise = false;
+  int max_blocks_per_head = 0;
+  const int *mask_offset = nullptr;
 };
 
 __forceinline__ __host__ __device__ int div_up(int a, int b) {

--- a/fastdeploy/cache_manager/prefix_cache_manager.py
+++ b/fastdeploy/cache_manager/prefix_cache_manager.py
@@ -86,12 +86,6 @@ class PrefixCacheManager:
             # Head-wise mode uses logical block count from total_block_num.
             self.num_gpu_blocks = self.cache_config.total_block_num
 
-        if self.enable_head_wise_kv_cache and envs.ENABLE_V1_KVCACHE_SCHEDULER:
-            logger.warning(
-                "[HEAD_WISE] Head-wise KV cache mode is enabled but v1 scheduler is also enabled. "
-                "Please ensure head-wise allocation is supported in this scheduler path."
-            )
-
         if self.enable_head_wise_kv_cache:
             # Head-wise mode with true cache_id-based architecture.
             # cache_id is global (not encoded with head info).

--- a/fastdeploy/cache_manager/prefix_cache_manager.py
+++ b/fastdeploy/cache_manager/prefix_cache_manager.py
@@ -76,8 +76,30 @@ class PrefixCacheManager:
         else:
             self.num_gpu_blocks = self.cache_config.prefill_kvcache_block_num
         self.num_cpu_blocks = self.cache_config.num_cpu_blocks
+        # Head-wise KV cache management
+        self.enable_head_wise_kv_cache = envs.FD_HEAD_WISE_KV_CACHE == 1
+        self.kv_num_heads = max(
+            1,
+            int(config.model_config.num_key_value_heads) // config.parallel_config.tensor_parallel_size,
+        )
+        if self.enable_head_wise_kv_cache:
+            # Head-wise mode uses logical block count from total_block_num.
+            self.num_gpu_blocks = self.cache_config.total_block_num
 
-        self.gpu_free_block_list = list(range(self.num_gpu_blocks - 1, -1, -1))
+        if self.enable_head_wise_kv_cache and envs.ENABLE_V1_KVCACHE_SCHEDULER:
+            logger.warning(
+                "[HEAD_WISE] Head-wise KV cache mode is enabled but v1 scheduler is also enabled. "
+                "Please ensure head-wise allocation is supported in this scheduler path."
+            )
+
+        if self.enable_head_wise_kv_cache:
+            # Head-wise mode with true cache_id-based architecture.
+            # cache_id is global (not encoded with head info).
+            # Physical layout: [cache_id, block_size, head_dim].
+            self.total_cache_ids = self.num_gpu_blocks * self.kv_num_heads
+            self.gpu_free_block_list = list(range(self.total_cache_ids - 1, -1, -1))
+        else:
+            self.gpu_free_block_list = list(range(self.num_gpu_blocks - 1, -1, -1))
         if self.num_cpu_blocks > 0:
             self.cpu_free_block_list = list(range(self.num_cpu_blocks - 1, -1, -1))
         else:
@@ -170,6 +192,9 @@ class PrefixCacheManager:
 
     @property
     def available_gpu_resource(self):
+        if self.enable_head_wise_kv_cache:
+            free_block_count = len(self.gpu_free_block_list) // self.kv_num_heads
+            return free_block_count / self.num_gpu_blocks if self.num_gpu_blocks > 0 else 0.0
         return len(self.gpu_free_block_list) / self.num_gpu_blocks if self.num_gpu_blocks > 0 else 0.0
 
     def launch_cache_manager(
@@ -441,17 +466,30 @@ class PrefixCacheManager:
         """
         update cache config
         """
+        old_num_gpu_blocks = self.num_gpu_blocks
+        old_total_cache_ids = getattr(self, "total_cache_ids", None)
+
         self.cache_config = cache_config
-        if envs.ENABLE_V1_KVCACHE_SCHEDULER:
+        if self.enable_head_wise_kv_cache:
             self.num_gpu_blocks = cache_config.total_block_num
-            self.gpu_free_block_list = list(
-                range(self.num_gpu_blocks - 1, -1, -1)
-            )  # All gpu blocks are managed by cache manager
         else:
-            self.num_gpu_blocks = cache_config.prefill_kvcache_block_num
-            self.gpu_free_block_list = list(
-                range(self.num_gpu_blocks - 1, -1, -1)
-            )  # Only block table divided for prefill managed by server
+            if envs.ENABLE_V1_KVCACHE_SCHEDULER:
+                self.num_gpu_blocks = cache_config.total_block_num
+            else:
+                self.num_gpu_blocks = cache_config.prefill_kvcache_block_num
+
+        if self.enable_head_wise_kv_cache:
+            self.total_cache_ids = self.num_gpu_blocks * self.kv_num_heads
+            self.gpu_free_block_list = list(range(self.total_cache_ids - 1, -1, -1))
+            logger.info(
+                f"[HEAD_WISE] update_cache_config: num_gpu_blocks {old_num_gpu_blocks} -> {self.num_gpu_blocks}, "
+                f"total_cache_ids {old_total_cache_ids} -> {self.total_cache_ids}"
+            )
+        else:
+            self.gpu_free_block_list = list(range(self.num_gpu_blocks - 1, -1, -1))
+            logger.info(
+                f"update_cache_config: num_gpu_blocks changed from {old_num_gpu_blocks} to {self.num_gpu_blocks}"
+            )
 
         heapq.heapify(self.gpu_free_block_list)
         self.node_id_pool = list(range(self.num_gpu_blocks + self.num_cpu_blocks))
@@ -459,17 +497,27 @@ class PrefixCacheManager:
         main_process_metrics.max_gpu_block_num.set(self.num_gpu_blocks)
         main_process_metrics.max_cpu_block_num.set(self.num_cpu_blocks)
         main_process_metrics.available_gpu_block_num.set(self.num_gpu_blocks)
-        main_process_metrics.free_gpu_block_num.set(self.num_gpu_blocks)
+        free_block_count = len(self.gpu_free_block_list)
+        if self.enable_head_wise_kv_cache:
+            free_block_count = free_block_count // self.kv_num_heads
+        main_process_metrics.free_gpu_block_num.set(free_block_count)
         main_process_metrics.available_gpu_resource.set(1.0)
 
     def can_allocate_gpu_blocks(self, num_blocks: int, try_free_gpu_blocks: bool = True):
         """
         Check if num_blocks gpu blocks can be allocated.
         """
-        if len(self.gpu_free_block_list) < num_blocks:
+        available_blocks = len(self.gpu_free_block_list)
+        if self.enable_head_wise_kv_cache:
+            available_blocks = available_blocks // self.kv_num_heads
+
+        if available_blocks < num_blocks:
             if self.cache_config.enable_prefix_caching and try_free_gpu_blocks:
                 self.free_block_ids(num_blocks)
-            if len(self.gpu_free_block_list) < num_blocks:
+            available_blocks = len(self.gpu_free_block_list)
+            if self.enable_head_wise_kv_cache:
+                available_blocks = available_blocks // self.kv_num_heads
+            if available_blocks < num_blocks:
                 return False
             else:
                 return True
@@ -480,6 +528,9 @@ class PrefixCacheManager:
         """
         allocate gpu blocks.
         """
+        if self.enable_head_wise_kv_cache:
+            return self._allocate_gpu_blocks_head_wise(num_blocks, req_id)
+
         assert num_blocks <= len(
             self.gpu_free_block_list
         ), f"gpu free block num: {len(self.gpu_free_block_list)} < needed number {num_blocks}"
@@ -492,10 +543,37 @@ class PrefixCacheManager:
         main_process_metrics.available_gpu_resource.set(self.available_gpu_resource)
         return allocated_block_ids
 
+    def _allocate_gpu_blocks_head_wise(self, num_blocks, req_id=None):
+        """
+        Allocate cache_ids for head-wise mode.
+
+        Returns 2D cache_ids: List[List[int]] with shape [kv_num_heads][num_blocks].
+        """
+        total_needed = num_blocks * self.kv_num_heads
+        assert total_needed <= len(
+            self.gpu_free_block_list
+        ), f"gpu free cache_id num: {len(self.gpu_free_block_list)} < needed number {total_needed}"
+        logger.debug(f"{req_id} start allocate head-wise cache_ids...")
+
+        allocated_cache_ids = [heapq.heappop(self.gpu_free_block_list) for _ in range(total_needed)]
+        cache_ids_2d = []
+        for head_id in range(self.kv_num_heads):
+            start = head_id * num_blocks
+            end = start + num_blocks
+            cache_ids_2d.append(allocated_cache_ids[start:end])
+
+        free_block_count = len(self.gpu_free_block_list) // self.kv_num_heads
+        main_process_metrics.free_gpu_block_num.set(free_block_count)
+        main_process_metrics.available_gpu_resource.set(self.available_gpu_resource)
+        return cache_ids_2d
+
     def recycle_gpu_blocks(self, gpu_block_ids, req_id=None):
         """
         recycle gpu blocks.
         """
+        if self.enable_head_wise_kv_cache:
+            return self._recycle_gpu_blocks_head_wise(gpu_block_ids, req_id)
+
         if (
             hasattr(self, "prefix_tree_status_signal")
             and self.prefix_tree_status_signal.value[0] != PrefixTreeStatus.NORMAL
@@ -524,6 +602,30 @@ class PrefixCacheManager:
             heapq.heappush(self.gpu_free_block_list, gpu_block_ids)
         logger.debug(f"req_id:{req_id} recycle blocks end")
         main_process_metrics.free_gpu_block_num.set(len(self.gpu_free_block_list))
+        main_process_metrics.available_gpu_resource.set(self.available_gpu_resource)
+
+    def _recycle_gpu_blocks_head_wise(self, cache_ids_2d, req_id=None):
+        """
+        Recycle cache_ids for head-wise mode.
+        """
+        if (
+            hasattr(self, "prefix_tree_status_signal")
+            and self.prefix_tree_status_signal.value[0] != PrefixTreeStatus.NORMAL
+        ):
+            logger.warning("Prefix tree is not normal, skip recycle gpu blocks")
+            return
+        if not isinstance(cache_ids_2d, list):
+            cache_ids_2d = [cache_ids_2d]
+
+        logger.info(
+            f"req_id:{req_id} recycle head-wise cache_ids, len(self.gpu_free_block_list) {len(self.gpu_free_block_list)}"
+        )
+        for head_ids in cache_ids_2d:
+            for cache_id in head_ids:
+                heapq.heappush(self.gpu_free_block_list, cache_id)
+        logger.debug(f"req_id:{req_id} recycle head-wise cache_ids end")
+        free_block_count = len(self.gpu_free_block_list) // self.kv_num_heads
+        main_process_metrics.free_gpu_block_num.set(free_block_count)
         main_process_metrics.available_gpu_resource.set(self.available_gpu_resource)
 
     def allocate_cpu_blocks(self, num_blocks):

--- a/fastdeploy/cache_manager/prefix_cache_manager.py
+++ b/fastdeploy/cache_manager/prefix_cache_manager.py
@@ -628,7 +628,20 @@ class PrefixCacheManager:
                 if item is not None and item >= 0:
                     normalized.append(item)
 
-        normalized = list(dict.fromkeys(normalized))
+        unique_normalized = list(dict.fromkeys(normalized))
+        if len(unique_normalized) != len(normalized):
+            dup_count_map = {}
+            for cid in normalized:
+                dup_count_map[cid] = dup_count_map.get(cid, 0) + 1
+            duplicate_ids = [cid for cid, cnt in dup_count_map.items() if cnt > 1]
+            logger.error(
+                "req_id:%s detected duplicate cache_ids in head-wise recycle path, total_ids=%d, unique_ids=%d, duplicate_ids(sample)=%s",
+                req_id,
+                len(normalized),
+                len(unique_normalized),
+                duplicate_ids[:16],
+            )
+        normalized = unique_normalized
         logger.debug(f"req_id:{req_id} recycle head-wise cache_ids after normalization: {normalized}")
 
         if not normalized:

--- a/fastdeploy/cache_manager/prefix_cache_manager.py
+++ b/fastdeploy/cache_manager/prefix_cache_manager.py
@@ -619,14 +619,28 @@ class PrefixCacheManager:
         )
 
         normalized = []
+        invalid_cache_ids = []
         for item in cache_ids:
             if isinstance(item, list):
                 for cid in item:
-                    if cid is not None and cid >= 0:
+                    if cid is not None and 0 <= cid < self.total_cache_ids:
                         normalized.append(cid)
+                    elif cid is not None and cid >= 0:
+                        invalid_cache_ids.append(cid)
             else:
-                if item is not None and item >= 0:
+                if item is not None and 0 <= item < self.total_cache_ids:
                     normalized.append(item)
+                elif item is not None and item >= 0:
+                    invalid_cache_ids.append(item)
+
+        if invalid_cache_ids:
+            unique_invalid_ids = list(dict.fromkeys(invalid_cache_ids))
+            logger.error(
+                "req_id:%s detected out-of-range cache_ids in head-wise recycle path, total_cache_ids=%d, invalid_ids(sample)=%s",
+                req_id,
+                self.total_cache_ids,
+                unique_invalid_ids[:16],
+            )
 
         unique_normalized = list(dict.fromkeys(normalized))
         if len(unique_normalized) != len(normalized):
@@ -642,7 +656,12 @@ class PrefixCacheManager:
                 duplicate_ids[:16],
             )
         normalized = unique_normalized
-        logger.debug(f"req_id:{req_id} recycle head-wise cache_ids after normalization: {normalized}")
+        logger.debug(
+            "req_id:%s recycle head-wise cache_ids after normalization: total_ids=%d, sample=%s",
+            req_id,
+            len(normalized),
+            normalized[:16],
+        )
 
         if not normalized:
             logger.debug("No valid cache_ids received, skip recycling.")

--- a/fastdeploy/cache_manager/prefix_cache_manager.py
+++ b/fastdeploy/cache_manager/prefix_cache_manager.py
@@ -604,7 +604,7 @@ class PrefixCacheManager:
         main_process_metrics.free_gpu_block_num.set(len(self.gpu_free_block_list))
         main_process_metrics.available_gpu_resource.set(self.available_gpu_resource)
 
-    def _recycle_gpu_blocks_head_wise(self, cache_ids_2d, req_id=None):
+    def _recycle_gpu_blocks_head_wise(self, cache_ids, req_id=None):
         """
         Recycle cache_ids for head-wise mode.
         """
@@ -614,15 +614,44 @@ class PrefixCacheManager:
         ):
             logger.warning("Prefix tree is not normal, skip recycle gpu blocks")
             return
-        if not isinstance(cache_ids_2d, list):
-            cache_ids_2d = [cache_ids_2d]
+        if cache_ids is None:
+            return
 
-        logger.info(
+        if not isinstance(cache_ids, list):
+            cache_ids = [cache_ids]
+
+        logger.debug(
             f"req_id:{req_id} recycle head-wise cache_ids, len(self.gpu_free_block_list) {len(self.gpu_free_block_list)}"
         )
-        for head_ids in cache_ids_2d:
-            for cache_id in head_ids:
-                heapq.heappush(self.gpu_free_block_list, cache_id)
+
+        normalized = []
+        for item in cache_ids:
+            if isinstance(item, list):
+                for cid in item:
+                    if cid is not None and cid >= 0:
+                        normalized.append(cid)
+            else:
+                if item is not None and item >= 0:
+                    normalized.append(item)
+
+        normalized = list(dict.fromkeys(normalized))
+        logger.debug(f"req_id:{req_id} recycle head-wise cache_ids after normalization: {normalized}")
+
+        if not normalized:
+            logger.debug("No valid cache_ids received, skip recycling.")
+            return
+
+        if len(self.gpu_free_block_list) + len(normalized) > self.total_cache_ids:
+            logger.error(
+                f"The number of free gpu blocks {len(self.gpu_free_block_list)} plus the number of recycled "
+                f"gpu blocks {len(normalized)} exceeds the total number of cache ids {self.total_cache_ids} \n"
+                f"this indicates a block allocation and deallocation error, recycled blocks will be discarded {normalized}"
+            )
+            return
+
+        for cache_id in normalized:
+            heapq.heappush(self.gpu_free_block_list, cache_id)
+
         logger.debug(f"req_id:{req_id} recycle head-wise cache_ids end")
         free_block_count = len(self.gpu_free_block_list) // self.kv_num_heads
         main_process_metrics.free_gpu_block_num.set(free_block_count)

--- a/fastdeploy/engine/resource_manager.py
+++ b/fastdeploy/engine/resource_manager.py
@@ -325,9 +325,7 @@ class ResourceManager:
                     # 2. if prefill/decode disaggregation is enabled
                     if task.disaggregate_info is not None:
                         if self.enable_head_wise_kv_cache:
-                            raise NotImplementedError(
-                                "Head-wise KV cache does not support PD disaggregation yet."
-                            )
+                            raise NotImplementedError("Head-wise KV cache does not support PD disaggregation yet.")
                         task.disaggregate_info["block_tables"] = block_tables
                         if task.disaggregate_info["role"] == "prefill":
                             self.req_dict[task.request_id] = allocated_position

--- a/fastdeploy/engine/resource_manager.py
+++ b/fastdeploy/engine/resource_manager.py
@@ -356,10 +356,19 @@ class ResourceManager:
             for task in self.tasks_list:
                 if task and getattr(task, "block_tables_3d", None):
                     head_tables = task.block_tables_3d
-                    if head_tables and len(head_tables) > 0:
-                        # Count all blocks across all heads for each task
-                        for head_blocks in head_tables:
-                            num_blocks_used_by_tasks += len(head_blocks)
+                    if head_tables:
+                        # Count logical blocks (not per-head physical cache_ids) in head-wise mode.
+                        # Use max per-head length to tolerate sparse/uneven rows (e.g. SWA).
+                        per_head_block_counts = [
+                            len(head_blocks)
+                            for head_blocks in head_tables
+                            if head_blocks is not None and len(head_blocks) > 0
+                        ]
+                        if per_head_block_counts:
+                            num_blocks_used_by_tasks += max(per_head_block_counts)
+                elif task:
+                    # Compatibility fallback: if 3D tables are absent, fall back to 2D mirror.
+                    num_blocks_used_by_tasks += len(task.block_tables) if task.block_tables else 0
         else:
             num_blocks_used_by_tasks = sum([len(task.block_tables) if task else 0 for task in self.tasks_list])
         main_process_metrics.available_gpu_block_num.set(self.total_block_number() - num_blocks_used_by_tasks)

--- a/fastdeploy/engine/resource_manager.py
+++ b/fastdeploy/engine/resource_manager.py
@@ -152,7 +152,7 @@ class ResourceManager:
             return block_list
         block_list = self.cache_manager.allocate_gpu_blocks(block_num)
         if self.enable_head_wise_kv_cache:
-            llm_logger.info(
+            llm_logger.debug(
                 f"[HEAD_WISE] _get_block_tables: allocated {block_num} blocks, "
                 f"cache_ids_2d shape: [{len(block_list)}][{len(block_list[0]) if block_list else 0}]"
             )
@@ -194,7 +194,7 @@ class ResourceManager:
                 self.cache_manager.recycle_gpu_blocks(cache_ids_2d, req_id)
                 cur_number = self.available_block_num()
                 main_process_metrics.gpu_cache_usage_perc.set(self.get_gpu_cache_usage_perc())
-                llm_logger.info(
+                llm_logger.debug(
                     f"[HEAD_WISE] recycle {req_id} {cur_number - ori_number} blocks. "
                     f"cache_ids_2d shape: [{len(cache_ids_2d)}][{len(cache_ids_2d[0]) if cache_ids_2d else 0}]"
                 )

--- a/fastdeploy/engine/resource_manager.py
+++ b/fastdeploy/engine/resource_manager.py
@@ -361,7 +361,9 @@ class ResourceManager:
                 if task and getattr(task, "block_tables_3d", None):
                     head_tables = task.block_tables_3d
                     if head_tables and len(head_tables) > 0:
-                        num_blocks_used_by_tasks += len(head_tables[0])
+                        # Count all blocks across all heads for each task
+                        for head_blocks in head_tables:
+                            num_blocks_used_by_tasks += len(head_blocks)
         else:
             num_blocks_used_by_tasks = sum([len(task.block_tables) if task else 0 for task in self.tasks_list])
         main_process_metrics.available_gpu_block_num.set(self.total_block_number() - num_blocks_used_by_tasks)

--- a/fastdeploy/engine/resource_manager.py
+++ b/fastdeploy/engine/resource_manager.py
@@ -70,8 +70,6 @@ class ResourceManager:
             )
             if self.enable_prefix_cache:
                 raise NotImplementedError("Head-wise KV cache does not support prefix caching yet.")
-            if getattr(config.cache_config, "enable_chunked_prefill", False):
-                raise NotImplementedError("Head-wise KV cache does not support chunked prefill yet.")
 
         llm_logger.info(f"{self.info()}")
         main_process_metrics.max_batch_size.set(max_num_seqs)

--- a/fastdeploy/engine/resource_manager.py
+++ b/fastdeploy/engine/resource_manager.py
@@ -20,6 +20,7 @@ import time
 
 import numpy as np
 
+from fastdeploy import envs
 from fastdeploy.cache_manager.prefix_cache_manager import PrefixCacheManager
 from fastdeploy.metrics.metrics import main_process_metrics
 from fastdeploy.utils import llm_logger
@@ -59,6 +60,19 @@ class ResourceManager:
         # current batch status of the engine
         self.real_bsz = 0
         self.abort_req_ids_set = set()
+
+        # Head-wise KV cache management
+        self.enable_head_wise_kv_cache = envs.FD_HEAD_WISE_KV_CACHE == 1
+        if self.enable_head_wise_kv_cache:
+            self.kv_num_heads = max(
+                1,
+                int(config.model_config.num_key_value_heads) // config.parallel_config.tensor_parallel_size,
+            )
+            if self.enable_prefix_cache:
+                raise NotImplementedError("Head-wise KV cache does not support prefix caching yet.")
+            if getattr(config.cache_config, "enable_chunked_prefill", False):
+                raise NotImplementedError("Head-wise KV cache does not support chunked prefill yet.")
+
         llm_logger.info(f"{self.info()}")
         main_process_metrics.max_batch_size.set(max_num_seqs)
 
@@ -122,7 +136,7 @@ class ResourceManager:
             required_type (str): required type
 
         Returns:
-            list: block list
+            list: block list (1D block_ids) or 2D cache_ids (head-wise mode)
         """
         if required_type == "all":
             block_num = self.get_required_block_number(input_token_num)
@@ -139,7 +153,13 @@ class ResourceManager:
             llm_logger.error(f"block_num:{block_num} > free_list len:{current_block_num}")
             return block_list
         block_list = self.cache_manager.allocate_gpu_blocks(block_num)
-        llm_logger.debug(f"dispatch {len(block_list)} blocks.")
+        if self.enable_head_wise_kv_cache:
+            llm_logger.info(
+                f"[HEAD_WISE] _get_block_tables: allocated {block_num} blocks, "
+                f"cache_ids_2d shape: [{len(block_list)}][{len(block_list[0]) if block_list else 0}]"
+            )
+        else:
+            llm_logger.debug(f"dispatch {len(block_list)} blocks.")
         return block_list
 
     def check_and_free_block_tables(self):
@@ -156,7 +176,7 @@ class ResourceManager:
         Recycling memory resource blocks
 
         Args:
-            block_tables (list): block list
+            task: task object containing block_tables or cache_ids_2d
         """
 
         if self.enable_prefix_cache:
@@ -165,13 +185,27 @@ class ResourceManager:
             req_id = task.request_id
             if isinstance(task, list):
                 block_tables = task
+                cache_ids_2d = block_tables if self.enable_head_wise_kv_cache else None
             else:
                 block_tables = task.block_tables
-            ori_number = self.available_block_num()
-            self.cache_manager.recycle_gpu_blocks(block_tables)
-            cur_number = self.available_block_num()
-            main_process_metrics.gpu_cache_usage_perc.set(self.get_gpu_cache_usage_perc())
-            llm_logger.info(f"recycle {req_id} {cur_number - ori_number} blocks.")
+                cache_ids_2d = getattr(task, "block_tables_3d", None)
+            if self.enable_head_wise_kv_cache:
+                if cache_ids_2d is None:
+                    cache_ids_2d = block_tables
+                ori_number = self.available_block_num()
+                self.cache_manager.recycle_gpu_blocks(cache_ids_2d, req_id)
+                cur_number = self.available_block_num()
+                main_process_metrics.gpu_cache_usage_perc.set(self.get_gpu_cache_usage_perc())
+                llm_logger.info(
+                    f"[HEAD_WISE] recycle {req_id} {cur_number - ori_number} blocks. "
+                    f"cache_ids_2d shape: [{len(cache_ids_2d)}][{len(cache_ids_2d[0]) if cache_ids_2d else 0}]"
+                )
+            else:
+                ori_number = self.available_block_num()
+                self.cache_manager.recycle_gpu_blocks(block_tables)
+                cur_number = self.available_block_num()
+                main_process_metrics.gpu_cache_usage_perc.set(self.get_gpu_cache_usage_perc())
+                llm_logger.info(f"recycle {req_id} {cur_number - ori_number} blocks.")
 
     def available_batch(self):
         """
@@ -189,6 +223,8 @@ class ResourceManager:
         Returns:
             int: available block size
         """
+        if self.enable_head_wise_kv_cache:
+            return len(self.cache_manager.gpu_free_block_list) // self.kv_num_heads
         return len(self.cache_manager.gpu_free_block_list)
 
     def is_resource_sufficient(self, input_token_num):
@@ -280,10 +316,18 @@ class ResourceManager:
                         llm_logger.error(f"req_id: {task.request_id} block_tables is empty")
                         continue  # retry
                     else:
-                        task.block_tables = block_tables
+                        if self.enable_head_wise_kv_cache:
+                            task.block_tables_3d = block_tables
+                            task.block_tables = block_tables[0] if block_tables else []
+                        else:
+                            task.block_tables = block_tables
                     task.need_block_tables = task.block_tables
                     # 2. if prefill/decode disaggregation is enabled
                     if task.disaggregate_info is not None:
+                        if self.enable_head_wise_kv_cache:
+                            raise NotImplementedError(
+                                "Head-wise KV cache does not support PD disaggregation yet."
+                            )
                         task.disaggregate_info["block_tables"] = block_tables
                         if task.disaggregate_info["role"] == "prefill":
                             self.req_dict[task.request_id] = allocated_position
@@ -311,7 +355,15 @@ class ResourceManager:
                 break
 
         # record batch size here
-        num_blocks_used_by_tasks = sum([len(task.block_tables) if task else 0 for task in self.tasks_list])
+        if self.enable_head_wise_kv_cache:
+            num_blocks_used_by_tasks = 0
+            for task in self.tasks_list:
+                if task and getattr(task, "block_tables_3d", None):
+                    head_tables = task.block_tables_3d
+                    if head_tables and len(head_tables) > 0:
+                        num_blocks_used_by_tasks += len(head_tables[0])
+        else:
+            num_blocks_used_by_tasks = sum([len(task.block_tables) if task else 0 for task in self.tasks_list])
         main_process_metrics.available_gpu_block_num.set(self.total_block_number() - num_blocks_used_by_tasks)
         main_process_metrics.batch_size.set(self.max_num_seqs - self.available_batch())
         main_process_metrics.gpu_cache_usage_perc.set(self.get_gpu_cache_usage_perc())
@@ -390,6 +442,8 @@ class ResourceManager:
         """
         num_total_gpu = self.total_block_number()
         num_free_gpu = len(self.cache_manager.gpu_free_block_list)
+        if self.enable_head_wise_kv_cache:
+            num_free_gpu = num_free_gpu // self.kv_num_heads
         if num_total_gpu > 0:
             return 1.0 - (num_free_gpu / num_total_gpu)
         return 0.0

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -1751,10 +1751,14 @@ class ResourceManagerV1(ResourceManager):
                 if self.enable_head_wise_kv_cache and hasattr(task, "block_tables_3d") and task.block_tables_3d:
                     # block_tables_3d is a 2D list: [[cache_ids_head0], [cache_ids_head1], ...]
                     for head_blocks in task.block_tables_3d:
-                        blocks_used_by_tasks.update(head_blocks)
+                        for cache_id in head_blocks:
+                            if cache_id is not None and cache_id >= 0:
+                                blocks_used_by_tasks.add(cache_id)
                 else:
                     # Non-head-wise mode: block_tables is a list of block_ids
-                    blocks_used_by_tasks.update(task.block_tables)
+                    for block_id in task.block_tables:
+                        if block_id is not None and block_id >= 0:
+                            blocks_used_by_tasks.add(block_id)
         main_process_metrics.available_gpu_block_num.set(self.total_block_number() - len(blocks_used_by_tasks))
         main_process_metrics.batch_size.set(self.max_num_seqs - self.available_batch())
         main_process_metrics.gpu_cache_usage_perc.set(self.get_gpu_cache_usage_perc())

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -234,6 +234,9 @@ class ResourceManagerV1(ResourceManager):
 
         # SWA recycle
         self.request_head_recycle_upto = {}
+        # request_id -> num_total_tokens captured at last decode dispatch.
+        # Used as a lightweight overlap safety gate for SWA timely recycle.
+        self.request_last_decode_dispatch_tokens = {}
         self.swa_window_size = getattr(self.config.model_config, "window_size", 0)
         try:
             self.swa_sink_size = int(getattr(self.config.model_config, "sink_size", 0) or 0)
@@ -294,6 +297,27 @@ class ResourceManagerV1(ResourceManager):
             block_tables=list(request.block_tables),
             block_tables_3d=block_tables_3d,
         )
+
+    def _mark_decode_dispatched(self, request: Request) -> None:
+        if not self.config.scheduler_config.enable_overlap_schedule:
+            return
+        self.request_last_decode_dispatch_tokens[request.request_id] = request.num_total_tokens
+
+    def _should_skip_swa_recycle_for_overlap(self, request: Request) -> bool:
+        """
+        In overlap scheduling, delay SWA recycle until request token count advances
+        beyond the last decode-dispatched snapshot.
+        """
+        if not self.config.scheduler_config.enable_overlap_schedule:
+            return False
+        last_dispatched_tokens = self.request_last_decode_dispatch_tokens.get(request.request_id)
+        if last_dispatched_tokens is None:
+            return True
+        return request.num_total_tokens <= last_dispatched_tokens
+
+    def _append_decode_task(self, scheduled_reqs, request: Request) -> None:
+        scheduled_reqs.append(self._prepare_decode_task(request))
+        self._mark_decode_dispatched(request)
 
     def _extend_head_wise_block_tables(self, request: Request, new_blocks):
         """Append newly allocated blocks/cache_ids to request block tables."""
@@ -959,7 +983,14 @@ class ResourceManagerV1(ResourceManager):
                         and self.swa_kv_head_indices
                         and not self.config.cache_config.enable_prefix_caching
                     ):  # recycle for swa
-                        self.recycle_request_swa_head_cache(request)
+                        if self._should_skip_swa_recycle_for_overlap(request):
+                            llm_logger.debug(
+                                f"[SWA_RECYCLE] skip by overlap gate, request_id={request.request_id}, "
+                                f"num_total_tokens={request.num_total_tokens}, "
+                                f"last_dispatched_tokens={self.request_last_decode_dispatch_tokens.get(request.request_id)}"
+                            )
+                        else:
+                            self.recycle_request_swa_head_cache(request)
 
                     if (
                         self.allocated_slots(request) - request.num_total_tokens
@@ -975,7 +1006,7 @@ class ResourceManagerV1(ResourceManager):
                             )
                             self._extend_head_wise_block_tables(request, decode_extend_blocks)
                             # Prepare decoding task
-                            scheduled_reqs.append(self._prepare_decode_task(request))
+                            self._append_decode_task(scheduled_reqs, request)
                         else:
                             # Not enough blocks to allocate, trigger preemption
                             can_schedule = self._trigger_preempt(
@@ -989,7 +1020,7 @@ class ResourceManagerV1(ResourceManager):
                             )
                             self._extend_head_wise_block_tables(request, decode_extend_blocks)
                             # Prepare decoding task
-                            scheduled_reqs.append(self._prepare_decode_task(request))
+                            self._append_decode_task(scheduled_reqs, request)
                         num_decoding_req_nums += 1
                     token_budget -= 1
                     if (
@@ -1006,7 +1037,7 @@ class ResourceManagerV1(ResourceManager):
                                 allocate_block_num, request.request_id
                             )
                             self._extend_head_wise_block_tables(request, decode_blocks)
-                            scheduled_reqs.append(self._prepare_decode_task(request))
+                            self._append_decode_task(scheduled_reqs, request)
 
                             # Prepare extend task
                             reuse_block_num = request.num_total_tokens // self.config.cache_config.block_size
@@ -1697,6 +1728,7 @@ class ResourceManagerV1(ResourceManager):
             del self.reuse_block_num_map[request.request_id]
             del self.need_block_num_map[request.request_id]
         self.request_head_recycle_upto.pop(request.request_id, None)
+        self.request_last_decode_dispatch_tokens.pop(request.request_id, None)
 
     def finish_requests_async(self, request_ids: Union[str, Iterable[str]]):
         return self.finish_execution_pool.submit(self.finish_requests, request_ids)
@@ -1761,6 +1793,7 @@ class ResourceManagerV1(ResourceManager):
     def clear_data(self):
         self.waiting: deque[Request] = deque()
         self.to_be_rescheduled_request_id_set = set()
+        self.request_last_decode_dispatch_tokens = {}
         self.update_metrics(verbose=True)
 
     def update_metrics(self, verbose=False):

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -834,7 +834,7 @@ class ResourceManagerV1(ResourceManager):
             head_recycled_str = ",".join(f"h{h}:{c}" for h, c in head_recycled.items())
             head_progress_str = ",".join(f"h{h}:{s}->{e}" for h, (s, e) in head_progress.items())
             if total_recycled > 0:
-                llm_logger.info(
+                llm_logger.debug(
                     f"[SWA_RECYCLE] request_id={request.request_id}, total_tokens={total_tokens}, "
                     f"start_block={start_block}, end_block={end_block}, recycled_blocks={total_recycled}, "
                     f"swa_heads={len(self.swa_kv_head_indices)}, recycled_by_head={head_recycled_str}, "

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -768,17 +768,17 @@ class ResourceManagerV1(ResourceManager):
         end_block_idx,
     ):
         if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
-            return
+            return start_block_idx, 0
         if head_idx >= len(request.block_tables_3d):
-            return
+            return start_block_idx, 0
 
         row = request.block_tables_3d[head_idx]
         if start_block_idx >= len(row):
-            return
+            return start_block_idx, 0
 
         end_block_idx = min(end_block_idx, len(row))
         if end_block_idx <= start_block_idx:
-            return
+            return start_block_idx, 0
 
         cache_ids_to_recycle = []
         for i in range(start_block_idx, end_block_idx):
@@ -789,6 +789,7 @@ class ResourceManagerV1(ResourceManager):
 
         if cache_ids_to_recycle:
             self.cache_manager.recycle_gpu_blocks(cache_ids_to_recycle, request.request_id)
+        return end_block_idx, len(cache_ids_to_recycle)
 
     def recycle_request_swa_head_cache(self, request):
         if not self.enable_head_wise_kv_cache:
@@ -812,12 +813,40 @@ class ResourceManagerV1(ResourceManager):
             self.request_head_recycle_upto[request.request_id] = [0] * self.kv_num_heads
 
         recycle_upto = self.request_head_recycle_upto[request.request_id]
+        total_recycled = 0
+        head_recycled = {}
+        head_progress = {}
+        window_moved = False
 
         for head_idx in self.swa_kv_head_indices:
             old_upto = max(recycle_upto[head_idx], start_block)
             if end_block > old_upto:
-                self._recycle_request_swa_head_cache_helper(request, head_idx, old_upto, end_block)
-                recycle_upto[head_idx] = end_block
+                window_moved = True
+                new_upto, recycled_count = self._recycle_request_swa_head_cache_helper(
+                    request, head_idx, old_upto, end_block
+                )
+                recycle_upto[head_idx] = max(recycle_upto[head_idx], new_upto)
+                total_recycled += recycled_count
+                head_recycled[head_idx] = recycled_count
+                head_progress[head_idx] = (old_upto, new_upto)
+
+        if window_moved:
+            head_recycled_str = ",".join(f"h{h}:{c}" for h, c in head_recycled.items())
+            head_progress_str = ",".join(f"h{h}:{s}->{e}" for h, (s, e) in head_progress.items())
+            if total_recycled > 0:
+                llm_logger.info(
+                    f"[SWA_RECYCLE] request_id={request.request_id}, total_tokens={total_tokens}, "
+                    f"start_block={start_block}, end_block={end_block}, recycled_blocks={total_recycled}, "
+                    f"swa_heads={len(self.swa_kv_head_indices)}, recycled_by_head={head_recycled_str}, "
+                    f"recycle_upto_by_head={head_progress_str}"
+                )
+            else:
+                llm_logger.debug(
+                    f"[SWA_RECYCLE] request_id={request.request_id}, total_tokens={total_tokens}, "
+                    f"start_block={start_block}, end_block={end_block}, recycled_blocks=0, "
+                    f"swa_heads={len(self.swa_kv_head_indices)}, recycled_by_head={head_recycled_str}, "
+                    f"recycle_upto_by_head={head_progress_str}"
+                )
 
     def exist_mm_prefill(self, scheduled_reqs):
         for request in scheduled_reqs:

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -15,6 +15,7 @@
 """
 
 import copy
+import os
 import threading
 import time
 import traceback
@@ -234,7 +235,14 @@ class ResourceManagerV1(ResourceManager):
 
         # SWA recycle
         self.request_head_recycle_upto = {}
+        self.head_wise_hole_log = bool(int(os.getenv("FD_HEAD_WISE_HOLE_LOG", "0")))
+        self._head_wise_hole_log_count = 0
         self.swa_window_size = getattr(self.config.model_config, "window_size", 0)
+        try:
+            self.swa_sink_size = int(getattr(self.config.model_config, "sink_size", 0) or 0)
+        except (TypeError, ValueError):
+            self.swa_sink_size = 0
+        self.swa_sink_size = max(0, self.swa_sink_size)
         self.swa_kv_head_indices = []
         self.full_kv_head_indices = []
 
@@ -254,7 +262,7 @@ class ResourceManagerV1(ResourceManager):
             self.swa_kv_head_indices = list(range(num_kv_heads - num_swa_heads, num_kv_heads))
             self.full_kv_head_indices = list(range(0, num_kv_heads - num_swa_heads))
             llm_logger.debug(
-                f"[SWA Config] window_size={self.swa_window_size}, "
+                f"[SWA Config] window_size={self.swa_window_size}, sink_size={self.swa_sink_size}, "
                 f"swa_ratio={swa_ratio}, num_kv_heads={num_kv_heads}, "
                 f"swa_heads={self.swa_kv_head_indices}, full_heads={self.full_kv_head_indices}"
             )
@@ -771,8 +779,11 @@ class ResourceManagerV1(ResourceManager):
         return num_new_tokens
 
     def _get_swa_recycle_start_block(self):
-        # prepare for sink size
-        return 0
+        # Keep sink tokens resident in KV cache. Convert sink token count to block index.
+        block_size = self.config.cache_config.block_size
+        if block_size <= 0:
+            return 0
+        return (self.swa_sink_size + block_size - 1) // block_size
 
     def _get_swa_recycle_end_block(self, total_tokens):
         block_size = self.config.cache_config.block_size
@@ -781,6 +792,53 @@ class ResourceManagerV1(ResourceManager):
             return 0
 
         return max(0, (total_tokens - window_size) // block_size)
+
+    @staticmethod
+    def _head_wise_row_layout_stats(row):
+        if row is None:
+            return 0, 0, 0
+        row_len = len(row)
+        last_valid_idx = -1
+        for idx, cid in enumerate(row):
+            if cid is not None and cid >= 0:
+                last_valid_idx = idx
+        if last_valid_idx < 0:
+            return row_len, 0, 0
+
+        contiguous_len = last_valid_idx + 1
+        hole_before_last_valid = 0
+        for cid in row[:contiguous_len]:
+            if cid is None or cid < 0:
+                hole_before_last_valid += 1
+        return row_len, contiguous_len, hole_before_last_valid
+
+    def _maybe_log_swa_recycle_hole_diag(
+        self,
+        request_id: str,
+        head_idx: int,
+        row,
+        start_block_idx: int,
+        end_block_idx: int,
+        recycled_count: int,
+    ) -> None:
+        if not self.head_wise_hole_log:
+            return
+
+        row_len, contiguous_len, hole_before_last_valid = self._head_wise_row_layout_stats(row)
+        if hole_before_last_valid <= 0:
+            return
+
+        should_log = self._head_wise_hole_log_count < 100 or self._head_wise_hole_log_count % 100 == 0
+        self._head_wise_hole_log_count += 1
+        if not should_log:
+            return
+
+        llm_logger.warning(
+            f"[swa_recycle_hole_diag] request_id={request_id} head={head_idx} "
+            f"recycle_range=[{start_block_idx},{end_block_idx}) recycled={recycled_count} "
+            f"row_len={row_len} contiguous_len={contiguous_len} hole_before_last_valid={hole_before_last_valid} "
+            f"row_prefix={row[: min(24, row_len)] if row is not None else []}"
+        )
 
     def _recycle_request_swa_head_cache_helper(
         self,
@@ -811,6 +869,14 @@ class ResourceManagerV1(ResourceManager):
 
         if cache_ids_to_recycle:
             self.cache_manager.recycle_gpu_blocks(cache_ids_to_recycle, request.request_id)
+        self._maybe_log_swa_recycle_hole_diag(
+            request_id=request.request_id,
+            head_idx=head_idx,
+            row=row,
+            start_block_idx=start_block_idx,
+            end_block_idx=end_block_idx,
+            recycled_count=len(cache_ids_to_recycle),
+        )
         return end_block_idx, len(cache_ids_to_recycle)
 
     def recycle_request_swa_head_cache(self, request):

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -288,11 +288,17 @@ class ResourceManagerV1(ResourceManager):
         return request
 
     def _prepare_decode_task(self, request):
+        block_tables_3d = getattr(request, "block_tables_3d", None)
+        if block_tables_3d is not None:
+            block_tables_3d = [
+                list(head_blocks) if head_blocks is not None else []
+                for head_blocks in block_tables_3d
+            ]
         return ScheduledDecodeTask(
             idx=request.idx,
             request_id=request.request_id,
             block_tables=list(request.block_tables),
-            block_tables_3d=copy.deepcopy(getattr(request, "block_tables_3d", None)),
+            block_tables_3d=block_tables_3d,
         )
 
     def _extend_head_wise_block_tables(self, request: Request, new_blocks):

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -61,6 +61,7 @@ class ScheduledDecodeTask:
     idx: int
     request_id: str
     block_tables: list[int]
+    block_tables_3d: Union[list[list[int]], None] = None
     task_type: RequestType = RequestType.DECODE
 
 
@@ -252,7 +253,12 @@ class ResourceManagerV1(ResourceManager):
         return request
 
     def _prepare_decode_task(self, request):
-        return ScheduledDecodeTask(idx=request.idx, request_id=request.request_id, block_tables=request.block_tables)
+        return ScheduledDecodeTask(
+            idx=request.idx,
+            request_id=request.request_id,
+            block_tables=list(request.block_tables),
+            block_tables_3d=copy.deepcopy(getattr(request, "block_tables_3d", None)),
+        )
 
     def _prepare_preempt_task(self, request):
         return ScheduledPreemptTask(idx=request.idx, request_id=request.request_id)

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -287,10 +287,7 @@ class ResourceManagerV1(ResourceManager):
     def _prepare_decode_task(self, request):
         block_tables_3d = getattr(request, "block_tables_3d", None)
         if block_tables_3d is not None:
-            block_tables_3d = [
-                list(head_blocks) if head_blocks is not None else []
-                for head_blocks in block_tables_3d
-            ]
+            block_tables_3d = [list(head_blocks) if head_blocks is not None else [] for head_blocks in block_tables_3d]
         return ScheduledDecodeTask(
             idx=request.idx,
             request_id=request.request_id,

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -805,11 +805,20 @@ class ResourceManagerV1(ResourceManager):
                             llm_logger.debug(
                                 f"schedule decoding task: {request} request.num_total_tokens {request.num_total_tokens} request.num_computed_tokens {request.num_computed_tokens}"
                             )
-                            request.block_tables.extend(
-                                self.cache_manager.allocate_gpu_blocks(
-                                    self.config.cache_config.enc_dec_block_num, request.request_id
-                                )
+                            decode_extend_blocks = self.cache_manager.allocate_gpu_blocks(
+                                self.config.cache_config.enc_dec_block_num, request.request_id
                             )
+                            if self.enable_head_wise_kv_cache:
+                                if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
+                                    request.block_tables_3d = []
+                                for head_idx, head_blocks in enumerate(decode_extend_blocks):
+                                    if head_idx < len(request.block_tables_3d):
+                                        request.block_tables_3d[head_idx].extend(head_blocks)
+                                    else:
+                                        request.block_tables_3d.append(head_blocks)
+                                request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
+                            else:
+                                request.block_tables.extend(decode_extend_blocks)
                             # Prepare decoding task
                             scheduled_reqs.append(self._prepare_decode_task(request))
                         else:
@@ -841,6 +850,7 @@ class ResourceManagerV1(ResourceManager):
                     token_budget -= 1
                     if (
                         request.use_extend_tables
+                        and not self.enable_head_wise_kv_cache
                         and request.request_id not in self.using_extend_tables_req_id
                         and self.need_block_num_map[request.request_id].watch() > 0
                     ):

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -279,6 +279,20 @@ class ResourceManagerV1(ResourceManager):
             block_tables_3d=copy.deepcopy(getattr(request, "block_tables_3d", None)),
         )
 
+    def _extend_head_wise_block_tables(self, request: Request, new_blocks):
+        """Append newly allocated blocks/cache_ids to request block tables."""
+        if self.enable_head_wise_kv_cache:
+            if not hasattr(request, "block_tables_3d") or request.block_tables_3d is None:
+                request.block_tables_3d = []
+            for head_idx, head_blocks in enumerate(new_blocks):
+                if head_idx < len(request.block_tables_3d):
+                    request.block_tables_3d[head_idx].extend(head_blocks)
+                else:
+                    request.block_tables_3d.append(list(head_blocks))
+            request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
+        else:
+            request.block_tables.extend(new_blocks)
+
     def _prepare_preempt_task(self, request):
         return ScheduledPreemptTask(idx=request.idx, request_id=request.request_id)
 
@@ -940,17 +954,7 @@ class ResourceManagerV1(ResourceManager):
                             decode_extend_blocks = self.cache_manager.allocate_gpu_blocks(
                                 self.config.cache_config.enc_dec_block_num, request.request_id
                             )
-                            if self.enable_head_wise_kv_cache:
-                                if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
-                                    request.block_tables_3d = []
-                                for head_idx, head_blocks in enumerate(decode_extend_blocks):
-                                    if head_idx < len(request.block_tables_3d):
-                                        request.block_tables_3d[head_idx].extend(head_blocks)
-                                    else:
-                                        request.block_tables_3d.append(head_blocks)
-                                request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
-                            else:
-                                request.block_tables.extend(decode_extend_blocks)
+                            self._extend_head_wise_block_tables(request, decode_extend_blocks)
                             # Prepare decoding task
                             scheduled_reqs.append(self._prepare_decode_task(request))
                         else:
@@ -964,18 +968,7 @@ class ResourceManagerV1(ResourceManager):
                             decode_extend_blocks = self.cache_manager.allocate_gpu_blocks(
                                 self.config.cache_config.enc_dec_block_num, request.request_id
                             )
-                            # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
-                            if self.enable_head_wise_kv_cache:
-                                if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
-                                    request.block_tables_3d = []
-                                for head_idx, head_blocks in enumerate(decode_extend_blocks):
-                                    if head_idx < len(request.block_tables_3d):
-                                        request.block_tables_3d[head_idx].extend(head_blocks)
-                                    else:
-                                        request.block_tables_3d.append(head_blocks)
-                                request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
-                            else:
-                                request.block_tables.extend(decode_extend_blocks)
+                            self._extend_head_wise_block_tables(request, decode_extend_blocks)
                             # Prepare decoding task
                             scheduled_reqs.append(self._prepare_decode_task(request))
                         num_decoding_req_nums += 1
@@ -993,18 +986,7 @@ class ResourceManagerV1(ResourceManager):
                             decode_blocks = self.cache_manager.allocate_gpu_blocks(
                                 allocate_block_num, request.request_id
                             )
-                            # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
-                            if self.enable_head_wise_kv_cache:
-                                if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
-                                    request.block_tables_3d = []
-                                for head_idx, head_blocks in enumerate(decode_blocks):
-                                    if head_idx < len(request.block_tables_3d):
-                                        request.block_tables_3d[head_idx].extend(head_blocks)
-                                    else:
-                                        request.block_tables_3d.append(head_blocks)
-                                request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
-                            else:
-                                request.block_tables.extend(decode_blocks)
+                            self._extend_head_wise_block_tables(request, decode_blocks)
                             scheduled_reqs.append(self._prepare_decode_task(request))
 
                             # Prepare extend task
@@ -1073,18 +1055,7 @@ class ResourceManagerV1(ResourceManager):
                     # Allocate blocks to prefill
                     if self.cache_manager.can_allocate_gpu_blocks(num_new_block):
                         prefill_blocks = self.cache_manager.allocate_gpu_blocks(num_new_block, request.request_id)
-                        # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
-                        if self.enable_head_wise_kv_cache:
-                            if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
-                                request.block_tables_3d = []
-                            for head_idx, head_blocks in enumerate(prefill_blocks):
-                                if head_idx < len(request.block_tables_3d):
-                                    request.block_tables_3d[head_idx].extend(head_blocks)
-                                else:
-                                    request.block_tables_3d.append(head_blocks)
-                            request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
-                        else:
-                            request.block_tables.extend(prefill_blocks)
+                        self._extend_head_wise_block_tables(request, prefill_blocks)
                         # Prepare prefill task
                         scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
                     else:  # Not enough blocks to allocate, trigger preemption
@@ -1092,18 +1063,7 @@ class ResourceManagerV1(ResourceManager):
                         if not can_schedule:
                             break
                         prefill_blocks = self.cache_manager.allocate_gpu_blocks(num_new_block, request.request_id)
-                        # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
-                        if self.enable_head_wise_kv_cache:
-                            if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
-                                request.block_tables_3d = []
-                            for head_idx, head_blocks in enumerate(prefill_blocks):
-                                if head_idx < len(request.block_tables_3d):
-                                    request.block_tables_3d[head_idx].extend(head_blocks)
-                                else:
-                                    request.block_tables_3d.append(head_blocks)
-                            request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
-                        else:
-                            request.block_tables.extend(prefill_blocks)
+                        self._extend_head_wise_block_tables(request, prefill_blocks)
                         # Prepare prefill task
                         scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
                     token_budget -= num_new_tokens
@@ -1195,22 +1155,7 @@ class ResourceManagerV1(ResourceManager):
                                 extra_gpu_block_ids = self.cache_manager.allocate_gpu_blocks(
                                     num_new_block, request.request_id
                                 )
-                                # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
-                                if self.enable_head_wise_kv_cache:
-                                    if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
-                                        request.block_tables_3d = []
-                                    # Extend block_tables_3d for each head
-                                    for head_idx, head_blocks in enumerate(extra_gpu_block_ids):
-                                        if head_idx < len(request.block_tables_3d):
-                                            request.block_tables_3d[head_idx].extend(head_blocks)
-                                        else:
-                                            request.block_tables_3d.append(head_blocks)
-                                    # Update block_tables for backward compatibility
-                                    request.block_tables = (
-                                        request.block_tables_3d[0] if request.block_tables_3d else []
-                                    )
-                                else:
-                                    request.block_tables.extend(extra_gpu_block_ids)
+                                self._extend_head_wise_block_tables(request, extra_gpu_block_ids)
                             self.waiting.popleft()
                             self.running.append(request)
                             scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
@@ -1279,22 +1224,7 @@ class ResourceManagerV1(ResourceManager):
                                 extra_gpu_block_ids = self.cache_manager.allocate_gpu_blocks(
                                     num_new_block, request.request_id
                                 )
-                                # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
-                                if self.enable_head_wise_kv_cache:
-                                    if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
-                                        request.block_tables_3d = []
-                                    # Extend block_tables_3d for each head
-                                    for head_idx, head_blocks in enumerate(extra_gpu_block_ids):
-                                        if head_idx < len(request.block_tables_3d):
-                                            request.block_tables_3d[head_idx].extend(head_blocks)
-                                        else:
-                                            request.block_tables_3d.append(head_blocks)
-                                    # Update block_tables for backward compatibility
-                                    request.block_tables = (
-                                        request.block_tables_3d[0] if request.block_tables_3d else []
-                                    )
-                                else:
-                                    request.block_tables.extend(extra_gpu_block_ids)
+                                self._extend_head_wise_block_tables(request, extra_gpu_block_ids)
                             self.waiting.popleft()
                             self.running.append(request)
                             scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
@@ -1587,18 +1517,7 @@ class ResourceManagerV1(ResourceManager):
                     extra_gpu_block_ids = self.cache_manager.allocate_gpu_blocks(
                         need_extra_prefill_blocks, request.request_id
                     )
-                    # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
-                    if self.enable_head_wise_kv_cache:
-                        if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
-                            request.block_tables_3d = []
-                        for head_idx, head_blocks in enumerate(extra_gpu_block_ids):
-                            if head_idx < len(request.block_tables_3d):
-                                request.block_tables_3d[head_idx].extend(head_blocks)
-                            else:
-                                request.block_tables_3d.append(head_blocks)
-                        request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
-                    else:
-                        request.block_tables.extend(extra_gpu_block_ids)
+                    self._extend_head_wise_block_tables(request, extra_gpu_block_ids)
                     allocated_position = self.get_available_position()
                     request.idx = allocated_position
                     self.tasks_list[request.idx] = request
@@ -1615,12 +1534,10 @@ class ResourceManagerV1(ResourceManager):
                     prealloc_blocks = self.cache_manager.allocate_gpu_blocks(
                         need_prealloc_prefill_blocks, request.request_id
                     )
-                    # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
                     if self.enable_head_wise_kv_cache:
-                        request.block_tables_3d = prealloc_blocks
-                        request.block_tables = prealloc_blocks[0] if prealloc_blocks else []
-                    else:
-                        request.block_tables.extend(prealloc_blocks)
+                        request.block_tables = []
+                        request.block_tables_3d = []
+                    self._extend_head_wise_block_tables(request, prealloc_blocks)
                     request.num_computed_tokens = 0
                     allocated_position = self.get_available_position()
                     request.idx = allocated_position
@@ -1658,8 +1575,9 @@ class ResourceManagerV1(ResourceManager):
                 need_prealloc_prefill_blocks, request.request_id
             )
             if self.enable_head_wise_kv_cache:
-                request.block_tables_3d = allocated_cache_ids
-                request.block_tables = allocated_cache_ids[0] if allocated_cache_ids else []
+                request.block_tables = []
+                request.block_tables_3d = []
+                self._extend_head_wise_block_tables(request, allocated_cache_ids)
             else:
                 request.block_tables = allocated_cache_ids
             request.num_computed_tokens = request.need_prefill_tokens

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -234,12 +234,20 @@ class ResourceManagerV1(ResourceManager):
 
         # SWA recycle
         self.request_head_recycle_upto = {}
-        self.swa_window_size = getattr(self.config.model_config, "sliding_window", 0)
+        self.swa_window_size = getattr(self.config.model_config, "window_size", 0)
 
         if self.enable_head_wise_kv_cache:
-            # To do：
-            # swa_kv_head_indices需要根据模型设置赋值
-            self.swa_kv_head_indices = []
+            num_kv_heads = self.config.model_config.num_key_value_heads
+            swa_ratio = getattr(self.config.model_config, "head_wise_swa_ratio", 0.75)
+            num_swa_heads = int(num_kv_heads * swa_ratio)
+
+            self.swa_kv_head_indices = list(range(num_kv_heads - num_swa_heads, num_kv_heads))
+            self.full_kv_head_indices = list(range(0, num_kv_heads - num_swa_heads))
+            llm_logger.debug(
+                f"[SWA Config] window_size={self.swa_window_size}, "
+                f"swa_ratio={swa_ratio}, num_kv_heads={num_kv_heads}, "
+                f"swa_heads={self.swa_kv_head_indices}, full_heads={self.full_kv_head_indices}"
+            )
         else:
             self.head_wise_kv_cache = None
 

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -235,11 +235,21 @@ class ResourceManagerV1(ResourceManager):
         # SWA recycle
         self.request_head_recycle_upto = {}
         self.swa_window_size = getattr(self.config.model_config, "window_size", 0)
+        self.swa_kv_head_indices = []
+        self.full_kv_head_indices = []
 
         if self.enable_head_wise_kv_cache:
-            num_kv_heads = self.config.model_config.num_key_value_heads
+            # Use local kv_num_heads (after tensor-parallel split) to keep indices
+            # aligned with request.block_tables_3d shape on this rank.
+            num_kv_heads = self.kv_num_heads
             swa_ratio = getattr(self.config.model_config, "head_wise_swa_ratio", 0.75)
+            try:
+                swa_ratio = float(swa_ratio)
+            except (TypeError, ValueError):
+                swa_ratio = 0.75
+            swa_ratio = max(0.0, min(1.0, swa_ratio))
             num_swa_heads = int(num_kv_heads * swa_ratio)
+            num_swa_heads = max(0, min(num_kv_heads, num_swa_heads))
 
             self.swa_kv_head_indices = list(range(num_kv_heads - num_swa_heads, num_kv_heads))
             self.full_kv_head_indices = list(range(0, num_kv_heads - num_swa_heads))
@@ -248,8 +258,6 @@ class ResourceManagerV1(ResourceManager):
                 f"swa_ratio={swa_ratio}, num_kv_heads={num_kv_heads}, "
                 f"swa_heads={self.swa_kv_head_indices}, full_heads={self.full_kv_head_indices}"
             )
-        else:
-            self.head_wise_kv_cache = None
 
     def allocated_slots(self, request: Request):
         return len(request.block_tables) * self.config.cache_config.block_size

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -820,11 +820,21 @@ class ResourceManagerV1(ResourceManager):
                             if not can_schedule:
                                 break
                             # Allocation for next decoding blocks
-                            request.block_tables.extend(
-                                self.cache_manager.allocate_gpu_blocks(
-                                    self.config.cache_config.enc_dec_block_num, request.request_id
-                                )
+                            decode_extend_blocks = self.cache_manager.allocate_gpu_blocks(
+                                self.config.cache_config.enc_dec_block_num, request.request_id
                             )
+                            # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
+                            if self.enable_head_wise_kv_cache:
+                                if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
+                                    request.block_tables_3d = []
+                                for head_idx, head_blocks in enumerate(decode_extend_blocks):
+                                    if head_idx < len(request.block_tables_3d):
+                                        request.block_tables_3d[head_idx].extend(head_blocks)
+                                    else:
+                                        request.block_tables_3d.append(head_blocks)
+                                request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
+                            else:
+                                request.block_tables.extend(decode_extend_blocks)
                             # Prepare decoding task
                             scheduled_reqs.append(self._prepare_decode_task(request))
                         num_decoding_req_nums += 1
@@ -838,9 +848,19 @@ class ResourceManagerV1(ResourceManager):
                         def _allocate_decode_and_extend():
                             allocate_block_num = self.need_block_num_map[request.request_id].consume()
                             # Prepare decoding task
-                            request.block_tables.extend(
-                                self.cache_manager.allocate_gpu_blocks(allocate_block_num, request.request_id)
-                            )
+                            decode_blocks = self.cache_manager.allocate_gpu_blocks(allocate_block_num, request.request_id)
+                            # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
+                            if self.enable_head_wise_kv_cache:
+                                if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
+                                    request.block_tables_3d = []
+                                for head_idx, head_blocks in enumerate(decode_blocks):
+                                    if head_idx < len(request.block_tables_3d):
+                                        request.block_tables_3d[head_idx].extend(head_blocks)
+                                    else:
+                                        request.block_tables_3d.append(head_blocks)
+                                request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
+                            else:
+                                request.block_tables.extend(decode_blocks)
                             scheduled_reqs.append(self._prepare_decode_task(request))
 
                             # Prepare extend task
@@ -908,18 +928,38 @@ class ResourceManagerV1(ResourceManager):
                     num_new_block = self.get_new_block_nums(request, num_new_tokens)
                     # Allocate blocks to prefill
                     if self.cache_manager.can_allocate_gpu_blocks(num_new_block):
-                        request.block_tables.extend(
-                            self.cache_manager.allocate_gpu_blocks(num_new_block, request.request_id)
-                        )
+                        prefill_blocks = self.cache_manager.allocate_gpu_blocks(num_new_block, request.request_id)
+                        # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
+                        if self.enable_head_wise_kv_cache:
+                            if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
+                                request.block_tables_3d = []
+                            for head_idx, head_blocks in enumerate(prefill_blocks):
+                                if head_idx < len(request.block_tables_3d):
+                                    request.block_tables_3d[head_idx].extend(head_blocks)
+                                else:
+                                    request.block_tables_3d.append(head_blocks)
+                            request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
+                        else:
+                            request.block_tables.extend(prefill_blocks)
                         # Prepare prefill task
                         scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
                     else:  # Not enough blocks to allocate, trigger preemption
                         can_schedule = self._trigger_preempt(request, num_new_block, preempted_reqs, scheduled_reqs)
                         if not can_schedule:
                             break
-                        request.block_tables.extend(
-                            self.cache_manager.allocate_gpu_blocks(num_new_block, request.request_id)
-                        )
+                        prefill_blocks = self.cache_manager.allocate_gpu_blocks(num_new_block, request.request_id)
+                        # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
+                        if self.enable_head_wise_kv_cache:
+                            if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
+                                request.block_tables_3d = []
+                            for head_idx, head_blocks in enumerate(prefill_blocks):
+                                if head_idx < len(request.block_tables_3d):
+                                    request.block_tables_3d[head_idx].extend(head_blocks)
+                                else:
+                                    request.block_tables_3d.append(head_blocks)
+                            request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
+                        else:
+                            request.block_tables.extend(prefill_blocks)
                         # Prepare prefill task
                         scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
                     token_budget -= num_new_tokens
@@ -1011,7 +1051,20 @@ class ResourceManagerV1(ResourceManager):
                                 extra_gpu_block_ids = self.cache_manager.allocate_gpu_blocks(
                                     num_new_block, request.request_id
                                 )
-                                request.block_tables.extend(extra_gpu_block_ids)
+                                # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
+                                if self.enable_head_wise_kv_cache:
+                                    if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
+                                        request.block_tables_3d = []
+                                    # Extend block_tables_3d for each head
+                                    for head_idx, head_blocks in enumerate(extra_gpu_block_ids):
+                                        if head_idx < len(request.block_tables_3d):
+                                            request.block_tables_3d[head_idx].extend(head_blocks)
+                                        else:
+                                            request.block_tables_3d.append(head_blocks)
+                                    # Update block_tables for backward compatibility
+                                    request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
+                                else:
+                                    request.block_tables.extend(extra_gpu_block_ids)
                             self.waiting.popleft()
                             self.running.append(request)
                             scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
@@ -1080,7 +1133,20 @@ class ResourceManagerV1(ResourceManager):
                                 extra_gpu_block_ids = self.cache_manager.allocate_gpu_blocks(
                                     num_new_block, request.request_id
                                 )
-                                request.block_tables.extend(extra_gpu_block_ids)
+                                # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
+                                if self.enable_head_wise_kv_cache:
+                                    if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
+                                        request.block_tables_3d = []
+                                    # Extend block_tables_3d for each head
+                                    for head_idx, head_blocks in enumerate(extra_gpu_block_ids):
+                                        if head_idx < len(request.block_tables_3d):
+                                            request.block_tables_3d[head_idx].extend(head_blocks)
+                                        else:
+                                            request.block_tables_3d.append(head_blocks)
+                                    # Update block_tables for backward compatibility
+                                    request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
+                                else:
+                                    request.block_tables.extend(extra_gpu_block_ids)
                             self.waiting.popleft()
                             self.running.append(request)
                             scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
@@ -1262,7 +1328,13 @@ class ResourceManagerV1(ResourceManager):
             )
 
             request.cache_info = [matched_block_num, no_cache_block_num]
-            request.block_tables = common_block_ids
+            # In head-wise mode, common_block_ids is 2D cache_ids
+            if self.enable_head_wise_kv_cache:
+                request.block_tables_3d = common_block_ids
+                request.block_tables = common_block_ids[0] if common_block_ids else []
+            else:
+                request.block_tables = common_block_ids
+            request.skip_allocate = False
             request.num_cached_tokens = matched_token_num
             if self.config.cache_config.disable_chunked_mm_input:
                 if matched_token_num == request.need_prefill_tokens:
@@ -1367,7 +1439,18 @@ class ResourceManagerV1(ResourceManager):
                     extra_gpu_block_ids = self.cache_manager.allocate_gpu_blocks(
                         need_extra_prefill_blocks, request.request_id
                     )
-                    request.block_tables.extend(extra_gpu_block_ids)
+                    # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
+                    if self.enable_head_wise_kv_cache:
+                        if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
+                            request.block_tables_3d = []
+                        for head_idx, head_blocks in enumerate(extra_gpu_block_ids):
+                            if head_idx < len(request.block_tables_3d):
+                                request.block_tables_3d[head_idx].extend(head_blocks)
+                            else:
+                                request.block_tables_3d.append(head_blocks)
+                        request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
+                    else:
+                        request.block_tables.extend(extra_gpu_block_ids)
                     allocated_position = self.get_available_position()
                     request.idx = allocated_position
                     self.tasks_list[request.idx] = request
@@ -1381,9 +1464,13 @@ class ResourceManagerV1(ResourceManager):
 
             else:
                 if self.cache_manager.can_allocate_gpu_blocks(need_prealloc_prefill_blocks):
-                    request.block_tables.extend(
-                        self.cache_manager.allocate_gpu_blocks(need_prealloc_prefill_blocks, request.request_id)
-                    )
+                    prealloc_blocks = self.cache_manager.allocate_gpu_blocks(need_prealloc_prefill_blocks, request.request_id)
+                    # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
+                    if self.enable_head_wise_kv_cache:
+                        request.block_tables_3d = prealloc_blocks
+                        request.block_tables = prealloc_blocks[0] if prealloc_blocks else []
+                    else:
+                        request.block_tables.extend(prealloc_blocks)
                     request.num_computed_tokens = 0
                     allocated_position = self.get_available_position()
                     request.idx = allocated_position
@@ -1416,9 +1503,15 @@ class ResourceManagerV1(ResourceManager):
             if not self.cache_manager.can_allocate_gpu_blocks(total_need_blocks):
                 return False
 
-            request.block_tables = self.cache_manager.allocate_gpu_blocks(
+            # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
+            allocated_cache_ids = self.cache_manager.allocate_gpu_blocks(
                 need_prealloc_prefill_blocks, request.request_id
             )
+            if self.enable_head_wise_kv_cache:
+                request.block_tables_3d = allocated_cache_ids
+                request.block_tables = allocated_cache_ids[0] if allocated_cache_ids else []
+            else:
+                request.block_tables = allocated_cache_ids
             request.num_computed_tokens = request.need_prefill_tokens
             request.disaggregate_info["block_tables"] = request.block_tables
             allocated_position = self.get_available_position()
@@ -1472,11 +1565,34 @@ class ResourceManagerV1(ResourceManager):
     def _free_blocks(self, request: Request):
         if self.config.cache_config.enable_prefix_caching and self.config.scheduler_config.splitwise_role != "decode":
             self.cache_manager.release_block_ids(request)
-            self.cache_manager.recycle_gpu_blocks(
-                request.block_tables[request.num_cached_blocks :], request.request_id
-            )
+            # In head-wise mode, block_tables_3d contains cache_ids for all heads
+            if self.enable_head_wise_kv_cache and hasattr(request, "block_tables_3d") and request.block_tables_3d:
+                # Flatten block_tables_3d for recycling: [[head0_ids], [head1_ids], ...]
+                # Only recycle blocks after num_cached_blocks (for each head)
+                if request.num_cached_blocks > 0 and request.num_cached_blocks < len(request.block_tables_3d[0]):
+                    cache_ids_to_recycle = []
+                    for head_ids in request.block_tables_3d:
+                        cache_ids_to_recycle.extend(head_ids[request.num_cached_blocks:])
+                    self.cache_manager.recycle_gpu_blocks(cache_ids_to_recycle, request.request_id)
+                else:
+                    # Recycle all cache_ids
+                    cache_ids_to_recycle = []
+                    for head_ids in request.block_tables_3d:
+                        cache_ids_to_recycle.extend(head_ids)
+                    self.cache_manager.recycle_gpu_blocks(cache_ids_to_recycle, request.request_id)
+            else:
+                self.cache_manager.recycle_gpu_blocks(
+                    request.block_tables[request.num_cached_blocks :], request.request_id
+                )
         else:
-            self.cache_manager.recycle_gpu_blocks(request.block_tables, request.request_id)
+            # In head-wise mode, recycle all cache_ids from block_tables_3d
+            if self.enable_head_wise_kv_cache and hasattr(request, "block_tables_3d") and request.block_tables_3d:
+                cache_ids_to_recycle = []
+                for head_ids in request.block_tables_3d:
+                    cache_ids_to_recycle.extend(head_ids)
+                self.cache_manager.recycle_gpu_blocks(cache_ids_to_recycle, request.request_id)
+            else:
+                self.cache_manager.recycle_gpu_blocks(request.block_tables, request.request_id)
         request.block_tables = []
 
         if request.request_id in self.using_extend_tables_req_id:
@@ -1562,7 +1678,14 @@ class ResourceManagerV1(ResourceManager):
         blocks_used_by_tasks = set()
         for task in self.tasks_list:
             if task is not None:
-                blocks_used_by_tasks.update(task.block_tables)
+                # In head-wise mode, use block_tables_3d to get all cache_ids
+                if self.enable_head_wise_kv_cache and hasattr(task, "block_tables_3d") and task.block_tables_3d:
+                    # block_tables_3d is a 2D list: [[cache_ids_head0], [cache_ids_head1], ...]
+                    for head_blocks in task.block_tables_3d:
+                        blocks_used_by_tasks.update(head_blocks)
+                else:
+                    # Non-head-wise mode: block_tables is a list of block_ids
+                    blocks_used_by_tasks.update(task.block_tables)
         main_process_metrics.available_gpu_block_num.set(self.total_block_number() - len(blocks_used_by_tasks))
         main_process_metrics.batch_size.set(self.max_num_seqs - self.available_batch())
         main_process_metrics.gpu_cache_usage_perc.set(self.get_gpu_cache_usage_perc())

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -232,6 +232,17 @@ class ResourceManagerV1(ResourceManager):
         # Scheduler-side requests that have not been moved into resource manager waiting queue yet.
         self.scheduler_unhandled_request_num = 0
 
+        # SWA recycle
+        self.request_head_recycle_upto = {}
+        self.swa_window_size = getattr(self.config.model_config, "sliding_window", 0)
+
+        if self.enable_head_wise_kv_cache:
+            # To do：
+            # swa_kv_head_indices需要根据模型设置赋值
+            self.swa_kv_head_indices = []
+        else:
+            self.head_wise_kv_cache = None
+
     def allocated_slots(self, request: Request):
         return len(request.block_tables) * self.config.cache_config.block_size
 
@@ -729,6 +740,77 @@ class ResourceManagerV1(ResourceManager):
         # Compatible with scenarios without images and videos.
         return num_new_tokens
 
+    def _get_swa_recycle_start_block(self):
+        # prepare for sink size
+        return 0
+
+    def _get_swa_recycle_end_block(self, total_tokens):
+        block_size = self.config.cache_config.block_size
+        window_size = self.swa_window_size or 0
+        if window_size <= 0 or total_tokens <= window_size:
+            return 0
+
+        return max(0, (total_tokens - window_size) // block_size)
+
+    def _recycle_request_swa_head_cache_helper(
+        self,
+        request,
+        head_idx,
+        start_block_idx,
+        end_block_idx,
+    ):
+        if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
+            return
+        if head_idx >= len(request.block_tables_3d):
+            return
+
+        row = request.block_tables_3d[head_idx]
+        if start_block_idx >= len(row):
+            return
+
+        end_block_idx = min(end_block_idx, len(row))
+        if end_block_idx <= start_block_idx:
+            return
+
+        cache_ids_to_recycle = []
+        for i in range(start_block_idx, end_block_idx):
+            cid = row[i]
+            if cid is not None and cid >= 0:
+                cache_ids_to_recycle.append(cid)
+                row[i] = -1
+
+        if cache_ids_to_recycle:
+            self.cache_manager.recycle_gpu_blocks(cache_ids_to_recycle, request.request_id)
+
+    def recycle_request_swa_head_cache(self, request):
+        if not self.enable_head_wise_kv_cache:
+            return
+        if self.config.cache_config.enable_prefix_caching:
+            llm_logger.error("not support enable_prefix_caching and enable_head_wise_kv_caching at the same time")
+            return
+        if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
+            return
+        if not self.swa_kv_head_indices:
+            return
+
+        total_tokens = request.num_total_tokens
+        start_block = self._get_swa_recycle_start_block()
+        end_block = self._get_swa_recycle_end_block(total_tokens)
+
+        if end_block <= start_block:
+            return
+
+        if request.request_id not in self.request_head_recycle_upto:
+            self.request_head_recycle_upto[request.request_id] = [0] * self.kv_num_heads
+
+        recycle_upto = self.request_head_recycle_upto[request.request_id]
+
+        for head_idx in self.swa_kv_head_indices:
+            old_upto = max(recycle_upto[head_idx], start_block)
+            if end_block > old_upto:
+                self._recycle_request_swa_head_cache_helper(request, head_idx, old_upto, end_block)
+                recycle_upto[head_idx] = end_block
+
     def exist_mm_prefill(self, scheduled_reqs):
         for request in scheduled_reqs:
             if request.task_type == RequestType.PREFILL and self._is_mm_request(request):
@@ -801,6 +883,13 @@ class ResourceManagerV1(ResourceManager):
                         req_index += 1
                         need_abort_requests.append(request)
                         continue
+
+                    if (
+                        self.enable_head_wise_kv_cache
+                        and self.swa_kv_head_indices
+                        and not self.config.cache_config.enable_prefix_caching
+                    ):  # recycle for swa
+                        self.recycle_request_swa_head_cache(request)
 
                     if (
                         self.allocated_slots(request) - request.num_total_tokens
@@ -1630,6 +1719,7 @@ class ResourceManagerV1(ResourceManager):
             request.extend_block_tables = []
             del self.reuse_block_num_map[request.request_id]
             del self.need_block_num_map[request.request_id]
+        self.request_head_recycle_upto.pop(request.request_id, None)
 
     def finish_requests_async(self, request_ids: Union[str, Iterable[str]]):
         return self.finish_execution_pool.submit(self.finish_requests, request_ids)

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -15,7 +15,6 @@
 """
 
 import copy
-import os
 import threading
 import time
 import traceback
@@ -235,8 +234,6 @@ class ResourceManagerV1(ResourceManager):
 
         # SWA recycle
         self.request_head_recycle_upto = {}
-        self.head_wise_hole_log = bool(int(os.getenv("FD_HEAD_WISE_HOLE_LOG", "0")))
-        self._head_wise_hole_log_count = 0
         self.swa_window_size = getattr(self.config.model_config, "window_size", 0)
         try:
             self.swa_sink_size = int(getattr(self.config.model_config, "sink_size", 0) or 0)
@@ -799,53 +796,6 @@ class ResourceManagerV1(ResourceManager):
 
         return max(0, (total_tokens - window_size) // block_size)
 
-    @staticmethod
-    def _head_wise_row_layout_stats(row):
-        if row is None:
-            return 0, 0, 0
-        row_len = len(row)
-        last_valid_idx = -1
-        for idx, cid in enumerate(row):
-            if cid is not None and cid >= 0:
-                last_valid_idx = idx
-        if last_valid_idx < 0:
-            return row_len, 0, 0
-
-        contiguous_len = last_valid_idx + 1
-        hole_before_last_valid = 0
-        for cid in row[:contiguous_len]:
-            if cid is None or cid < 0:
-                hole_before_last_valid += 1
-        return row_len, contiguous_len, hole_before_last_valid
-
-    def _maybe_log_swa_recycle_hole_diag(
-        self,
-        request_id: str,
-        head_idx: int,
-        row,
-        start_block_idx: int,
-        end_block_idx: int,
-        recycled_count: int,
-    ) -> None:
-        if not self.head_wise_hole_log:
-            return
-
-        row_len, contiguous_len, hole_before_last_valid = self._head_wise_row_layout_stats(row)
-        if hole_before_last_valid <= 0:
-            return
-
-        should_log = self._head_wise_hole_log_count < 100 or self._head_wise_hole_log_count % 100 == 0
-        self._head_wise_hole_log_count += 1
-        if not should_log:
-            return
-
-        llm_logger.warning(
-            f"[swa_recycle_hole_diag] request_id={request_id} head={head_idx} "
-            f"recycle_range=[{start_block_idx},{end_block_idx}) recycled={recycled_count} "
-            f"row_len={row_len} contiguous_len={contiguous_len} hole_before_last_valid={hole_before_last_valid} "
-            f"row_prefix={row[: min(24, row_len)] if row is not None else []}"
-        )
-
     def _recycle_request_swa_head_cache_helper(
         self,
         request,
@@ -875,14 +825,6 @@ class ResourceManagerV1(ResourceManager):
 
         if cache_ids_to_recycle:
             self.cache_manager.recycle_gpu_blocks(cache_ids_to_recycle, request.request_id)
-        self._maybe_log_swa_recycle_hole_diag(
-            request_id=request.request_id,
-            head_idx=head_idx,
-            row=row,
-            start_block_idx=start_block_idx,
-            end_block_idx=end_block_idx,
-            recycled_count=len(cache_ids_to_recycle),
-        )
         return end_block_idx, len(cache_ids_to_recycle)
 
     def recycle_request_swa_head_cache(self, request):

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -1670,6 +1670,9 @@ class ResourceManagerV1(ResourceManager):
             else:
                 self.cache_manager.recycle_gpu_blocks(request.block_tables, request.request_id)
         request.block_tables = []
+        if hasattr(request, "block_tables_3d"):
+            # Avoid stale head-wise cache-id tables on reschedule/reuse.
+            request.block_tables_3d = []
 
         if request.request_id in self.using_extend_tables_req_id:
             reuse_block_num = self.reuse_block_num_map[request.request_id]

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -864,7 +864,9 @@ class ResourceManagerV1(ResourceManager):
                         def _allocate_decode_and_extend():
                             allocate_block_num = self.need_block_num_map[request.request_id].consume()
                             # Prepare decoding task
-                            decode_blocks = self.cache_manager.allocate_gpu_blocks(allocate_block_num, request.request_id)
+                            decode_blocks = self.cache_manager.allocate_gpu_blocks(
+                                allocate_block_num, request.request_id
+                            )
                             # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
                             if self.enable_head_wise_kv_cache:
                                 if not hasattr(request, "block_tables_3d") or not request.block_tables_3d:
@@ -1078,7 +1080,9 @@ class ResourceManagerV1(ResourceManager):
                                         else:
                                             request.block_tables_3d.append(head_blocks)
                                     # Update block_tables for backward compatibility
-                                    request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
+                                    request.block_tables = (
+                                        request.block_tables_3d[0] if request.block_tables_3d else []
+                                    )
                                 else:
                                     request.block_tables.extend(extra_gpu_block_ids)
                             self.waiting.popleft()
@@ -1160,7 +1164,9 @@ class ResourceManagerV1(ResourceManager):
                                         else:
                                             request.block_tables_3d.append(head_blocks)
                                     # Update block_tables for backward compatibility
-                                    request.block_tables = request.block_tables_3d[0] if request.block_tables_3d else []
+                                    request.block_tables = (
+                                        request.block_tables_3d[0] if request.block_tables_3d else []
+                                    )
                                 else:
                                     request.block_tables.extend(extra_gpu_block_ids)
                             self.waiting.popleft()
@@ -1480,7 +1486,9 @@ class ResourceManagerV1(ResourceManager):
 
             else:
                 if self.cache_manager.can_allocate_gpu_blocks(need_prealloc_prefill_blocks):
-                    prealloc_blocks = self.cache_manager.allocate_gpu_blocks(need_prealloc_prefill_blocks, request.request_id)
+                    prealloc_blocks = self.cache_manager.allocate_gpu_blocks(
+                        need_prealloc_prefill_blocks, request.request_id
+                    )
                     # In head-wise mode, allocate_gpu_blocks returns 2D cache_ids
                     if self.enable_head_wise_kv_cache:
                         request.block_tables_3d = prealloc_blocks
@@ -1588,7 +1596,7 @@ class ResourceManagerV1(ResourceManager):
                 if request.num_cached_blocks > 0 and request.num_cached_blocks < len(request.block_tables_3d[0]):
                     cache_ids_to_recycle = []
                     for head_ids in request.block_tables_3d:
-                        cache_ids_to_recycle.extend(head_ids[request.num_cached_blocks:])
+                        cache_ids_to_recycle.extend(head_ids[request.num_cached_blocks :])
                     self.cache_manager.recycle_gpu_blocks(cache_ids_to_recycle, request.request_id)
                 else:
                     # Recycle all cache_ids

--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -133,6 +133,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "FD_CONSOLE_DECODE_LOG_INTERVAL": lambda: int(os.getenv("FD_CONSOLE_DECODE_LOG_INTERVAL", "5")),
     # enable internal module to access LLMEngine.
     "FD_ENABLE_INTERNAL_ADAPTER": lambda: int(os.getenv("FD_ENABLE_INTERNAL_ADAPTER", "0")),
+    # Enable head-wise KV cache (0 or 1)
+    "FD_HEAD_WISE_KV_CACHE": lambda: int(os.getenv("FD_HEAD_WISE_KV_CACHE", "0")),
     # LLMEngine receive requests port, used when FD_ENABLE_INTERNAL_ADAPTER=1
     "FD_ZMQ_RECV_REQUEST_SERVER_PORT": lambda: os.getenv("FD_ZMQ_RECV_REQUEST_SERVER_PORT", None),
     # LLMEngine send response port, used when FD_ENABLE_INTERNAL_ADAPTER=1

--- a/fastdeploy/model_executor/forward_meta.py
+++ b/fastdeploy/model_executor/forward_meta.py
@@ -142,6 +142,10 @@ class ForwardMeta:
     pre_caches_length: int = 0
     # Block tables
     block_tables: Optional[paddle.Tensor] = None
+
+    # Head-wise KV cache: flattened block_tables for cache_id-based architecture
+    # block_tables_3d: [batch_size * kv_num_heads, max_blocks_per_head] storing cache_id directly
+    block_tables_3d: Optional[paddle.Tensor] = None
     # KV caches
     caches: Optional[list[paddle.Tensor]] = None
     # Flag of profile run

--- a/fastdeploy/model_executor/layers/attention/append_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/append_attn_backend.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, List, Optional
@@ -362,6 +363,7 @@ class AppendAttentionBackend(AttentionBackend):
         if (
             self.enable_head_wise_kv_cache
             and self.head_wise_debug_log
+            and logger.isEnabledFor(logging.DEBUG)
             and not getattr(forward_meta, "is_dummy_or_profile_run", False)
             and self._head_wise_debug_log_count < 200
         ):
@@ -387,7 +389,7 @@ class AppendAttentionBackend(AttentionBackend):
             seq_lens_this_time_list = forward_meta.seq_lens_this_time[:batch_size].numpy().tolist()
             seq_lens_encoder_list = forward_meta.seq_lens_encoder[:batch_size].numpy().tolist()
             seq_lens_decoder_list = forward_meta.seq_lens_decoder[:batch_size].numpy().tolist()
-            logger.info(
+            logger.debug(
                 f"[headwise kernel input] layer={layer.layer_id} q_heads={self.num_heads} kv_heads={self.kv_num_heads} "
                 f"group={self.num_heads // max(self.kv_num_heads, 1)} batch={batch_size} "
                 f"block_tables_3d_shape={block_tables_3d.shape if block_tables_3d is not None else None} "

--- a/fastdeploy/model_executor/layers/attention/append_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/append_attn_backend.py
@@ -359,7 +359,12 @@ class AppendAttentionBackend(AttentionBackend):
             )
 
         block_tables = forward_meta.block_tables_3d if self.enable_head_wise_kv_cache else forward_meta.block_tables
-        if self.enable_head_wise_kv_cache and self.head_wise_debug_log and self._head_wise_debug_log_count < 20:
+        if (
+            self.enable_head_wise_kv_cache
+            and self.head_wise_debug_log
+            and not getattr(forward_meta, "is_dummy_or_profile_run", False)
+            and self._head_wise_debug_log_count < 200
+        ):
             block_tables_3d = getattr(forward_meta, "block_tables_3d", None)
             batch_size = forward_meta.seq_lens_this_time.shape[0]
             expected_dim0 = batch_size * self.kv_num_heads

--- a/fastdeploy/model_executor/layers/attention/append_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/append_attn_backend.py
@@ -30,6 +30,7 @@ from fastdeploy.model_executor.layers.attention.ops import (
     init_signal_layerwise,
     open_shm_and_get_meta_signal,
 )
+from paddleformers.utils.log import logger
 
 if TYPE_CHECKING:
     from fastdeploy.model_executor.forward_meta import ForwardMeta
@@ -358,14 +359,14 @@ class AppendAttentionBackend(AttentionBackend):
         block_tables = forward_meta.block_tables_3d if self.enable_head_wise_kv_cache else forward_meta.block_tables
         if self.enable_head_wise_kv_cache:
             block_tables_3d = getattr(forward_meta, "block_tables_3d", None)
+            batch_size = forward_meta.seq_lens_this_time.shape[0]
             logger.info(
-                "[headwise dbg] q_heads=%s kv_heads=%s group=%s block_tables_3d=%s batch=%s cache_k=%s",
-                self.num_heads,
-                self.kv_num_heads,
-                self.num_heads // max(self.kv_num_heads, 1),
-                block_tables_3d.shape if block_tables_3d is not None else None,
-                forward_meta.seq_lens_this_time.shape[0],
-                cache_k.shape,
+                f"[headwise dbg] q_heads={self.num_heads} kv_heads={self.kv_num_heads} "
+                f"group={self.num_heads // max(self.kv_num_heads, 1)} "
+                f"block_tables_3d={block_tables_3d.shape if block_tables_3d is not None else None} "
+                f"batch={batch_size} cache_k={cache_k.shape} "
+                f"expected_block_tables_3d_dim0={batch_size * self.kv_num_heads} "
+                f"block_tables_3d_dtype={block_tables_3d.dtype if block_tables_3d is not None else None}"
             )
         if self.use_output:
             quant_max_bound = getattr(layer, "quant_max_bound", 0.0)

--- a/fastdeploy/model_executor/layers/attention/append_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/append_attn_backend.py
@@ -162,6 +162,8 @@ class AppendAttentionBackend(AttentionBackend):
         self.window_attn_skip_freq: int = getattr(fd_config.model_config, "window_attn_skip_freq", 0)
         self.head_wise_swa_ratio: float = getattr(fd_config.model_config, "head_wise_swa_ratio", 0.0)
         self.enable_head_wise_kv_cache: bool = envs.FD_HEAD_WISE_KV_CACHE == 1
+        self.head_wise_debug_log: bool = bool(int(os.getenv("FD_HEAD_WISE_KV_LOG", "0")))
+        self._head_wise_debug_log_count: int = 0
 
         if self.head_wise_swa_ratio > 0.0:
             self.head_wise_full_hidden = int((1 - self.head_wise_swa_ratio) * self.num_heads * self.head_dim)
@@ -357,17 +359,47 @@ class AppendAttentionBackend(AttentionBackend):
             )
 
         block_tables = forward_meta.block_tables_3d if self.enable_head_wise_kv_cache else forward_meta.block_tables
-        if self.enable_head_wise_kv_cache:
+        if self.enable_head_wise_kv_cache and self.head_wise_debug_log and self._head_wise_debug_log_count < 20:
             block_tables_3d = getattr(forward_meta, "block_tables_3d", None)
             batch_size = forward_meta.seq_lens_this_time.shape[0]
+            expected_dim0 = batch_size * self.kv_num_heads
+            cache_id_capacity = int(cache_k.shape[0]) if len(cache_k.shape) > 0 else -1
+            min_id = -1
+            max_id = -1
+            neg_count = 0
+            out_of_range_cnt = 0
+            sample_rows = []
+            if block_tables_3d is not None:
+                bt_np = block_tables_3d.numpy()
+                valid = bt_np[bt_np >= 0]
+                min_id = int(valid.min()) if valid.size > 0 else -1
+                max_id = int(valid.max()) if valid.size > 0 else -1
+                neg_count = int((bt_np < 0).sum())
+                if cache_id_capacity > 0:
+                    out_of_range_cnt = int((valid >= cache_id_capacity).sum())
+                sample_rows = bt_np[: min(4, bt_np.shape[0])].tolist()
+
             logger.info(
-                f"[headwise dbg] q_heads={self.num_heads} kv_heads={self.kv_num_heads} "
-                f"group={self.num_heads // max(self.kv_num_heads, 1)} "
-                f"block_tables_3d={block_tables_3d.shape if block_tables_3d is not None else None} "
-                f"batch={batch_size} cache_k={cache_k.shape} "
-                f"expected_block_tables_3d_dim0={batch_size * self.kv_num_heads} "
-                f"block_tables_3d_dtype={block_tables_3d.dtype if block_tables_3d is not None else None}"
+                f"[headwise kernel input] layer={layer.layer_id} q_heads={self.num_heads} kv_heads={self.kv_num_heads} "
+                f"group={self.num_heads // max(self.kv_num_heads, 1)} batch={batch_size} "
+                f"block_tables_3d_shape={block_tables_3d.shape if block_tables_3d is not None else None} "
+                f"expected_dim0={expected_dim0} block_tables_3d_dtype={block_tables_3d.dtype if block_tables_3d is not None else None} "
+                f"cache_k_shape={cache_k.shape} cache_id_capacity={cache_id_capacity} "
+                f"min_id={min_id} max_id={max_id} neg_count={neg_count} out_of_range_cnt={out_of_range_cnt} "
+                f"sample_rows={sample_rows}"
             )
+            if block_tables_3d is None or block_tables_3d.shape[0] != expected_dim0:
+                logger.warning(
+                    f"[headwise kernel input mismatch] layer={layer.layer_id} "
+                    f"block_tables_3d_shape={block_tables_3d.shape if block_tables_3d is not None else None} "
+                    f"expected_dim0={expected_dim0}"
+                )
+            if out_of_range_cnt > 0:
+                logger.error(
+                    f"[headwise kernel input invalid] layer={layer.layer_id} "
+                    f"found {out_of_range_cnt} cache ids >= cache_id_capacity({cache_id_capacity})"
+                )
+            self._head_wise_debug_log_count += 1
         if self.use_output:
             quant_max_bound = getattr(layer, "quant_max_bound", 0.0)
             cache_quant_type = getattr(layer, "cache_quant_type_str", "none")

--- a/fastdeploy/model_executor/layers/attention/append_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/append_attn_backend.py
@@ -160,6 +160,7 @@ class AppendAttentionBackend(AttentionBackend):
         self.sink_size: int = getattr(fd_config.model_config, "sink_size", 0)
         self.window_attn_skip_freq: int = getattr(fd_config.model_config, "window_attn_skip_freq", 0)
         self.head_wise_swa_ratio: float = getattr(fd_config.model_config, "head_wise_swa_ratio", 0.0)
+        self.enable_head_wise_kv_cache: bool = envs.FD_HEAD_WISE_KV_CACHE == 1
 
         if self.head_wise_swa_ratio > 0.0:
             self.head_wise_full_hidden = int((1 - self.head_wise_swa_ratio) * self.num_heads * self.head_dim)
@@ -264,6 +265,12 @@ class AppendAttentionBackend(AttentionBackend):
         """
         Calculate kv cache shape
         """
+        if self.enable_head_wise_kv_cache:
+            if kv_cache_quant_type is not None and kv_cache_quant_type != "none":
+                raise NotImplementedError("Head-wise KV cache does not support quantized cache.")
+            key_cache_shape = [max_num_blocks * self.kv_num_heads, self.block_size, self.head_dim]
+            value_cache_shape = key_cache_shape
+            return key_cache_shape, value_cache_shape
         key_cache_shape = [max_num_blocks, self.kv_num_heads, self.block_size, self.head_dim]
         if kv_cache_quant_type is not None and kv_cache_quant_type == "int4_zp":
             key_cache_shape[-1] = self.head_dim // 2
@@ -348,6 +355,7 @@ class AppendAttentionBackend(AttentionBackend):
                 self.block_size,
             )
 
+        block_tables = forward_meta.block_tables_3d if self.enable_head_wise_kv_cache else forward_meta.block_tables
         if self.use_output:
             quant_max_bound = getattr(layer, "quant_max_bound", 0.0)
             cache_quant_type = getattr(layer, "cache_quant_type_str", "none")
@@ -392,7 +400,7 @@ class AppendAttentionBackend(AttentionBackend):
                 forward_meta.seq_lens_this_time,
                 forward_meta.batch_id_per_token,
                 forward_meta.cu_seqlens_q,
-                forward_meta.block_tables,
+                block_tables,
                 forward_meta.encoder_batch_ids,
                 forward_meta.encoder_tile_ids_per_batch,
                 forward_meta.encoder_num_blocks_x_cpu,
@@ -449,7 +457,7 @@ class AppendAttentionBackend(AttentionBackend):
                 forward_meta.seq_lens_this_time,
                 forward_meta.batch_id_per_token,
                 forward_meta.cu_seqlens_q,
-                forward_meta.block_tables,
+                block_tables,
                 forward_meta.encoder_batch_ids,
                 forward_meta.encoder_tile_ids_per_batch,
                 forward_meta.encoder_num_blocks_x_cpu,

--- a/fastdeploy/model_executor/layers/attention/append_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/append_attn_backend.py
@@ -379,12 +379,18 @@ class AppendAttentionBackend(AttentionBackend):
                     out_of_range_cnt = int((valid >= cache_id_capacity).sum())
                 sample_rows = bt_np[: min(4, bt_np.shape[0])].tolist()
 
+            seq_lens_this_time_list = forward_meta.seq_lens_this_time[:batch_size].numpy().tolist()
+            seq_lens_encoder_list = forward_meta.seq_lens_encoder[:batch_size].numpy().tolist()
+            seq_lens_decoder_list = forward_meta.seq_lens_decoder[:batch_size].numpy().tolist()
             logger.info(
                 f"[headwise kernel input] layer={layer.layer_id} q_heads={self.num_heads} kv_heads={self.kv_num_heads} "
                 f"group={self.num_heads // max(self.kv_num_heads, 1)} batch={batch_size} "
                 f"block_tables_3d_shape={block_tables_3d.shape if block_tables_3d is not None else None} "
                 f"expected_dim0={expected_dim0} block_tables_3d_dtype={block_tables_3d.dtype if block_tables_3d is not None else None} "
                 f"cache_k_shape={cache_k.shape} cache_id_capacity={cache_id_capacity} "
+                f"cache_quant_type={cache_quant_type_str} qkv_dtype={qkv.dtype} cache_dtype={cache_k.dtype} "
+                f"use_output={self.use_output} enc_block_q={self.encoder_block_shape_q} dec_block_q={self.decoder_block_shape_q} "
+                f"seq_lens_this_time={seq_lens_this_time_list} seq_lens_encoder={seq_lens_encoder_list} seq_lens_decoder={seq_lens_decoder_list} "
                 f"min_id={min_id} max_id={max_id} neg_count={neg_count} out_of_range_cnt={out_of_range_cnt} "
                 f"sample_rows={sample_rows}"
             )

--- a/fastdeploy/model_executor/layers/attention/append_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/append_attn_backend.py
@@ -399,7 +399,7 @@ class AppendAttentionBackend(AttentionBackend):
                 f"min_id={min_id} max_id={max_id} neg_count={neg_count} out_of_range_cnt={out_of_range_cnt} "
                 f"sample_rows={sample_rows}"
             )
-            if block_tables_3d is None or block_tables_3d.shape[0] != expected_dim0:
+            if block_tables_3d is None or block_tables_3d.shape[0] < expected_dim0:
                 logger.warning(
                     f"[headwise kernel input mismatch] layer={layer.layer_id} "
                     f"block_tables_3d_shape={block_tables_3d.shape if block_tables_3d is not None else None} "

--- a/fastdeploy/model_executor/layers/attention/append_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/append_attn_backend.py
@@ -50,6 +50,22 @@ from fastdeploy.platforms import current_platform
 from fastdeploy.spec_decode import SpecMethod
 
 
+def _debug_logging_enabled() -> bool:
+    for candidate in (logger, getattr(logger, "logger", None), getattr(logger, "_logger", None)):
+        if candidate is None:
+            continue
+        is_enabled_for = getattr(candidate, "isEnabledFor", None)
+        if callable(is_enabled_for):
+            try:
+                return bool(is_enabled_for(logging.DEBUG))
+            except Exception:
+                continue
+        level = getattr(candidate, "level", None)
+        if isinstance(level, int):
+            return level <= logging.DEBUG
+    return False
+
+
 @dataclass
 class AppendAttentionMetadata(AttentionMetadata):
     """
@@ -363,7 +379,7 @@ class AppendAttentionBackend(AttentionBackend):
         if (
             self.enable_head_wise_kv_cache
             and self.head_wise_debug_log
-            and logger.isEnabledFor(logging.DEBUG)
+            and _debug_logging_enabled()
             and not getattr(forward_meta, "is_dummy_or_profile_run", False)
             and self._head_wise_debug_log_count < 200
         ):

--- a/fastdeploy/model_executor/layers/attention/append_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/append_attn_backend.py
@@ -286,8 +286,8 @@ class AppendAttentionBackend(AttentionBackend):
         Calculate kv cache shape
         """
         if self.enable_head_wise_kv_cache:
-            if kv_cache_quant_type is not None and kv_cache_quant_type != "none":
-                raise NotImplementedError("Head-wise KV cache does not support quantized cache.")
+            if kv_cache_quant_type is not None and kv_cache_quant_type not in ("none", "block_wise_fp8"):
+                raise NotImplementedError(f"Head-wise KV cache does not support {kv_cache_quant_type} cache.")
             key_cache_shape = [max_num_blocks * self.kv_num_heads, self.block_size, self.head_dim]
             value_cache_shape = key_cache_shape
             return key_cache_shape, value_cache_shape

--- a/fastdeploy/model_executor/layers/attention/append_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/append_attn_backend.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, List, Optional
 
 import paddle
+from paddleformers.utils.log import logger
 
 from fastdeploy.model_executor.layers.attention.ops import (
     append_attention,
@@ -31,7 +32,6 @@ from fastdeploy.model_executor.layers.attention.ops import (
     init_signal_layerwise,
     open_shm_and_get_meta_signal,
 )
-from paddleformers.utils.log import logger
 
 if TYPE_CHECKING:
     from fastdeploy.model_executor.forward_meta import ForwardMeta

--- a/fastdeploy/model_executor/layers/attention/append_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/append_attn_backend.py
@@ -356,6 +356,17 @@ class AppendAttentionBackend(AttentionBackend):
             )
 
         block_tables = forward_meta.block_tables_3d if self.enable_head_wise_kv_cache else forward_meta.block_tables
+        if self.enable_head_wise_kv_cache:
+            block_tables_3d = getattr(forward_meta, "block_tables_3d", None)
+            logger.info(
+                "[headwise dbg] q_heads=%s kv_heads=%s group=%s block_tables_3d=%s batch=%s cache_k=%s",
+                self.num_heads,
+                self.kv_num_heads,
+                self.num_heads // max(self.kv_num_heads, 1),
+                block_tables_3d.shape if block_tables_3d is not None else None,
+                forward_meta.seq_lens_this_time.shape[0],
+                cache_k.shape,
+            )
         if self.use_output:
             quant_max_bound = getattr(layer, "quant_max_bound", 0.0)
             cache_quant_type = getattr(layer, "cache_quant_type_str", "none")

--- a/fastdeploy/spec_decode/__init__.py
+++ b/fastdeploy/spec_decode/__init__.py
@@ -18,4 +18,17 @@ speculative decoding module
 from .base import Proposer
 from .types import SpecMethod, VerifyStrategy
 
-__all__ = ["Proposer", "SpecMethod", "VerifyStrategy"]
+__all__ = ["Proposer", "SpecMethod", "VerifyStrategy", "MTPProposer", "NgramProposer"]
+
+
+def __getattr__(name: str):
+    """Backward-compatible lazy exports for external plugins."""
+    if name == "MTPProposer":
+        from .mtp import MTPProposer
+
+        return MTPProposer
+    if name == "NgramProposer":
+        from .ngram import NgramProposer
+
+        return NgramProposer
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1310,11 +1310,14 @@ class GPUModelRunner(ModelRunnerBase):
             self.share_inputs["encoder_block_lens"][idx : idx + 1] = block_num
             if self.enable_head_wise_kv_cache:
                 # In head-wise mode, block_tables should have shape [bsz, kv_num_heads * max_blocks_per_head]
-                # Each head gets its own set of block IDs
+                # Each head is laid out with fixed stride max_blocks_per_head.
+                max_blocks_per_head = self.share_inputs["block_tables"].shape[1] // self.kv_num_heads
                 base = idx * self.kv_num_heads * block_num
-                # Expand block_tables to include all heads
-                block_ids = np.arange(base, base + self.kv_num_heads * block_num, 1)
-                self.share_inputs["block_tables"][idx, : len(block_ids)] = block_ids
+                for head_idx in range(self.kv_num_heads):
+                    head_offset = head_idx * max_blocks_per_head
+                    head_base = base + head_idx * block_num
+                    head_block_ids = np.arange(head_base, head_base + block_num, 1, dtype="int32")
+                    self.share_inputs["block_tables"][idx, head_offset : head_offset + block_num] = head_block_ids
             else:
                 self.share_inputs["block_tables"][idx : idx + 1, :block_num] = np.arange(
                     idx * block_num, (idx + 1) * block_num, 1

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -208,14 +208,6 @@ class GPUModelRunner(ModelRunnerBase):
         self.cudagraph_capture_sizes_prefill = list(reversed(self.graph_opt_config.cudagraph_capture_sizes_prefill))
         self.sot_warmup_sizes = self.graph_opt_config.sot_warmup_sizes
         self.cudagraph_only_prefill = self.graph_opt_config.cudagraph_only_prefill
-        if self.enable_head_wise_kv_cache and self.use_cudagraph:
-            # Head-wise block_tables_3d is still dynamically rebuilt per step.
-            # Running this path under CUDA Graph can replay stale pointers/shapes.
-            logger.warning(
-                "[headwise] Disable CUDA Graph because head-wise KV cache has dynamic block_tables_3d."
-            )
-            self.use_cudagraph = False
-            self.graph_opt_config.use_cudagraph = False
 
         # Initialize input batch
         self.share_inputs = InputBatch(self.fd_config)

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1286,6 +1286,12 @@ class GPUModelRunner(ModelRunnerBase):
         """Set dummy prefill inputs to share_inputs"""
         batch_size = len(input_length_list)
         self.share_inputs["block_tables"][:, :] = -1
+        # Clear stale lengths from previous dummy/profile rounds.
+        self.share_inputs["seq_lens_this_time_buffer"][:] = 0
+        self.share_inputs["step_seq_lens_encoder"][:] = 0
+        self.share_inputs["seq_lens_encoder"][:] = 0
+        self.share_inputs["seq_lens_decoder"][:] = 0
+        self.share_inputs["encoder_block_lens"][:] = 0
         for i in range(batch_size):
             idx = i
             input_length = input_length_list[i]
@@ -1348,7 +1354,10 @@ class GPUModelRunner(ModelRunnerBase):
         if self.enable_head_wise_kv_cache:
             if is_dummy_or_profile_run:
                 # In dummy/profile run, construct block_tables_3d from block_tables
-                num_running_requests = int(self.share_inputs["seq_lens_this_time"].shape[0])
+                # seq_lens_this_time may point to max_num_seqs-sized buffer;
+                # only positive-length rows are active in dummy/profile rounds.
+                seq_lens_this_time = self.share_inputs["seq_lens_this_time"]
+                num_running_requests = int((seq_lens_this_time > 0).astype("int64").sum().item())
                 self._prepare_block_tables_3d_from_flat_tables(num_running_requests)
                 if num_running_requests > 0:
                     rows_np = self.share_inputs["block_tables_3d"][: num_running_requests * self.kv_num_heads].numpy()

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -872,6 +872,10 @@ class GPUModelRunner(ModelRunnerBase):
                     cache_ids_2d = self._normalize_head_wise_cache_ids_2d(cache_ids_2d)
                     if cache_ids_2d is not None:
                         request.block_tables_3d = cache_ids_2d
+                        head0_row = cache_ids_2d[0] if len(cache_ids_2d) > 0 and cache_ids_2d[0] is not None else []
+                        request.block_tables = list(head0_row)
+                    elif request.block_tables and isinstance(request.block_tables[0], list):
+                        request.block_tables = list(request.block_tables[0] or [])
                     self._update_block_tables_3d_slot(idx, cache_ids_2d, str(request.request_id))
                     if cache_ids_2d:
                         head0_row = cache_ids_2d[0] if cache_ids_2d[0] is not None else []
@@ -943,6 +947,10 @@ class GPUModelRunner(ModelRunnerBase):
                     cache_ids_2d = self._normalize_head_wise_cache_ids_2d(cache_ids_2d)
                     if cache_ids_2d is not None:
                         request.block_tables_3d = cache_ids_2d
+                        head0_row = cache_ids_2d[0] if len(cache_ids_2d) > 0 and cache_ids_2d[0] is not None else []
+                        request.block_tables = list(head0_row)
+                    elif request.block_tables and isinstance(request.block_tables[0], list):
+                        request.block_tables = list(request.block_tables[0] or [])
                     self._update_block_tables_3d_slot(idx, cache_ids_2d, str(request.request_id))
                     # Keep cached request metadata in sync for subsequent forward_meta assembly.
                     cached_req = self.forward_batch_reqs_list[idx]

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1183,6 +1183,13 @@ class GPUModelRunner(ModelRunnerBase):
         return normalized_cache_ids_2d
 
     def _flatten_head_wise_cache_ids_2d(self, cache_ids_2d):
+        """
+        Runtime compatibility helper for share_inputs["block_tables"] mirror.
+        This intentionally flattens by concatenation (variable valid length), while
+        authoritative head-wise routing uses block_tables_3d.
+        Fixed-stride layout for dummy/profile is handled in _dummy_prefill_inputs
+        + _prepare_block_tables_3d_from_flat_tables.
+        """
         if not cache_ids_2d:
             return []
         tables = []

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -853,17 +853,25 @@ class GPUModelRunner(ModelRunnerBase):
                         request.block_tables_3d = cache_ids_2d
                     if cache_ids_2d:
                         encoder_block_num = len(cache_ids_2d[0])
-                        head0_tables = cache_ids_2d[0]
                     else:
                         encoder_block_num = 0
-                        head0_tables = []
                 else:
                     encoder_block_num = len(request.block_tables)
                 self.share_inputs["encoder_block_lens"][idx : idx + 1] = encoder_block_num
                 self.share_inputs["block_tables"][idx : idx + 1, :] = -1
                 if encoder_block_num > 0:
-                    tables = head0_tables if self.enable_head_wise_kv_cache else request.block_tables
-                    self.share_inputs["block_tables"][idx : idx + 1, :encoder_block_num] = np.array(
+                    if self.enable_head_wise_kv_cache:
+                        # In head-wise mode, expand cache_ids_2d to include all heads
+                        # block_tables format: [bsz, kv_num_heads * max_blocks_per_head]
+                        tables = []
+                        for head_tables in cache_ids_2d:
+                            tables.extend(head_tables)
+                        logger.info(
+                            f"[headwise prefill] req {idx} cache_ids_2d={cache_ids_2d} tables={tables}"
+                        )
+                    else:
+                        tables = request.block_tables
+                    self.share_inputs["block_tables"][idx : idx + 1, :len(tables)] = np.array(
                         tables, dtype="int32"
                     )
                 self.share_inputs["stop_flags"][idx : idx + 1] = False
@@ -918,22 +926,27 @@ class GPUModelRunner(ModelRunnerBase):
                         request.block_tables_3d = cache_ids_2d
                     if cache_ids_2d:
                         encoder_block_num = len(cache_ids_2d[0])
-                        head0_tables = cache_ids_2d[0]
                     else:
                         encoder_block_num = 0
-                        head0_tables = []
                 else:
                     encoder_block_num = len(request.block_tables)
                 self.share_inputs["encoder_block_lens"][idx : idx + 1] = encoder_block_num
                 self.share_inputs["block_tables"][idx : idx + 1, :] = -1
                 if encoder_block_num > 0:
-                    tables = head0_tables if self.enable_head_wise_kv_cache else request.block_tables
+                    if self.enable_head_wise_kv_cache:
+                        # In head-wise mode, expand cache_ids_2d to include all heads
+                        # block_tables format: [bsz, kv_num_heads * max_blocks_per_head]
+                        tables = []
+                        for head_tables in cache_ids_2d:
+                            tables.extend(head_tables)
+                    else:
+                        tables = request.block_tables
                     if current_platform.is_cuda():
                         async_set_value(
-                            self.share_inputs["block_tables"][idx : idx + 1, :encoder_block_num], tables
+                            self.share_inputs["block_tables"][idx : idx + 1, :len(tables)], tables
                         )
                     else:
-                        self.share_inputs["block_tables"][idx : idx + 1, :encoder_block_num] = np.array(
+                        self.share_inputs["block_tables"][idx : idx + 1, :len(tables)] = np.array(
                             tables, dtype="int32"
                         )
                 if self.share_inputs["is_block_step"][idx]:  # has tasks to continue to decode
@@ -1045,13 +1058,16 @@ class GPUModelRunner(ModelRunnerBase):
             return
 
         max_blocks_per_head = 0
+        cache_ids_per_req = []
         for b in range(num_running_requests):
             req = self.forward_batch_reqs_list[b]
             cache_ids_2d = getattr(req, "block_tables_3d", None) if req is not None else None
+            cache_ids_per_req.append(cache_ids_2d)
             if cache_ids_2d and len(cache_ids_2d) > 0:
                 max_blocks_per_head = max(max_blocks_per_head, len(cache_ids_2d[0]))
 
         if max_blocks_per_head == 0:
+            logger.info(f"[headwise _prepare_block_tables_3d] max_blocks_per_head=0, returning None")
             self.share_inputs["block_tables_3d"] = None
             return
 
@@ -1061,6 +1077,7 @@ class GPUModelRunner(ModelRunnerBase):
             cache_ids_2d = getattr(req, "block_tables_3d", None) if req is not None else None
             if cache_ids_2d is None:
                 rows.extend([[-1] * max_blocks_per_head for _ in range(self.kv_num_heads)])
+                logger.info(f"[headwise _prepare_block_tables_3d] req {b}: cache_ids_2d=None, adding dummy rows")
                 continue
             for h in range(self.kv_num_heads):
                 row = list(cache_ids_2d[h])
@@ -1068,7 +1085,15 @@ class GPUModelRunner(ModelRunnerBase):
                     row.extend([-1] * (max_blocks_per_head - len(row)))
                 rows.append(row)
 
-        self.share_inputs["block_tables_3d"] = paddle.to_tensor(np.array(rows, dtype="int32"))
+        block_tables_3d = paddle.to_tensor(np.array(rows, dtype="int32"))
+        self.share_inputs["block_tables_3d"] = block_tables_3d
+        logger.info(
+            f"[headwise _prepare_block_tables_3d] shape={block_tables_3d.shape} "
+            f"num_running_requests={num_running_requests} "
+            f"kv_num_heads={self.kv_num_heads} "
+            f"max_blocks_per_head={max_blocks_per_head} "
+            f"first_rows={rows[:min(4, len(rows))]}"
+        )
 
     def insert_prefill_inputs(self, req_dicts: List[Request], num_running_requests: int):
         raise NotImplementedError("GPUs only support KVCACHE SCHEDULER V1 in versions 2.6 and above.")
@@ -1187,10 +1212,13 @@ class GPUModelRunner(ModelRunnerBase):
 
             self.share_inputs["encoder_block_lens"][idx : idx + 1] = block_num
             if self.enable_head_wise_kv_cache:
+                # In head-wise mode, block_tables should have shape [bsz, kv_num_heads * max_blocks_per_head]
+                # Each head gets its own set of block IDs
                 base = idx * self.kv_num_heads * block_num
-                self.share_inputs["block_tables"][idx : idx + 1, :block_num] = np.arange(
-                    base, base + block_num, 1
-                )
+                # Expand block_tables to include all heads
+                block_ids = np.arange(base, base + self.kv_num_heads * block_num, 1)
+                self.share_inputs["block_tables"][idx, :len(block_ids)] = block_ids
+                # block_tables_3d will be [bsz * kv_num_heads, max_blocks_per_head]
                 for h in range(self.kv_num_heads):
                     headwise_rows.append(np.arange(base + h * block_num, base + (h + 1) * block_num, 1))
             else:
@@ -1221,6 +1249,56 @@ class GPUModelRunner(ModelRunnerBase):
             self.cache_config.block_size,
             self.speculative_config.num_speculative_tokens if self.speculative_decoding else 0,
         )
+        # Prepare block_tables_3d for head-wise KV cache
+        if self.enable_head_wise_kv_cache:
+            if is_dummy_or_profile_run:
+                # In dummy/profile run, construct block_tables_3d from block_tables
+                # Use the full batch size from seq_lens_this_time shape, not the number of active requests
+                num_running_requests = int((self.share_inputs["seq_lens_this_time"] > 0).sum().item())
+                if num_running_requests > 0:
+                    # Get the batch size from the shape of seq_lens_this_time
+                    batch_size = self.share_inputs["seq_lens_this_time"].shape[0]
+                    block_tables = self.share_inputs["block_tables"][:batch_size].numpy()
+                    headwise_rows = []
+                    for b in range(batch_size):
+                        # block_tables[b] has format [kv_num_heads * max_blocks_per_head]
+                        # Need to split it into per-head blocks
+                        b_row = block_tables[b]
+                        # Filter out -1 values to get actual blocks per head
+                        valid_blocks = b_row[b_row >= 0]
+                        # In head-wise mode, block_tables are ordered as [head0_blocks, head1_blocks, ...]
+                        blocks_per_head = len(valid_blocks) // self.kv_num_heads
+                        if blocks_per_head == 0:
+                            # No valid blocks, add dummy rows
+                            for h in range(self.kv_num_heads):
+                                headwise_rows.append([-1])
+                            continue
+                        for h in range(self.kv_num_heads):
+                            # Each head gets its own set of block IDs
+                            head_start = h * blocks_per_head
+                            head_end = (h + 1) * blocks_per_head
+                            row = list(valid_blocks[head_start:head_end])
+                            headwise_rows.append(row)
+                    # Determine max_blocks_per_head for padding
+                    max_blocks_per_head = max([len(row) for row in headwise_rows]) if headwise_rows else 0
+                    # Pad rows to max_blocks_per_head
+                    padded_rows = []
+                    for row in headwise_rows:
+                        if len(row) < max_blocks_per_head:
+                            row = row + [-1] * (max_blocks_per_head - len(row))
+                        padded_rows.append(row)
+                    self.share_inputs["block_tables_3d"] = paddle.to_tensor(
+                        np.array(padded_rows, dtype="int32")
+                    )
+                    logger.info(
+                        f"[headwise dummy run] block_tables_3d shape={self.share_inputs['block_tables_3d'].shape} "
+                        f"max_blocks_per_head={max_blocks_per_head} "
+                        f"first_rows={self.share_inputs['block_tables_3d'].numpy()[:min(4, len(padded_rows))].tolist() if len(padded_rows) > 0 else []}"
+                    )
+            else:
+                # In real run, use forward_batch_reqs_list
+                num_running_requests = int((self.share_inputs["seq_lens_this_time"] > 0).sum().item())
+                self._prepare_block_tables_3d(num_running_requests)
         logprobs_reqs = [
             req
             for req in self.forward_batch_reqs_list

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1062,55 +1062,84 @@ class GPUModelRunner(ModelRunnerBase):
         if self.spec_method == SpecMethod.MTP:
             self.proposer.insert_tasks_v1(req_dicts, num_running_requests, self.share_inputs.index_to_batch_id)
 
+    def _get_head_wise_block_tables_buffer(self) -> paddle.Tensor:
+        block_tables_3d = self.share_inputs.get("block_tables_3d", None)
+        if block_tables_3d is not None:
+            return block_tables_3d
+
+        # Fallback guard. InputBatch should already allocate this when head-wise mode is enabled.
+        max_num_seqs = self.scheduler_config.max_num_seqs
+        max_blocks_per_head = self.share_inputs["block_tables"].shape[1] // self.kv_num_heads
+        block_tables_3d = paddle.full([max_num_seqs * self.kv_num_heads, max_blocks_per_head], -1, dtype="int32")
+        self.share_inputs["block_tables_3d"] = block_tables_3d
+        return block_tables_3d
+
+    def _prepare_block_tables_3d_from_flat_tables(self, num_running_requests: int):
+        """
+        Build head-wise tables from flattened self.share_inputs["block_tables"] in-place.
+        Used in dummy/profile runs where Request objects are not available.
+        """
+        block_tables_3d = self._get_head_wise_block_tables_buffer()
+        block_tables_3d[:] = -1
+        if num_running_requests is None or num_running_requests <= 0:
+            return
+
+        flat_block_tables = self.share_inputs["block_tables"][:num_running_requests].numpy()
+        max_blocks_per_head = block_tables_3d.shape[1]
+        for b in range(num_running_requests):
+            valid_blocks = flat_block_tables[b][flat_block_tables[b] >= 0]
+            if valid_blocks.size == 0:
+                continue
+            blocks_per_head = int(valid_blocks.size) // self.kv_num_heads
+            if blocks_per_head <= 0:
+                continue
+            copy_len = min(blocks_per_head, max_blocks_per_head)
+            for h in range(self.kv_num_heads):
+                start = h * blocks_per_head
+                end = start + copy_len
+                if end <= valid_blocks.size:
+                    row_idx = b * self.kv_num_heads + h
+                    block_tables_3d[row_idx, :copy_len] = paddle.to_tensor(valid_blocks[start:end], dtype="int32")
+
     def _prepare_block_tables_3d(self, num_running_requests: int):
         if not self.enable_head_wise_kv_cache:
             self.share_inputs["block_tables_3d"] = None
             return
+        block_tables_3d = self._get_head_wise_block_tables_buffer()
+        block_tables_3d[:] = -1
         if num_running_requests is None or num_running_requests <= 0:
-            self.share_inputs["block_tables_3d"] = None
             return
 
-        max_blocks_per_head = 0
+        max_blocks_per_head = block_tables_3d.shape[1]
         per_req_head_lens = []
-        cache_ids_per_req = []
         for b in range(num_running_requests):
             req = self.forward_batch_reqs_list[b]
             cache_ids_2d = getattr(req, "block_tables_3d", None) if req is not None else None
-            cache_ids_per_req.append(cache_ids_2d)
             if cache_ids_2d and len(cache_ids_2d) > 0:
                 head_lens = [len(head_ids) if head_ids is not None else 0 for head_ids in cache_ids_2d]
                 per_req_head_lens.append(head_lens)
-                max_blocks_per_head = max(max_blocks_per_head, len(cache_ids_2d[0]))
             else:
                 per_req_head_lens.append([])
 
-        if max_blocks_per_head == 0:
-            if self.head_wise_debug_log:
-                logger.info(f"[headwise _prepare_block_tables_3d] max_blocks_per_head=0, returning None")
-            self.share_inputs["block_tables_3d"] = None
-            return
-
-        rows = []
         for b in range(num_running_requests):
             req = self.forward_batch_reqs_list[b]
             cache_ids_2d = getattr(req, "block_tables_3d", None) if req is not None else None
             if cache_ids_2d is None:
-                rows.extend([[-1] * max_blocks_per_head for _ in range(self.kv_num_heads)])
                 if self.head_wise_debug_log:
-                    logger.info(f"[headwise _prepare_block_tables_3d] req {b}: cache_ids_2d=None, adding dummy rows")
+                    logger.info(f"[headwise _prepare_block_tables_3d] req {b}: cache_ids_2d=None, keep rows as -1")
                 continue
             for h in range(self.kv_num_heads):
                 if h >= len(cache_ids_2d) or cache_ids_2d[h] is None:
-                    row = []
+                    continue
                 else:
                     row = list(cache_ids_2d[h])
-                if len(row) < max_blocks_per_head:
-                    row.extend([-1] * (max_blocks_per_head - len(row)))
-                rows.append(row)
+                    copy_len = min(len(row), max_blocks_per_head)
+                    if copy_len > 0:
+                        row_idx = b * self.kv_num_heads + h
+                        block_tables_3d[row_idx, :copy_len] = paddle.to_tensor(row[:copy_len], dtype="int32")
 
-        block_tables_3d = paddle.to_tensor(np.array(rows, dtype="int32"))
-        self.share_inputs["block_tables_3d"] = block_tables_3d
-        rows_np = np.array(rows, dtype="int32")
+        active_rows = block_tables_3d[: num_running_requests * self.kv_num_heads]
+        rows_np = active_rows.numpy()
         valid_ids = rows_np[rows_np >= 0]
         min_id = int(valid_ids.min()) if valid_ids.size > 0 else -1
         max_id = int(valid_ids.max()) if valid_ids.size > 0 else -1
@@ -1126,11 +1155,11 @@ class GPUModelRunner(ModelRunnerBase):
         )
         if should_log_prepare:
             logger.info(
-                f"[headwise _prepare_block_tables_3d] shape={block_tables_3d.shape} "
+                f"[headwise _prepare_block_tables_3d] shape={active_rows.shape} "
                 f"num_running_requests={num_running_requests} kv_num_heads={self.kv_num_heads} "
                 f"max_blocks_per_head={max_blocks_per_head} min_id={min_id} max_id={max_id} "
                 f"neg_count={neg_count} cache_id_capacity={cache_id_capacity} "
-                f"out_of_range_cnt={out_of_range_cnt} first_rows={rows[:min(4, len(rows))]}"
+                f"out_of_range_cnt={out_of_range_cnt} first_rows={rows_np[:min(4, len(rows_np))].tolist()}"
             )
         if self.head_wise_debug_log:
             self._head_wise_prepare_log_count += 1
@@ -1238,7 +1267,7 @@ class GPUModelRunner(ModelRunnerBase):
     def _dummy_prefill_inputs(self, input_length_list: List[int], max_dec_len_list: List[int], block_num: int):
         """Set dummy prefill inputs to share_inputs"""
         batch_size = len(input_length_list)
-        headwise_rows = []
+        self.share_inputs["block_tables"][:, :] = -1
         for i in range(batch_size):
             idx = i
             input_length = input_length_list[i]
@@ -1268,16 +1297,11 @@ class GPUModelRunner(ModelRunnerBase):
                 # Expand block_tables to include all heads
                 block_ids = np.arange(base, base + self.kv_num_heads * block_num, 1)
                 self.share_inputs["block_tables"][idx, :len(block_ids)] = block_ids
-                # block_tables_3d will be [bsz * kv_num_heads, max_blocks_per_head]
-                for h in range(self.kv_num_heads):
-                    headwise_rows.append(np.arange(base + h * block_num, base + (h + 1) * block_num, 1))
             else:
                 self.share_inputs["block_tables"][idx : idx + 1, :block_num] = np.arange(
                     idx * block_num, (idx + 1) * block_num, 1
                 )
         self.share_inputs["seq_lens_this_time"] = self.share_inputs["seq_lens_this_time_buffer"]
-        if self.enable_head_wise_kv_cache:
-            self.share_inputs["block_tables_3d"] = paddle.to_tensor(np.array(headwise_rows, dtype="int32"))
 
     def _prepare_inputs(self, cached_token_num=-1, cached_real_bsz=-1, is_dummy_or_profile_run=False) -> None:
         """Prepare the model inputs"""
@@ -1303,47 +1327,16 @@ class GPUModelRunner(ModelRunnerBase):
         if self.enable_head_wise_kv_cache:
             if is_dummy_or_profile_run:
                 # In dummy/profile run, construct block_tables_3d from block_tables
-                # Use the full batch size from seq_lens_this_time shape, not the number of active requests
                 num_running_requests = int((self.share_inputs["seq_lens_this_time"] > 0).sum().item())
+                self._prepare_block_tables_3d_from_flat_tables(num_running_requests)
                 if num_running_requests > 0:
-                    # Get the batch size from the shape of seq_lens_this_time
-                    batch_size = self.share_inputs["seq_lens_this_time"].shape[0]
-                    block_tables = self.share_inputs["block_tables"][:batch_size].numpy()
-                    headwise_rows = []
-                    for b in range(batch_size):
-                        # block_tables[b] has format [kv_num_heads * max_blocks_per_head]
-                        # Need to split it into per-head blocks
-                        b_row = block_tables[b]
-                        # Filter out -1 values to get actual blocks per head
-                        valid_blocks = b_row[b_row >= 0]
-                        # In head-wise mode, block_tables are ordered as [head0_blocks, head1_blocks, ...]
-                        blocks_per_head = len(valid_blocks) // self.kv_num_heads
-                        if blocks_per_head == 0:
-                            # No valid blocks, add dummy rows
-                            for h in range(self.kv_num_heads):
-                                headwise_rows.append([-1])
-                            continue
-                        for h in range(self.kv_num_heads):
-                            # Each head gets its own set of block IDs
-                            head_start = h * blocks_per_head
-                            head_end = (h + 1) * blocks_per_head
-                            row = list(valid_blocks[head_start:head_end])
-                            headwise_rows.append(row)
-                    # Determine max_blocks_per_head for padding
-                    max_blocks_per_head = max([len(row) for row in headwise_rows]) if headwise_rows else 0
-                    # Pad rows to max_blocks_per_head
-                    padded_rows = []
-                    for row in headwise_rows:
-                        if len(row) < max_blocks_per_head:
-                            row = row + [-1] * (max_blocks_per_head - len(row))
-                        padded_rows.append(row)
-                    self.share_inputs["block_tables_3d"] = paddle.to_tensor(
-                        np.array(padded_rows, dtype="int32")
-                    )
+                    rows_np = self.share_inputs["block_tables_3d"][
+                        : num_running_requests * self.kv_num_heads
+                    ].numpy()
                     logger.info(
-                        f"[headwise dummy run] block_tables_3d shape={self.share_inputs['block_tables_3d'].shape} "
-                        f"max_blocks_per_head={max_blocks_per_head} "
-                        f"first_rows={self.share_inputs['block_tables_3d'].numpy()[:min(4, len(padded_rows))].tolist() if len(padded_rows) > 0 else []}"
+                        f"[headwise dummy run] block_tables_3d shape={rows_np.shape} "
+                        f"max_blocks_per_head={self.share_inputs['block_tables_3d'].shape[1]} "
+                        f"first_rows={rows_np[:min(4, len(rows_np))].tolist() if len(rows_np) > 0 else []}"
                     )
             else:
                 # In real run, use forward_batch_reqs_list
@@ -1495,6 +1488,10 @@ class GPUModelRunner(ModelRunnerBase):
             routing_replay_table = self.routing_replay_manager.get_routing_table()
 
         num_running_requests = self.share_inputs["seq_lens_this_time"].shape[0]
+        block_tables_3d = self.share_inputs.get("block_tables_3d", None)
+        if self.enable_head_wise_kv_cache and block_tables_3d is not None:
+            active_rows = int(num_running_requests) * self.kv_num_heads
+            block_tables_3d = block_tables_3d[:active_rows, :]
         self.forward_meta = ForwardMeta(
             ids_remove_padding=self.share_inputs["ids_remove_padding"],
             rotary_embs=self.share_inputs["rope_emb"],
@@ -1513,8 +1510,8 @@ class GPUModelRunner(ModelRunnerBase):
             batch_id_per_token=self.share_inputs["batch_id_per_token"],
             cu_seqlens_q=self.share_inputs["cu_seqlens_q"],
             cu_seqlens_k=self.share_inputs["cu_seqlens_k"],
-            block_tables=self.share_inputs["block_tables"][:num_running_requests],
-            block_tables_3d=self.share_inputs.get("block_tables_3d", None),
+            block_tables=self.share_inputs["block_tables"],
+            block_tables_3d=block_tables_3d,
             caches=self.share_inputs["caches"],
             encoder_batch_ids=self.share_inputs["encoder_batch_ids"],
             encoder_tile_ids_per_batch=self.share_inputs["encoder_tile_ids_per_batch"],

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -878,9 +878,8 @@ class GPUModelRunner(ModelRunnerBase):
                     self._update_block_tables_3d_slot(idx, cache_ids_2d, str(request.request_id))
                     if cache_ids_2d:
                         head0_row = cache_ids_2d[0] if cache_ids_2d[0] is not None else []
-                        encoder_block_num, head0_contiguous_len, head0_holes = self._head_wise_row_layout_stats(
-                            head0_row
-                        )
+                        encoder_block_num = sum(1 for cid in head0_row if cid is not None and cid >= 0)
+                        _, head0_contiguous_len, head0_holes = self._head_wise_row_layout_stats(head0_row)
                         if self.head_wise_hole_log and head0_holes > 0:
                             should_log = (
                                 self._head_wise_hole_log_count < 100
@@ -974,9 +973,8 @@ class GPUModelRunner(ModelRunnerBase):
                         self.forward_batch_reqs_list[idx] = request
                     if cache_ids_2d:
                         head0_row = cache_ids_2d[0] if cache_ids_2d[0] is not None else []
-                        encoder_block_num, head0_contiguous_len, head0_holes = self._head_wise_row_layout_stats(
-                            head0_row
-                        )
+                        encoder_block_num = sum(1 for cid in head0_row if cid is not None and cid >= 0)
+                        _, head0_contiguous_len, head0_holes = self._head_wise_row_layout_stats(head0_row)
                         if self.head_wise_hole_log and head0_holes > 0:
                             should_log = (
                                 self._head_wise_hole_log_count < 100
@@ -1210,7 +1208,7 @@ class GPUModelRunner(ModelRunnerBase):
                 block_tables_3d[row_idx, :copy_len] = paddle.to_tensor(flat_block_tables[b][start:end], dtype="int32")
 
     def _normalize_head_wise_cache_ids_2d(self, cache_ids_2d):
-        """Keep sparse per-head rows while normalizing None entries to -1."""
+        """Compact per-head rows to valid cache_ids only, preserving order."""
         if cache_ids_2d is None:
             return None
         normalized_cache_ids_2d = []
@@ -1218,7 +1216,14 @@ class GPUModelRunner(ModelRunnerBase):
             if head_tables is None:
                 normalized_cache_ids_2d.append([])
                 continue
-            normalized_cache_ids_2d.append([(-1 if cid is None else int(cid)) for cid in head_tables])
+            compacted_row = []
+            for cid in head_tables:
+                if cid is None:
+                    continue
+                cid = int(cid)
+                if cid >= 0:
+                    compacted_row.append(cid)
+            normalized_cache_ids_2d.append(compacted_row)
         return normalized_cache_ids_2d
 
     @staticmethod

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1477,12 +1477,18 @@ class GPUModelRunner(ModelRunnerBase):
     def _process_reorder(self) -> None:
         if self.attn_backends and getattr(self.attn_backends[0], "enable_ids_reorder", False):
             self.share_inputs.enable_pd_reorder = True
+            before_reorder = dict(self.share_inputs.index_to_batch_id)
             self.share_inputs.condense()
             reorder_split_prefill_and_decode(input_batch=self.share_inputs)
-            self._sync_forward_batch_reqs_after_reorder()
-            if self.speculative_decoding:
-                if self.spec_method == SpecMethod.MTP:
-                    self.proposer.reorder_inputs(self.share_inputs.index_to_batch_id)
+            after_reorder = self.share_inputs.index_to_batch_id
+            changed = before_reorder != after_reorder
+            if changed:
+                self._sync_forward_batch_reqs_after_reorder()
+                if self.speculative_decoding:
+                    if self.spec_method == SpecMethod.MTP:
+                        self.proposer.reorder_inputs(self.share_inputs.index_to_batch_id)
+            else:
+                return
 
     def _sync_forward_batch_reqs_after_reorder(self) -> None:
         """
@@ -1497,13 +1503,15 @@ class GPUModelRunner(ModelRunnerBase):
 
         list_cap = len(self.forward_batch_reqs_list)
         req_by_batch_id = {}
-        for req in self.forward_batch_reqs_list:
+        old_slot_by_batch_id = {}
+        for slot_idx, req in enumerate(self.forward_batch_reqs_list):
             if req is None:
                 continue
             req_batch_id = getattr(req, "idx", None)
             if req_batch_id is None:
                 continue
             req_by_batch_id[req_batch_id] = req
+            old_slot_by_batch_id[req_batch_id] = slot_idx
 
         aligned_reqs = [None for _ in range(list_cap)]
         for slot_idx, batch_id in index_to_batch_id.items():
@@ -1512,25 +1520,28 @@ class GPUModelRunner(ModelRunnerBase):
             aligned_reqs[slot_idx] = req_by_batch_id.get(batch_id)
 
         self.forward_batch_reqs_list = aligned_reqs
-        if self.enable_head_wise_kv_cache:
-            # InputBatch.swap_states/condense currently only reorders block_tables (2D).
-            # Rebuild block_tables_3d explicitly to keep cache-id rows aligned with reordered slots.
-            self._reset_head_wise_block_tables_state()
-            for slot_idx, req in enumerate(aligned_reqs):
-                if req is None:
-                    continue
-                cache_ids_2d = getattr(req, "block_tables_3d", None)
-                if cache_ids_2d is None and req.block_tables and isinstance(req.block_tables[0], list):
-                    cache_ids_2d = req.block_tables
-                cache_ids_2d = self._normalize_head_wise_cache_ids_2d(cache_ids_2d)
-                if cache_ids_2d is not None:
-                    req.block_tables_3d = cache_ids_2d
-                req_id = getattr(req, "request_id", None)
-                self._update_block_tables_3d_slot(
-                    slot_idx,
-                    cache_ids_2d,
-                    str(req_id) if req_id is not None else None,
-                )
+
+        if not self.enable_head_wise_kv_cache:
+            return
+
+        old_slot_req_ids = list(self._head_wise_slot_req_ids)
+        old_slot_active_rows = [list(rows) for rows in self._head_wise_slot_active_rows]
+        slot_cap = len(old_slot_req_ids)
+
+        new_slot_req_ids = [None for _ in range(slot_cap)]
+        new_slot_active_rows = [[0 for _ in range(self.kv_num_heads)] for _ in range(slot_cap)]
+
+        for new_slot, batch_id in index_to_batch_id.items():
+            if new_slot < 0 or new_slot >= slot_cap:
+                continue
+            old_slot = old_slot_by_batch_id.get(batch_id)
+            if old_slot is None or old_slot < 0 or old_slot >= slot_cap:
+                continue
+            new_slot_req_ids[new_slot] = old_slot_req_ids[old_slot]
+            new_slot_active_rows[new_slot] = list(old_slot_active_rows[old_slot])
+
+        self._head_wise_slot_req_ids = new_slot_req_ids
+        self._head_wise_slot_active_rows = new_slot_active_rows
 
     def load_model(self) -> None:
         """load or download model"""

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -971,9 +971,7 @@ class GPUModelRunner(ModelRunnerBase):
                     else:
                         tables = request.block_tables
                     if current_platform.is_cuda():
-                        async_set_value(
-                            self.share_inputs["block_tables"][idx : idx + 1, : len(tables)], tables
-                        )
+                        async_set_value(self.share_inputs["block_tables"][idx : idx + 1, : len(tables)], tables)
                     else:
                         self.share_inputs["block_tables"][idx : idx + 1, : len(tables)] = np.array(
                             tables, dtype="int32"
@@ -1672,7 +1670,11 @@ class GPUModelRunner(ModelRunnerBase):
             )
             indexer_cache_shape = []
         if kv_cache_quant_type == "block_wise_fp8":
-            kv_cache_scale_shape = [key_cache_shape[0], key_cache_shape[1], key_cache_shape[2]]
+            if self.enable_head_wise_kv_cache:
+                # head-wise: scale layout [max_cache_ids, block_size]
+                kv_cache_scale_shape = [key_cache_shape[0], key_cache_shape[1]]
+            else:
+                kv_cache_scale_shape = [key_cache_shape[0], key_cache_shape[1], key_cache_shape[2]]
         local_rank = self.local_rank % self.parallel_config.tensor_parallel_size
 
         # Check if gpu runner needs to create kv cache

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -126,6 +126,7 @@ class GPUModelRunner(ModelRunnerBase):
         self.enable_head_wise_kv_cache = envs.FD_HEAD_WISE_KV_CACHE == 1
         self.head_wise_debug_log = bool(int(os.getenv("FD_HEAD_WISE_KV_LOG", "0")))
         self._head_wise_debug_log_count = 0
+        self._head_wise_prepare_log_count = 0
         self.kv_num_heads = max(
             1,
             int(self.model_config.num_key_value_heads) // self.parallel_config.tensor_parallel_size,
@@ -934,6 +935,16 @@ class GPUModelRunner(ModelRunnerBase):
                         cache_ids_2d = request.block_tables
                     if cache_ids_2d is not None and getattr(request, "block_tables_3d", None) is None:
                         request.block_tables_3d = cache_ids_2d
+                    # Keep cached request metadata in sync for subsequent forward_meta assembly.
+                    cached_req = self.forward_batch_reqs_list[idx]
+                    if cached_req is not None:
+                        cached_req.block_tables = list(request.block_tables)
+                        if cache_ids_2d is not None:
+                            cached_req.block_tables_3d = cache_ids_2d
+                    else:
+                        logger.warning(
+                            f"[headwise decode] missing cached request at batch idx={idx}, request_id={request.request_id}"
+                        )
                     if cache_ids_2d:
                         encoder_block_num = len(cache_ids_2d[0])
                     else:
@@ -1082,7 +1093,8 @@ class GPUModelRunner(ModelRunnerBase):
                 per_req_head_lens.append([])
 
         if max_blocks_per_head == 0:
-            logger.info(f"[headwise _prepare_block_tables_3d] max_blocks_per_head=0, returning None")
+            if self.head_wise_debug_log:
+                logger.info(f"[headwise _prepare_block_tables_3d] max_blocks_per_head=0, returning None")
             self.share_inputs["block_tables_3d"] = None
             return
 
@@ -1092,7 +1104,8 @@ class GPUModelRunner(ModelRunnerBase):
             cache_ids_2d = getattr(req, "block_tables_3d", None) if req is not None else None
             if cache_ids_2d is None:
                 rows.extend([[-1] * max_blocks_per_head for _ in range(self.kv_num_heads)])
-                logger.info(f"[headwise _prepare_block_tables_3d] req {b}: cache_ids_2d=None, adding dummy rows")
+                if self.head_wise_debug_log:
+                    logger.info(f"[headwise _prepare_block_tables_3d] req {b}: cache_ids_2d=None, adding dummy rows")
                 continue
             for h in range(self.kv_num_heads):
                 if h >= len(cache_ids_2d) or cache_ids_2d[h] is None:
@@ -1116,13 +1129,24 @@ class GPUModelRunner(ModelRunnerBase):
             cache_id_capacity = int(self.share_inputs["caches"][0].shape[0])
         out_of_range_cnt = int((valid_ids >= cache_id_capacity).sum()) if cache_id_capacity > 0 else 0
 
-        logger.info(
-            f"[headwise _prepare_block_tables_3d] shape={block_tables_3d.shape} "
-            f"num_running_requests={num_running_requests} kv_num_heads={self.kv_num_heads} "
-            f"max_blocks_per_head={max_blocks_per_head} min_id={min_id} max_id={max_id} "
-            f"neg_count={neg_count} cache_id_capacity={cache_id_capacity} "
-            f"out_of_range_cnt={out_of_range_cnt} first_rows={rows[:min(4, len(rows))]}"
+        should_log_prepare = self.head_wise_debug_log and (
+            self._head_wise_prepare_log_count < 50 or self._head_wise_prepare_log_count % 100 == 0
         )
+        if should_log_prepare:
+            logger.info(
+                f"[headwise _prepare_block_tables_3d] shape={block_tables_3d.shape} "
+                f"num_running_requests={num_running_requests} kv_num_heads={self.kv_num_heads} "
+                f"max_blocks_per_head={max_blocks_per_head} min_id={min_id} max_id={max_id} "
+                f"neg_count={neg_count} cache_id_capacity={cache_id_capacity} "
+                f"out_of_range_cnt={out_of_range_cnt} first_rows={rows[:min(4, len(rows))]}"
+            )
+        if self.head_wise_debug_log:
+            self._head_wise_prepare_log_count += 1
+        if out_of_range_cnt > 0:
+            logger.error(
+                f"[headwise _prepare_block_tables_3d invalid] out_of_range_cnt={out_of_range_cnt}, "
+                f"cache_id_capacity={cache_id_capacity}, min_id={min_id}, max_id={max_id}"
+            )
         if self.head_wise_debug_log and self._head_wise_debug_log_count < 20:
             logger.info(
                 f"[headwise _prepare_block_tables_3d details] per_req_head_lens={per_req_head_lens[:num_running_requests]}"

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -870,7 +870,7 @@ class GPUModelRunner(ModelRunnerBase):
                     cache_ids_2d = getattr(request, "block_tables_3d", None)
                     if cache_ids_2d is None and request.block_tables and isinstance(request.block_tables[0], list):
                         cache_ids_2d = request.block_tables
-                    cache_ids_2d = self._compact_head_wise_cache_ids_2d(cache_ids_2d)
+                    cache_ids_2d = self._normalize_head_wise_cache_ids_2d(cache_ids_2d)
                     if cache_ids_2d is not None:
                         request.block_tables_3d = cache_ids_2d
                     if cache_ids_2d:
@@ -887,6 +887,8 @@ class GPUModelRunner(ModelRunnerBase):
                         # block_tables format: [bsz, kv_num_heads * max_blocks_per_head]
                         tables = []
                         for head_tables in cache_ids_2d:
+                            if head_tables is None:
+                                continue
                             tables.extend(head_tables)
                         if self.head_wise_debug_log and _debug_logging_enabled():
                             logger.debug(f"[headwise prefill] req {idx} cache_ids_2d={cache_ids_2d} tables={tables}")
@@ -941,7 +943,7 @@ class GPUModelRunner(ModelRunnerBase):
                     cache_ids_2d = getattr(request, "block_tables_3d", None)
                     if cache_ids_2d is None and request.block_tables and isinstance(request.block_tables[0], list):
                         cache_ids_2d = request.block_tables
-                    cache_ids_2d = self._compact_head_wise_cache_ids_2d(cache_ids_2d)
+                    cache_ids_2d = self._normalize_head_wise_cache_ids_2d(cache_ids_2d)
                     if cache_ids_2d is not None:
                         request.block_tables_3d = cache_ids_2d
                     # Keep cached request metadata in sync for subsequent forward_meta assembly.
@@ -967,6 +969,8 @@ class GPUModelRunner(ModelRunnerBase):
                         # block_tables format: [bsz, kv_num_heads * max_blocks_per_head]
                         tables = []
                         for head_tables in cache_ids_2d:
+                            if head_tables is None:
+                                continue
                             tables.extend(head_tables)
                     else:
                         tables = request.block_tables
@@ -1097,19 +1101,18 @@ class GPUModelRunner(ModelRunnerBase):
         flat_block_tables = self.share_inputs["block_tables"][:num_running_requests].numpy()
         max_blocks_per_head = block_tables_3d.shape[1]
         for b in range(num_running_requests):
-            valid_blocks = flat_block_tables[b][flat_block_tables[b] >= 0]
-            if valid_blocks.size == 0:
-                continue
-            blocks_per_head = int(valid_blocks.size) // self.kv_num_heads
-            if blocks_per_head <= 0:
-                continue
-            copy_len = min(blocks_per_head, max_blocks_per_head)
             for h in range(self.kv_num_heads):
-                start = h * blocks_per_head
-                end = start + copy_len
-                if end <= valid_blocks.size:
-                    row_idx = b * self.kv_num_heads + h
-                    block_tables_3d[row_idx, :copy_len] = paddle.to_tensor(valid_blocks[start:end], dtype="int32")
+                start = h * max_blocks_per_head
+                if start >= flat_block_tables.shape[1]:
+                    break
+                end = min(start + max_blocks_per_head, flat_block_tables.shape[1])
+                copy_len = end - start
+                if copy_len <= 0:
+                    continue
+                row_idx = b * self.kv_num_heads + h
+                block_tables_3d[row_idx, :copy_len] = paddle.to_tensor(
+                    flat_block_tables[b][start:end], dtype="int32"
+                )
 
     def _prepare_block_tables_3d(self, num_running_requests: int):
         if not self.enable_head_wise_kv_cache:
@@ -1146,12 +1149,15 @@ class GPUModelRunner(ModelRunnerBase):
                     continue
 
                 row = cache_ids_2d[h]
-                compact_row = [cid for cid in row if cid is not None and cid >= 0]
-                head_lens.append(len(compact_row))
-                copy_len = min(len(compact_row), max_blocks_per_head)
+                valid_cnt = sum(1 for cid in row if cid is not None and cid >= 0)
+                head_lens.append(valid_cnt)
+                normalized_row = [(-1 if cid is None else int(cid)) for cid in row]
+                copy_len = min(len(normalized_row), max_blocks_per_head)
                 if copy_len > 0:
                     row_idx = b * self.kv_num_heads + h
-                    block_tables_3d[row_idx, :copy_len] = paddle.to_tensor(compact_row[:copy_len], dtype="int32")
+                    block_tables_3d[row_idx, :copy_len] = paddle.to_tensor(
+                        normalized_row[:copy_len], dtype="int32"
+                    )
             per_req_head_lens.append(head_lens)
 
         # Fallback for dummy/profile or missing request cache metadata.
@@ -1196,17 +1202,17 @@ class GPUModelRunner(ModelRunnerBase):
             )
             self._head_wise_debug_log_count += 1
 
-    def _compact_head_wise_cache_ids_2d(self, cache_ids_2d):
-        """Remove recycled holes (-1) from per-head cache rows."""
+    def _normalize_head_wise_cache_ids_2d(self, cache_ids_2d):
+        """Keep sparse per-head rows while normalizing None entries to -1."""
         if cache_ids_2d is None:
             return None
-        compact_cache_ids_2d = []
+        normalized_cache_ids_2d = []
         for head_tables in cache_ids_2d:
             if head_tables is None:
-                compact_cache_ids_2d.append([])
+                normalized_cache_ids_2d.append([])
                 continue
-            compact_cache_ids_2d.append([cid for cid in head_tables if cid is not None and cid >= 0])
-        return compact_cache_ids_2d
+            normalized_cache_ids_2d.append([(-1 if cid is None else int(cid)) for cid in head_tables])
+        return normalized_cache_ids_2d
 
     def insert_prefill_inputs(self, req_dicts: List[Request], num_running_requests: int):
         raise NotImplementedError("GPUs only support KVCACHE SCHEDULER V1 in versions 2.6 and above.")

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -124,6 +124,8 @@ class GPUModelRunner(ModelRunnerBase):
         self.local_rank = local_rank
         self.device_id = device_id
         self.enable_head_wise_kv_cache = envs.FD_HEAD_WISE_KV_CACHE == 1
+        self.head_wise_debug_log = bool(int(os.getenv("FD_HEAD_WISE_KV_LOG", "0")))
+        self._head_wise_debug_log_count = 0
         self.kv_num_heads = max(
             1,
             int(self.model_config.num_key_value_heads) // self.parallel_config.tensor_parallel_size,
@@ -1058,13 +1060,18 @@ class GPUModelRunner(ModelRunnerBase):
             return
 
         max_blocks_per_head = 0
+        per_req_head_lens = []
         cache_ids_per_req = []
         for b in range(num_running_requests):
             req = self.forward_batch_reqs_list[b]
             cache_ids_2d = getattr(req, "block_tables_3d", None) if req is not None else None
             cache_ids_per_req.append(cache_ids_2d)
             if cache_ids_2d and len(cache_ids_2d) > 0:
+                head_lens = [len(head_ids) if head_ids is not None else 0 for head_ids in cache_ids_2d]
+                per_req_head_lens.append(head_lens)
                 max_blocks_per_head = max(max_blocks_per_head, len(cache_ids_2d[0]))
+            else:
+                per_req_head_lens.append([])
 
         if max_blocks_per_head == 0:
             logger.info(f"[headwise _prepare_block_tables_3d] max_blocks_per_head=0, returning None")
@@ -1080,20 +1087,39 @@ class GPUModelRunner(ModelRunnerBase):
                 logger.info(f"[headwise _prepare_block_tables_3d] req {b}: cache_ids_2d=None, adding dummy rows")
                 continue
             for h in range(self.kv_num_heads):
-                row = list(cache_ids_2d[h])
+                if h >= len(cache_ids_2d) or cache_ids_2d[h] is None:
+                    row = []
+                else:
+                    row = list(cache_ids_2d[h])
                 if len(row) < max_blocks_per_head:
                     row.extend([-1] * (max_blocks_per_head - len(row)))
                 rows.append(row)
 
         block_tables_3d = paddle.to_tensor(np.array(rows, dtype="int32"))
         self.share_inputs["block_tables_3d"] = block_tables_3d
+        rows_np = np.array(rows, dtype="int32")
+        valid_ids = rows_np[rows_np >= 0]
+        min_id = int(valid_ids.min()) if valid_ids.size > 0 else -1
+        max_id = int(valid_ids.max()) if valid_ids.size > 0 else -1
+        neg_count = int((rows_np < 0).sum())
+
+        cache_id_capacity = -1
+        if self.share_inputs.get("caches") and len(self.share_inputs["caches"]) > 0:
+            cache_id_capacity = int(self.share_inputs["caches"][0].shape[0])
+        out_of_range_cnt = int((valid_ids >= cache_id_capacity).sum()) if cache_id_capacity > 0 else 0
+
         logger.info(
             f"[headwise _prepare_block_tables_3d] shape={block_tables_3d.shape} "
-            f"num_running_requests={num_running_requests} "
-            f"kv_num_heads={self.kv_num_heads} "
-            f"max_blocks_per_head={max_blocks_per_head} "
-            f"first_rows={rows[:min(4, len(rows))]}"
+            f"num_running_requests={num_running_requests} kv_num_heads={self.kv_num_heads} "
+            f"max_blocks_per_head={max_blocks_per_head} min_id={min_id} max_id={max_id} "
+            f"neg_count={neg_count} cache_id_capacity={cache_id_capacity} "
+            f"out_of_range_cnt={out_of_range_cnt} first_rows={rows[:min(4, len(rows))]}"
         )
+        if self.head_wise_debug_log and self._head_wise_debug_log_count < 20:
+            logger.info(
+                f"[headwise _prepare_block_tables_3d details] per_req_head_lens={per_req_head_lens[:num_running_requests]}"
+            )
+            self._head_wise_debug_log_count += 1
 
     def insert_prefill_inputs(self, req_dicts: List[Request], num_running_requests: int):
         raise NotImplementedError("GPUs only support KVCACHE SCHEDULER V1 in versions 2.6 and above.")

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1078,7 +1078,11 @@ class GPUModelRunner(ModelRunnerBase):
 
         self.share_inputs["seq_lens_this_time"] = self.share_inputs["seq_lens_this_time_buffer"][:num_running_requests]
         if self.spec_method == SpecMethod.MTP:
-            self.proposer.insert_tasks_v1(req_dicts, num_running_requests, self.share_inputs.index_to_batch_id)
+            try:
+                self.proposer.insert_tasks_v1(req_dicts, num_running_requests, self.share_inputs.index_to_batch_id)
+            except TypeError:
+                # Backward compatibility with older proposer signature.
+                self.proposer.insert_tasks_v1(req_dicts, num_running_requests)
 
     def _get_head_wise_block_tables_buffer(self) -> paddle.Tensor:
         block_tables_3d = self.share_inputs.get("block_tables_3d", None)
@@ -1505,7 +1509,11 @@ class GPUModelRunner(ModelRunnerBase):
                 self._sync_forward_batch_reqs_after_reorder()
                 if self.speculative_decoding:
                     if self.spec_method == SpecMethod.MTP:
-                        self.proposer.reorder_inputs(self.share_inputs.index_to_batch_id)
+                        try:
+                            self.proposer.reorder_inputs(self.share_inputs.index_to_batch_id)
+                        except TypeError:
+                            # Backward compatibility with older proposer signature.
+                            self.proposer.reorder_inputs()
             else:
                 return
 
@@ -1617,7 +1625,6 @@ class GPUModelRunner(ModelRunnerBase):
         routing_replay_table = None
         if self.routing_replay_manager is not None:
             routing_replay_table = self.routing_replay_manager.get_routing_table()
-
         num_running_requests = self.share_inputs["seq_lens_this_time"].shape[0]
         block_tables_3d = self.share_inputs.get("block_tables_3d", None)
         if self.enable_head_wise_kv_cache and block_tables_3d is not None:
@@ -1641,7 +1648,7 @@ class GPUModelRunner(ModelRunnerBase):
             batch_id_per_token=self.share_inputs["batch_id_per_token"],
             cu_seqlens_q=self.share_inputs["cu_seqlens_q"],
             cu_seqlens_k=self.share_inputs["cu_seqlens_k"],
-            block_tables=self.share_inputs["block_tables"],
+            block_tables=self.share_inputs["block_tables"][:num_running_requests],
             block_tables_3d=block_tables_3d,
             caches=self.share_inputs["caches"],
             encoder_batch_ids=self.share_inputs["encoder_batch_ids"],
@@ -2097,7 +2104,7 @@ class GPUModelRunner(ModelRunnerBase):
             enable_pd_reorder=getattr(self.share_inputs, "enable_pd_reorder", False),
         )
 
-        post_process(
+        post_process_kwargs = dict(
             sampler_or_pooler_output=sampler_output,
             model_output=model_output_data,
             share_inputs=self.share_inputs,
@@ -2109,7 +2116,17 @@ class GPUModelRunner(ModelRunnerBase):
             think_end_id=self.model_config.think_end_id,
             splitwise_role_is_decode=self.scheduler_config.splitwise_role == "decode",
             enable_entropy=self.enable_entropy and self.parallel_config.tensor_parallel_rank == 0,
+            is_naive_mode=(self.speculative_decoding and self.proposer is None),
+            prefill_one_step_stop=self.parallel_config.prefill_one_step_stop,
         )
+        try:
+            post_process(**post_process_kwargs)
+        except TypeError:
+            # Backward/forward compatibility with post_process signatures that
+            # do not accept speculative compatibility kwargs.
+            post_process_kwargs.pop("is_naive_mode", None)
+            post_process_kwargs.pop("prefill_one_step_stop", None)
+            post_process(**post_process_kwargs)
         self.exist_prefill_flag = False
         if self.speculative_decoding:
             if self.spec_method == SpecMethod.MTP:

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1208,22 +1208,24 @@ class GPUModelRunner(ModelRunnerBase):
                 block_tables_3d[row_idx, :copy_len] = paddle.to_tensor(flat_block_tables[b][start:end], dtype="int32")
 
     def _normalize_head_wise_cache_ids_2d(self, cache_ids_2d):
-        """Compact per-head rows to valid cache_ids only, preserving order."""
+        """Normalize per-head cache rows while preserving block index layout."""
         if cache_ids_2d is None:
             return None
+
         normalized_cache_ids_2d = []
         for head_tables in cache_ids_2d:
             if head_tables is None:
                 normalized_cache_ids_2d.append([])
                 continue
-            compacted_row = []
-            for cid in head_tables:
-                if cid is None:
-                    continue
-                cid = int(cid)
-                if cid >= 0:
-                    compacted_row.append(cid)
-            normalized_cache_ids_2d.append(compacted_row)
+
+            # Keep row indices stable: None -> -1, keep negative holes in-place.
+            normalized_row = [(-1 if cid is None else int(cid)) for cid in head_tables]
+
+            # Trim only trailing invalid entries to keep row compact.
+            while normalized_row and normalized_row[-1] < 0:
+                normalized_row.pop()
+
+            normalized_cache_ids_2d.append(normalized_row)
         return normalized_cache_ids_2d
 
     @staticmethod

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -977,8 +977,6 @@ class GPUModelRunner(ModelRunnerBase):
                         self.share_inputs["block_tables"][idx : idx + 1, : len(tables)] = np.array(
                             tables, dtype="int32"
                         )
-                if self.share_inputs["is_block_step"][idx]:  # has tasks to continue to decode
-                    has_decode_task = True
                 self.share_inputs["preempted_idx"][idx : idx + 1, :] = 0
                 continue
             else:  # preempted task

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -230,6 +230,7 @@ class GPUModelRunner(ModelRunnerBase):
         # Initialize input batch
         self.share_inputs = InputBatch(self.fd_config)
         self.share_inputs.init_share_inputs()
+        self._init_head_wise_slot_states()
         self.increment_value = (
             4 if not self.speculative_decoding else (self.speculative_config.num_speculative_tokens + 1) * 4
         )
@@ -873,6 +874,7 @@ class GPUModelRunner(ModelRunnerBase):
                     cache_ids_2d = self._normalize_head_wise_cache_ids_2d(cache_ids_2d)
                     if cache_ids_2d is not None:
                         request.block_tables_3d = cache_ids_2d
+                    self._update_block_tables_3d_slot(idx, cache_ids_2d, str(request.request_id))
                     if cache_ids_2d:
                         encoder_block_num = len(cache_ids_2d[0])
                     else:
@@ -946,6 +948,7 @@ class GPUModelRunner(ModelRunnerBase):
                     cache_ids_2d = self._normalize_head_wise_cache_ids_2d(cache_ids_2d)
                     if cache_ids_2d is not None:
                         request.block_tables_3d = cache_ids_2d
+                    self._update_block_tables_3d_slot(idx, cache_ids_2d, str(request.request_id))
                     # Keep cached request metadata in sync for subsequent forward_meta assembly.
                     cached_req = self.forward_batch_reqs_list[idx]
                     if cached_req is not None:
@@ -997,6 +1000,7 @@ class GPUModelRunner(ModelRunnerBase):
                 self.prompt_logprobs_reqs.pop(request.request_id, None)
                 self.in_progress_prompt_logprobs.pop(request.request_id, None)
                 self.forward_batch_reqs_list[idx] = None
+                self._clear_block_tables_3d_slot(idx)
 
                 # Routing Replay
                 if self.fd_config.routing_replay_config.enable_routing_replay:
@@ -1088,6 +1092,68 @@ class GPUModelRunner(ModelRunnerBase):
         self.share_inputs["block_tables_3d"] = block_tables_3d
         return block_tables_3d
 
+    def _init_head_wise_slot_states(self) -> None:
+        slot_cap = self.scheduler_config.max_num_seqs
+        self._head_wise_slot_req_ids: list[Optional[str]] = [None for _ in range(slot_cap)]
+        self._head_wise_slot_active_rows: list[list[int]] = [[0 for _ in range(self.kv_num_heads)] for _ in range(slot_cap)]
+
+    def _clear_block_tables_3d_slot(self, idx: int) -> None:
+        if not self.enable_head_wise_kv_cache:
+            return
+        if idx < 0 or idx >= len(self._head_wise_slot_active_rows):
+            return
+
+        block_tables_3d = self.share_inputs.get("block_tables_3d", None)
+        active_lens = self._head_wise_slot_active_rows[idx]
+        if block_tables_3d is not None:
+            max_blocks_per_head = block_tables_3d.shape[1]
+            base_row = idx * self.kv_num_heads
+            for h in range(self.kv_num_heads):
+                clear_len = min(int(active_lens[h]), max_blocks_per_head)
+                if clear_len > 0:
+                    block_tables_3d[base_row + h, :clear_len] = -1
+        for h in range(self.kv_num_heads):
+            active_lens[h] = 0
+        self._head_wise_slot_req_ids[idx] = None
+
+    def _update_block_tables_3d_slot(self, idx: int, cache_ids_2d, req_id: Optional[str] = None) -> None:
+        if not self.enable_head_wise_kv_cache:
+            return
+        if idx < 0 or idx >= len(self._head_wise_slot_active_rows):
+            return
+        if cache_ids_2d is None:
+            self._clear_block_tables_3d_slot(idx)
+            return
+
+        if req_id is not None and self._head_wise_slot_req_ids[idx] not in (None, req_id):
+            self._clear_block_tables_3d_slot(idx)
+
+        block_tables_3d = self._get_head_wise_block_tables_buffer()
+        max_blocks_per_head = block_tables_3d.shape[1]
+        base_row = idx * self.kv_num_heads
+        active_lens = self._head_wise_slot_active_rows[idx]
+
+        for h in range(self.kv_num_heads):
+            clear_len = min(int(active_lens[h]), max_blocks_per_head)
+            if clear_len > 0:
+                block_tables_3d[base_row + h, :clear_len] = -1
+
+            row = cache_ids_2d[h] if h < len(cache_ids_2d) and cache_ids_2d[h] is not None else []
+            copy_len = min(len(row), max_blocks_per_head)
+            if copy_len > 0:
+                normalized_row = [(-1 if cid is None else int(cid)) for cid in row[:copy_len]]
+                block_tables_3d[base_row + h, :copy_len] = paddle.to_tensor(normalized_row, dtype="int32")
+            active_lens[h] = copy_len
+
+        self._head_wise_slot_req_ids[idx] = req_id
+
+    def _reset_head_wise_block_tables_state(self) -> None:
+        self._init_head_wise_slot_states()
+        if self.enable_head_wise_kv_cache:
+            block_tables_3d = self.share_inputs.get("block_tables_3d", None)
+            if block_tables_3d is not None:
+                block_tables_3d[:] = -1
+
     def _prepare_block_tables_3d_from_flat_tables(self, num_running_requests: int):
         """
         Build head-wise tables from flattened self.share_inputs["block_tables"] in-place.
@@ -1125,32 +1191,41 @@ class GPUModelRunner(ModelRunnerBase):
 
         max_blocks_per_head = block_tables_3d.shape[1]
         has_request_level_tables = False
-        per_req_head_lens = []
+        collect_prepare_debug_stats = self.head_wise_debug_log and _debug_logging_enabled()
+        should_log_prepare = (
+            collect_prepare_debug_stats
+            and (self._head_wise_prepare_log_count < 50 or self._head_wise_prepare_log_count % 100 == 0)
+        )
+        per_req_head_lens = [] if collect_prepare_debug_stats else None
         req_list = getattr(self, "forward_batch_reqs_list", None)
 
         for b in range(num_running_requests):
             if req_list is None or b >= len(req_list):
-                per_req_head_lens.append([])
+                if per_req_head_lens is not None:
+                    per_req_head_lens.append([])
                 continue
 
             req = req_list[b]
             cache_ids_2d = getattr(req, "block_tables_3d", None) if req is not None else None
             if cache_ids_2d is None:
-                if self.head_wise_debug_log and _debug_logging_enabled():
+                if collect_prepare_debug_stats:
                     logger.debug(f"[headwise _prepare_block_tables_3d] req {b}: cache_ids_2d=None, keep rows as -1")
-                per_req_head_lens.append([])
+                if per_req_head_lens is not None:
+                    per_req_head_lens.append([])
                 continue
 
             has_request_level_tables = True
-            head_lens = []
+            head_lens = [] if per_req_head_lens is not None else None
             for h in range(self.kv_num_heads):
                 if h >= len(cache_ids_2d) or cache_ids_2d[h] is None:
-                    head_lens.append(0)
+                    if head_lens is not None:
+                        head_lens.append(0)
                     continue
 
                 row = cache_ids_2d[h]
-                valid_cnt = sum(1 for cid in row if cid is not None and cid >= 0)
-                head_lens.append(valid_cnt)
+                if head_lens is not None:
+                    valid_cnt = sum(1 for cid in row if cid is not None and cid >= 0)
+                    head_lens.append(valid_cnt)
                 normalized_row = [(-1 if cid is None else int(cid)) for cid in row]
                 copy_len = min(len(normalized_row), max_blocks_per_head)
                 if copy_len > 0:
@@ -1158,47 +1233,45 @@ class GPUModelRunner(ModelRunnerBase):
                     block_tables_3d[row_idx, :copy_len] = paddle.to_tensor(
                         normalized_row[:copy_len], dtype="int32"
                     )
-            per_req_head_lens.append(head_lens)
+            if per_req_head_lens is not None:
+                per_req_head_lens.append(head_lens)
 
         # Fallback for dummy/profile or missing request cache metadata.
         if not has_request_level_tables:
             self._prepare_block_tables_3d_from_flat_tables(num_running_requests)
 
-        active_rows = block_tables_3d[: num_running_requests * self.kv_num_heads]
-        rows_np = active_rows.numpy()
-        valid_ids = rows_np[rows_np >= 0]
-        min_id = int(valid_ids.min()) if valid_ids.size > 0 else -1
-        max_id = int(valid_ids.max()) if valid_ids.size > 0 else -1
-        neg_count = int((rows_np < 0).sum())
+        if collect_prepare_debug_stats:
+            active_rows = block_tables_3d[: num_running_requests * self.kv_num_heads]
+            rows_np = active_rows.numpy()
+            valid_ids = rows_np[rows_np >= 0]
+            min_id = int(valid_ids.min()) if valid_ids.size > 0 else -1
+            max_id = int(valid_ids.max()) if valid_ids.size > 0 else -1
+            neg_count = int((rows_np < 0).sum())
 
-        cache_id_capacity = -1
-        if self.share_inputs.get("caches") and len(self.share_inputs["caches"]) > 0:
-            cache_id_capacity = int(self.share_inputs["caches"][0].shape[0])
-        out_of_range_cnt = int((valid_ids >= cache_id_capacity).sum()) if cache_id_capacity > 0 else 0
+            cache_id_capacity = -1
+            if self.share_inputs.get("caches") and len(self.share_inputs["caches"]) > 0:
+                cache_id_capacity = int(self.share_inputs["caches"][0].shape[0])
+            out_of_range_cnt = int((valid_ids >= cache_id_capacity).sum()) if cache_id_capacity > 0 else 0
 
-        should_log_prepare = (
-            self.head_wise_debug_log
-            and _debug_logging_enabled()
-            and (self._head_wise_prepare_log_count < 50 or self._head_wise_prepare_log_count % 100 == 0)
-        )
-        if should_log_prepare:
-            logger.debug(
-                f"[headwise _prepare_block_tables_3d] shape={active_rows.shape} "
-                f"num_running_requests={num_running_requests} kv_num_heads={self.kv_num_heads} "
-                f"max_blocks_per_head={max_blocks_per_head} min_id={min_id} max_id={max_id} "
-                f"neg_count={neg_count} cache_id_capacity={cache_id_capacity} "
-                f"out_of_range_cnt={out_of_range_cnt} first_rows={rows_np[:min(4, len(rows_np))].tolist()}"
-            )
+            if should_log_prepare:
+                logger.debug(
+                    f"[headwise _prepare_block_tables_3d] shape={active_rows.shape} "
+                    f"num_running_requests={num_running_requests} kv_num_heads={self.kv_num_heads} "
+                    f"max_blocks_per_head={max_blocks_per_head} min_id={min_id} max_id={max_id} "
+                    f"neg_count={neg_count} cache_id_capacity={cache_id_capacity} "
+                    f"out_of_range_cnt={out_of_range_cnt} first_rows={rows_np[:min(4, len(rows_np))].tolist()}"
+                )
+            if out_of_range_cnt > 0:
+                logger.error(
+                    f"[headwise _prepare_block_tables_3d invalid] out_of_range_cnt={out_of_range_cnt}, "
+                    f"cache_id_capacity={cache_id_capacity}, min_id={min_id}, max_id={max_id}"
+                )
         if self.head_wise_debug_log:
             self._head_wise_prepare_log_count += 1
-        if out_of_range_cnt > 0:
-            logger.error(
-                f"[headwise _prepare_block_tables_3d invalid] out_of_range_cnt={out_of_range_cnt}, "
-                f"cache_id_capacity={cache_id_capacity}, min_id={min_id}, max_id={max_id}"
-            )
-        if self.head_wise_debug_log and _debug_logging_enabled() and self._head_wise_debug_log_count < 20:
+        if collect_prepare_debug_stats and self._head_wise_debug_log_count < 20:
             logger.debug(
-                f"[headwise _prepare_block_tables_3d details] per_req_head_lens={per_req_head_lens[:num_running_requests]}"
+                f"[headwise _prepare_block_tables_3d details] "
+                f"per_req_head_lens={per_req_head_lens[:num_running_requests]}"
             )
             self._head_wise_debug_log_count += 1
 
@@ -1376,10 +1449,6 @@ class GPUModelRunner(ModelRunnerBase):
                         f"max_blocks_per_head={self.share_inputs['block_tables_3d'].shape[1]} "
                         f"first_rows={rows_np[:min(4, len(rows_np))].tolist() if len(rows_np) > 0 else []}"
                     )
-            else:
-                # In real run, use forward_batch_reqs_list
-                num_running_requests = int(self.share_inputs["seq_lens_this_time"].shape[0])
-                self._prepare_block_tables_3d(num_running_requests)
         logprobs_reqs = [
             req
             for req in self.forward_batch_reqs_list
@@ -1501,6 +1570,8 @@ class GPUModelRunner(ModelRunnerBase):
 
         list_cap = len(self.forward_batch_reqs_list)
         req_by_batch_id = {}
+        slot_rows_by_batch_id = {}
+        slot_req_id_by_batch_id = {}
         for req in self.forward_batch_reqs_list:
             if req is None:
                 continue
@@ -1508,14 +1579,35 @@ class GPUModelRunner(ModelRunnerBase):
             if req_batch_id is None:
                 continue
             req_by_batch_id[req_batch_id] = req
+        if self.enable_head_wise_kv_cache:
+            for slot_idx, req in enumerate(self.forward_batch_reqs_list):
+                if req is None:
+                    continue
+                req_batch_id = getattr(req, "idx", None)
+                if req_batch_id is None:
+                    continue
+                slot_rows_by_batch_id[req_batch_id] = list(self._head_wise_slot_active_rows[slot_idx])
+                slot_req_id_by_batch_id[req_batch_id] = self._head_wise_slot_req_ids[slot_idx]
 
         aligned_reqs = [None for _ in range(list_cap)]
+        aligned_slot_active_rows = (
+            [[0 for _ in range(self.kv_num_heads)] for _ in range(list_cap)]
+            if self.enable_head_wise_kv_cache
+            else None
+        )
+        aligned_slot_req_ids = [None for _ in range(list_cap)] if self.enable_head_wise_kv_cache else None
         for slot_idx, batch_id in index_to_batch_id.items():
             if slot_idx < 0 or slot_idx >= list_cap:
                 continue
             aligned_reqs[slot_idx] = req_by_batch_id.get(batch_id)
+            if self.enable_head_wise_kv_cache and batch_id in slot_rows_by_batch_id:
+                aligned_slot_active_rows[slot_idx] = slot_rows_by_batch_id[batch_id]
+                aligned_slot_req_ids[slot_idx] = slot_req_id_by_batch_id.get(batch_id)
 
         self.forward_batch_reqs_list = aligned_reqs
+        if self.enable_head_wise_kv_cache:
+            self._head_wise_slot_active_rows = aligned_slot_active_rows
+            self._head_wise_slot_req_ids = aligned_slot_req_ids
 
     def load_model(self) -> None:
         """load or download model"""
@@ -2979,9 +3071,13 @@ class GPUModelRunner(ModelRunnerBase):
         self.in_progress_prompt_logprobs.clear()
         self.forward_batch_reqs_list = [None for _ in range(self.scheduler_config.max_num_seqs)]
 
+        self._reset_head_wise_block_tables_state()
         # Routing Replay
         if self.routing_replay_manager:
-            self.routing_replay_manager.clear_all_request()
+            if hasattr(self.routing_replay_manager, "put_table_to_store"):
+                self.routing_replay_manager.put_table_to_store()
+            else:
+                self.routing_replay_manager.clear_all_request()
 
     def update_parameters(self, pid):
         """Dynamic model loader use to update parameters use for RL"""
@@ -2992,6 +3088,7 @@ class GPUModelRunner(ModelRunnerBase):
 
         # Reset share_inputs
         self.share_inputs.reset_share_inputs()
+        self._reset_head_wise_block_tables_state()
         if self.spec_method == SpecMethod.MTP:
             self.proposer.model_inputs.reset_model_inputs()
             self.proposer.initialize_kv_cache(main_model_num_blocks=self.num_gpu_blocks)

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1327,7 +1327,7 @@ class GPUModelRunner(ModelRunnerBase):
         if self.enable_head_wise_kv_cache:
             if is_dummy_or_profile_run:
                 # In dummy/profile run, construct block_tables_3d from block_tables
-                num_running_requests = int((self.share_inputs["seq_lens_this_time"] > 0).sum().item())
+                num_running_requests = int(self.share_inputs["seq_lens_this_time"].shape[0])
                 self._prepare_block_tables_3d_from_flat_tables(num_running_requests)
                 if num_running_requests > 0:
                     rows_np = self.share_inputs["block_tables_3d"][
@@ -1340,7 +1340,7 @@ class GPUModelRunner(ModelRunnerBase):
                     )
             else:
                 # In real run, use forward_batch_reqs_list
-                num_running_requests = int((self.share_inputs["seq_lens_this_time"] > 0).sum().item())
+                num_running_requests = int(self.share_inputs["seq_lens_this_time"].shape[0])
                 self._prepare_block_tables_3d(num_running_requests)
         logprobs_reqs = [
             req
@@ -1445,9 +1445,39 @@ class GPUModelRunner(ModelRunnerBase):
             self.share_inputs.enable_pd_reorder = True
             self.share_inputs.condense()
             reorder_split_prefill_and_decode(input_batch=self.share_inputs)
+            self._sync_forward_batch_reqs_after_reorder()
             if self.speculative_decoding:
                 if self.spec_method == SpecMethod.MTP:
                     self.proposer.reorder_inputs(self.share_inputs.index_to_batch_id)
+
+    def _sync_forward_batch_reqs_after_reorder(self) -> None:
+        """
+        Keep forward_batch_reqs_list aligned with current batch slots after PD reorder.
+
+        InputBatch reorder updates share_inputs tensors and index_to_batch_id mapping,
+        but forward_batch_reqs_list needs to be realigned explicitly.
+        """
+        index_to_batch_id = getattr(self.share_inputs, "index_to_batch_id", None)
+        if not index_to_batch_id:
+            return
+
+        list_cap = len(self.forward_batch_reqs_list)
+        req_by_batch_id = {}
+        for req in self.forward_batch_reqs_list:
+            if req is None:
+                continue
+            req_batch_id = getattr(req, "idx", None)
+            if req_batch_id is None:
+                continue
+            req_by_batch_id[req_batch_id] = req
+
+        aligned_reqs = [None for _ in range(list_cap)]
+        for slot_idx, batch_id in index_to_batch_id.items():
+            if slot_idx < 0 or slot_idx >= list_cap:
+                continue
+            aligned_reqs[slot_idx] = req_by_batch_id.get(batch_id)
+
+        self.forward_batch_reqs_list = aligned_reqs
 
     def load_model(self) -> None:
         """load or download model"""

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -888,14 +888,10 @@ class GPUModelRunner(ModelRunnerBase):
                         for head_tables in cache_ids_2d:
                             tables.extend(head_tables)
                         if self.head_wise_debug_log and _debug_logging_enabled():
-                            logger.debug(
-                                f"[headwise prefill] req {idx} cache_ids_2d={cache_ids_2d} tables={tables}"
-                            )
+                            logger.debug(f"[headwise prefill] req {idx} cache_ids_2d={cache_ids_2d} tables={tables}")
                     else:
                         tables = request.block_tables
-                    self.share_inputs["block_tables"][idx : idx + 1, :len(tables)] = np.array(
-                        tables, dtype="int32"
-                    )
+                    self.share_inputs["block_tables"][idx : idx + 1, : len(tables)] = np.array(tables, dtype="int32")
                 self.share_inputs["stop_flags"][idx : idx + 1] = False
                 self.share_inputs["seq_lens_decoder"][idx : idx + 1] = prefill_start_index
                 self.share_inputs["seq_lens_this_time_buffer"][idx : idx + 1] = length
@@ -975,10 +971,10 @@ class GPUModelRunner(ModelRunnerBase):
                         tables = request.block_tables
                     if current_platform.is_cuda():
                         async_set_value(
-                            self.share_inputs["block_tables"][idx : idx + 1, :len(tables)], tables
+                            self.share_inputs["block_tables"][idx : idx + 1, : len(tables)], tables
                         )
                     else:
-                        self.share_inputs["block_tables"][idx : idx + 1, :len(tables)] = np.array(
+                        self.share_inputs["block_tables"][idx : idx + 1, : len(tables)] = np.array(
                             tables, dtype="int32"
                         )
                 if self.share_inputs["is_block_step"][idx]:  # has tasks to continue to decode
@@ -1167,8 +1163,10 @@ class GPUModelRunner(ModelRunnerBase):
             cache_id_capacity = int(self.share_inputs["caches"][0].shape[0])
         out_of_range_cnt = int((valid_ids >= cache_id_capacity).sum()) if cache_id_capacity > 0 else 0
 
-        should_log_prepare = self.head_wise_debug_log and _debug_logging_enabled() and (
-            self._head_wise_prepare_log_count < 50 or self._head_wise_prepare_log_count % 100 == 0
+        should_log_prepare = (
+            self.head_wise_debug_log
+            and _debug_logging_enabled()
+            and (self._head_wise_prepare_log_count < 50 or self._head_wise_prepare_log_count % 100 == 0)
         )
         if should_log_prepare:
             logger.debug(
@@ -1313,7 +1311,7 @@ class GPUModelRunner(ModelRunnerBase):
                 base = idx * self.kv_num_heads * block_num
                 # Expand block_tables to include all heads
                 block_ids = np.arange(base, base + self.kv_num_heads * block_num, 1)
-                self.share_inputs["block_tables"][idx, :len(block_ids)] = block_ids
+                self.share_inputs["block_tables"][idx, : len(block_ids)] = block_ids
             else:
                 self.share_inputs["block_tables"][idx : idx + 1, :block_num] = np.arange(
                     idx * block_num, (idx + 1) * block_num, 1
@@ -1347,9 +1345,7 @@ class GPUModelRunner(ModelRunnerBase):
                 num_running_requests = int(self.share_inputs["seq_lens_this_time"].shape[0])
                 self._prepare_block_tables_3d_from_flat_tables(num_running_requests)
                 if num_running_requests > 0:
-                    rows_np = self.share_inputs["block_tables_3d"][
-                        : num_running_requests * self.kv_num_heads
-                    ].numpy()
+                    rows_np = self.share_inputs["block_tables_3d"][: num_running_requests * self.kv_num_heads].numpy()
                     logger.debug(
                         f"[headwise dummy run] block_tables_3d shape={rows_np.shape} "
                         f"max_blocks_per_head={self.share_inputs['block_tables_3d'].shape[1]} "

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -870,7 +870,8 @@ class GPUModelRunner(ModelRunnerBase):
                     cache_ids_2d = getattr(request, "block_tables_3d", None)
                     if cache_ids_2d is None and request.block_tables and isinstance(request.block_tables[0], list):
                         cache_ids_2d = request.block_tables
-                    if cache_ids_2d is not None and getattr(request, "block_tables_3d", None) is None:
+                    cache_ids_2d = self._compact_head_wise_cache_ids_2d(cache_ids_2d)
+                    if cache_ids_2d is not None:
                         request.block_tables_3d = cache_ids_2d
                     if cache_ids_2d:
                         encoder_block_num = len(cache_ids_2d[0])
@@ -940,7 +941,8 @@ class GPUModelRunner(ModelRunnerBase):
                     cache_ids_2d = getattr(request, "block_tables_3d", None)
                     if cache_ids_2d is None and request.block_tables and isinstance(request.block_tables[0], list):
                         cache_ids_2d = request.block_tables
-                    if cache_ids_2d is not None and getattr(request, "block_tables_3d", None) is None:
+                    cache_ids_2d = self._compact_head_wise_cache_ids_2d(cache_ids_2d)
+                    if cache_ids_2d is not None:
                         request.block_tables_3d = cache_ids_2d
                     # Keep cached request metadata in sync for subsequent forward_meta assembly.
                     cached_req = self.forward_batch_reqs_list[idx]
@@ -949,9 +951,8 @@ class GPUModelRunner(ModelRunnerBase):
                         if cache_ids_2d is not None:
                             cached_req.block_tables_3d = cache_ids_2d
                     else:
-                        logger.warning(
-                            f"[headwise decode] missing cached request at batch idx={idx}, request_id={request.request_id}"
-                        )
+                        # Keep metadata for requests that enter decode path directly.
+                        self.forward_batch_reqs_list[idx] = request
                     if cache_ids_2d:
                         encoder_block_num = len(cache_ids_2d[0])
                     else:
@@ -1122,32 +1123,42 @@ class GPUModelRunner(ModelRunnerBase):
             return
 
         max_blocks_per_head = block_tables_3d.shape[1]
+        has_request_level_tables = False
         per_req_head_lens = []
-        for b in range(num_running_requests):
-            req = self.forward_batch_reqs_list[b]
-            cache_ids_2d = getattr(req, "block_tables_3d", None) if req is not None else None
-            if cache_ids_2d and len(cache_ids_2d) > 0:
-                head_lens = [len(head_ids) if head_ids is not None else 0 for head_ids in cache_ids_2d]
-                per_req_head_lens.append(head_lens)
-            else:
-                per_req_head_lens.append([])
+        req_list = getattr(self, "forward_batch_reqs_list", None)
 
         for b in range(num_running_requests):
-            req = self.forward_batch_reqs_list[b]
+            if req_list is None or b >= len(req_list):
+                per_req_head_lens.append([])
+                continue
+
+            req = req_list[b]
             cache_ids_2d = getattr(req, "block_tables_3d", None) if req is not None else None
             if cache_ids_2d is None:
                 if self.head_wise_debug_log and _debug_logging_enabled():
                     logger.debug(f"[headwise _prepare_block_tables_3d] req {b}: cache_ids_2d=None, keep rows as -1")
+                per_req_head_lens.append([])
                 continue
+
+            has_request_level_tables = True
+            head_lens = []
             for h in range(self.kv_num_heads):
                 if h >= len(cache_ids_2d) or cache_ids_2d[h] is None:
+                    head_lens.append(0)
                     continue
-                else:
-                    row = list(cache_ids_2d[h])
-                    copy_len = min(len(row), max_blocks_per_head)
-                    if copy_len > 0:
-                        row_idx = b * self.kv_num_heads + h
-                        block_tables_3d[row_idx, :copy_len] = paddle.to_tensor(row[:copy_len], dtype="int32")
+
+                row = cache_ids_2d[h]
+                compact_row = [cid for cid in row if cid is not None and cid >= 0]
+                head_lens.append(len(compact_row))
+                copy_len = min(len(compact_row), max_blocks_per_head)
+                if copy_len > 0:
+                    row_idx = b * self.kv_num_heads + h
+                    block_tables_3d[row_idx, :copy_len] = paddle.to_tensor(compact_row[:copy_len], dtype="int32")
+            per_req_head_lens.append(head_lens)
+
+        # Fallback for dummy/profile or missing request cache metadata.
+        if not has_request_level_tables:
+            self._prepare_block_tables_3d_from_flat_tables(num_running_requests)
 
         active_rows = block_tables_3d[: num_running_requests * self.kv_num_heads]
         rows_np = active_rows.numpy()
@@ -1186,6 +1197,18 @@ class GPUModelRunner(ModelRunnerBase):
                 f"[headwise _prepare_block_tables_3d details] per_req_head_lens={per_req_head_lens[:num_running_requests]}"
             )
             self._head_wise_debug_log_count += 1
+
+    def _compact_head_wise_cache_ids_2d(self, cache_ids_2d):
+        """Remove recycled holes (-1) from per-head cache rows."""
+        if cache_ids_2d is None:
+            return None
+        compact_cache_ids_2d = []
+        for head_tables in cache_ids_2d:
+            if head_tables is None:
+                compact_cache_ids_2d.append([])
+                continue
+            compact_cache_ids_2d.append([cid for cid in head_tables if cid is not None and cid >= 0])
+        return compact_cache_ids_2d
 
     def insert_prefill_inputs(self, req_dicts: List[Request], num_running_requests: int):
         raise NotImplementedError("GPUs only support KVCACHE SCHEDULER V1 in versions 2.6 and above.")

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1369,7 +1369,7 @@ class GPUModelRunner(ModelRunnerBase):
                 seq_lens_this_time = self.share_inputs["seq_lens_this_time"]
                 num_running_requests = int((seq_lens_this_time > 0).astype("int64").sum().item())
                 self._prepare_block_tables_3d_from_flat_tables(num_running_requests)
-                if num_running_requests > 0:
+                if num_running_requests > 0 and self.head_wise_debug_log and _debug_logging_enabled():
                     rows_np = self.share_inputs["block_tables_3d"][: num_running_requests * self.kv_num_heads].numpy()
                     logger.debug(
                         f"[headwise dummy run] block_tables_3d shape={rows_np.shape} "

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -15,6 +15,7 @@
 """
 
 import copy
+import logging
 import os
 import queue
 import time
@@ -869,9 +870,10 @@ class GPUModelRunner(ModelRunnerBase):
                         tables = []
                         for head_tables in cache_ids_2d:
                             tables.extend(head_tables)
-                        logger.info(
-                            f"[headwise prefill] req {idx} cache_ids_2d={cache_ids_2d} tables={tables}"
-                        )
+                        if self.head_wise_debug_log and logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(
+                                f"[headwise prefill] req {idx} cache_ids_2d={cache_ids_2d} tables={tables}"
+                            )
                     else:
                         tables = request.block_tables
                     self.share_inputs["block_tables"][idx : idx + 1, :len(tables)] = np.array(
@@ -1125,8 +1127,8 @@ class GPUModelRunner(ModelRunnerBase):
             req = self.forward_batch_reqs_list[b]
             cache_ids_2d = getattr(req, "block_tables_3d", None) if req is not None else None
             if cache_ids_2d is None:
-                if self.head_wise_debug_log:
-                    logger.info(f"[headwise _prepare_block_tables_3d] req {b}: cache_ids_2d=None, keep rows as -1")
+                if self.head_wise_debug_log and logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(f"[headwise _prepare_block_tables_3d] req {b}: cache_ids_2d=None, keep rows as -1")
                 continue
             for h in range(self.kv_num_heads):
                 if h >= len(cache_ids_2d) or cache_ids_2d[h] is None:
@@ -1150,11 +1152,11 @@ class GPUModelRunner(ModelRunnerBase):
             cache_id_capacity = int(self.share_inputs["caches"][0].shape[0])
         out_of_range_cnt = int((valid_ids >= cache_id_capacity).sum()) if cache_id_capacity > 0 else 0
 
-        should_log_prepare = self.head_wise_debug_log and (
+        should_log_prepare = self.head_wise_debug_log and logger.isEnabledFor(logging.DEBUG) and (
             self._head_wise_prepare_log_count < 50 or self._head_wise_prepare_log_count % 100 == 0
         )
         if should_log_prepare:
-            logger.info(
+            logger.debug(
                 f"[headwise _prepare_block_tables_3d] shape={active_rows.shape} "
                 f"num_running_requests={num_running_requests} kv_num_heads={self.kv_num_heads} "
                 f"max_blocks_per_head={max_blocks_per_head} min_id={min_id} max_id={max_id} "
@@ -1168,8 +1170,8 @@ class GPUModelRunner(ModelRunnerBase):
                 f"[headwise _prepare_block_tables_3d invalid] out_of_range_cnt={out_of_range_cnt}, "
                 f"cache_id_capacity={cache_id_capacity}, min_id={min_id}, max_id={max_id}"
             )
-        if self.head_wise_debug_log and self._head_wise_debug_log_count < 20:
-            logger.info(
+        if self.head_wise_debug_log and logger.isEnabledFor(logging.DEBUG) and self._head_wise_debug_log_count < 20:
+            logger.debug(
                 f"[headwise _prepare_block_tables_3d details] per_req_head_lens={per_req_head_lens[:num_running_requests]}"
             )
             self._head_wise_debug_log_count += 1
@@ -1333,7 +1335,7 @@ class GPUModelRunner(ModelRunnerBase):
                     rows_np = self.share_inputs["block_tables_3d"][
                         : num_running_requests * self.kv_num_heads
                     ].numpy()
-                    logger.info(
+                    logger.debug(
                         f"[headwise dummy run] block_tables_3d shape={rows_np.shape} "
                         f"max_blocks_per_head={self.share_inputs['block_tables_3d'].shape[1]} "
                         f"first_rows={rows_np[:min(4, len(rows_np))].tolist() if len(rows_np) > 0 else []}"

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1475,8 +1475,6 @@ class GPUModelRunner(ModelRunnerBase):
 
         list_cap = len(self.forward_batch_reqs_list)
         req_by_batch_id = {}
-        slot_rows_by_batch_id = {}
-        slot_req_id_by_batch_id = {}
         for req in self.forward_batch_reqs_list:
             if req is None:
                 continue
@@ -1484,35 +1482,33 @@ class GPUModelRunner(ModelRunnerBase):
             if req_batch_id is None:
                 continue
             req_by_batch_id[req_batch_id] = req
-        if self.enable_head_wise_kv_cache:
-            for slot_idx, req in enumerate(self.forward_batch_reqs_list):
-                if req is None:
-                    continue
-                req_batch_id = getattr(req, "idx", None)
-                if req_batch_id is None:
-                    continue
-                slot_rows_by_batch_id[req_batch_id] = list(self._head_wise_slot_active_rows[slot_idx])
-                slot_req_id_by_batch_id[req_batch_id] = self._head_wise_slot_req_ids[slot_idx]
 
         aligned_reqs = [None for _ in range(list_cap)]
-        aligned_slot_active_rows = (
-            [[0 for _ in range(self.kv_num_heads)] for _ in range(list_cap)]
-            if self.enable_head_wise_kv_cache
-            else None
-        )
-        aligned_slot_req_ids = [None for _ in range(list_cap)] if self.enable_head_wise_kv_cache else None
         for slot_idx, batch_id in index_to_batch_id.items():
             if slot_idx < 0 or slot_idx >= list_cap:
                 continue
             aligned_reqs[slot_idx] = req_by_batch_id.get(batch_id)
-            if self.enable_head_wise_kv_cache and batch_id in slot_rows_by_batch_id:
-                aligned_slot_active_rows[slot_idx] = slot_rows_by_batch_id[batch_id]
-                aligned_slot_req_ids[slot_idx] = slot_req_id_by_batch_id.get(batch_id)
 
         self.forward_batch_reqs_list = aligned_reqs
         if self.enable_head_wise_kv_cache:
-            self._head_wise_slot_active_rows = aligned_slot_active_rows
-            self._head_wise_slot_req_ids = aligned_slot_req_ids
+            # InputBatch.swap_states/condense currently only reorders block_tables (2D).
+            # Rebuild block_tables_3d explicitly to keep cache-id rows aligned with reordered slots.
+            self._reset_head_wise_block_tables_state()
+            for slot_idx, req in enumerate(aligned_reqs):
+                if req is None:
+                    continue
+                cache_ids_2d = getattr(req, "block_tables_3d", None)
+                if cache_ids_2d is None and req.block_tables and isinstance(req.block_tables[0], list):
+                    cache_ids_2d = req.block_tables
+                cache_ids_2d = self._normalize_head_wise_cache_ids_2d(cache_ids_2d)
+                if cache_ids_2d is not None:
+                    req.block_tables_3d = cache_ids_2d
+                req_id = getattr(req, "request_id", None)
+                self._update_block_tables_3d_slot(
+                    slot_idx,
+                    cache_ids_2d,
+                    str(req_id) if req_id is not None else None,
+                )
 
     def load_model(self) -> None:
         """load or download model"""

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -143,6 +143,8 @@ class GPUModelRunner(ModelRunnerBase):
         self.device_id = device_id
         self.enable_head_wise_kv_cache = envs.FD_HEAD_WISE_KV_CACHE == 1
         self.head_wise_debug_log = bool(int(os.getenv("FD_HEAD_WISE_KV_LOG", "0")))
+        self.head_wise_hole_log = bool(int(os.getenv("FD_HEAD_WISE_HOLE_LOG", "0")))
+        self._head_wise_hole_log_count: int = 0
         self.kv_num_heads = max(
             1,
             int(self.model_config.num_key_value_heads) // self.parallel_config.tensor_parallel_size,
@@ -870,11 +872,28 @@ class GPUModelRunner(ModelRunnerBase):
                     if cache_ids_2d is None and request.block_tables and isinstance(request.block_tables[0], list):
                         cache_ids_2d = request.block_tables
                     cache_ids_2d = self._normalize_head_wise_cache_ids_2d(cache_ids_2d)
+                    self._maybe_log_head_wise_hole_diag(cache_ids_2d, str(request.request_id), "prefill")
                     if cache_ids_2d is not None:
                         request.block_tables_3d = cache_ids_2d
                     self._update_block_tables_3d_slot(idx, cache_ids_2d, str(request.request_id))
                     if cache_ids_2d:
-                        encoder_block_num = len(cache_ids_2d[0])
+                        head0_row = cache_ids_2d[0] if cache_ids_2d[0] is not None else []
+                        encoder_block_num, head0_contiguous_len, head0_holes = self._head_wise_row_layout_stats(
+                            head0_row
+                        )
+                        if self.head_wise_hole_log and head0_holes > 0:
+                            should_log = (
+                                self._head_wise_hole_log_count < 100
+                                or self._head_wise_hole_log_count % 100 == 0
+                            )
+                            self._head_wise_hole_log_count += 1
+                            if should_log:
+                                logger.warning(
+                                    f"[headwise_encoder_len_diag] stage=prefill req_id={request.request_id} "
+                                    f"len_based={encoder_block_num} contiguous_len={head0_contiguous_len} "
+                                    f"hole_before_last_valid={head0_holes} "
+                                    f"head0_prefix={head0_row[: min(24, len(head0_row))]}"
+                                )
                     else:
                         encoder_block_num = 0
                 else:
@@ -940,6 +959,7 @@ class GPUModelRunner(ModelRunnerBase):
                     if cache_ids_2d is None and request.block_tables and isinstance(request.block_tables[0], list):
                         cache_ids_2d = request.block_tables
                     cache_ids_2d = self._normalize_head_wise_cache_ids_2d(cache_ids_2d)
+                    self._maybe_log_head_wise_hole_diag(cache_ids_2d, str(request.request_id), "decode")
                     if cache_ids_2d is not None:
                         request.block_tables_3d = cache_ids_2d
                     self._update_block_tables_3d_slot(idx, cache_ids_2d, str(request.request_id))
@@ -953,7 +973,23 @@ class GPUModelRunner(ModelRunnerBase):
                         # Keep metadata for requests that enter decode path directly.
                         self.forward_batch_reqs_list[idx] = request
                     if cache_ids_2d:
-                        encoder_block_num = len(cache_ids_2d[0])
+                        head0_row = cache_ids_2d[0] if cache_ids_2d[0] is not None else []
+                        encoder_block_num, head0_contiguous_len, head0_holes = self._head_wise_row_layout_stats(
+                            head0_row
+                        )
+                        if self.head_wise_hole_log and head0_holes > 0:
+                            should_log = (
+                                self._head_wise_hole_log_count < 100
+                                or self._head_wise_hole_log_count % 100 == 0
+                            )
+                            self._head_wise_hole_log_count += 1
+                            if should_log:
+                                logger.warning(
+                                    f"[headwise_encoder_len_diag] stage=decode req_id={request.request_id} "
+                                    f"len_based={encoder_block_num} contiguous_len={head0_contiguous_len} "
+                                    f"hole_before_last_valid={head0_holes} "
+                                    f"head0_prefix={head0_row[: min(24, len(head0_row))]}"
+                                )
                     else:
                         encoder_block_num = 0
                 else:
@@ -1184,6 +1220,57 @@ class GPUModelRunner(ModelRunnerBase):
                 continue
             normalized_cache_ids_2d.append([(-1 if cid is None else int(cid)) for cid in head_tables])
         return normalized_cache_ids_2d
+
+    @staticmethod
+    def _head_wise_row_layout_stats(row):
+        """Return (len_based, contiguous_len, hole_before_last_valid) for diagnostics."""
+        if row is None:
+            return 0, 0, 0
+
+        row_len = len(row)
+        last_valid_idx = -1
+        for idx, cid in enumerate(row):
+            if cid is not None and cid >= 0:
+                last_valid_idx = idx
+
+        if last_valid_idx < 0:
+            return row_len, 0, 0
+
+        contiguous_len = last_valid_idx + 1
+        hole_before_last_valid = 0
+        for cid in row[:contiguous_len]:
+            if cid is None or cid < 0:
+                hole_before_last_valid += 1
+        return row_len, contiguous_len, hole_before_last_valid
+
+    def _maybe_log_head_wise_hole_diag(self, cache_ids_2d, req_id: str, stage: str) -> None:
+        if not self.head_wise_hole_log or not cache_ids_2d:
+            return
+
+        suspicious = []
+        for head_idx, row in enumerate(cache_ids_2d):
+            row_len, contiguous_len, hole_before_last_valid = self._head_wise_row_layout_stats(row)
+            if hole_before_last_valid <= 0:
+                continue
+            suspicious.append((head_idx, row_len, contiguous_len, hole_before_last_valid))
+
+        if not suspicious:
+            return
+
+        should_log = self._head_wise_hole_log_count < 100 or self._head_wise_hole_log_count % 100 == 0
+        self._head_wise_hole_log_count += 1
+        if not should_log:
+            return
+
+        sample = suspicious[:4]
+        sample_str = ", ".join(
+            f"h{head_idx}:len={row_len},contiguous={contiguous_len},holes={hole_count}"
+            for head_idx, row_len, contiguous_len, hole_count in sample
+        )
+        logger.warning(
+            f"[headwise_hole_diag] stage={stage} req_id={req_id} "
+            f"heads_with_holes={len(suspicious)}/{len(cache_ids_2d)} sample=[{sample_str}]"
+        )
 
     def _flatten_head_wise_cache_ids_2d(self, cache_ids_2d):
         """

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -143,8 +143,6 @@ class GPUModelRunner(ModelRunnerBase):
         self.device_id = device_id
         self.enable_head_wise_kv_cache = envs.FD_HEAD_WISE_KV_CACHE == 1
         self.head_wise_debug_log = bool(int(os.getenv("FD_HEAD_WISE_KV_LOG", "0")))
-        self.head_wise_hole_log = bool(int(os.getenv("FD_HEAD_WISE_HOLE_LOG", "0")))
-        self._head_wise_hole_log_count: int = 0
         self.kv_num_heads = max(
             1,
             int(self.model_config.num_key_value_heads) // self.parallel_config.tensor_parallel_size,
@@ -872,27 +870,12 @@ class GPUModelRunner(ModelRunnerBase):
                     if cache_ids_2d is None and request.block_tables and isinstance(request.block_tables[0], list):
                         cache_ids_2d = request.block_tables
                     cache_ids_2d = self._normalize_head_wise_cache_ids_2d(cache_ids_2d)
-                    self._maybe_log_head_wise_hole_diag(cache_ids_2d, str(request.request_id), "prefill")
                     if cache_ids_2d is not None:
                         request.block_tables_3d = cache_ids_2d
                     self._update_block_tables_3d_slot(idx, cache_ids_2d, str(request.request_id))
                     if cache_ids_2d:
                         head0_row = cache_ids_2d[0] if cache_ids_2d[0] is not None else []
                         encoder_block_num = sum(1 for cid in head0_row if cid is not None and cid >= 0)
-                        _, head0_contiguous_len, head0_holes = self._head_wise_row_layout_stats(head0_row)
-                        if self.head_wise_hole_log and head0_holes > 0:
-                            should_log = (
-                                self._head_wise_hole_log_count < 100
-                                or self._head_wise_hole_log_count % 100 == 0
-                            )
-                            self._head_wise_hole_log_count += 1
-                            if should_log:
-                                logger.warning(
-                                    f"[headwise_encoder_len_diag] stage=prefill req_id={request.request_id} "
-                                    f"len_based={encoder_block_num} contiguous_len={head0_contiguous_len} "
-                                    f"hole_before_last_valid={head0_holes} "
-                                    f"head0_prefix={head0_row[: min(24, len(head0_row))]}"
-                                )
                     else:
                         encoder_block_num = 0
                 else:
@@ -958,7 +941,6 @@ class GPUModelRunner(ModelRunnerBase):
                     if cache_ids_2d is None and request.block_tables and isinstance(request.block_tables[0], list):
                         cache_ids_2d = request.block_tables
                     cache_ids_2d = self._normalize_head_wise_cache_ids_2d(cache_ids_2d)
-                    self._maybe_log_head_wise_hole_diag(cache_ids_2d, str(request.request_id), "decode")
                     if cache_ids_2d is not None:
                         request.block_tables_3d = cache_ids_2d
                     self._update_block_tables_3d_slot(idx, cache_ids_2d, str(request.request_id))
@@ -974,20 +956,6 @@ class GPUModelRunner(ModelRunnerBase):
                     if cache_ids_2d:
                         head0_row = cache_ids_2d[0] if cache_ids_2d[0] is not None else []
                         encoder_block_num = sum(1 for cid in head0_row if cid is not None and cid >= 0)
-                        _, head0_contiguous_len, head0_holes = self._head_wise_row_layout_stats(head0_row)
-                        if self.head_wise_hole_log and head0_holes > 0:
-                            should_log = (
-                                self._head_wise_hole_log_count < 100
-                                or self._head_wise_hole_log_count % 100 == 0
-                            )
-                            self._head_wise_hole_log_count += 1
-                            if should_log:
-                                logger.warning(
-                                    f"[headwise_encoder_len_diag] stage=decode req_id={request.request_id} "
-                                    f"len_based={encoder_block_num} contiguous_len={head0_contiguous_len} "
-                                    f"hole_before_last_valid={head0_holes} "
-                                    f"head0_prefix={head0_row[: min(24, len(head0_row))]}"
-                                )
                     else:
                         encoder_block_num = 0
                 else:
@@ -1227,57 +1195,6 @@ class GPUModelRunner(ModelRunnerBase):
 
             normalized_cache_ids_2d.append(normalized_row)
         return normalized_cache_ids_2d
-
-    @staticmethod
-    def _head_wise_row_layout_stats(row):
-        """Return (len_based, contiguous_len, hole_before_last_valid) for diagnostics."""
-        if row is None:
-            return 0, 0, 0
-
-        row_len = len(row)
-        last_valid_idx = -1
-        for idx, cid in enumerate(row):
-            if cid is not None and cid >= 0:
-                last_valid_idx = idx
-
-        if last_valid_idx < 0:
-            return row_len, 0, 0
-
-        contiguous_len = last_valid_idx + 1
-        hole_before_last_valid = 0
-        for cid in row[:contiguous_len]:
-            if cid is None or cid < 0:
-                hole_before_last_valid += 1
-        return row_len, contiguous_len, hole_before_last_valid
-
-    def _maybe_log_head_wise_hole_diag(self, cache_ids_2d, req_id: str, stage: str) -> None:
-        if not self.head_wise_hole_log or not cache_ids_2d:
-            return
-
-        suspicious = []
-        for head_idx, row in enumerate(cache_ids_2d):
-            row_len, contiguous_len, hole_before_last_valid = self._head_wise_row_layout_stats(row)
-            if hole_before_last_valid <= 0:
-                continue
-            suspicious.append((head_idx, row_len, contiguous_len, hole_before_last_valid))
-
-        if not suspicious:
-            return
-
-        should_log = self._head_wise_hole_log_count < 100 or self._head_wise_hole_log_count % 100 == 0
-        self._head_wise_hole_log_count += 1
-        if not should_log:
-            return
-
-        sample = suspicious[:4]
-        sample_str = ", ".join(
-            f"h{head_idx}:len={row_len},contiguous={contiguous_len},holes={hole_count}"
-            for head_idx, row_len, contiguous_len, hole_count in sample
-        )
-        logger.warning(
-            f"[headwise_hole_diag] stage={stage} req_id={req_id} "
-            f"heads_with_holes={len(suspicious)}/{len(cache_ids_2d)} sample=[{sample_str}]"
-        )
 
     def _flatten_head_wise_cache_ids_2d(self, cache_ids_2d):
         """

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -207,6 +207,14 @@ class GPUModelRunner(ModelRunnerBase):
         self.cudagraph_capture_sizes_prefill = list(reversed(self.graph_opt_config.cudagraph_capture_sizes_prefill))
         self.sot_warmup_sizes = self.graph_opt_config.sot_warmup_sizes
         self.cudagraph_only_prefill = self.graph_opt_config.cudagraph_only_prefill
+        if self.enable_head_wise_kv_cache and self.use_cudagraph:
+            # Head-wise block_tables_3d is still dynamically rebuilt per step.
+            # Running this path under CUDA Graph can replay stale pointers/shapes.
+            logger.warning(
+                "[headwise] Disable CUDA Graph because head-wise KV cache has dynamic block_tables_3d."
+            )
+            self.use_cudagraph = False
+            self.graph_opt_config.use_cudagraph = False
 
         # Initialize input batch
         self.share_inputs = InputBatch(self.fd_config)

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1524,6 +1524,24 @@ class GPUModelRunner(ModelRunnerBase):
         if not self.enable_head_wise_kv_cache:
             return
 
+        # Reorder block_tables_3d once after PD permutation instead of per-swap updates.
+        block_tables_3d = self.share_inputs.get("block_tables_3d", None)
+        if block_tables_3d is not None:
+            old_block_tables_3d = block_tables_3d.clone()
+            block_tables_3d[:] = -1
+            slot_cap_by_tensor = block_tables_3d.shape[0] // self.kv_num_heads
+            for new_slot, batch_id in index_to_batch_id.items():
+                if new_slot < 0 or new_slot >= slot_cap_by_tensor:
+                    continue
+                old_slot = old_slot_by_batch_id.get(batch_id)
+                if old_slot is None or old_slot < 0 or old_slot >= slot_cap_by_tensor:
+                    continue
+                new_start = new_slot * self.kv_num_heads
+                old_start = old_slot * self.kv_num_heads
+                block_tables_3d[new_start : new_start + self.kv_num_heads, :] = old_block_tables_3d[
+                    old_start : old_start + self.kv_num_heads, :
+                ]
+
         old_slot_req_ids = list(self._head_wise_slot_req_ids)
         old_slot_active_rows = [list(rows) for rows in self._head_wise_slot_active_rows]
         slot_cap = len(old_slot_req_ids)

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1132,7 +1132,10 @@ class GPUModelRunner(ModelRunnerBase):
             copy_len = min(len(row), max_blocks_per_head)
             if copy_len > 0:
                 normalized_row = [(-1 if cid is None else int(cid)) for cid in row[:copy_len]]
-                block_tables_3d[base_row + h, :copy_len] = paddle.to_tensor(normalized_row, dtype="int32")
+                if current_platform.is_cuda():
+                    async_set_value(block_tables_3d[base_row + h, :copy_len], normalized_row)
+                else:
+                    block_tables_3d[base_row + h, :copy_len] = np.array(normalized_row, dtype="int32")
             active_lens[h] = copy_len
 
         self._head_wise_slot_req_ids[idx] = req_id

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -143,8 +143,6 @@ class GPUModelRunner(ModelRunnerBase):
         self.device_id = device_id
         self.enable_head_wise_kv_cache = envs.FD_HEAD_WISE_KV_CACHE == 1
         self.head_wise_debug_log = bool(int(os.getenv("FD_HEAD_WISE_KV_LOG", "0")))
-        self._head_wise_debug_log_count = 0
-        self._head_wise_prepare_log_count = 0
         self.kv_num_heads = max(
             1,
             int(self.model_config.num_key_value_heads) // self.parallel_config.tensor_parallel_size,
@@ -887,11 +885,7 @@ class GPUModelRunner(ModelRunnerBase):
                     if self.enable_head_wise_kv_cache:
                         # In head-wise mode, expand cache_ids_2d to include all heads
                         # block_tables format: [bsz, kv_num_heads * max_blocks_per_head]
-                        tables = []
-                        for head_tables in cache_ids_2d:
-                            if head_tables is None:
-                                continue
-                            tables.extend(head_tables)
+                        tables = self._flatten_head_wise_cache_ids_2d(cache_ids_2d)
                         if self.head_wise_debug_log and _debug_logging_enabled():
                             logger.debug(f"[headwise prefill] req {idx} cache_ids_2d={cache_ids_2d} tables={tables}")
                     else:
@@ -970,11 +964,7 @@ class GPUModelRunner(ModelRunnerBase):
                     if self.enable_head_wise_kv_cache:
                         # In head-wise mode, expand cache_ids_2d to include all heads
                         # block_tables format: [bsz, kv_num_heads * max_blocks_per_head]
-                        tables = []
-                        for head_tables in cache_ids_2d:
-                            if head_tables is None:
-                                continue
-                            tables.extend(head_tables)
+                        tables = self._flatten_head_wise_cache_ids_2d(cache_ids_2d)
                     else:
                         tables = request.block_tables
                     if current_platform.is_cuda():
@@ -1180,101 +1170,6 @@ class GPUModelRunner(ModelRunnerBase):
                     flat_block_tables[b][start:end], dtype="int32"
                 )
 
-    def _prepare_block_tables_3d(self, num_running_requests: int):
-        if not self.enable_head_wise_kv_cache:
-            self.share_inputs["block_tables_3d"] = None
-            return
-        block_tables_3d = self._get_head_wise_block_tables_buffer()
-        block_tables_3d[:] = -1
-        if num_running_requests is None or num_running_requests <= 0:
-            return
-
-        max_blocks_per_head = block_tables_3d.shape[1]
-        has_request_level_tables = False
-        collect_prepare_debug_stats = self.head_wise_debug_log and _debug_logging_enabled()
-        should_log_prepare = (
-            collect_prepare_debug_stats
-            and (self._head_wise_prepare_log_count < 50 or self._head_wise_prepare_log_count % 100 == 0)
-        )
-        per_req_head_lens = [] if collect_prepare_debug_stats else None
-        req_list = getattr(self, "forward_batch_reqs_list", None)
-
-        for b in range(num_running_requests):
-            if req_list is None or b >= len(req_list):
-                if per_req_head_lens is not None:
-                    per_req_head_lens.append([])
-                continue
-
-            req = req_list[b]
-            cache_ids_2d = getattr(req, "block_tables_3d", None) if req is not None else None
-            if cache_ids_2d is None:
-                if collect_prepare_debug_stats:
-                    logger.debug(f"[headwise _prepare_block_tables_3d] req {b}: cache_ids_2d=None, keep rows as -1")
-                if per_req_head_lens is not None:
-                    per_req_head_lens.append([])
-                continue
-
-            has_request_level_tables = True
-            head_lens = [] if per_req_head_lens is not None else None
-            for h in range(self.kv_num_heads):
-                if h >= len(cache_ids_2d) or cache_ids_2d[h] is None:
-                    if head_lens is not None:
-                        head_lens.append(0)
-                    continue
-
-                row = cache_ids_2d[h]
-                if head_lens is not None:
-                    valid_cnt = sum(1 for cid in row if cid is not None and cid >= 0)
-                    head_lens.append(valid_cnt)
-                normalized_row = [(-1 if cid is None else int(cid)) for cid in row]
-                copy_len = min(len(normalized_row), max_blocks_per_head)
-                if copy_len > 0:
-                    row_idx = b * self.kv_num_heads + h
-                    block_tables_3d[row_idx, :copy_len] = paddle.to_tensor(
-                        normalized_row[:copy_len], dtype="int32"
-                    )
-            if per_req_head_lens is not None:
-                per_req_head_lens.append(head_lens)
-
-        # Fallback for dummy/profile or missing request cache metadata.
-        if not has_request_level_tables:
-            self._prepare_block_tables_3d_from_flat_tables(num_running_requests)
-
-        if collect_prepare_debug_stats:
-            active_rows = block_tables_3d[: num_running_requests * self.kv_num_heads]
-            rows_np = active_rows.numpy()
-            valid_ids = rows_np[rows_np >= 0]
-            min_id = int(valid_ids.min()) if valid_ids.size > 0 else -1
-            max_id = int(valid_ids.max()) if valid_ids.size > 0 else -1
-            neg_count = int((rows_np < 0).sum())
-
-            cache_id_capacity = -1
-            if self.share_inputs.get("caches") and len(self.share_inputs["caches"]) > 0:
-                cache_id_capacity = int(self.share_inputs["caches"][0].shape[0])
-            out_of_range_cnt = int((valid_ids >= cache_id_capacity).sum()) if cache_id_capacity > 0 else 0
-
-            if should_log_prepare:
-                logger.debug(
-                    f"[headwise _prepare_block_tables_3d] shape={active_rows.shape} "
-                    f"num_running_requests={num_running_requests} kv_num_heads={self.kv_num_heads} "
-                    f"max_blocks_per_head={max_blocks_per_head} min_id={min_id} max_id={max_id} "
-                    f"neg_count={neg_count} cache_id_capacity={cache_id_capacity} "
-                    f"out_of_range_cnt={out_of_range_cnt} first_rows={rows_np[:min(4, len(rows_np))].tolist()}"
-                )
-            if out_of_range_cnt > 0:
-                logger.error(
-                    f"[headwise _prepare_block_tables_3d invalid] out_of_range_cnt={out_of_range_cnt}, "
-                    f"cache_id_capacity={cache_id_capacity}, min_id={min_id}, max_id={max_id}"
-                )
-        if self.head_wise_debug_log:
-            self._head_wise_prepare_log_count += 1
-        if collect_prepare_debug_stats and self._head_wise_debug_log_count < 20:
-            logger.debug(
-                f"[headwise _prepare_block_tables_3d details] "
-                f"per_req_head_lens={per_req_head_lens[:num_running_requests]}"
-            )
-            self._head_wise_debug_log_count += 1
-
     def _normalize_head_wise_cache_ids_2d(self, cache_ids_2d):
         """Keep sparse per-head rows while normalizing None entries to -1."""
         if cache_ids_2d is None:
@@ -1286,6 +1181,16 @@ class GPUModelRunner(ModelRunnerBase):
                 continue
             normalized_cache_ids_2d.append([(-1 if cid is None else int(cid)) for cid in head_tables])
         return normalized_cache_ids_2d
+
+    def _flatten_head_wise_cache_ids_2d(self, cache_ids_2d):
+        if not cache_ids_2d:
+            return []
+        tables = []
+        for head_tables in cache_ids_2d:
+            if head_tables is None:
+                continue
+            tables.extend(head_tables)
+        return tables
 
     def insert_prefill_inputs(self, req_dicts: List[Request], num_running_requests: int):
         raise NotImplementedError("GPUs only support KVCACHE SCHEDULER V1 in versions 2.6 and above.")

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -58,6 +58,23 @@ from fastdeploy.spec_decode import SpecMethod
 from fastdeploy.utils import print_gpu_memory_use
 from fastdeploy.worker.input_batch import InputBatch, reorder_split_prefill_and_decode
 
+
+def _debug_logging_enabled() -> bool:
+    for candidate in (logger, getattr(logger, "logger", None), getattr(logger, "_logger", None)):
+        if candidate is None:
+            continue
+        is_enabled_for = getattr(candidate, "isEnabledFor", None)
+        if callable(is_enabled_for):
+            try:
+                return bool(is_enabled_for(logging.DEBUG))
+            except Exception:
+                continue
+        level = getattr(candidate, "level", None)
+        if isinstance(level, int):
+            return level <= logging.DEBUG
+    return False
+
+
 if current_platform.is_iluvatar():
     from fastdeploy.model_executor.ops.iluvatar import (
         recover_decode_task,
@@ -870,7 +887,7 @@ class GPUModelRunner(ModelRunnerBase):
                         tables = []
                         for head_tables in cache_ids_2d:
                             tables.extend(head_tables)
-                        if self.head_wise_debug_log and logger.isEnabledFor(logging.DEBUG):
+                        if self.head_wise_debug_log and _debug_logging_enabled():
                             logger.debug(
                                 f"[headwise prefill] req {idx} cache_ids_2d={cache_ids_2d} tables={tables}"
                             )
@@ -1127,7 +1144,7 @@ class GPUModelRunner(ModelRunnerBase):
             req = self.forward_batch_reqs_list[b]
             cache_ids_2d = getattr(req, "block_tables_3d", None) if req is not None else None
             if cache_ids_2d is None:
-                if self.head_wise_debug_log and logger.isEnabledFor(logging.DEBUG):
+                if self.head_wise_debug_log and _debug_logging_enabled():
                     logger.debug(f"[headwise _prepare_block_tables_3d] req {b}: cache_ids_2d=None, keep rows as -1")
                 continue
             for h in range(self.kv_num_heads):
@@ -1152,7 +1169,7 @@ class GPUModelRunner(ModelRunnerBase):
             cache_id_capacity = int(self.share_inputs["caches"][0].shape[0])
         out_of_range_cnt = int((valid_ids >= cache_id_capacity).sum()) if cache_id_capacity > 0 else 0
 
-        should_log_prepare = self.head_wise_debug_log and logger.isEnabledFor(logging.DEBUG) and (
+        should_log_prepare = self.head_wise_debug_log and _debug_logging_enabled() and (
             self._head_wise_prepare_log_count < 50 or self._head_wise_prepare_log_count % 100 == 0
         )
         if should_log_prepare:
@@ -1170,7 +1187,7 @@ class GPUModelRunner(ModelRunnerBase):
                 f"[headwise _prepare_block_tables_3d invalid] out_of_range_cnt={out_of_range_cnt}, "
                 f"cache_id_capacity={cache_id_capacity}, min_id={min_id}, max_id={max_id}"
             )
-        if self.head_wise_debug_log and logger.isEnabledFor(logging.DEBUG) and self._head_wise_debug_log_count < 20:
+        if self.head_wise_debug_log and _debug_logging_enabled() and self._head_wise_debug_log_count < 20:
             logger.debug(
                 f"[headwise _prepare_block_tables_3d details] per_req_head_lens={per_req_head_lens[:num_running_requests]}"
             )

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1477,10 +1477,10 @@ class GPUModelRunner(ModelRunnerBase):
     def _process_reorder(self) -> None:
         if self.attn_backends and getattr(self.attn_backends[0], "enable_ids_reorder", False):
             self.share_inputs.enable_pd_reorder = True
-            before_reorder = dict(self.share_inputs.index_to_batch_id)
+            before_reorder = tuple(sorted(self.share_inputs.index_to_batch_id.items()))
             self.share_inputs.condense()
             reorder_split_prefill_and_decode(input_batch=self.share_inputs)
-            after_reorder = self.share_inputs.index_to_batch_id
+            after_reorder = tuple(sorted(self.share_inputs.index_to_batch_id.items()))
             changed = before_reorder != after_reorder
             if changed:
                 self._sync_forward_batch_reqs_after_reorder()
@@ -1504,14 +1504,14 @@ class GPUModelRunner(ModelRunnerBase):
         list_cap = len(self.forward_batch_reqs_list)
         req_by_batch_id = {}
         old_slot_by_batch_id = {}
-        for slot_idx, req in enumerate(self.forward_batch_reqs_list):
+        for old_slot, req in enumerate(self.forward_batch_reqs_list):
             if req is None:
                 continue
             req_batch_id = getattr(req, "idx", None)
             if req_batch_id is None:
                 continue
             req_by_batch_id[req_batch_id] = req
-            old_slot_by_batch_id[req_batch_id] = slot_idx
+            old_slot_by_batch_id[req_batch_id] = old_slot
 
         aligned_reqs = [None for _ in range(list_cap)]
         for slot_idx, batch_id in index_to_batch_id.items():

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1076,8 +1076,6 @@ class GPUModelRunner(ModelRunnerBase):
                 self.share_inputs["rope_emb"][idx : idx + 1, :] = rope_3d_lst[i]
 
         self.share_inputs["seq_lens_this_time"] = self.share_inputs["seq_lens_this_time_buffer"][:num_running_requests]
-        if self.enable_head_wise_kv_cache:
-            self._prepare_block_tables_3d(num_running_requests)
         if self.spec_method == SpecMethod.MTP:
             self.proposer.insert_tasks_v1(req_dicts, num_running_requests, self.share_inputs.index_to_batch_id)
 

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1085,7 +1085,9 @@ class GPUModelRunner(ModelRunnerBase):
     def _init_head_wise_slot_states(self) -> None:
         slot_cap = self.scheduler_config.max_num_seqs
         self._head_wise_slot_req_ids: list[Optional[str]] = [None for _ in range(slot_cap)]
-        self._head_wise_slot_active_rows: list[list[int]] = [[0 for _ in range(self.kv_num_heads)] for _ in range(slot_cap)]
+        self._head_wise_slot_active_rows: list[list[int]] = [
+            [0 for _ in range(self.kv_num_heads)] for _ in range(slot_cap)
+        ]
 
     def _clear_block_tables_3d_slot(self, idx: int) -> None:
         if not self.enable_head_wise_kv_cache:
@@ -1169,9 +1171,7 @@ class GPUModelRunner(ModelRunnerBase):
                 if copy_len <= 0:
                     continue
                 row_idx = b * self.kv_num_heads + h
-                block_tables_3d[row_idx, :copy_len] = paddle.to_tensor(
-                    flat_block_tables[b][start:end], dtype="int32"
-                )
+                block_tables_3d[row_idx, :copy_len] = paddle.to_tensor(flat_block_tables[b][start:end], dtype="int32")
 
     def _normalize_head_wise_cache_ids_2d(self, cache_ids_2d):
         """Keep sparse per-head rows while normalizing None entries to -1."""

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -123,8 +123,14 @@ class GPUModelRunner(ModelRunnerBase):
         self.rank = rank
         self.local_rank = local_rank
         self.device_id = device_id
+        self.enable_head_wise_kv_cache = envs.FD_HEAD_WISE_KV_CACHE == 1
+        self.kv_num_heads = max(
+            1,
+            int(self.model_config.num_key_value_heads) // self.parallel_config.tensor_parallel_size,
+        )
         self.spec_method = self.fd_config.speculative_config.method
         self.speculative_decoding = self.spec_method is not None
+        self.speculative_method = self.spec_method
         self.enable_logprob = fd_config.model_config.enable_logprob
         self.enable_early_stop = self.fd_config.early_stop_config.enable_early_stop
         self.is_pooling_model = self.fd_config.model_config.runner_type == "pooling"
@@ -839,12 +845,27 @@ class GPUModelRunner(ModelRunnerBase):
                 self.share_inputs["input_ids"][idx : idx + 1, :length] = np.array(
                     input_ids[prefill_start_index:prefill_end_index]
                 )
-                encoder_block_num = len(request.block_tables)
+                if self.enable_head_wise_kv_cache:
+                    cache_ids_2d = getattr(request, "block_tables_3d", None)
+                    if cache_ids_2d is None and request.block_tables and isinstance(request.block_tables[0], list):
+                        cache_ids_2d = request.block_tables
+                    if cache_ids_2d is not None and getattr(request, "block_tables_3d", None) is None:
+                        request.block_tables_3d = cache_ids_2d
+                    if cache_ids_2d:
+                        encoder_block_num = len(cache_ids_2d[0])
+                        head0_tables = cache_ids_2d[0]
+                    else:
+                        encoder_block_num = 0
+                        head0_tables = []
+                else:
+                    encoder_block_num = len(request.block_tables)
                 self.share_inputs["encoder_block_lens"][idx : idx + 1] = encoder_block_num
                 self.share_inputs["block_tables"][idx : idx + 1, :] = -1
-                self.share_inputs["block_tables"][idx : idx + 1, :encoder_block_num] = np.array(
-                    request.block_tables, dtype="int32"
-                )
+                if encoder_block_num > 0:
+                    tables = head0_tables if self.enable_head_wise_kv_cache else request.block_tables
+                    self.share_inputs["block_tables"][idx : idx + 1, :encoder_block_num] = np.array(
+                        tables, dtype="int32"
+                    )
                 self.share_inputs["stop_flags"][idx : idx + 1] = False
                 self.share_inputs["seq_lens_decoder"][idx : idx + 1] = prefill_start_index
                 self.share_inputs["seq_lens_this_time_buffer"][idx : idx + 1] = length
@@ -889,17 +910,34 @@ class GPUModelRunner(ModelRunnerBase):
                         )
             elif request.task_type.value == RequestType.DECODE.value:  # decode task
                 logger.debug(f"Handle decode request {request} at idx {idx}")
-                encoder_block_num = len(request.block_tables)
+                if self.enable_head_wise_kv_cache:
+                    cache_ids_2d = getattr(request, "block_tables_3d", None)
+                    if cache_ids_2d is None and request.block_tables and isinstance(request.block_tables[0], list):
+                        cache_ids_2d = request.block_tables
+                    if cache_ids_2d is not None and getattr(request, "block_tables_3d", None) is None:
+                        request.block_tables_3d = cache_ids_2d
+                    if cache_ids_2d:
+                        encoder_block_num = len(cache_ids_2d[0])
+                        head0_tables = cache_ids_2d[0]
+                    else:
+                        encoder_block_num = 0
+                        head0_tables = []
+                else:
+                    encoder_block_num = len(request.block_tables)
                 self.share_inputs["encoder_block_lens"][idx : idx + 1] = encoder_block_num
                 self.share_inputs["block_tables"][idx : idx + 1, :] = -1
-                if current_platform.is_cuda():
-                    async_set_value(
-                        self.share_inputs["block_tables"][idx : idx + 1, :encoder_block_num], request.block_tables
-                    )
-                else:
-                    self.share_inputs["block_tables"][idx : idx + 1, :encoder_block_num] = np.array(
-                        request.block_tables, dtype="int32"
-                    )
+                if encoder_block_num > 0:
+                    tables = head0_tables if self.enable_head_wise_kv_cache else request.block_tables
+                    if current_platform.is_cuda():
+                        async_set_value(
+                            self.share_inputs["block_tables"][idx : idx + 1, :encoder_block_num], tables
+                        )
+                    else:
+                        self.share_inputs["block_tables"][idx : idx + 1, :encoder_block_num] = np.array(
+                            tables, dtype="int32"
+                        )
+                if self.share_inputs["is_block_step"][idx]:  # has tasks to continue to decode
+                    has_decode_task = True
                 self.share_inputs["preempted_idx"][idx : idx + 1, :] = 0
                 continue
             else:  # preempted task
@@ -993,8 +1031,44 @@ class GPUModelRunner(ModelRunnerBase):
                 self.share_inputs["rope_emb"][idx : idx + 1, :] = rope_3d_lst[i]
 
         self.share_inputs["seq_lens_this_time"] = self.share_inputs["seq_lens_this_time_buffer"][:num_running_requests]
+        if self.enable_head_wise_kv_cache:
+            self._prepare_block_tables_3d(num_running_requests)
         if self.spec_method == SpecMethod.MTP:
             self.proposer.insert_tasks_v1(req_dicts, num_running_requests, self.share_inputs.index_to_batch_id)
+
+    def _prepare_block_tables_3d(self, num_running_requests: int):
+        if not self.enable_head_wise_kv_cache:
+            self.share_inputs["block_tables_3d"] = None
+            return
+        if num_running_requests is None or num_running_requests <= 0:
+            self.share_inputs["block_tables_3d"] = None
+            return
+
+        max_blocks_per_head = 0
+        for b in range(num_running_requests):
+            req = self.forward_batch_reqs_list[b]
+            cache_ids_2d = getattr(req, "block_tables_3d", None) if req is not None else None
+            if cache_ids_2d and len(cache_ids_2d) > 0:
+                max_blocks_per_head = max(max_blocks_per_head, len(cache_ids_2d[0]))
+
+        if max_blocks_per_head == 0:
+            self.share_inputs["block_tables_3d"] = None
+            return
+
+        rows = []
+        for b in range(num_running_requests):
+            req = self.forward_batch_reqs_list[b]
+            cache_ids_2d = getattr(req, "block_tables_3d", None) if req is not None else None
+            if cache_ids_2d is None:
+                rows.extend([[-1] * max_blocks_per_head for _ in range(self.kv_num_heads)])
+                continue
+            for h in range(self.kv_num_heads):
+                row = list(cache_ids_2d[h])
+                if len(row) < max_blocks_per_head:
+                    row.extend([-1] * (max_blocks_per_head - len(row)))
+                rows.append(row)
+
+        self.share_inputs["block_tables_3d"] = paddle.to_tensor(np.array(rows, dtype="int32"))
 
     def insert_prefill_inputs(self, req_dicts: List[Request], num_running_requests: int):
         raise NotImplementedError("GPUs only support KVCACHE SCHEDULER V1 in versions 2.6 and above.")
@@ -1089,6 +1163,7 @@ class GPUModelRunner(ModelRunnerBase):
     def _dummy_prefill_inputs(self, input_length_list: List[int], max_dec_len_list: List[int], block_num: int):
         """Set dummy prefill inputs to share_inputs"""
         batch_size = len(input_length_list)
+        headwise_rows = []
         for i in range(batch_size):
             idx = i
             input_length = input_length_list[i]
@@ -1111,10 +1186,20 @@ class GPUModelRunner(ModelRunnerBase):
             self.share_inputs["temperature"][idx : idx + 1] = 1
 
             self.share_inputs["encoder_block_lens"][idx : idx + 1] = block_num
-            self.share_inputs["block_tables"][idx : idx + 1, :block_num] = np.arange(
-                idx * block_num, (idx + 1) * block_num, 1
-            )
+            if self.enable_head_wise_kv_cache:
+                base = idx * self.kv_num_heads * block_num
+                self.share_inputs["block_tables"][idx : idx + 1, :block_num] = np.arange(
+                    base, base + block_num, 1
+                )
+                for h in range(self.kv_num_heads):
+                    headwise_rows.append(np.arange(base + h * block_num, base + (h + 1) * block_num, 1))
+            else:
+                self.share_inputs["block_tables"][idx : idx + 1, :block_num] = np.arange(
+                    idx * block_num, (idx + 1) * block_num, 1
+                )
         self.share_inputs["seq_lens_this_time"] = self.share_inputs["seq_lens_this_time_buffer"]
+        if self.enable_head_wise_kv_cache:
+            self.share_inputs["block_tables_3d"] = paddle.to_tensor(np.array(headwise_rows, dtype="int32"))
 
     def _prepare_inputs(self, cached_token_num=-1, cached_real_bsz=-1, is_dummy_or_profile_run=False) -> None:
         """Prepare the model inputs"""
@@ -1301,6 +1386,7 @@ class GPUModelRunner(ModelRunnerBase):
             cu_seqlens_q=self.share_inputs["cu_seqlens_q"],
             cu_seqlens_k=self.share_inputs["cu_seqlens_k"],
             block_tables=self.share_inputs["block_tables"][:num_running_requests],
+            block_tables_3d=self.share_inputs.get("block_tables_3d", None),
             caches=self.share_inputs["caches"],
             encoder_batch_ids=self.share_inputs["encoder_batch_ids"],
             encoder_tile_ids_per_batch=self.share_inputs["encoder_tile_ids_per_batch"],

--- a/fastdeploy/worker/input_batch.py
+++ b/fastdeploy/worker/input_batch.py
@@ -17,6 +17,7 @@
 import paddle
 from paddleformers.utils.log import logger
 
+from fastdeploy import envs
 from fastdeploy.config import (
     CacheConfig,
     DeployModality,
@@ -102,6 +103,7 @@ class InputBatch:
         self.speculative_config: SpeculativeConfig = fd_config.speculative_config
         self.speculative_decoding = self.speculative_config.method is not None
         self.enable_mm = self.model_config.enable_mm
+        self.enable_head_wise_kv_cache = envs.FD_HEAD_WISE_KV_CACHE == 1
         self.enable_expert_parallel = fd_config.parallel_config.enable_expert_parallel
         self.index_to_batch_id = {}
         self.enable_pd_reorder = False
@@ -237,11 +239,17 @@ class InputBatch:
             self.model_config.max_model_len + self.cache_config.block_size - 1
         ) // self.cache_config.block_size + self.cache_config.enc_dec_block_num
         kv_num_heads = max(1, self.model_config.num_key_value_heads // self.fd_config.parallel_config.tensor_parallel_size)
+        self.kv_num_heads = kv_num_heads
+        self.pre_max_block_num = pre_max_block_num
         # In head-wise mode, block_tables needs to accommodate all heads
         block_tables_cols = pre_max_block_num * kv_num_heads
         self.block_tables = paddle.full([max_num_seqs, block_tables_cols], -1, dtype="int32")
-        # Head-wise KV cache: flattened [batch*kv_num_heads, max_blocks_per_head] (set dynamically)
-        self.block_tables_3d = None
+        # Head-wise KV cache table buffer.
+        # Keep this tensor shape fixed to make CUDA Graph replay safe.
+        if self.enable_head_wise_kv_cache:
+            self.block_tables_3d = paddle.full([max_num_seqs * kv_num_heads, pre_max_block_num], -1, dtype="int32")
+        else:
+            self.block_tables_3d = None
 
         # Initialize free list
         free_list = list(
@@ -606,6 +614,8 @@ class InputBatch:
 
             # Reset block tables
             fill_paddle_tensor(self, "block_tables", -1)
+            if self.block_tables_3d is not None:
+                fill_paddle_tensor(self, "block_tables_3d", -1)
 
             # Reset free list (requires special handling)
             free_list = list(

--- a/fastdeploy/worker/input_batch.py
+++ b/fastdeploy/worker/input_batch.py
@@ -440,6 +440,15 @@ class InputBatch:
         # # Swap block tables
         swap_data(self.block_tables, i1, i2)
 
+        # Swap blocks for head-wise
+        if self.enable_head_wise_kv_cache and self.block_tables_3d is not None:
+            h = self.kv_num_heads
+            s1, e1 = i1 * h, (i1 + 1) * h
+            s2, e2 = i2 * h, (i2 + 1) * h
+            tmp = self.block_tables_3d[s1:e1].clone()
+            self.block_tables_3d[s1:e1] = self.block_tables_3d[s2:e2].clone()
+            self.block_tables_3d[s2:e2] = tmp
+
         # # Swap stop sequences
         swap_data(self.stop_seqs_len, i1, i2)
         swap_data(self.stop_seqs, i1, i2)

--- a/fastdeploy/worker/input_batch.py
+++ b/fastdeploy/worker/input_batch.py
@@ -440,15 +440,6 @@ class InputBatch:
         # # Swap block tables
         swap_data(self.block_tables, i1, i2)
 
-        # Swap blocks for head-wise
-        if self.enable_head_wise_kv_cache and self.block_tables_3d is not None:
-            h = self.kv_num_heads
-            s1, e1 = i1 * h, (i1 + 1) * h
-            s2, e2 = i2 * h, (i2 + 1) * h
-            tmp = self.block_tables_3d[s1:e1].clone()
-            self.block_tables_3d[s1:e1] = self.block_tables_3d[s2:e2].clone()
-            self.block_tables_3d[s2:e2] = tmp
-
         # # Swap stop sequences
         swap_data(self.stop_seqs_len, i1, i2)
         swap_data(self.stop_seqs, i1, i2)

--- a/fastdeploy/worker/input_batch.py
+++ b/fastdeploy/worker/input_batch.py
@@ -237,6 +237,8 @@ class InputBatch:
             self.model_config.max_model_len + self.cache_config.block_size - 1
         ) // self.cache_config.block_size + self.cache_config.enc_dec_block_num
         self.block_tables = paddle.full([max_num_seqs, pre_max_block_num], -1, dtype="int32")
+        # Head-wise KV cache: flattened [batch*kv_num_heads, max_blocks_per_head] (set dynamically)
+        self.block_tables_3d = None
 
         # Initialize free list
         free_list = list(

--- a/fastdeploy/worker/input_batch.py
+++ b/fastdeploy/worker/input_batch.py
@@ -243,8 +243,12 @@ class InputBatch:
         )
         self.kv_num_heads = kv_num_heads
         self.pre_max_block_num = pre_max_block_num
-        # In head-wise mode, block_tables needs to accommodate all heads
-        block_tables_cols = pre_max_block_num * kv_num_heads
+        if self.enable_head_wise_kv_cache:
+            # In head-wise mode, block_tables needs to accommodate all heads
+            block_tables_cols = pre_max_block_num * kv_num_heads
+        else:
+            # In non head-wise mode, keep original semantics: one block table per sequence
+            block_tables_cols = pre_max_block_num
         self.block_tables = paddle.full([max_num_seqs, block_tables_cols], -1, dtype="int32")
         # Head-wise KV cache table buffer.
         # Keep this tensor shape fixed to make CUDA Graph replay safe.

--- a/fastdeploy/worker/input_batch.py
+++ b/fastdeploy/worker/input_batch.py
@@ -236,7 +236,10 @@ class InputBatch:
         pre_max_block_num = (
             self.model_config.max_model_len + self.cache_config.block_size - 1
         ) // self.cache_config.block_size + self.cache_config.enc_dec_block_num
-        self.block_tables = paddle.full([max_num_seqs, pre_max_block_num], -1, dtype="int32")
+        kv_num_heads = max(1, self.model_config.num_key_value_heads // self.fd_config.parallel_config.tensor_parallel_size)
+        # In head-wise mode, block_tables needs to accommodate all heads
+        block_tables_cols = pre_max_block_num * kv_num_heads
+        self.block_tables = paddle.full([max_num_seqs, block_tables_cols], -1, dtype="int32")
         # Head-wise KV cache: flattened [batch*kv_num_heads, max_blocks_per_head] (set dynamically)
         self.block_tables_3d = None
 

--- a/fastdeploy/worker/input_batch.py
+++ b/fastdeploy/worker/input_batch.py
@@ -238,7 +238,9 @@ class InputBatch:
         pre_max_block_num = (
             self.model_config.max_model_len + self.cache_config.block_size - 1
         ) // self.cache_config.block_size + self.cache_config.enc_dec_block_num
-        kv_num_heads = max(1, self.model_config.num_key_value_heads // self.fd_config.parallel_config.tensor_parallel_size)
+        kv_num_heads = max(
+            1, self.model_config.num_key_value_heads // self.fd_config.parallel_config.tensor_parallel_size
+        )
         self.kv_num_heads = kv_num_heads
         self.pre_max_block_num = pre_max_block_num
         # In head-wise mode, block_tables needs to accommodate all heads


### PR DESCRIPTION
## Motivation
- Introduce head-wise KV cache support so each KV head can maintain its own cache block mapping instead of sharing a flat block table across heads.
- This provides an explicit per-head cache layout for attention kernels and request scheduling, which is required for experimenting with finer-grained KV cache organization and future head-level cache management strategies.
- The feature covers both runtime execution and serving/benchmark workflows, including request scheduling, cache allocation, forward metadata assembly, and attention kernel input preparation.

<!-- Detail the changes made in this pull request. -->

## Modifications
- Added end-to-end `head-wise KV cache` data flow across the serving stack:
  - scheduler/resource manager allocates and tracks per-head cache ids
  - request objects carry `block_tables_3d`
  - model runner prepares `block_tables_3d `for forward
  - `ForwardMeta`  passes head-wise block tables into attention backend
  - append attention custom op consumes head-wise cache layout

- Updated worker/model-runner path to support head-wise request preparation:
  - build per-head block tables from request metadata
  - support dummy/profile/warmup path for head-wise block-table preparation
  - keep request metadata aligned with runtime reorder behavior

- Added head-wise handling in attention backend and kernel input plumbing:
  - switch from flat block_tables to block_tables_3d when head-wise mode is enabled
  - propagate head-wise cache layout into append attention op

<!-- Detail the changes made in this pull request. -->

## Usage or Command
```bash 
export FD_HEAD_WISE_KV_CACHE=1

python -m fastdeploy.entrypoints.openai.api_server \
  --model baidu/ERNIE-4.5-0.3B-Base-Paddle \
  --port 8188 \
  --tensor-parallel-size 1 \
  --max-model-len 8192 \
  --no-enable-prefix-caching
```
<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests
### script
```bash 
python -m fastdeploy.entrypoints.openai.api_server --model PaddlePaddle/ERNIE-4.5-0.3B-Paddle --tensor-parallel-size 1  --port 8300 --max-model-len 8192 --no-enable-prefix-caching
```
```bash 
MODEL_SIZE=0.3B URL=http://localhost:8300/v1/chat/completions python gsm8k.py
```
### result
- baseline
```bash
🎯 Evaluation Complete: Accuracy = 3.62% (25/690)
平均准确率：3.24%
```
- head-wise
```bash
🎯 Evaluation Complete: Accuracy = 3.91% (27/690)
平均准确率：3.33%
```
### Summary

- The head-wise KV cache path runs through successfully in the GSM8K accuracy test.

- No obvious accuracy regression is observed compared with the baseline in this test.

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.