### PR TITLE
[CI]【Hackathon 10th Spring No.39】fused_moe_marlin_backend 单测补充

### DIFF
--- a/tests/layers/test_fused_moe_marlin_backend.py
+++ b/tests/layers/test_fused_moe_marlin_backend.py
@@ -14,10 +14,11 @@
 
 import sys
 import types
+import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import paddle
-import pytest
 
 # Stub GPU-only ops so the import chain (moe → triton_backend → fp8_utils →
 # ops.gpu.deep_gemm) resolves without compiled CUDA extensions.
@@ -91,80 +92,100 @@ def _init(layer):
 # ── Tests ──────────────────────────────────────────────────────────────────────
 
 
-def test_pure_functions():
-    """get_scale_perms + marlin_permute_scales (both branches)."""
-    perm, single = mb.get_scale_perms()
-    assert len(perm) == 64 and len(single) == 32
-    s = paddle.arange(128, dtype="float32").reshape([2, 64])
-    assert mb.marlin_permute_scales(s, 16, 64, 8).shape == [2, 64]
-    assert mb.marlin_permute_scales(s, 16, 64, -1).shape == [2, 64]
+class TestFusedMoeMarlinBackend(unittest.TestCase):
+    """Tests for MarlinWeightOnlyMoEMethod."""
 
+    def test_pure_functions(self):
+        """get_scale_perms + marlin_permute_scales (both branches)."""
+        perm, single = mb.get_scale_perms()
+        self.assertEqual(len(perm), 64)
+        self.assertEqual(len(single), 32)
+        s = paddle.arange(128, dtype="float32").reshape([2, 64])
+        self.assertEqual(list(mb.marlin_permute_scales(s, 16, 64, 8).shape), [2, 64])
+        self.assertEqual(list(mb.marlin_permute_scales(s, 16, 64, -1).shape), [2, 64])
 
