### PR TITLE
[BugFix][Graph Optimization] Fix deterministic mode + CUDAGraph garbled output by making reset_share_inputs CUDAGraph-safe`

### DIFF
--- a/fastdeploy/worker/input_batch.py
+++ b/fastdeploy/worker/input_batch.py
@@ -18,6 +18,7 @@ import paddle
 from paddleformers.utils.log import logger
 
 from fastdeploy.config import CacheConfig, FDConfig, ModelConfig, SpeculativeConfig
+from fastdeploy.engine import envs
 from fastdeploy.model_executor.layers.rotary_embedding import get_rope
 from fastdeploy.model_executor.logits_processor import build_logits_processors
 from fastdeploy.platforms import current_platform
@@ -577,7 +578,11 @@ class InputBatch:
             # Reset reasoning buffers
             fill_paddle_tensor(self, "reasoning_status", 0)
             # Reset reasoning allowed tokens (not using fill_paddle_tensor since it's a fixed tensor)
-            self.reasoning_allowed_tokens = paddle.to_tensor([100973, 100975], dtype="int64")
+            if envs.FD_DETERMINISTIC_MODE and hasattr(self, "reasoning_allowed_tokens"):
+                # In-place copy to preserve GPU address for CUDAGraph safety.
+                self.reasoning_allowed_tokens[:] = paddle.to_tensor([100973, 100975], dtype="int64")
+            else:
+                self.reasoning_allowed_tokens = paddle.to_tensor([100973, 100975], dtype="int64")
 
             # Reset block tables
             fill_paddle_tensor(self, "block_tables", -1)
@@ -590,8 +595,15 @@ class InputBatch:
                     -1,
                 )
             )
-            self.free_list = paddle.to_tensor(free_list, dtype="int32")
-            self.free_list_len = paddle.full([1], len(free_list), dtype="int32")
+            if envs.FD_DETERMINISTIC_MODE and hasattr(self, "free_list"):
+                # In-place copy to preserve GPU address for CUDAGraph safety.
+                self.free_list.fill_(0)
+                free_list_tensor = paddle.to_tensor(free_list, dtype="int32")
+                self.free_list[: len(free_list)] = free_list_tensor
+                self.free_list_len.fill_(len(free_list))
+            else:
+                self.free_list = paddle.to_tensor(free_list, dtype="int32")
+                self.free_list_len = paddle.full([1], len(free_list), dtype="int32")
 
             # Reset stop sequences
             fill_paddle_tensor(self, "stop_seqs_len", 0)
@@ -625,29 +637,44 @@ class InputBatch:
                 else:
                     rope_head_dim = head_dim // 2
 
-                self.rope_emb = paddle.full(
-                    shape=[
-                        max_num_seqs,
-                        2,
-                        1,
-                        self.model_config.max_model_len,
-                        1,
-                        rope_head_dim,
-                    ],
-                    fill_value=0,
-                    dtype="float32",
-                )
+                if envs.FD_DETERMINISTIC_MODE and hasattr(self, "rope_emb"):
+                    # In-place fill to preserve GPU address for CUDAGraph safety.
+                    self.rope_emb.fill_(0)
+                else:
+                    self.rope_emb = paddle.full(
+                        shape=[
+                            max_num_seqs,
+                            2,
+                            1,
+                            self.model_config.max_model_len,
+                            1,
+                            rope_head_dim,
+                        ],
+                        fill_value=0,
+                        dtype="float32",
+                    )
                 self.image_features = None
                 self.image_features_list = None
             else:
                 # Reset non-multimodal rope_emb
-                self.rope_emb = get_rope(
-                    rotary_dim=self.model_config.head_dim,
-                    position_ids=paddle.arange(self.model_config.max_model_len).reshape((1, -1)),
-                    base=self.model_config.rope_theta,
-                    model_config=self.model_config,
-                    partial_rotary_factor=self.model_config.partial_rotary_factor,
-                )
+                if envs.FD_DETERMINISTIC_MODE and hasattr(self, "rope_emb"):
+                    # In-place copy to preserve GPU address for CUDAGraph safety.
+                    new_rope_emb = get_rope(
+                        rotary_dim=self.model_config.head_dim,
+                        position_ids=paddle.arange(self.model_config.max_model_len).reshape((1, -1)),
+                        base=self.model_config.rope_theta,
+                        model_config=self.model_config,
+                        partial_rotary_factor=self.model_config.partial_rotary_factor,
+                    )
+                    self.rope_emb.copy_(new_rope_emb, False)
+                else:
+                    self.rope_emb = get_rope(
+                        rotary_dim=self.model_config.head_dim,
+                        position_ids=paddle.arange(self.model_config.max_model_len).reshape((1, -1)),
+                        base=self.model_config.rope_theta,
+                        model_config=self.model_config,
+                        partial_rotary_factor=self.model_config.partial_rotary_factor,
+                    )
 
             # Reset other miscellaneous tensors
             fill_paddle_tensor(self, "mask_rollback", 0)

--- a/fastdeploy/worker/input_batch.py
+++ b/fastdeploy/worker/input_batch.py
@@ -17,8 +17,8 @@
 import paddle
 from paddleformers.utils.log import logger
 
+from fastdeploy import envs
 from fastdeploy.config import CacheConfig, FDConfig, ModelConfig, SpeculativeConfig
-from fastdeploy.engine import envs
 from fastdeploy.model_executor.layers.rotary_embedding import get_rope
 from fastdeploy.model_executor.logits_processor import build_logits_processors
 from fastdeploy.platforms import current_platform


### PR DESCRIPTION
### Motivation

When `FD_DETERMINISTIC_MODE=1` and `use_cudagraph=True` are both enabled, model output is garbled. Either feature works correctly in isolation, but the combination fails.

Root cause: `reset_share_inputs()` is called **after** CUDAGraph capture in the deterministic mode post-warmup path (`gpu_worker.py`). Several lines inside `reset_share_inputs()` create new tensor objects (`paddle.to_tensor(...)` / `paddle.full(...)`), which allocate new GPU addresses. CUDAGraph has already baked the old addresses during capture, so replay reads/writes stale memory — producing garbage output.

### Modifications

**`fastdeploy/worker/input_batch.py`**:
- For 4 tensor fields (`reasoning_allowed_tokens`, `free_list`, `free_list_len`, `rope_emb`) that previously created new tensor objects in `reset_share_inputs()`, add `FD_DETERMINISTIC_MODE` guard to use in-place operations (`fill_`, `copy_`, slice assignment) instead, preserving GPU addresses for CUDAGraph safety.
- Non-deterministic mode behavior is completely unchanged.

**`fastdeploy/worker/gpu_worker.py`**:
- Remove the `if not self.model_runner.use_cudagraph` skip around `reset_share_inputs()`. Since `reset_share_inputs()` is now CUDAGraph-safe under deterministic mode, it can be called unconditionally.

### Accuracy Tests

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 pytest tests/e2e/4cards_cases/test_determinism_long.py -v
```
