### PR TITLE
[BugFix] Fix updating weight when enable cache storage

### DIFF
--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -486,7 +486,7 @@ class PaddleDisWorkerProc:
                     self.kv_cache_status.value[0] = self.model_weights_signal[0]
                     cache_flag = (
                         self.fd_config.cache_config.num_cpu_blocks > 0
-                        or self.fd_config.kvcache_storage_backend is not None
+                        or self.fd_config.cache_config.kvcache_storage_backend is not None
                     )
                     DynamicWeightManager.check_model_weights_status(
                         self.model_weights_status,

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -484,9 +484,13 @@ class PaddleDisWorkerProc:
 
                     self.model_weights_status.value[0] = self.model_weights_signal[0]
                     self.kv_cache_status.value[0] = self.model_weights_signal[0]
+                    cache_flag = (
+                        self.fd_config.cache_config.num_cpu_blocks > 0
+                        and self.fd_config.kvcache_storage_backend is not None
+                    )
                     DynamicWeightManager.check_model_weights_status(
                         self.model_weights_status,
-                        self.kv_cache_status if self.fd_config.cache_config.num_cpu_blocks > 0 else None,
+                        self.kv_cache_status if cache_flag else None,
                         # model_weights_signal
                         self.worker.model_runner,
                         self.parallel_config.local_engine_worker_queue_port,

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -486,7 +486,7 @@ class PaddleDisWorkerProc:
                     self.kv_cache_status.value[0] = self.model_weights_signal[0]
                     cache_flag = (
                         self.fd_config.cache_config.num_cpu_blocks > 0
-                        and self.fd_config.kvcache_storage_backend is not None
+                        or self.fd_config.kvcache_storage_backend is not None
                     )
                     DynamicWeightManager.check_model_weights_status(
                         self.model_weights_status,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
Fix updating weight when enable cache storage

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications
Pass kv_cache_status to DynamicWeightManager.check_model_weights_status.
<!-- Detail the changes made in this pull request. -->

## Usage or Command
None
<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests
None
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