-def test_create_and_process(monkeypatch):
-    """create_weights -> process_loaded_weights end-to-end."""
-    layer = _DummyLayer()
-    m = _init(layer)
-    assert hasattr(layer, "up_gate_proj_weight")
-    assert hasattr(layer, "down_proj_weight")
-    monkeypatch.setattr(
-        _gpu,
-        "gptq_marlin_repack",
-        lambda w, p, sk, sn, nb: paddle.zeros([sk // 16, sn * (nb // 2)], dtype=w.dtype),
-    )
-    m.process_loaded_weights(layer, dict(zip(("up", "down"), _make_weights(layer))))
+    def test_create_and_process(self):
+        """create_weights -> process_loaded_weights end-to-end."""
+        layer = _DummyLayer()
+        m = _init(layer)
+        self.assertTrue(hasattr(layer, "up_gate_proj_weight"))
+        self.assertTrue(hasattr(layer, "down_proj_weight"))
+        with patch.object(
+            _gpu,
+            "gptq_marlin_repack",
+            lambda w, p, sk, sn, nb: paddle.zeros([sk // 16, sn * (nb // 2)], dtype=w.dtype),
+        ):
+            m.process_loaded_weights(layer, dict(zip(("up", "down"), _make_weights(layer))))
 
+    def test_apply_topk(self):
+        """apply() with default topk_method='topk'."""
+        layer = _DummyLayer()
+        m = _init(layer)
+        gate = paddle.nn.Linear(64, 2, bias_attr=False)
+        x = paddle.ones([2, 64], dtype="float32")
+        with (
+            patch.object(
+                mb,
+                "MoeWna16MarlinGemmApi",
+                lambda *_a, **kw: (paddle.zeros([kw["size_m"], kw["size_n"]], "float32"),),
+            ),
+            patch.object(
+                mb,
+                "tritonmoe_preprocess_func",
+                lambda ids, ne, bm: (
+                    paddle.zeros([4], "int32"),
+                    paddle.zeros([1], "int32"),
+                    paddle.to_tensor([4], "int32"),
+                ),
+            ),
+            patch.object(
+                _gpu,
+                "moe_topk_select",
+                lambda g, b, k, *_: (
+                    paddle.zeros([g.shape[0], k], "int64"),
+                    paddle.ones([g.shape[0], k], "float32"),
+                ),
+            ),
+            patch("paddle.incubate.nn.functional.swiglu", lambda x: x[..., : x.shape[-1] // 2]),
+        ):
+            out = m.apply(layer, x, gate, topk_ids_hookfunc=lambda **_: None)
+        self.assertEqual(list(out.shape), [2, 64])
 
-def test_apply_topk(monkeypatch):
-    """apply() with default topk_method='topk'."""
-    layer = _DummyLayer()
-    m = _init(layer)
-    gate = paddle.nn.Linear(64, 2, bias_attr=False)
-    x = paddle.ones([2, 64], dtype="float32")
-    monkeypatch.setattr(
-        mb, "MoeWna16MarlinGemmApi", lambda *_a, **kw: (paddle.zeros([kw["size_m"], kw["size_n"]], "float32"),)
-    )
-    monkeypatch.setattr(
-        mb,
-        "tritonmoe_preprocess_func",
-        lambda ids, ne, bm: (paddle.zeros([4], "int32"), paddle.zeros([1], "int32"), paddle.to_tensor([4], "int32")),
-    )
-    monkeypatch.setattr(
-        _gpu,
-        "moe_topk_select",
-        lambda g, b, k, *_: (paddle.zeros([g.shape[0], k], "int64"), paddle.ones([g.shape[0], k], "float32")),
-    )
-    monkeypatch.setattr("paddle.incubate.nn.functional.swiglu", lambda x: x[..., : x.shape[-1] // 2])
-    out = m.apply(layer, x, gate, topk_ids_hookfunc=lambda **_: None)
-    assert out.shape == [2, 64]
-
-
-def test_apply_noaux_tc(monkeypatch):
-    """apply() with topk_method='noaux_tc'."""
-    layer = _DummyLayer()
-    layer.topk_method = "noaux_tc"
-    m = _init(layer)
-    gate = paddle.nn.Linear(64, 2, bias_attr=False)
-    x = paddle.ones([2, 64], dtype="float32")
-    monkeypatch.setattr(
-        mb, "MoeWna16MarlinGemmApi", lambda *_a, **kw: (paddle.zeros([kw["size_m"], kw["size_n"]], "float32"),)
-    )
-    monkeypatch.setattr(
-        mb,
-        "tritonmoe_preprocess_func",
-        lambda ids, ne, bm: (paddle.zeros([4], "int32"), paddle.zeros([1], "int32"), paddle.to_tensor([4], "int32")),
-    )
-    monkeypatch.setattr(
-        "fastdeploy.model_executor.layers.moe.moe.get_moe_scores",
-        lambda g, ng, tg, k, s, b, r: (
-            g,
-            paddle.ones([g.shape[0], k], "float32"),
-            paddle.zeros([g.shape[0], k], "int64"),
-        ),
-    )
-    monkeypatch.setattr("paddle.incubate.nn.functional.swiglu", lambda x: x[..., : x.shape[-1] // 2])
-    out = m.apply(layer, x, gate, topk_ids_hookfunc=lambda **_: None)
-    assert out.shape == [2, 64]
+    def test_apply_noaux_tc(self):
+        """apply() with topk_method='noaux_tc'."""
+        layer = _DummyLayer()
+        layer.topk_method = "noaux_tc"
+        m = _init(layer)
+        gate = paddle.nn.Linear(64, 2, bias_attr=False)
+        x = paddle.ones([2, 64], dtype="float32")
+        with (
+            patch.object(
+                mb,
+                "MoeWna16MarlinGemmApi",
+                lambda *_a, **kw: (paddle.zeros([kw["size_m"], kw["size_n"]], "float32"),),
+            ),
+            patch.object(
+                mb,
+                "tritonmoe_preprocess_func",
+                lambda ids, ne, bm: (
+                    paddle.zeros([4], "int32"),
+                    paddle.zeros([1], "int32"),
+                    paddle.to_tensor([4], "int32"),
+                ),
+            ),
+            patch(
+                "fastdeploy.model_executor.layers.moe.moe.get_moe_scores",
+                lambda g, ng, tg, k, s, b, r: (
+                    g,
+                    paddle.ones([g.shape[0], k], "float32"),
+                    paddle.zeros([g.shape[0], k], "int64"),
+                ),
+            ),
+            patch("paddle.incubate.nn.functional.swiglu", lambda x: x[..., : x.shape[-1] // 2]),
+        ):
+            out = m.apply(layer, x, gate, topk_ids_hookfunc=lambda **_: None)
+        self.assertEqual(list(out.shape), [2, 64])
 
 
 if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+    unittest.main()

--- a/tests/layers/test_fused_moe_marlin_backend.py
+++ b/tests/layers/test_fused_moe_marlin_backend.py
@@ -105,6 +105,40 @@ class TestFusedMoeMarlinBackend(unittest.TestCase):
         self.assertEqual(list(mb.marlin_permute_scales(s, 16, 64, 8).shape), [2, 64])
         self.assertEqual(list(mb.marlin_permute_scales(s, 16, 64, -1).shape), [2, 64])
 
+    def test_gptq_marlin_moe_repack(self):
+        """gptq_marlin_moe_repack loops over experts and repacks via C++ op."""
+        num_experts, size_k, size_n, num_bits = 2, 32, 16, 4
+        b_q_weight = paddle.ones([num_experts, size_k, size_n], dtype="int32")
+        perm = paddle.zeros([num_experts, size_k], dtype="int32")
+        with (
+            patch.dict(
+                sys.modules,
+                {_GPU_OPS: _gpu_ops_stub, _DEEP_GEMM: _deep_gemm_stub},
+                clear=False,
+            ),
+            patch.object(
+                _gpu_ops_stub,
+                "gptq_marlin_repack",
+                lambda w, p, sk, sn, nb: paddle.zeros([sk // 16, sn * (nb // 2)], dtype=w.dtype),
+            ),
+        ):
+            out = mb.gptq_marlin_moe_repack(b_q_weight, perm, size_k, size_n, num_bits)
+        self.assertEqual(list(out.shape), [num_experts, size_k // 16, size_n * (num_bits // 2)])
+
+    def test_marlin_moe_permute_scales(self):
+        """marlin_moe_permute_scales loops over experts applying scale permutation."""
+        num_experts, size_k, size_n, group_size = 3, 64, 64, 8
+        num_groups = size_k // group_size  # 8
+        s = paddle.arange(num_experts * num_groups * size_n, dtype="float32").reshape(
+            [num_experts, num_groups, size_n]
+        )
+        out = mb.marlin_moe_permute_scales(s, size_k, size_n, group_size)
+        self.assertEqual(list(out.shape), [num_experts, num_groups, size_n])
+        # Each expert slice should match the single-expert function
+        for e in range(num_experts):
+            expected = mb.marlin_permute_scales(s[e], size_k, size_n, group_size)
+            self.assertTrue(paddle.equal_all(out[e], expected).item())
+
     def test_create_and_process(self):
         """create_weights -> process_loaded_weights end-to-end."""
         layer = _DummyLayer()

--- a/tests/layers/test_fused_moe_marlin_backend.py
+++ b/tests/layers/test_fused_moe_marlin_backend.py
@@ -25,7 +25,15 @@ _gpu = sys.modules.get("fastdeploy.model_executor.ops.gpu")
 if _gpu is None:
     _gpu = types.ModuleType("fastdeploy.model_executor.ops.gpu")
     sys.modules["fastdeploy.model_executor.ops.gpu"] = _gpu
-for _a in ("MoeWna16MarlinGemmApi", "tritonmoe_preprocess_func", "gptq_marlin_repack", "moe_topk_select"):
+for _a in (
+    "MoeWna16MarlinGemmApi",
+    "moe_expert_dispatch",
+    "moe_expert_reduce",
+    "tritonmoe_preprocess_func",
+    "gptq_marlin_repack",
+    "moe_topk_select",
+    "get_padding_offset",
+):
     if not hasattr(_gpu, _a):
         setattr(_gpu, _a, None)
 

--- a/tests/layers/test_fused_moe_marlin_backend.py
+++ b/tests/layers/test_fused_moe_marlin_backend.py
@@ -22,7 +22,13 @@ import paddle
 
 # Stub GPU-only ops so the import chain (moe → triton_backend → fp8_utils →
 # ops.gpu.deep_gemm) resolves without compiled CUDA extensions.
-# Must be installed BEFORE any fastdeploy import that touches ops.gpu.
+# Stubs are scoped: saved before, restored immediately after import.
+
+_STUB_KEYS = [
+    "fastdeploy.model_executor.ops.gpu",
+    "fastdeploy.model_executor.ops.gpu.deep_gemm",
+]
+_saved_modules = {k: sys.modules.get(k) for k in _STUB_KEYS}
 
 
 class _GpuOpsStub(types.ModuleType):
@@ -51,6 +57,13 @@ _gpu = sys.modules["fastdeploy.model_executor.ops.gpu"]
 from fastdeploy.model_executor.layers.moe import (  # noqa: E402
     fused_moe_marlin_backend as mb,
 )
+
+# Restore original modules immediately after import to avoid global pollution.
+for _k in _STUB_KEYS:
+    if _saved_modules[_k] is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _saved_modules[_k]
 
 
 class _DummyLayer(paddle.nn.Layer):
@@ -146,7 +159,11 @@ class TestFusedMoeMarlinBackend(unittest.TestCase):
                     paddle.ones([g.shape[0], k], "float32"),
                 ),
             ),
-            patch("paddle.incubate.nn.functional.swiglu", lambda x: x[..., : x.shape[-1] // 2]),
+            patch(
+                "paddle.incubate.nn.functional.swiglu",
+                lambda x: x[..., : x.shape[-1] // 2],
+                create=True,
+            ),
         ):
             out = m.apply(layer, x, gate, topk_ids_hookfunc=lambda **_: None)
         self.assertEqual(list(out.shape), [2, 64])
@@ -181,7 +198,11 @@ class TestFusedMoeMarlinBackend(unittest.TestCase):
                     paddle.zeros([g.shape[0], k], "int64"),
                 ),
             ),
-            patch("paddle.incubate.nn.functional.swiglu", lambda x: x[..., : x.shape[-1] // 2]),
+            patch(
+                "paddle.incubate.nn.functional.swiglu",
+                lambda x: x[..., : x.shape[-1] // 2],
+                create=True,
+            ),
         ):
             out = m.apply(layer, x, gate, topk_ids_hookfunc=lambda **_: None)
         self.assertEqual(list(out.shape), [2, 64])

--- a/tests/layers/test_fused_moe_marlin_backend.py
+++ b/tests/layers/test_fused_moe_marlin_backend.py
@@ -22,13 +22,7 @@ import paddle
 
 # Stub GPU-only ops so the import chain (moe → triton_backend → fp8_utils →
 # ops.gpu.deep_gemm) resolves without compiled CUDA extensions.
-# Stubs are scoped: saved before, restored immediately after import.
-
-_STUB_KEYS = [
-    "fastdeploy.model_executor.ops.gpu",
-    "fastdeploy.model_executor.ops.gpu.deep_gemm",
-]
-_saved_modules = {k: sys.modules.get(k) for k in _STUB_KEYS}
+# Scoped via patch.dict so sys.modules is restored after the import.
 
 
 class _GpuOpsStub(types.ModuleType):
@@ -44,26 +38,20 @@ class _GpuOpsStub(types.ModuleType):
         return None
 
 
-sys.modules["fastdeploy.model_executor.ops.gpu"] = _GpuOpsStub("fastdeploy.model_executor.ops.gpu")
-# fp8_utils.py:52 uses `import ...ops.gpu.deep_gemm as deep_gemm`
-_deep_gemm_stub = types.ModuleType("fastdeploy.model_executor.ops.gpu.deep_gemm")
+_GPU_OPS = "fastdeploy.model_executor.ops.gpu"
+_DEEP_GEMM = f"{_GPU_OPS}.deep_gemm"
+
+_gpu_ops_stub = _GpuOpsStub(_GPU_OPS)
+_deep_gemm_stub = types.ModuleType(_DEEP_GEMM)
 _deep_gemm_stub.m_grouped_fp8_gemm_nt_contiguous = None
 _deep_gemm_stub.m_grouped_fp8_gemm_nt_masked = None
 _deep_gemm_stub.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous = None
 _deep_gemm_stub.m_grouped_gemm_fp8_fp8_bf16_nt_masked = None
-sys.modules["fastdeploy.model_executor.ops.gpu.deep_gemm"] = _deep_gemm_stub
-_gpu = sys.modules["fastdeploy.model_executor.ops.gpu"]
 
-from fastdeploy.model_executor.layers.moe import (  # noqa: E402
-    fused_moe_marlin_backend as mb,
-)
-
-# Restore original modules immediately after import to avoid global pollution.
-for _k in _STUB_KEYS:
-    if _saved_modules[_k] is None:
-        sys.modules.pop(_k, None)
-    else:
-        sys.modules[_k] = _saved_modules[_k]
+with patch.dict(sys.modules, {_GPU_OPS: _gpu_ops_stub, _DEEP_GEMM: _deep_gemm_stub}, clear=False):
+    from fastdeploy.model_executor.layers.moe import (  # noqa: E402
+        fused_moe_marlin_backend as mb,
+    )
 
 
 class _DummyLayer(paddle.nn.Layer):
@@ -124,7 +112,7 @@ class TestFusedMoeMarlinBackend(unittest.TestCase):
         self.assertTrue(hasattr(layer, "up_gate_proj_weight"))
         self.assertTrue(hasattr(layer, "down_proj_weight"))
         with patch.object(
-            _gpu,
+            _gpu_ops_stub,
             "gptq_marlin_repack",
             lambda w, p, sk, sn, nb: paddle.zeros([sk // 16, sn * (nb // 2)], dtype=w.dtype),
         ):
@@ -152,7 +140,7 @@ class TestFusedMoeMarlinBackend(unittest.TestCase):
                 ),
             ),
             patch.object(
-                _gpu,
+                _gpu_ops_stub,
                 "moe_topk_select",
                 lambda g, b, k, *_: (
                     paddle.zeros([g.shape[0], k], "int64"),

--- a/tests/layers/test_fused_moe_marlin_backend.py
+++ b/tests/layers/test_fused_moe_marlin_backend.py
@@ -1,3 +1,4 @@
+"""
 # Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,504 +12,137 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""Unit tests for fastdeploy/model_executor/layers/moe/fused_moe_marlin_backend.py"""
+"""
 
 import sys
-import unittest
-from unittest.mock import MagicMock, patch
+import types
+from types import SimpleNamespace
 
-import numpy as np
 import paddle
-from paddle import nn
 
-# Mock GPU ops before importing the module under test.
-# These ops require compiled CUDA extensions not available on CPU.
-_mock_gpu = MagicMock()
-sys.modules.setdefault("fastdeploy.model_executor.ops.gpu", _mock_gpu)
+# Stub GPU-only ops for CPU environments (cf. test_fused_moe_cutlass_backend.py)
+_gpu = sys.modules.get("fastdeploy.model_executor.ops.gpu")
+if _gpu is None:
+    _gpu = types.ModuleType("fastdeploy.model_executor.ops.gpu")
+    sys.modules["fastdeploy.model_executor.ops.gpu"] = _gpu
+for _a in ("MoeWna16MarlinGemmApi", "tritonmoe_preprocess_func", "gptq_marlin_repack", "moe_topk_select"):
+    if not hasattr(_gpu, _a):
+        setattr(_gpu, _a, None)
 
-from fastdeploy.model_executor.layers.moe.fused_moe_marlin_backend import (  # noqa: E402
-    MarlinWeightOnlyMoEMethod,
-    get_scale_perms,
-    gptq_marlin_moe_repack,
-    marlin_moe_permute_scales,
-    marlin_permute_scales,
+from fastdeploy.model_executor.layers.moe import (  # noqa: E402
+    fused_moe_marlin_backend as mb,
 )
 
-MB = "fastdeploy.model_executor.layers.moe.fused_moe_marlin_backend"
 
+class _DummyLayer(paddle.nn.Layer):
+    """Minimal FusedMoE surface for MarlinWeightOnlyMoEMethod."""
 
-# ── helpers ──────────────────────────────────────────────────────────────
-class _DummyLayer(nn.Layer):
-    """Minimal layer mock matching FusedMoE's attributes."""
-
-    def __init__(
-        self,
-        hidden_size=128,
-        moe_intermediate_size=64,
-        num_local_experts=2,
-        num_experts=2,
-        top_k=2,
-    ):
+    def __init__(self, hidden=64, inter=32, experts=2):
         super().__init__()
-        self.hidden_size = hidden_size
-        self.moe_intermediate_size = moe_intermediate_size
-        self.num_local_experts = num_local_experts
-        self.num_experts = num_experts
-        self.top_k = top_k
-        self.n_group = 1
-        self.topk_group = 1
+        self.num_local_experts = self.num_experts = experts
+        self.hidden_size, self.moe_intermediate_size = hidden, inter
+        self.top_k = self.n_group = self.topk_group = 1
         self.topk_method = "topk"
         self.routed_scaling_factor = 1.0
-        self.gate_correction_bias = paddle.zeros([num_experts], dtype="float32")
-
-    def extract_moe_ffn_weights(self, state_dict):
-        return state_dict["up"], state_dict["down"], None, None
-
-
-# ── get_scale_perms ──────────────────────────────────────────────────────
-class TestGetScalePerms(unittest.TestCase):
-    def test_returns_two_lists(self):
-        sp, sps = get_scale_perms()
-        self.assertIsInstance(sp, list)
-        self.assertIsInstance(sps, list)
-
-    def test_scale_perm_length(self):
-        sp, _ = get_scale_perms()
-        self.assertEqual(len(sp), 64)
-
-    def test_scale_perm_single_length(self):
-        _, sps = get_scale_perms()
-        self.assertEqual(len(sps), 32)
-
-    def test_scale_perm_contains_all_values(self):
-        sp, _ = get_scale_perms()
-        self.assertEqual(sorted(sp), list(range(64)))
-
-    def test_scale_perm_single_elements_in_range(self):
-        _, sps = get_scale_perms()
-        for v in sps:
-            self.assertGreaterEqual(v, 0)
-            self.assertLess(v, 32)
-
-    def test_deterministic(self):
-        sp1, sps1 = get_scale_perms()
-        sp2, sps2 = get_scale_perms()
-        self.assertEqual(sp1, sp2)
-        self.assertEqual(sps1, sps2)
-
-
-# ── marlin_permute_scales ────────────────────────────────────────────────
-class TestMarlinPermuteScales(unittest.TestCase):
-    def test_per_channel_shape(self):
-        """group_size=-1 → uses scale_perm_single (32 elems)."""
-        s = paddle.arange(32, dtype="float32").reshape([1, 32])
-        result = marlin_permute_scales(s, size_k=128, size_n=32, group_size=-1)
-        self.assertEqual(list(result.shape), [1, 32])
-
-    def test_per_group_shape(self):
-        """group_size < size_k → uses scale_perm (64 elems)."""
-        s = paddle.arange(256, dtype="float32").reshape([4, 64])
-        result = marlin_permute_scales(s, size_k=128, size_n=64, group_size=32)
-        self.assertEqual(list(result.shape), [4, 64])
-
-    def test_per_channel_permutes_values(self):
-        s = paddle.arange(32, dtype="float32").reshape([1, 32])
-        result = marlin_permute_scales(s, size_k=128, size_n=32, group_size=-1)
-        # Values should be permuted (not identity)
-        original = s.numpy().flatten()
-        permuted = result.numpy().flatten()
-        self.assertFalse(np.array_equal(original, permuted))
-        # But same set of values
-        np.testing.assert_array_equal(sorted(original), sorted(permuted))
-
-    def test_per_group_permutes_values(self):
-        s = paddle.arange(64, dtype="float32").reshape([1, 64])
-        result = marlin_permute_scales(s, size_k=128, size_n=64, group_size=32)
-        original = s.numpy().flatten()
-        permuted = result.numpy().flatten()
-        self.assertFalse(np.array_equal(original, permuted))
-        np.testing.assert_array_equal(sorted(original), sorted(permuted))
-
-    def test_preserves_dtype(self):
-        s = paddle.ones([1, 32], dtype="float16")
-        result = marlin_permute_scales(s, size_k=128, size_n=32, group_size=-1)
-        self.assertEqual(result.dtype, paddle.float16)
-
-
-# ── marlin_moe_permute_scales ────────────────────────────────────────────
-class TestMarlinMoePermuteScales(unittest.TestCase):
-    def test_output_shape_matches_input(self):
-        num_experts = 4
-        s = paddle.ones([num_experts, 1, 32], dtype="float32")
-        result = marlin_moe_permute_scales(s, size_k=128, size_n=32, group_size=-1)
-        self.assertEqual(list(result.shape), [num_experts, 1, 32])
-
-    def test_each_expert_permuted_independently(self):
-        s = paddle.stack(
-            [
-                paddle.arange(32, dtype="float32").reshape([1, 32]),
-                paddle.arange(32, 64, dtype="float32").reshape([1, 32]),
-            ],
-            axis=0,
-        )
-        result = marlin_moe_permute_scales(s, size_k=128, size_n=32, group_size=-1)
-        # Each expert should have different values
-        e0 = result[0].numpy().flatten()
-        e1 = result[1].numpy().flatten()
-        self.assertFalse(np.array_equal(e0, e1))
-
-    def test_preserves_dtype_float16(self):
-        s = paddle.ones([2, 1, 32], dtype="float16")
-        result = marlin_moe_permute_scales(s, size_k=128, size_n=32, group_size=-1)
-        self.assertEqual(result.dtype, paddle.float16)
-
-    def test_single_expert(self):
-        s = paddle.arange(32, dtype="float32").reshape([1, 1, 32])
-        result = marlin_moe_permute_scales(s, size_k=128, size_n=32, group_size=-1)
-        self.assertEqual(list(result.shape), [1, 1, 32])
-
-
-# ── gptq_marlin_moe_repack ──────────────────────────────────────────────
-class TestGptqMarlinMoeRepack(unittest.TestCase):
-    def test_calls_repack_per_expert(self):
-        num_experts = 3
-        size_k = 64
-        size_n = 32
-        num_bits = 4
-        b_q_weight = paddle.zeros([num_experts, size_k, size_n], dtype="int32")
-        perm = paddle.zeros([num_experts, 0], dtype="int32")
-
-        mock_repack = MagicMock(return_value=paddle.ones([size_k // 16, size_n * (num_bits // 2)], dtype="int32"))
-        _mock_gpu.gptq_marlin_repack = mock_repack
-        result = gptq_marlin_moe_repack(b_q_weight, perm, size_k, size_n, num_bits)
-
-        self.assertEqual(mock_repack.call_count, num_experts)
-        self.assertEqual(list(result.shape), [num_experts, size_k // 16, size_n * (num_bits // 2)])
-
-    def test_size_k_alignment(self):
-        """size_k must be divisible by 16."""
-        b_q_weight = paddle.zeros([1, 15, 8], dtype="int32")
-        perm = paddle.zeros([1, 0], dtype="int32")
-        with self.assertRaises(AssertionError):
-            gptq_marlin_moe_repack(b_q_weight, perm, 15, 8, 4)
-
-
-# ── MarlinWeightOnlyMoEMethod.__init__ ───────────────────────────────────
-class TestMarlinInit(unittest.TestCase):
-    def test_default_attrs(self):
-        method = MarlinWeightOnlyMoEMethod()
-        self.assertIsNone(method.quant_method)
-        self.assertEqual(len(method.added_weight_attrs), 2)
-        self.assertEqual(len(method.added_scale_attrs), 2)
-        self.assertEqual(len(method.added_zeros_attrs), 2)
-
-    def test_custom_quant_method(self):
-        method = MarlinWeightOnlyMoEMethod(quant_method="gptq")
-        self.assertEqual(method.quant_method, "gptq")
-
-    def test_weight_attr_names(self):
-        method = MarlinWeightOnlyMoEMethod()
-        self.assertIn("up_gate_proj_weight", method.added_weight_attrs)
-        self.assertIn("down_proj_weight", method.added_weight_attrs)
-
-    def test_scale_attr_names(self):
-        method = MarlinWeightOnlyMoEMethod()
-        self.assertIn("up_gate_proj_weight_scale", method.added_scale_attrs)
-        self.assertIn("down_proj_weight_scale", method.added_scale_attrs)
-
-
-# ── MarlinWeightOnlyMoEMethod.create_weights ─────────────────────────────
-class TestMarlinCreateWeights(unittest.TestCase):
-    def test_creates_weight_parameters(self):
-        method = MarlinWeightOnlyMoEMethod()
-        layer = _DummyLayer(hidden_size=128, moe_intermediate_size=64, num_local_experts=2)
-        method.create_weights(layer)
-
-        self.assertTrue(hasattr(layer, "up_gate_proj_weight"))
-        self.assertTrue(hasattr(layer, "down_proj_weight"))
-
-    def test_weight_shapes(self):
-        method = MarlinWeightOnlyMoEMethod()
-        layer = _DummyLayer(hidden_size=128, moe_intermediate_size=64, num_local_experts=2)
-        method.create_weights(layer)
-
-        # up_gate: [E, hidden//16, intermediate*4]
-        self.assertEqual(list(layer.up_gate_proj_weight.shape), [2, 128 // 16, 64 * 4])
-        # down: [E, intermediate//16, hidden*2]
-        self.assertEqual(list(layer.down_proj_weight.shape), [2, 64 // 16, 128 * 2])
-
-    def test_scale_shapes(self):
-        method = MarlinWeightOnlyMoEMethod()
-        layer = _DummyLayer(hidden_size=128, moe_intermediate_size=64, num_local_experts=2)
-        method.create_weights(layer)
-
-        self.assertTrue(hasattr(layer, "up_gate_proj_weight_scale"))
-        self.assertTrue(hasattr(layer, "down_proj_weight_scale"))
-        # up_gate_scale: [E, 1, intermediate*2]
-        self.assertEqual(list(layer.up_gate_proj_weight_scale.shape), [2, 1, 64 * 2])
-        # down_scale: [E, 1, hidden]
-        self.assertEqual(list(layer.down_proj_weight_scale.shape), [2, 1, 128])
-
-    def test_weight_dtype_is_int32(self):
-        method = MarlinWeightOnlyMoEMethod()
-        layer = _DummyLayer()
-        method.create_weights(layer)
-        self.assertEqual(layer.up_gate_proj_weight.dtype, paddle.int32)
-        self.assertEqual(layer.down_proj_weight.dtype, paddle.int32)
-
-    def test_stores_shapes(self):
-        method = MarlinWeightOnlyMoEMethod()
-        layer = _DummyLayer(hidden_size=256, moe_intermediate_size=128, num_local_experts=4)
-        method.create_weights(layer)
-        self.assertEqual(method.up_gate_proj_weight_shape[0], 4)
-        self.assertEqual(method.down_proj_weight_shape[0], 4)
-
-
-# ── MarlinWeightOnlyMoEMethod.process_loaded_weights ─────────────────────
-class TestMarlinProcessLoadedWeights(unittest.TestCase):
-    @patch(f"{MB}.marlin_moe_permute_scales")
-    @patch(f"{MB}.gptq_marlin_moe_repack")
-    def test_processes_all_experts(self, mock_repack, mock_permute):
-        method = MarlinWeightOnlyMoEMethod()
-        hidden = 128
-        inter = 64
-        num_experts = 2
-        layer = _DummyLayer(hidden_size=hidden, moe_intermediate_size=inter, num_local_experts=num_experts)
-        method.create_weights(layer)
-
-        up_weights = [paddle.randn([hidden, inter * 2]) for _ in range(num_experts)]
-        down_weights = [paddle.randn([inter, hidden]) for _ in range(num_experts)]
-        state_dict = {"up": up_weights, "down": down_weights}
-
-        mock_repack.side_effect = lambda w, p, k, n, b: paddle.zeros(
-            [num_experts, k // 16, n * (b // 2)], dtype="int32"
-        )
-        mock_permute.side_effect = lambda s, **kw: s
-
-        method.process_loaded_weights(layer, state_dict)
-
-        # gptq_marlin_moe_repack called once per weight type (up_gate + down)
-        self.assertEqual(mock_repack.call_count, 2)
-        # marlin_moe_permute_scales called once per scale type
-        self.assertEqual(mock_permute.call_count, 2)
-
-    @patch(f"{MB}.marlin_moe_permute_scales")
-    @patch(f"{MB}.gptq_marlin_moe_repack")
-    def test_assertion_on_wrong_expert_count(self, mock_repack, mock_permute):
-        method = MarlinWeightOnlyMoEMethod()
-        layer = _DummyLayer(hidden_size=128, moe_intermediate_size=64, num_local_experts=2)
-        method.create_weights(layer)
-
-        # Provide wrong number of experts
-        up_weights = [paddle.randn([128, 128])]  # only 1 expert
-        down_weights = [paddle.randn([64, 128]), paddle.randn([64, 128])]
-        state_dict = {"up": up_weights, "down": down_weights}
-
-        with self.assertRaises(AssertionError):
-            method.process_loaded_weights(layer, state_dict)
-
-    @patch(f"{MB}.marlin_moe_permute_scales")
-    @patch(f"{MB}.gptq_marlin_moe_repack")
-    def test_assertion_on_wrong_weight_shape(self, mock_repack, mock_permute):
-        method = MarlinWeightOnlyMoEMethod()
-        layer = _DummyLayer(hidden_size=128, moe_intermediate_size=64, num_local_experts=1)
-        method.create_weights(layer)
-
-        # Wrong shape: [hidden, wrong_size] instead of [hidden, inter*2]
-        up_weights = [paddle.randn([128, 999])]
-        down_weights = [paddle.randn([64, 128])]
-        state_dict = {"up": up_weights, "down": down_weights}
-
-        with self.assertRaises(AssertionError):
-            method.process_loaded_weights(layer, state_dict)
-
-
-# ── MarlinWeightOnlyMoEMethod.apply ──────────────────────────────────────
-class TestMarlinApply(unittest.TestCase):
-    def _setup_method_and_layer(self):
-        method = MarlinWeightOnlyMoEMethod()
-        layer = _DummyLayer(
-            hidden_size=128,
-            moe_intermediate_size=64,
-            num_local_experts=4,
-            num_experts=4,
-            top_k=2,
-        )
-        method.create_weights(layer)
-        return method, layer
-
-    @patch(f"{MB}.tritonmoe_preprocess_func")
-    @patch(f"{MB}.MoeWna16MarlinGemmApi")
-    @patch("fastdeploy.model_executor.ops.gpu.moe_topk_select")
-    def test_apply_output_shape(self, mock_topk, mock_gemm, mock_preproc):
-        method, layer = self._setup_method_and_layer()
-        batch, hidden = 4, 128
-        x = paddle.randn([batch, hidden])
-        gate = nn.Linear(hidden, layer.num_experts, bias_attr=False)
-
-        # Setup mocks
-        topk_ids = paddle.zeros([batch, layer.top_k], dtype="int32")
-        topk_weights = paddle.ones([batch, layer.top_k], dtype="float32")
-        mock_topk.return_value = (topk_ids, topk_weights)
-        mock_preproc.return_value = (
-            paddle.zeros([16], dtype="int32"),
-            paddle.zeros([4], dtype="int32"),
-            paddle.to_tensor([16], dtype="int32"),
-        )
-        # MoeWna16MarlinGemmApi returns tuple; first call = up_gate+swiglu, second = down
-        final_out = paddle.randn([batch * layer.top_k, hidden])
-        mock_gemm.side_effect = [
-            (paddle.randn([batch * layer.top_k, layer.moe_intermediate_size * 2]),),
-            (final_out,),
-        ]
-
-        result = method.apply(layer, x, gate)
-        self.assertEqual(list(result.shape), [batch, hidden])
-
-    @patch(f"{MB}.tritonmoe_preprocess_func")
-    @patch(f"{MB}.MoeWna16MarlinGemmApi")
-    @patch("fastdeploy.model_executor.ops.gpu.moe_topk_select")
-    def test_apply_calls_gemm_twice(self, mock_topk, mock_gemm, mock_preproc):
-        """apply() should call MoeWna16MarlinGemmApi exactly twice (up_gate + down)."""
-        method, layer = self._setup_method_and_layer()
-        batch, hidden = 2, 128
-        x = paddle.randn([batch, hidden])
-        gate = nn.Linear(hidden, layer.num_experts, bias_attr=False)
-
-        topk_ids = paddle.zeros([batch, layer.top_k], dtype="int32")
-        topk_weights = paddle.ones([batch, layer.top_k], dtype="float32")
-        mock_topk.return_value = (topk_ids, topk_weights)
-        mock_preproc.return_value = (
-            paddle.zeros([8], dtype="int32"),
-            paddle.zeros([4], dtype="int32"),
-            paddle.to_tensor([8], dtype="int32"),
-        )
-        mock_gemm.side_effect = [
-            (paddle.randn([batch * layer.top_k, layer.moe_intermediate_size * 2]),),
-            (paddle.randn([batch * layer.top_k, hidden]),),
-        ]
-
-        method.apply(layer, x, gate)
-        self.assertEqual(mock_gemm.call_count, 2)
-
-    @patch(f"{MB}.tritonmoe_preprocess_func")
-    @patch(f"{MB}.MoeWna16MarlinGemmApi")
-    @patch("fastdeploy.model_executor.ops.gpu.moe_topk_select")
-    def test_apply_with_hookfunc(self, mock_topk, mock_gemm, mock_preproc):
-        """topk_ids_hookfunc should be called with topk_ids."""
-        method, layer = self._setup_method_and_layer()
-        batch, hidden = 2, 128
-        x = paddle.randn([batch, hidden])
-        gate = nn.Linear(hidden, layer.num_experts, bias_attr=False)
-
-        topk_ids = paddle.zeros([batch, layer.top_k], dtype="int32")
-        topk_weights = paddle.ones([batch, layer.top_k], dtype="float32")
-        mock_topk.return_value = (topk_ids, topk_weights)
-        mock_preproc.return_value = (
-            paddle.zeros([8], dtype="int32"),
-            paddle.zeros([4], dtype="int32"),
-            paddle.to_tensor([8], dtype="int32"),
-        )
-        mock_gemm.side_effect = [
-            (paddle.randn([batch * layer.top_k, layer.moe_intermediate_size * 2]),),
-            (paddle.randn([batch * layer.top_k, hidden]),),
-        ]
-
-        hook = MagicMock()
-        method.apply(layer, x, gate, topk_ids_hookfunc=hook)
-        hook.assert_called_once()
-
-    @patch(f"{MB}.tritonmoe_preprocess_func")
-    @patch(f"{MB}.MoeWna16MarlinGemmApi")
-    def test_apply_noaux_tc_topk_method(self, mock_gemm, mock_preproc):
-        """When topk_method='noaux_tc', should use get_moe_scores instead of moe_topk_select."""
-        method, layer = self._setup_method_and_layer()
-        layer.topk_method = "noaux_tc"
-        batch, hidden = 2, 128
-        x = paddle.randn([batch, hidden])
-        gate = nn.Linear(hidden, layer.num_experts, bias_attr=False)
-
-        mock_preproc.return_value = (
-            paddle.zeros([8], dtype="int32"),
-            paddle.zeros([4], dtype="int32"),
-            paddle.to_tensor([8], dtype="int32"),
-        )
-        mock_gemm.side_effect = [
-            (paddle.randn([batch * layer.top_k, layer.moe_intermediate_size * 2]),),
-            (paddle.randn([batch * layer.top_k, hidden]),),
-        ]
-
-        mock_scores = MagicMock(
-            return_value=(
-                None,
-                paddle.ones([batch, layer.top_k], dtype="float32"),
-                paddle.zeros([batch, layer.top_k], dtype="int32"),
-            )
-        )
-        with patch(f"{MB}.get_moe_scores", mock_scores, create=True):
-            with patch("fastdeploy.model_executor.layers.moe.moe.get_moe_scores", mock_scores, create=True):
-                result = method.apply(layer, x, gate)
-        self.assertEqual(list(result.shape), [batch, hidden])
-
-    @patch(f"{MB}.tritonmoe_preprocess_func")
-    @patch(f"{MB}.MoeWna16MarlinGemmApi")
-    @patch("fastdeploy.model_executor.ops.gpu.moe_topk_select")
-    def test_block_size_selection(self, mock_topk, mock_gemm, mock_preproc):
-        """Block size should be selected based on token_num * top_k / num_experts ratio."""
-        method, layer = self._setup_method_and_layer()
-        # Use small batch to trigger small block_size
-        batch, hidden = 1, 128
-        x = paddle.randn([batch, hidden])
-        gate = nn.Linear(hidden, layer.num_experts, bias_attr=False)
-
-        topk_ids = paddle.zeros([batch, layer.top_k], dtype="int32")
-        topk_weights = paddle.ones([batch, layer.top_k], dtype="float32")
-        mock_topk.return_value = (topk_ids, topk_weights)
-        mock_preproc.return_value = (
-            paddle.zeros([8], dtype="int32"),
-            paddle.zeros([4], dtype="int32"),
-            paddle.to_tensor([8], dtype="int32"),
-        )
-        mock_gemm.side_effect = [
-            (paddle.randn([batch * layer.top_k, layer.moe_intermediate_size * 2]),),
-            (paddle.randn([batch * layer.top_k, hidden]),),
-        ]
-
-        method.apply(layer, x, gate)
-        # Verify preprocess was called (block_size_m passed implicitly)
-        mock_preproc.assert_called_once()
-
-
-# ── Edge cases / integration ─────────────────────────────────────────────
-class TestEdgeCases(unittest.TestCase):
-    def test_single_expert_permute(self):
-        s = paddle.arange(32, dtype="float32").reshape([1, 1, 32])
-        result = marlin_moe_permute_scales(s, size_k=128, size_n=32, group_size=-1)
-        self.assertEqual(list(result.shape), [1, 1, 32])
-
-    def test_large_num_experts(self):
-        num_experts = 16
-        s = paddle.ones([num_experts, 1, 32], dtype="float32")
-        result = marlin_moe_permute_scales(s, size_k=128, size_n=32, group_size=-1)
-        self.assertEqual(list(result.shape), [num_experts, 1, 32])
-
-    def test_method_inherits_quant_base(self):
-        from fastdeploy.model_executor.layers.quantization.quant_base import (
-            QuantMethodBase,
-        )
-
-        self.assertTrue(issubclass(MarlinWeightOnlyMoEMethod, QuantMethodBase))
-
-    def test_create_weights_different_sizes(self):
-        """Test create_weights with various hidden/intermediate size combos."""
-        for hidden, inter in [(256, 128), (512, 256), (64, 32)]:
-            method = MarlinWeightOnlyMoEMethod()
-            layer = _DummyLayer(hidden_size=hidden, moe_intermediate_size=inter, num_local_experts=1)
-            method.create_weights(layer)
-            self.assertEqual(list(layer.up_gate_proj_weight.shape), [1, hidden // 16, inter * 4])
-            self.assertEqual(list(layer.down_proj_weight.shape), [1, inter // 16, hidden * 2])
-
-
-if __name__ == "__main__":
-    unittest.main()
+        self.gate_correction_bias = paddle.zeros([experts], dtype="float32")
+        self.renormalize = True
+        self.fd_config = SimpleNamespace()
+
+    def extract_moe_ffn_weights(self, sd):
+        return sd["up"], sd["down"], None, None
+
+
+def _make_weights(layer):
+    u = [
+        paddle.ones([layer.hidden_size, layer.moe_intermediate_size * 2], "float32")
+        for _ in range(layer.num_local_experts)
+    ]
+    d = [
+        paddle.ones([layer.moe_intermediate_size, layer.hidden_size], "float32")
+        for _ in range(layer.num_local_experts)
+    ]
+    return u, d
+
+
+def _init(layer):
+    m = mb.MarlinWeightOnlyMoEMethod()
+    m.create_weights(layer)
+    return m
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+
+def test_pure_functions():
+    """get_scale_perms + marlin_permute_scales (both branches)."""
+    perm, single = mb.get_scale_perms()
+    assert len(perm) == 64 and len(single) == 32
+    s = paddle.arange(128, dtype="float32").reshape([2, 64])
+    assert mb.marlin_permute_scales(s, 16, 64, 8).shape == [2, 64]
+    assert mb.marlin_permute_scales(s, 16, 64, -1).shape == [2, 64]
+
+
+def test_create_and_process(monkeypatch):
+    """create_weights -> process_loaded_weights end-to-end."""
+    layer = _DummyLayer()
+    m = _init(layer)
+    assert hasattr(layer, "up_gate_proj_weight")
+    assert hasattr(layer, "down_proj_weight")
+    monkeypatch.setattr(
+        _gpu,
+        "gptq_marlin_repack",
+        lambda w, p, sk, sn, nb: paddle.zeros([sk // 16, sn * (nb // 2)], dtype=w.dtype),
+    )
+    m.process_loaded_weights(layer, dict(zip(("up", "down"), _make_weights(layer))))
+
+
+def test_apply_topk(monkeypatch):
+    """apply() with default topk_method='topk'."""
+    layer = _DummyLayer()
+    m = _init(layer)
+    gate = paddle.nn.Linear(64, 2, bias_attr=False)
+    x = paddle.ones([2, 64], dtype="float32")
+    monkeypatch.setattr(
+        mb, "MoeWna16MarlinGemmApi", lambda *_a, **kw: (paddle.zeros([kw["size_m"], kw["size_n"]], "float32"),)
+    )
+    monkeypatch.setattr(
+        mb,
+        "tritonmoe_preprocess_func",
+        lambda ids, ne, bm: (paddle.zeros([4], "int32"), paddle.zeros([1], "int32"), paddle.to_tensor([4], "int32")),
+    )
+    monkeypatch.setattr(
+        _gpu,
+        "moe_topk_select",
+        lambda g, b, k, *_: (paddle.zeros([g.shape[0], k], "int64"), paddle.ones([g.shape[0], k], "float32")),
+    )
+    monkeypatch.setattr("paddle.incubate.nn.functional.swiglu", lambda x: x[..., : x.shape[-1] // 2])
+    out = m.apply(layer, x, gate, topk_ids_hookfunc=lambda **_: None)
+    assert out.shape == [2, 64]
+
+
+def test_apply_noaux_tc(monkeypatch):
+    """apply() with topk_method='noaux_tc'."""
+    layer = _DummyLayer()
+    layer.topk_method = "noaux_tc"
+    m = _init(layer)
+    gate = paddle.nn.Linear(64, 2, bias_attr=False)
+    x = paddle.ones([2, 64], dtype="float32")
+    monkeypatch.setattr(
+        mb, "MoeWna16MarlinGemmApi", lambda *_a, **kw: (paddle.zeros([kw["size_m"], kw["size_n"]], "float32"),)
+    )
+    monkeypatch.setattr(
+        mb,
+        "tritonmoe_preprocess_func",
+        lambda ids, ne, bm: (paddle.zeros([4], "int32"), paddle.zeros([1], "int32"), paddle.to_tensor([4], "int32")),
+    )
+    monkeypatch.setattr(
+        "fastdeploy.model_executor.layers.moe.moe.get_moe_scores",
+        lambda g, ng, tg, k, s, b, r: (
+            g,
+            paddle.ones([g.shape[0], k], "float32"),
+            paddle.zeros([g.shape[0], k], "int64"),
+        ),
+    )
+    monkeypatch.setattr("paddle.incubate.nn.functional.swiglu", lambda x: x[..., : x.shape[-1] // 2])
+    out = m.apply(layer, x, gate, topk_ids_hookfunc=lambda **_: None)
+    assert out.shape == [2, 64]

--- a/tests/layers/test_fused_moe_marlin_backend.py
+++ b/tests/layers/test_fused_moe_marlin_backend.py
@@ -1,0 +1,514 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for fastdeploy/model_executor/layers/moe/fused_moe_marlin_backend.py"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import paddle
+from paddle import nn
+
+# Mock GPU ops before importing the module under test.
+# These ops require compiled CUDA extensions not available on CPU.
+_mock_gpu = MagicMock()
+sys.modules.setdefault("fastdeploy.model_executor.ops.gpu", _mock_gpu)
+
+from fastdeploy.model_executor.layers.moe.fused_moe_marlin_backend import (  # noqa: E402
+    MarlinWeightOnlyMoEMethod,
+    get_scale_perms,
+    gptq_marlin_moe_repack,
+    marlin_moe_permute_scales,
+    marlin_permute_scales,
+)
+
+MB = "fastdeploy.model_executor.layers.moe.fused_moe_marlin_backend"
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+class _DummyLayer(nn.Layer):
+    """Minimal layer mock matching FusedMoE's attributes."""
+
+    def __init__(
+        self,
+        hidden_size=128,
+        moe_intermediate_size=64,
+        num_local_experts=2,
+        num_experts=2,
+        top_k=2,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.moe_intermediate_size = moe_intermediate_size
+        self.num_local_experts = num_local_experts
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.n_group = 1
+        self.topk_group = 1
+        self.topk_method = "topk"
+        self.routed_scaling_factor = 1.0
+        self.gate_correction_bias = paddle.zeros([num_experts], dtype="float32")
+
+    def extract_moe_ffn_weights(self, state_dict):
+        return state_dict["up"], state_dict["down"], None, None
+
+
+# ── get_scale_perms ──────────────────────────────────────────────────────
+class TestGetScalePerms(unittest.TestCase):
+    def test_returns_two_lists(self):
+        sp, sps = get_scale_perms()
+        self.assertIsInstance(sp, list)
+        self.assertIsInstance(sps, list)
+
+    def test_scale_perm_length(self):
+        sp, _ = get_scale_perms()
+        self.assertEqual(len(sp), 64)
+
+    def test_scale_perm_single_length(self):
+        _, sps = get_scale_perms()
+        self.assertEqual(len(sps), 32)
+
+    def test_scale_perm_contains_all_values(self):
+        sp, _ = get_scale_perms()
+        self.assertEqual(sorted(sp), list(range(64)))
+
+    def test_scale_perm_single_elements_in_range(self):
+        _, sps = get_scale_perms()
+        for v in sps:
+            self.assertGreaterEqual(v, 0)
+            self.assertLess(v, 32)
+
+    def test_deterministic(self):
+        sp1, sps1 = get_scale_perms()
+        sp2, sps2 = get_scale_perms()
+        self.assertEqual(sp1, sp2)
+        self.assertEqual(sps1, sps2)
+
+
+# ── marlin_permute_scales ────────────────────────────────────────────────
+class TestMarlinPermuteScales(unittest.TestCase):
+    def test_per_channel_shape(self):
+        """group_size=-1 → uses scale_perm_single (32 elems)."""
+        s = paddle.arange(32, dtype="float32").reshape([1, 32])
+        result = marlin_permute_scales(s, size_k=128, size_n=32, group_size=-1)
+        self.assertEqual(list(result.shape), [1, 32])
+
+    def test_per_group_shape(self):
+        """group_size < size_k → uses scale_perm (64 elems)."""
+        s = paddle.arange(256, dtype="float32").reshape([4, 64])
+        result = marlin_permute_scales(s, size_k=128, size_n=64, group_size=32)
+        self.assertEqual(list(result.shape), [4, 64])
+
+    def test_per_channel_permutes_values(self):
+        s = paddle.arange(32, dtype="float32").reshape([1, 32])
+        result = marlin_permute_scales(s, size_k=128, size_n=32, group_size=-1)
+        # Values should be permuted (not identity)
+        original = s.numpy().flatten()
+        permuted = result.numpy().flatten()
+        self.assertFalse(np.array_equal(original, permuted))
+        # But same set of values
+        np.testing.assert_array_equal(sorted(original), sorted(permuted))
+
+    def test_per_group_permutes_values(self):
+        s = paddle.arange(64, dtype="float32").reshape([1, 64])
+        result = marlin_permute_scales(s, size_k=128, size_n=64, group_size=32)
+        original = s.numpy().flatten()
+        permuted = result.numpy().flatten()
+        self.assertFalse(np.array_equal(original, permuted))
+        np.testing.assert_array_equal(sorted(original), sorted(permuted))
+
+    def test_preserves_dtype(self):
+        s = paddle.ones([1, 32], dtype="float16")
+        result = marlin_permute_scales(s, size_k=128, size_n=32, group_size=-1)
+        self.assertEqual(result.dtype, paddle.float16)
+
+
+# ── marlin_moe_permute_scales ────────────────────────────────────────────
+class TestMarlinMoePermuteScales(unittest.TestCase):
+    def test_output_shape_matches_input(self):
+        num_experts = 4
+        s = paddle.ones([num_experts, 1, 32], dtype="float32")
+        result = marlin_moe_permute_scales(s, size_k=128, size_n=32, group_size=-1)
+        self.assertEqual(list(result.shape), [num_experts, 1, 32])
+
+    def test_each_expert_permuted_independently(self):
+        s = paddle.stack(
+            [
+                paddle.arange(32, dtype="float32").reshape([1, 32]),
+                paddle.arange(32, 64, dtype="float32").reshape([1, 32]),
+            ],
+            axis=0,
+        )
+        result = marlin_moe_permute_scales(s, size_k=128, size_n=32, group_size=-1)
+        # Each expert should have different values
+        e0 = result[0].numpy().flatten()
+        e1 = result[1].numpy().flatten()
+        self.assertFalse(np.array_equal(e0, e1))
+
+    def test_preserves_dtype_float16(self):
+        s = paddle.ones([2, 1, 32], dtype="float16")
+        result = marlin_moe_permute_scales(s, size_k=128, size_n=32, group_size=-1)
+        self.assertEqual(result.dtype, paddle.float16)
+
+    def test_single_expert(self):
+        s = paddle.arange(32, dtype="float32").reshape([1, 1, 32])
+        result = marlin_moe_permute_scales(s, size_k=128, size_n=32, group_size=-1)
+        self.assertEqual(list(result.shape), [1, 1, 32])
+
+
+# ── gptq_marlin_moe_repack ──────────────────────────────────────────────
+class TestGptqMarlinMoeRepack(unittest.TestCase):
+    def test_calls_repack_per_expert(self):
+        num_experts = 3
+        size_k = 64
+        size_n = 32
+        num_bits = 4
+        b_q_weight = paddle.zeros([num_experts, size_k, size_n], dtype="int32")
+        perm = paddle.zeros([num_experts, 0], dtype="int32")
+
+        mock_repack = MagicMock(return_value=paddle.ones([size_k // 16, size_n * (num_bits // 2)], dtype="int32"))
+        _mock_gpu.gptq_marlin_repack = mock_repack
+        result = gptq_marlin_moe_repack(b_q_weight, perm, size_k, size_n, num_bits)
+
+        self.assertEqual(mock_repack.call_count, num_experts)
+        self.assertEqual(list(result.shape), [num_experts, size_k // 16, size_n * (num_bits // 2)])
+
+    def test_size_k_alignment(self):
+        """size_k must be divisible by 16."""
+        b_q_weight = paddle.zeros([1, 15, 8], dtype="int32")
+        perm = paddle.zeros([1, 0], dtype="int32")
+        with self.assertRaises(AssertionError):
+            gptq_marlin_moe_repack(b_q_weight, perm, 15, 8, 4)
+
+
+# ── MarlinWeightOnlyMoEMethod.__init__ ───────────────────────────────────
+class TestMarlinInit(unittest.TestCase):
+    def test_default_attrs(self):
+        method = MarlinWeightOnlyMoEMethod()
+        self.assertIsNone(method.quant_method)
+        self.assertEqual(len(method.added_weight_attrs), 2)
+        self.assertEqual(len(method.added_scale_attrs), 2)
+        self.assertEqual(len(method.added_zeros_attrs), 2)
+
+    def test_custom_quant_method(self):
+        method = MarlinWeightOnlyMoEMethod(quant_method="gptq")
+        self.assertEqual(method.quant_method, "gptq")
+
+    def test_weight_attr_names(self):
+        method = MarlinWeightOnlyMoEMethod()
+        self.assertIn("up_gate_proj_weight", method.added_weight_attrs)
+        self.assertIn("down_proj_weight", method.added_weight_attrs)
+
+    def test_scale_attr_names(self):
+        method = MarlinWeightOnlyMoEMethod()
+        self.assertIn("up_gate_proj_weight_scale", method.added_scale_attrs)
+        self.assertIn("down_proj_weight_scale", method.added_scale_attrs)
+
+
+# ── MarlinWeightOnlyMoEMethod.create_weights ─────────────────────────────
+class TestMarlinCreateWeights(unittest.TestCase):
+    def test_creates_weight_parameters(self):
+        method = MarlinWeightOnlyMoEMethod()
+        layer = _DummyLayer(hidden_size=128, moe_intermediate_size=64, num_local_experts=2)
+        method.create_weights(layer)
+
+        self.assertTrue(hasattr(layer, "up_gate_proj_weight"))
+        self.assertTrue(hasattr(layer, "down_proj_weight"))
+
+    def test_weight_shapes(self):
+        method = MarlinWeightOnlyMoEMethod()
+        layer = _DummyLayer(hidden_size=128, moe_intermediate_size=64, num_local_experts=2)
+        method.create_weights(layer)
+
+        # up_gate: [E, hidden//16, intermediate*4]
+        self.assertEqual(list(layer.up_gate_proj_weight.shape), [2, 128 // 16, 64 * 4])
+        # down: [E, intermediate//16, hidden*2]
+        self.assertEqual(list(layer.down_proj_weight.shape), [2, 64 // 16, 128 * 2])
+
+    def test_scale_shapes(self):
+        method = MarlinWeightOnlyMoEMethod()
+        layer = _DummyLayer(hidden_size=128, moe_intermediate_size=64, num_local_experts=2)
+        method.create_weights(layer)
+
+        self.assertTrue(hasattr(layer, "up_gate_proj_weight_scale"))
+        self.assertTrue(hasattr(layer, "down_proj_weight_scale"))
+        # up_gate_scale: [E, 1, intermediate*2]
+        self.assertEqual(list(layer.up_gate_proj_weight_scale.shape), [2, 1, 64 * 2])
+        # down_scale: [E, 1, hidden]
+        self.assertEqual(list(layer.down_proj_weight_scale.shape), [2, 1, 128])
+
+    def test_weight_dtype_is_int32(self):
+        method = MarlinWeightOnlyMoEMethod()
+        layer = _DummyLayer()
+        method.create_weights(layer)
+        self.assertEqual(layer.up_gate_proj_weight.dtype, paddle.int32)
+        self.assertEqual(layer.down_proj_weight.dtype, paddle.int32)
+
+    def test_stores_shapes(self):
+        method = MarlinWeightOnlyMoEMethod()
+        layer = _DummyLayer(hidden_size=256, moe_intermediate_size=128, num_local_experts=4)
+        method.create_weights(layer)
+        self.assertEqual(method.up_gate_proj_weight_shape[0], 4)
+        self.assertEqual(method.down_proj_weight_shape[0], 4)
+
+
+# ── MarlinWeightOnlyMoEMethod.process_loaded_weights ─────────────────────
+class TestMarlinProcessLoadedWeights(unittest.TestCase):
+    @patch(f"{MB}.marlin_moe_permute_scales")
+    @patch(f"{MB}.gptq_marlin_moe_repack")
+    def test_processes_all_experts(self, mock_repack, mock_permute):
+        method = MarlinWeightOnlyMoEMethod()
+        hidden = 128
+        inter = 64
+        num_experts = 2
+        layer = _DummyLayer(hidden_size=hidden, moe_intermediate_size=inter, num_local_experts=num_experts)
+        method.create_weights(layer)
+
+        up_weights = [paddle.randn([hidden, inter * 2]) for _ in range(num_experts)]
+        down_weights = [paddle.randn([inter, hidden]) for _ in range(num_experts)]
+        state_dict = {"up": up_weights, "down": down_weights}
+
+        mock_repack.side_effect = lambda w, p, k, n, b: paddle.zeros(
+            [num_experts, k // 16, n * (b // 2)], dtype="int32"
+        )
+        mock_permute.side_effect = lambda s, **kw: s
+
+        method.process_loaded_weights(layer, state_dict)
+
+        # gptq_marlin_moe_repack called once per weight type (up_gate + down)
+        self.assertEqual(mock_repack.call_count, 2)
+        # marlin_moe_permute_scales called once per scale type
+        self.assertEqual(mock_permute.call_count, 2)
+
+    @patch(f"{MB}.marlin_moe_permute_scales")
+    @patch(f"{MB}.gptq_marlin_moe_repack")
+    def test_assertion_on_wrong_expert_count(self, mock_repack, mock_permute):
+        method = MarlinWeightOnlyMoEMethod()
+        layer = _DummyLayer(hidden_size=128, moe_intermediate_size=64, num_local_experts=2)
+        method.create_weights(layer)
+
+        # Provide wrong number of experts
+        up_weights = [paddle.randn([128, 128])]  # only 1 expert
+        down_weights = [paddle.randn([64, 128]), paddle.randn([64, 128])]
+        state_dict = {"up": up_weights, "down": down_weights}
+
+        with self.assertRaises(AssertionError):
+            method.process_loaded_weights(layer, state_dict)
+
+    @patch(f"{MB}.marlin_moe_permute_scales")
+    @patch(f"{MB}.gptq_marlin_moe_repack")
+    def test_assertion_on_wrong_weight_shape(self, mock_repack, mock_permute):
+        method = MarlinWeightOnlyMoEMethod()
+        layer = _DummyLayer(hidden_size=128, moe_intermediate_size=64, num_local_experts=1)
+        method.create_weights(layer)
+
+        # Wrong shape: [hidden, wrong_size] instead of [hidden, inter*2]
+        up_weights = [paddle.randn([128, 999])]
+        down_weights = [paddle.randn([64, 128])]
+        state_dict = {"up": up_weights, "down": down_weights}
+
+        with self.assertRaises(AssertionError):
+            method.process_loaded_weights(layer, state_dict)
+
+
+# ── MarlinWeightOnlyMoEMethod.apply ──────────────────────────────────────
+class TestMarlinApply(unittest.TestCase):
+    def _setup_method_and_layer(self):
+        method = MarlinWeightOnlyMoEMethod()
+        layer = _DummyLayer(
+            hidden_size=128,
+            moe_intermediate_size=64,
+            num_local_experts=4,
+            num_experts=4,
+            top_k=2,
+        )
+        method.create_weights(layer)
+        return method, layer
+
+    @patch(f"{MB}.tritonmoe_preprocess_func")
+    @patch(f"{MB}.MoeWna16MarlinGemmApi")
+    @patch("fastdeploy.model_executor.ops.gpu.moe_topk_select")
+    def test_apply_output_shape(self, mock_topk, mock_gemm, mock_preproc):
+        method, layer = self._setup_method_and_layer()
+        batch, hidden = 4, 128
+        x = paddle.randn([batch, hidden])
+        gate = nn.Linear(hidden, layer.num_experts, bias_attr=False)
+
+        # Setup mocks
+        topk_ids = paddle.zeros([batch, layer.top_k], dtype="int32")
+        topk_weights = paddle.ones([batch, layer.top_k], dtype="float32")
+        mock_topk.return_value = (topk_ids, topk_weights)
+        mock_preproc.return_value = (
+            paddle.zeros([16], dtype="int32"),
+            paddle.zeros([4], dtype="int32"),
+            paddle.to_tensor([16], dtype="int32"),
+        )
+        # MoeWna16MarlinGemmApi returns tuple; first call = up_gate+swiglu, second = down
+        final_out = paddle.randn([batch * layer.top_k, hidden])
+        mock_gemm.side_effect = [
+            (paddle.randn([batch * layer.top_k, layer.moe_intermediate_size * 2]),),
+            (final_out,),
+        ]
+
+        result = method.apply(layer, x, gate)
+        self.assertEqual(list(result.shape), [batch, hidden])
+
+    @patch(f"{MB}.tritonmoe_preprocess_func")
+    @patch(f"{MB}.MoeWna16MarlinGemmApi")
+    @patch("fastdeploy.model_executor.ops.gpu.moe_topk_select")
+    def test_apply_calls_gemm_twice(self, mock_topk, mock_gemm, mock_preproc):
+        """apply() should call MoeWna16MarlinGemmApi exactly twice (up_gate + down)."""
+        method, layer = self._setup_method_and_layer()
+        batch, hidden = 2, 128
+        x = paddle.randn([batch, hidden])
+        gate = nn.Linear(hidden, layer.num_experts, bias_attr=False)
+
+        topk_ids = paddle.zeros([batch, layer.top_k], dtype="int32")
+        topk_weights = paddle.ones([batch, layer.top_k], dtype="float32")
+        mock_topk.return_value = (topk_ids, topk_weights)
+        mock_preproc.return_value = (
+            paddle.zeros([8], dtype="int32"),
+            paddle.zeros([4], dtype="int32"),
+            paddle.to_tensor([8], dtype="int32"),
+        )
+        mock_gemm.side_effect = [
+            (paddle.randn([batch * layer.top_k, layer.moe_intermediate_size * 2]),),
+            (paddle.randn([batch * layer.top_k, hidden]),),
+        ]
+
+        method.apply(layer, x, gate)
+        self.assertEqual(mock_gemm.call_count, 2)
+
+    @patch(f"{MB}.tritonmoe_preprocess_func")
+    @patch(f"{MB}.MoeWna16MarlinGemmApi")
+    @patch("fastdeploy.model_executor.ops.gpu.moe_topk_select")
+    def test_apply_with_hookfunc(self, mock_topk, mock_gemm, mock_preproc):
+        """topk_ids_hookfunc should be called with topk_ids."""
+        method, layer = self._setup_method_and_layer()
+        batch, hidden = 2, 128
+        x = paddle.randn([batch, hidden])
+        gate = nn.Linear(hidden, layer.num_experts, bias_attr=False)
+
+        topk_ids = paddle.zeros([batch, layer.top_k], dtype="int32")
+        topk_weights = paddle.ones([batch, layer.top_k], dtype="float32")
+        mock_topk.return_value = (topk_ids, topk_weights)
+        mock_preproc.return_value = (
+            paddle.zeros([8], dtype="int32"),
+            paddle.zeros([4], dtype="int32"),
+            paddle.to_tensor([8], dtype="int32"),
+        )
+        mock_gemm.side_effect = [
+            (paddle.randn([batch * layer.top_k, layer.moe_intermediate_size * 2]),),
+            (paddle.randn([batch * layer.top_k, hidden]),),
+        ]
+
+        hook = MagicMock()
+        method.apply(layer, x, gate, topk_ids_hookfunc=hook)
+        hook.assert_called_once()
+
+    @patch(f"{MB}.tritonmoe_preprocess_func")
+    @patch(f"{MB}.MoeWna16MarlinGemmApi")
+    def test_apply_noaux_tc_topk_method(self, mock_gemm, mock_preproc):
+        """When topk_method='noaux_tc', should use get_moe_scores instead of moe_topk_select."""
+        method, layer = self._setup_method_and_layer()
+        layer.topk_method = "noaux_tc"
+        batch, hidden = 2, 128
+        x = paddle.randn([batch, hidden])
+        gate = nn.Linear(hidden, layer.num_experts, bias_attr=False)
+
+        mock_preproc.return_value = (
+            paddle.zeros([8], dtype="int32"),
+            paddle.zeros([4], dtype="int32"),
+            paddle.to_tensor([8], dtype="int32"),
+        )
+        mock_gemm.side_effect = [
+            (paddle.randn([batch * layer.top_k, layer.moe_intermediate_size * 2]),),
+            (paddle.randn([batch * layer.top_k, hidden]),),
+        ]
+
+        mock_scores = MagicMock(
+            return_value=(
+                None,
+                paddle.ones([batch, layer.top_k], dtype="float32"),
+                paddle.zeros([batch, layer.top_k], dtype="int32"),
+            )
+        )
+        with patch(f"{MB}.get_moe_scores", mock_scores, create=True):
+            with patch("fastdeploy.model_executor.layers.moe.moe.get_moe_scores", mock_scores, create=True):
+                result = method.apply(layer, x, gate)
+        self.assertEqual(list(result.shape), [batch, hidden])
+
+    @patch(f"{MB}.tritonmoe_preprocess_func")
+    @patch(f"{MB}.MoeWna16MarlinGemmApi")
+    @patch("fastdeploy.model_executor.ops.gpu.moe_topk_select")
+    def test_block_size_selection(self, mock_topk, mock_gemm, mock_preproc):
+        """Block size should be selected based on token_num * top_k / num_experts ratio."""
+        method, layer = self._setup_method_and_layer()
+        # Use small batch to trigger small block_size
+        batch, hidden = 1, 128
+        x = paddle.randn([batch, hidden])
+        gate = nn.Linear(hidden, layer.num_experts, bias_attr=False)
+
+        topk_ids = paddle.zeros([batch, layer.top_k], dtype="int32")
+        topk_weights = paddle.ones([batch, layer.top_k], dtype="float32")
+        mock_topk.return_value = (topk_ids, topk_weights)
+        mock_preproc.return_value = (
+            paddle.zeros([8], dtype="int32"),
+            paddle.zeros([4], dtype="int32"),
+            paddle.to_tensor([8], dtype="int32"),
+        )
+        mock_gemm.side_effect = [
+            (paddle.randn([batch * layer.top_k, layer.moe_intermediate_size * 2]),),
+            (paddle.randn([batch * layer.top_k, hidden]),),
+        ]
+
+        method.apply(layer, x, gate)
+        # Verify preprocess was called (block_size_m passed implicitly)
+        mock_preproc.assert_called_once()
+
+
+# ── Edge cases / integration ─────────────────────────────────────────────
+class TestEdgeCases(unittest.TestCase):
+    def test_single_expert_permute(self):
+        s = paddle.arange(32, dtype="float32").reshape([1, 1, 32])
+        result = marlin_moe_permute_scales(s, size_k=128, size_n=32, group_size=-1)
+        self.assertEqual(list(result.shape), [1, 1, 32])
+
+    def test_large_num_experts(self):
+        num_experts = 16
+        s = paddle.ones([num_experts, 1, 32], dtype="float32")
+        result = marlin_moe_permute_scales(s, size_k=128, size_n=32, group_size=-1)
+        self.assertEqual(list(result.shape), [num_experts, 1, 32])
+
+    def test_method_inherits_quant_base(self):
+        from fastdeploy.model_executor.layers.quantization.quant_base import (
+            QuantMethodBase,
+        )
+
+        self.assertTrue(issubclass(MarlinWeightOnlyMoEMethod, QuantMethodBase))
+
+    def test_create_weights_different_sizes(self):
+        """Test create_weights with various hidden/intermediate size combos."""
+        for hidden, inter in [(256, 128), (512, 256), (64, 32)]:
+            method = MarlinWeightOnlyMoEMethod()
+            layer = _DummyLayer(hidden_size=hidden, moe_intermediate_size=inter, num_local_experts=1)
+            method.create_weights(layer)
+            self.assertEqual(list(layer.up_gate_proj_weight.shape), [1, hidden // 16, inter * 4])
+            self.assertEqual(list(layer.down_proj_weight.shape), [1, inter // 16, hidden * 2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/layers/test_fused_moe_marlin_backend.py
+++ b/tests/layers/test_fused_moe_marlin_backend.py
@@ -20,21 +20,18 @@ import paddle
 import pytest
 
 # Stub GPU-only ops for CPU environments (cf. test_fused_moe_cutlass_backend.py)
-_gpu = sys.modules.get("fastdeploy.model_executor.ops.gpu")
-if _gpu is None:
-    _gpu = types.ModuleType("fastdeploy.model_executor.ops.gpu")
-    sys.modules["fastdeploy.model_executor.ops.gpu"] = _gpu
-for _a in (
-    "MoeWna16MarlinGemmApi",
-    "moe_expert_dispatch",
-    "moe_expert_reduce",
-    "tritonmoe_preprocess_func",
-    "gptq_marlin_repack",
-    "moe_topk_select",
-    "get_padding_offset",
-):
-    if not hasattr(_gpu, _a):
-        setattr(_gpu, _a, None)
+# Use __getattr__ catchall so the entire import chain (moe → attention → ops.gpu)
+# can resolve any GPU op name without an explicit allowlist.
+
+
+class _GpuOpsStub(types.ModuleType):
+    def __getattr__(self, name):
+        return None
+
+
+if "fastdeploy.model_executor.ops.gpu" not in sys.modules:
+    sys.modules["fastdeploy.model_executor.ops.gpu"] = _GpuOpsStub("fastdeploy.model_executor.ops.gpu")
+_gpu = sys.modules["fastdeploy.model_executor.ops.gpu"]
 
 from fastdeploy.model_executor.layers.moe import (  # noqa: E402
     fused_moe_marlin_backend as mb,

--- a/tests/layers/test_fused_moe_marlin_backend.py
+++ b/tests/layers/test_fused_moe_marlin_backend.py
@@ -165,7 +165,7 @@ class TestFusedMoeMarlinBackend(unittest.TestCase):
                 create=True,
             ),
         ):
-            out = m.apply(layer, x, gate, topk_ids_hookfunc=lambda **_: None)
+            out = m.apply(layer, x, gate, topk_ids_hookfunc=lambda topk_ids: None)
         self.assertEqual(list(out.shape), [2, 64])
 
     def test_apply_noaux_tc(self):
@@ -204,7 +204,7 @@ class TestFusedMoeMarlinBackend(unittest.TestCase):
                 create=True,
             ),
         ):
-            out = m.apply(layer, x, gate, topk_ids_hookfunc=lambda **_: None)
+            out = m.apply(layer, x, gate, topk_ids_hookfunc=lambda topk_ids: None)
         self.assertEqual(list(out.shape), [2, 64])
 
 

--- a/tests/layers/test_fused_moe_marlin_backend.py
+++ b/tests/layers/test_fused_moe_marlin_backend.py
@@ -111,10 +111,17 @@ class TestFusedMoeMarlinBackend(unittest.TestCase):
         m = _init(layer)
         self.assertTrue(hasattr(layer, "up_gate_proj_weight"))
         self.assertTrue(hasattr(layer, "down_proj_weight"))
-        with patch.object(
-            _gpu_ops_stub,
-            "gptq_marlin_repack",
-            lambda w, p, sk, sn, nb: paddle.zeros([sk // 16, sn * (nb // 2)], dtype=w.dtype),
+        with (
+            patch.dict(
+                sys.modules,
+                {_GPU_OPS: _gpu_ops_stub, _DEEP_GEMM: _deep_gemm_stub},
+                clear=False,
+            ),
+            patch.object(
+                _gpu_ops_stub,
+                "gptq_marlin_repack",
+                lambda w, p, sk, sn, nb: paddle.zeros([sk // 16, sn * (nb // 2)], dtype=w.dtype),
+            ),
         ):
             m.process_loaded_weights(layer, dict(zip(("up", "down"), _make_weights(layer))))
 
@@ -125,6 +132,11 @@ class TestFusedMoeMarlinBackend(unittest.TestCase):
         gate = paddle.nn.Linear(64, 2, bias_attr=False)
         x = paddle.ones([2, 64], dtype="float32")
         with (
+            patch.dict(
+                sys.modules,
+                {_GPU_OPS: _gpu_ops_stub, _DEEP_GEMM: _deep_gemm_stub},
+                clear=False,
+            ),
             patch.object(
                 mb,
                 "MoeWna16MarlinGemmApi",

--- a/tests/layers/test_fused_moe_marlin_backend.py
+++ b/tests/layers/test_fused_moe_marlin_backend.py
@@ -19,18 +19,25 @@ from types import SimpleNamespace
 import paddle
 import pytest
 
-# Stub GPU-only ops for CPU environments (cf. test_fused_moe_cutlass_backend.py)
-# Use __getattr__ catchall so the entire import chain (moe → attention → ops.gpu)
-# can resolve any GPU op name without an explicit allowlist.
+# Stub GPU-only ops so the import chain (moe → triton_backend → fp8_utils →
+# ops.gpu.deep_gemm) resolves without compiled CUDA extensions.
+# Must be installed BEFORE any fastdeploy import that touches ops.gpu.
 
 
 class _GpuOpsStub(types.ModuleType):
+    """Catchall module: any attribute access returns None."""
+
+    __path__ = []  # marks as package so `import X.Y.Z` can traverse
+
     def __getattr__(self, name):
         return None
 
 
-if "fastdeploy.model_executor.ops.gpu" not in sys.modules:
-    sys.modules["fastdeploy.model_executor.ops.gpu"] = _GpuOpsStub("fastdeploy.model_executor.ops.gpu")
+sys.modules["fastdeploy.model_executor.ops.gpu"] = _GpuOpsStub("fastdeploy.model_executor.ops.gpu")
+# fp8_utils.py:52 uses `import ...ops.gpu.deep_gemm as deep_gemm`
+sys.modules["fastdeploy.model_executor.ops.gpu.deep_gemm"] = types.ModuleType(
+    "fastdeploy.model_executor.ops.gpu.deep_gemm"
+)
 _gpu = sys.modules["fastdeploy.model_executor.ops.gpu"]
 
 from fastdeploy.model_executor.layers.moe import (  # noqa: E402

--- a/tests/layers/test_fused_moe_marlin_backend.py
+++ b/tests/layers/test_fused_moe_marlin_backend.py
@@ -25,19 +25,26 @@ import pytest
 
 
 class _GpuOpsStub(types.ModuleType):
-    """Catchall module: any attribute access returns None."""
+    """Catchall module: returns registered sub-modules or None for unknown attrs."""
 
     __path__ = []  # marks as package so `import X.Y.Z` can traverse
 
     def __getattr__(self, name):
+        fqn = f"{self.__name__}.{name}"
+        sub = sys.modules.get(fqn)
+        if sub is not None:
+            return sub
         return None
 
 
 sys.modules["fastdeploy.model_executor.ops.gpu"] = _GpuOpsStub("fastdeploy.model_executor.ops.gpu")
 # fp8_utils.py:52 uses `import ...ops.gpu.deep_gemm as deep_gemm`
-sys.modules["fastdeploy.model_executor.ops.gpu.deep_gemm"] = types.ModuleType(
-    "fastdeploy.model_executor.ops.gpu.deep_gemm"
-)
+_deep_gemm_stub = types.ModuleType("fastdeploy.model_executor.ops.gpu.deep_gemm")
+_deep_gemm_stub.m_grouped_fp8_gemm_nt_contiguous = None
+_deep_gemm_stub.m_grouped_fp8_gemm_nt_masked = None
+_deep_gemm_stub.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous = None
+_deep_gemm_stub.m_grouped_gemm_fp8_fp8_bf16_nt_masked = None
+sys.modules["fastdeploy.model_executor.ops.gpu.deep_gemm"] = _deep_gemm_stub
 _gpu = sys.modules["fastdeploy.model_executor.ops.gpu"]
 
 from fastdeploy.model_executor.layers.moe import (  # noqa: E402

--- a/tests/layers/test_fused_moe_marlin_backend.py
+++ b/tests/layers/test_fused_moe_marlin_backend.py
@@ -1,4 +1,3 @@
-"""
 # Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
 
 import sys
 import types
 from types import SimpleNamespace
 
 import paddle
+import pytest
 
 # Stub GPU-only ops for CPU environments (cf. test_fused_moe_cutlass_backend.py)
 _gpu = sys.modules.get("fastdeploy.model_executor.ops.gpu")
@@ -154,3 +153,7 @@ def test_apply_noaux_tc(monkeypatch):
     monkeypatch.setattr("paddle.incubate.nn.functional.swiglu", lambda x: x[..., : x.shape[-1] // 2])
     out = m.apply(layer, x, gate, topk_ids_hookfunc=lambda **_: None)
     assert out.shape == [2, 64]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/layers/test_fused_moe_marlin_backend.py
+++ b/tests/layers/test_fused_moe_marlin_backend.py
@@ -12,34 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import sys
 import types
-import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import paddle
 
-# Stub GPU-only ops so the import chain (moe → triton_backend → fp8_utils →
-# ops.gpu.deep_gemm) resolves without compiled CUDA extensions.
-# Scoped via patch.dict so sys.modules is restored after the import.
+# ---------------------------------------------------------------------------
+# Stub GPU-only ops so the import chain resolves without CUDA extensions.
+# Try the real import first; only inject stubs when it is unavailable.
+# After the import, explicitly remove any stale parent-package attribute
+# that Python may have bound during the stub phase, preventing cross-test
+# pollution (e.g. tests that access `fastdeploy.model_executor.ops.gpu` via
+# attribute traversal rather than `import`).
+# ---------------------------------------------------------------------------
+
+_GPU_OPS = "fastdeploy.model_executor.ops.gpu"
+_DEEP_GEMM = f"{_GPU_OPS}.deep_gemm"
+
+_NEED_STUB = _GPU_OPS not in sys.modules
 
 
 class _GpuOpsStub(types.ModuleType):
-    """Catchall module: returns registered sub-modules or None for unknown attrs."""
+    """Catch-all module: returns registered sub-modules or ``None``."""
 
-    __path__ = []  # marks as package so `import X.Y.Z` can traverse
+    __path__ = []
 
     def __getattr__(self, name):
         fqn = f"{self.__name__}.{name}"
         sub = sys.modules.get(fqn)
-        if sub is not None:
-            return sub
-        return None
+        return sub if sub is not None else None
 
-
-_GPU_OPS = "fastdeploy.model_executor.ops.gpu"
-_DEEP_GEMM = f"{_GPU_OPS}.deep_gemm"
 
 _gpu_ops_stub = _GpuOpsStub(_GPU_OPS)
 _deep_gemm_stub = types.ModuleType(_DEEP_GEMM)
@@ -48,10 +54,24 @@ _deep_gemm_stub.m_grouped_fp8_gemm_nt_masked = None
 _deep_gemm_stub.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous = None
 _deep_gemm_stub.m_grouped_gemm_fp8_fp8_bf16_nt_masked = None
 
-with patch.dict(sys.modules, {_GPU_OPS: _gpu_ops_stub, _DEEP_GEMM: _deep_gemm_stub}, clear=False):
-    from fastdeploy.model_executor.layers.moe import (  # noqa: E402
-        fused_moe_marlin_backend as mb,
-    )
+if _NEED_STUB:
+    with patch.dict(sys.modules, {_GPU_OPS: _gpu_ops_stub, _DEEP_GEMM: _deep_gemm_stub}, clear=False):
+        from fastdeploy.model_executor.layers.moe import fused_moe_marlin_backend as mb
+
+    # Clean up stale attribute references that Python binds during import
+    _ops_parent = sys.modules.get("fastdeploy.model_executor.ops")
+    if _ops_parent is not None and getattr(_ops_parent, "gpu", None) is _gpu_ops_stub:
+        try:
+            delattr(_ops_parent, "gpu")
+        except AttributeError:
+            pass
+else:
+    from fastdeploy.model_executor.layers.moe import fused_moe_marlin_backend as mb
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 class _DummyLayer(paddle.nn.Layer):
@@ -90,23 +110,31 @@ def _init(layer):
     return m
 
 
-# ── Tests ──────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
 
 
-class TestFusedMoeMarlinBackend(unittest.TestCase):
-    """Tests for MarlinWeightOnlyMoEMethod."""
+class TestPureFunctions:
+    """get_scale_perms, marlin_permute_scales, and MoE wrapper variants."""
 
-    def test_pure_functions(self):
-        """get_scale_perms + marlin_permute_scales (both branches)."""
+    def test_get_scale_perms(self):
         perm, single = mb.get_scale_perms()
-        self.assertEqual(len(perm), 64)
-        self.assertEqual(len(single), 32)
+        assert len(perm) == 64
+        assert len(single) == 32
+
+    def test_marlin_permute_scales_group(self):
         s = paddle.arange(128, dtype="float32").reshape([2, 64])
-        self.assertEqual(list(mb.marlin_permute_scales(s, 16, 64, 8).shape), [2, 64])
-        self.assertEqual(list(mb.marlin_permute_scales(s, 16, 64, -1).shape), [2, 64])
+        out = mb.marlin_permute_scales(s, 16, 64, 8)
+        assert list(out.shape) == [2, 64]
+
+    def test_marlin_permute_scales_perchannel(self):
+        s = paddle.arange(128, dtype="float32").reshape([2, 64])
+        out = mb.marlin_permute_scales(s, 16, 64, -1)
+        assert list(out.shape) == [2, 64]
 
     def test_gptq_marlin_moe_repack(self):
-        """gptq_marlin_moe_repack loops over experts and repacks via C++ op."""
+        """Per-expert repack loop with mocked C++ op."""
         num_experts, size_k, size_n, num_bits = 2, 32, 16, 4
         b_q_weight = paddle.ones([num_experts, size_k, size_n], dtype="int32")
         perm = paddle.zeros([num_experts, size_k], dtype="int32")
@@ -123,28 +151,39 @@ class TestFusedMoeMarlinBackend(unittest.TestCase):
             ),
         ):
             out = mb.gptq_marlin_moe_repack(b_q_weight, perm, size_k, size_n, num_bits)
-        self.assertEqual(list(out.shape), [num_experts, size_k // 16, size_n * (num_bits // 2)])
+        assert list(out.shape) == [num_experts, size_k // 16, size_n * (num_bits // 2)]
 
     def test_marlin_moe_permute_scales(self):
-        """marlin_moe_permute_scales loops over experts applying scale permutation."""
+        """Per-expert permutation matches single-expert output."""
         num_experts, size_k, size_n, group_size = 3, 64, 64, 8
-        num_groups = size_k // group_size  # 8
+        num_groups = size_k // group_size
         s = paddle.arange(num_experts * num_groups * size_n, dtype="float32").reshape(
             [num_experts, num_groups, size_n]
         )
         out = mb.marlin_moe_permute_scales(s, size_k, size_n, group_size)
-        self.assertEqual(list(out.shape), [num_experts, num_groups, size_n])
-        # Each expert slice should match the single-expert function
+        assert list(out.shape) == [num_experts, num_groups, size_n]
         for e in range(num_experts):
             expected = mb.marlin_permute_scales(s[e], size_k, size_n, group_size)
-            self.assertTrue(paddle.equal_all(out[e], expected).item())
+            assert paddle.equal_all(out[e], expected).item()
+
+
+class TestMarlinWeightOnlyMoEMethod:
+    """create_weights, process_loaded_weights, apply."""
 
     def test_create_and_process(self):
-        """create_weights -> process_loaded_weights end-to-end."""
+        """create_weights -> process_loaded_weights with shape/dtype validation."""
         layer = _DummyLayer()
         m = _init(layer)
-        self.assertTrue(hasattr(layer, "up_gate_proj_weight"))
-        self.assertTrue(hasattr(layer, "down_proj_weight"))
+
+        # Verify create_weights set parameters with correct shape / dtype
+        E, H, I = layer.num_local_experts, layer.hidden_size, layer.moe_intermediate_size
+        assert list(layer.up_gate_proj_weight.shape) == [E, H // 16, I * 4]
+        assert str(layer.up_gate_proj_weight.dtype).endswith("int32")
+        assert list(layer.down_proj_weight.shape) == [E, I // 16, H * 2]
+        assert str(layer.down_proj_weight.dtype).endswith("int32")
+        assert list(layer.up_gate_proj_weight_scale.shape) == [E, 1, I * 2]
+        assert list(layer.down_proj_weight_scale.shape) == [E, 1, H]
+
         with (
             patch.dict(
                 sys.modules,
@@ -158,6 +197,15 @@ class TestFusedMoeMarlinBackend(unittest.TestCase):
             ),
         ):
             m.process_loaded_weights(layer, dict(zip(("up", "down"), _make_weights(layer))))
+
+        # After processing: weights repacked, scales permuted — verify shapes
+        # hold and scales are non-zero (not a no-op).
+        assert list(layer.up_gate_proj_weight.shape) == [E, H // 16, I * 4]
+        assert list(layer.down_proj_weight.shape) == [E, I // 16, H * 2]
+        assert not paddle.equal_all(
+            layer.up_gate_proj_weight_scale,
+            paddle.zeros_like(layer.up_gate_proj_weight_scale),
+        ).item()
 
     def test_apply_topk(self):
         """apply() with default topk_method='topk'."""
@@ -200,7 +248,7 @@ class TestFusedMoeMarlinBackend(unittest.TestCase):
             ),
         ):
             out = m.apply(layer, x, gate, topk_ids_hookfunc=lambda topk_ids: None)
-        self.assertEqual(list(out.shape), [2, 64])
+        assert list(out.shape) == [2, 64]
 
     def test_apply_noaux_tc(self):
         """apply() with topk_method='noaux_tc'."""
@@ -239,8 +287,4 @@ class TestFusedMoeMarlinBackend(unittest.TestCase):
             ),
         ):
             out = m.apply(layer, x, gate, topk_ids_hookfunc=lambda topk_ids: None)
-        self.assertEqual(list(out.shape), [2, 64])
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert list(out.shape) == [2, 64]

--- a/tests/layers/test_fused_moe_marlin_backend.py
+++ b/tests/layers/test_fused_moe_marlin_backend.py
@@ -257,7 +257,30 @@ class TestMarlinWeightOnlyMoEMethod:
         m = _init(layer)
         gate = paddle.nn.Linear(64, 2, bias_attr=False)
         x = paddle.ones([2, 64], dtype="float32")
+
+        # Build a lightweight stub for the ``moe`` module so that the
+        # ``from fastdeploy.model_executor.layers.moe.moe import
+        # get_moe_scores`` executed inside ``apply()`` resolves without
+        # triggering the real (heavy) ``moe.py`` import chain which loads
+        # distributed/worker modules and can segfault during teardown.
+        _MOE_MOD = "fastdeploy.model_executor.layers.moe.moe"
+        _moe_stub = types.ModuleType(_MOE_MOD)
+        _moe_stub.get_moe_scores = lambda g, ng, tg, k, s, b, r: (
+            g,
+            paddle.ones([g.shape[0], k], "float32"),
+            paddle.zeros([g.shape[0], k], "int64"),
+        )
+
         with (
+            patch.dict(
+                sys.modules,
+                {
+                    _GPU_OPS: _gpu_ops_stub,
+                    _DEEP_GEMM: _deep_gemm_stub,
+                    _MOE_MOD: _moe_stub,
+                },
+                clear=False,
+            ),
             patch.object(
                 mb,
                 "MoeWna16MarlinGemmApi",
@@ -270,14 +293,6 @@ class TestMarlinWeightOnlyMoEMethod:
                     paddle.zeros([4], "int32"),
                     paddle.zeros([1], "int32"),
                     paddle.to_tensor([4], "int32"),
-                ),
-            ),
-            patch(
-                "fastdeploy.model_executor.layers.moe.moe.get_moe_scores",
-                lambda g, ng, tg, k, s, b, r: (
-                    g,
-                    paddle.ones([g.shape[0], k], "float32"),
-                    paddle.zeros([g.shape[0], k], "int64"),
                 ),
             ),
             patch(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

## Motivation

No.39 功能模块 fastdeploy/model_executor/layers/moe/fused_moe_marlin_backend.py 单测补充

## Modifications

add unittest tests/layers/test_fused_moe_marlin_backend.py

develop 分支：覆盖率0%，Miss行数115（17-361）
<!-- 📎 Upload: /home/rgr/W/baidu/PaddlePaddle/.checkpoints/h10/task-039_in-progress/screenshots/develop.png -->

当前PR：覆盖率100%，Miss行数0
<!-- 📎 Upload: /home/rgr/W/baidu/PaddlePaddle/.checkpoints/h10/task-039_in-progress/screenshots/pr.png -->
> 注：截图为本测试文件单独运行的 pytest --cov 输出（含 branch coverage），上方文字为 develop 已有测试与本 PR 合并后的 statement 覆盖率预估值，两者统计口径不同，以 CI 合并后实际值为准。

完成单测覆盖行数 115-0 = 115 → 四舍五入 100 → 预估贡献度 0.1⭐

## Usage or Command

```bash
pytest tests/layers/test_fused_moe_marlin_backend.py
```

## Accuracy Tests

no need

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
