### PR TITLE
[Cherry-Pick] [BugFix] fix grpc failure when tracing init before workers forked (#6732)

### DIFF
--- a/fastdeploy/entrypoints/openai/api_server.py
+++ b/fastdeploy/entrypoints/openai/api_server.py
@@ -84,7 +84,7 @@ from fastdeploy.utils import (
     retrive_model_from_server,
 )
 
-tracing.process_tracing_init()
+_tracing_inited = False
 
 parser = make_arg_parser(FlexibleArgumentParser())
 args = parser.parse_args()
@@ -170,7 +170,14 @@ async def lifespan(app: FastAPI):
     async context manager for FastAPI lifespan
     """
     global engine_args
+    global _tracing_inited
     import logging
+
+    # Initialize tracing in worker lifecycle instead of module import time.
+    # This avoids creating grpc/cygrpc state before gunicorn forks workers.
+    if not _tracing_inited:
+        tracing.process_tracing_init()
+        _tracing_inited = True
 
     uvicorn_access = logging.getLogger("uvicorn.access")
     uvicorn_access.handlers.clear()

--- a/fastdeploy/metrics/trace.py
+++ b/fastdeploy/metrics/trace.py
@@ -289,7 +289,7 @@ def get_otlp_span_exporter(endpoint, headers):
         OTLPSpanExporter as HTTPSpanExporter,
     )
 
-    protocol = os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, "grpc")
+    protocol = os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, "http/protobuf")
     supported_protocols = {"grpc", "http/protobuf"}
 
     if protocol not in supported_protocols:

--- a/tests/metrics/test_trace.py
+++ b/tests/metrics/test_trace.py
@@ -908,6 +908,8 @@ class TestAdditionalCoverage:
 
     def test_get_otlp_span_exporter_grpc(self):
         """Test get_otlp_span_exporter with grpc protocol"""
+        # Set environment variable for grpc protocol
+        os.environ["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"] = "grpc"
         exporter = trace.get_otlp_span_exporter("http://localhost:4317", None)
         from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
             OTLPSpanExporter as GRPCSpanExporter,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

When tracing was initialized at module import time, the gRPC C-core runtime (fd, pollset, timer threads) was initialized in the master process. After `gunicorn` forks workers, child processes inherited this corrupted state, leading to `SIGSEGV` crashes.

## Modifications

- Fix worker crash (core dump) caused by gRPC/cygrpc state being created in gunicorn master process before fork. Move `process_tracing_init()` from module import time to FastAPI lifespan handler, ensuring gRPC channels are only created inside forked worker processes.
- Change default OTLP exporter protocol from `grpc` to `http/protobuf` to avoid gRPC C-core related stability issues (reconnect crash, shutdown race condition) when the collector is temporarily unavailable.

## Usage or Command

As usual

## Accuracy Tests

No side effect on accuracy.

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
