### PR TITLE
[CUDA][build] cuda13.0, implement changes to CCCL

### DIFF
--- a/custom_ops/gpu_ops/beam_search_softmax.cu
+++ b/custom_ops/gpu_ops/beam_search_softmax.cu
@@ -30,6 +30,7 @@ namespace cub = hipcub;
 #include <algorithm>
 #include "helper.h"
 #include "stdint.h"
+#include "cccl_compat.h"  // CCCL 3.0 compatibility
 
 #define FLT_MAX 1e38
 
@@ -368,7 +369,7 @@ __launch_bounds__(THREADBLOCK_SIZE, 1) __global__
 
   using KVPair = cub::KeyValuePair<int, T>;
   KVPair topKVPairPartial{vocab_size - 1, -MAX_T_VAL};
-  cub::ArgMax argmax;
+  fd_cub_compat::ArgMax argmax;
 
   T const *local_logits = logits + beam_batch_id * vocab_size;
 #pragma unroll 1
@@ -595,7 +596,7 @@ __launch_bounds__(THREADBLOCK_SIZE) __global__
     typename BlockReduceMD::TempStorage md;
   } smemReduceBuffer;
 
-  cub::ArgMax argmax;
+  fd_cub_compat::ArgMax argmax;
   MD partial_md{-MAX_T_VAL, 0.0f};
   KVPair topKVPair{vocab_size - 1, -MAX_T_VAL};
 

--- a/custom_ops/gpu_ops/cccl_compat.h
+++ b/custom_ops/gpu_ops/cccl_compat.h
@@ -1,0 +1,151 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// CCCL 3.0 compatibility header for CUDA 13.0+
+// In CCCL 3.0, cub::Sum, cub::Max, cub::Min are removed from the cub namespace.
+// This header provides compatible implementations that work with both old and
+// new versions.
+
+// Include cub headers based on platform
+#ifdef PADDLE_WITH_HIP
+#include <hipcub/hipcub.hpp>
+#else
+#include <cub/cub.cuh>
+#endif
+
+// Detect CUDA 13.0+ (CCCL 3.0)
+// __CUDACC_VER_MAJOR__ >= 13 indicates CUDA 13.0 or later
+#if defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ >= 13
+#define FD_CCCL_V3 1
+#endif
+
+namespace fd_cub_compat {
+
+// ============================================================================
+// Sum, Max, Min functors
+// ============================================================================
+
+#ifdef FD_CCCL_V3
+// CUDA 13.0+ (CCCL 3.0): Use custom implementations since cub::Sum/Max/Min are
+// removed
+
+/// Functor for computing the sum of two values
+struct Sum {
+  /// Apply the sum operation
+  template <typename T>
+  __host__ __device__ __forceinline__ T operator()(const T &a,
+                                                   const T &b) const {
+    return a + b;
+  }
+};
+
+/// Functor for computing the maximum of two values
+struct Max {
+  /// Apply the max operation
+  template <typename T>
+  __host__ __device__ __forceinline__ T operator()(const T &a,
+                                                   const T &b) const {
+    return (b > a) ? b : a;
+  }
+};
+
+/// Functor for computing the minimum of two values
+struct Min {
+  /// Apply the min operation
+  template <typename T>
+  __host__ __device__ __forceinline__ T operator()(const T &a,
+                                                   const T &b) const {
+    return (b < a) ? b : a;
+  }
+};
+
+#else
+// CUDA 12.x and earlier: Use native cub implementations
+
+#ifdef PADDLE_WITH_HIP
+using Sum = hipcub::Sum;
+using Max = hipcub::Max;
+using Min = hipcub::Min;
+#else
+using Sum = cub::Sum;
+using Max = cub::Max;
+using Min = cub::Min;
+#endif
+
+#endif  // FD_CCCL_V3
+
+// ============================================================================
+// ArgMax, ArgMin functors
+// These are also removed in CCCL 3.0
+// ============================================================================
+
+#ifdef FD_CCCL_V3
+// CUDA 13.0+ (CCCL 3.0): Use custom implementations since cub::ArgMax/ArgMin
+// are removed
+
+/// Functor for computing the ArgMax of two values (for cub::BlockReduce with
+/// KeyValuePair) Returns the key-value pair with the larger value
+struct ArgMax {
+  /// Apply ArgMax operation (returns pair with max value and its key/index)
+  template <typename KeyValuePair>
+  __host__ __device__ __forceinline__ KeyValuePair
+  operator()(const KeyValuePair &a, const KeyValuePair &b) const {
+    return (b.value > a.value) ? b : a;
+  }
+};
+
+/// Functor for computing the ArgMin of two values (for cub::BlockReduce with
+/// KeyValuePair) Returns the key-value pair with the smaller value
+struct ArgMin {
+  /// Apply ArgMin operation (returns pair with min value and its key/index)
+  template <typename KeyValuePair>
+  __host__ __device__ __forceinline__ KeyValuePair
+  operator()(const KeyValuePair &a, const KeyValuePair &b) const {
+    return (b.value < a.value) ? b : a;
+  }
+};
+
+#else
+// CUDA 12.x and earlier: Use native cub implementations
+
+#ifdef PADDLE_WITH_HIP
+using ArgMax = hipcub::ArgMax;
+using ArgMin = hipcub::ArgMin;
+#else
+// For older CUDA versions, wrap the native cub::ArgMax/ArgMin
+struct ArgMax {
+  template <typename KeyValuePair>
+  __host__ __device__ __forceinline__ KeyValuePair
+  operator()(const KeyValuePair &a, const KeyValuePair &b) const {
+    cub::ArgMax argmax;
+    return argmax(a, b);
+  }
+};
+
+struct ArgMin {
+  template <typename KeyValuePair>
+  __host__ __device__ __forceinline__ KeyValuePair
+  operator()(const KeyValuePair &a, const KeyValuePair &b) const {
+    cub::ArgMin argmin;
+    return argmin(a, b);
+  }
+};
+
+#endif  // PADDLE_WITH_HIP
+
+#endif  // FD_CCCL_V3
+
+}  // namespace fd_cub_compat

--- a/custom_ops/gpu_ops/moe/fused_moe_op.h
+++ b/custom_ops/gpu_ops/moe/fused_moe_op.h
@@ -32,6 +32,8 @@
 
 #include "helper.h"
 
+#include "../cccl_compat.h"  // CCCL 3.0 compatibility
+
 #define WARP_SIZE 32
 
 namespace phi {
@@ -335,7 +337,7 @@ __launch_bounds__(TPB) __global__
   }
   const int64_t thread_row_offset = globalIdx * num_cols;
 
-  cub::Sum sum;
+  fd_cub_compat::Sum sum;
   float threadData(-FLT_MAX);
 
   for (int ii = threadIdx.x; ii < num_cols; ii += TPB) {
@@ -343,7 +345,8 @@ __launch_bounds__(TPB) __global__
     threadData = max(static_cast<float>(input[idx]), threadData);
   }
 
-  const float maxElem = BlockReduce(tmpStorage).Reduce(threadData, cub::Max());
+  const float maxElem =
+      BlockReduce(tmpStorage).Reduce(threadData, fd_cub_compat::Max());
   if (threadIdx.x == 0) {
     float_max = maxElem;
   }
@@ -373,7 +376,8 @@ __launch_bounds__(TPB) __global__
     threadData = max(static_cast<float>(T(val)), threadData);
   }
 
-  const float maxOut = BlockReduce(tmpStorage).Reduce(threadData, cub::Max());
+  const float maxOut =
+      BlockReduce(tmpStorage).Reduce(threadData, fd_cub_compat::Max());
   if (threadIdx.x == 0) {
     // group max probs
     max_out = 1.f / maxOut;
@@ -405,7 +409,7 @@ __launch_bounds__(TPB) __global__ void moe_softmax(const T* input,
   }
   const int64_t thread_row_offset = globalIdx * num_cols;
 
-  cub::Sum sum;
+  fd_cub_compat::Sum sum;
   float threadData(-FLT_MAX);
 
   for (int ii = threadIdx.x; ii < num_cols; ii += TPB) {
@@ -413,7 +417,8 @@ __launch_bounds__(TPB) __global__ void moe_softmax(const T* input,
     threadData = max(static_cast<float>(input[idx]), threadData);
   }
 
-  const float maxElem = BlockReduce(tmpStorage).Reduce(threadData, cub::Max());
+  const float maxElem =
+      BlockReduce(tmpStorage).Reduce(threadData, fd_cub_compat::Max());
   if (threadIdx.x == 0) {
     float_max = maxElem;
   }
@@ -456,7 +461,7 @@ __launch_bounds__(TPB) __global__
   __shared__ typename BlockReduce::TempStorage tmpStorage;
 
   cub_kvp thread_kvp;
-  cub::ArgMax arg_max;
+  fd_cub_compat::ArgMax arg_max;
 
   const int block_row = blockIdx.x + blockIdx.y * gridDim.x;
   if (block_row >= num_rows) {
@@ -514,7 +519,7 @@ __launch_bounds__(TPB) __global__ void moe_top_k(const T* inputs_after_softmax,
   __shared__ typename BlockReduce::TempStorage tmpStorage;
 
   cub_kvp thread_kvp;
-  cub::ArgMax arg_max;
+  fd_cub_compat::ArgMax arg_max;
 
   const int block_row = blockIdx.x + blockIdx.y * gridDim.x;
   if (block_row >= num_rows) {
@@ -609,12 +614,13 @@ __launch_bounds__(TPB) __global__
   const int64_t thread_row_offset = globalIdx * num_experts;
   const int64_t idx = thread_row_offset + threadIdx.x;
 
-  cub::Sum sum;
+  fd_cub_compat::Sum sum;
 
   float threadData =
       (threadIdx.x < num_experts) ? static_cast<float>(input[idx]) : (-FLT_MAX);
 
-  const float maxElem = BlockReduce(tmpStorage).Reduce(threadData, cub::Max());
+  const float maxElem =
+      BlockReduce(tmpStorage).Reduce(threadData, fd_cub_compat::Max());
   if (threadIdx.x == 0) {
     float_max = maxElem;
   }
@@ -639,7 +645,7 @@ __launch_bounds__(TPB) __global__
   __shared__ typename BlockReduceP::TempStorage tmpStorageP;
 
   cub_kvp thread_kvp;
-  cub::ArgMax arg_max;
+  fd_cub_compat::ArgMax arg_max;
 
   T weight_sum = static_cast<T>(0);
   T* row_outputs = nullptr;
@@ -727,7 +733,7 @@ __launch_bounds__(TPB) __global__
   __shared__ typename BlockReduce::TempStorage tmpStorage;
 
   cub_kvp thread_kvp;
-  cub::ArgMax arg_max;
+  fd_cub_compat::ArgMax arg_max;
 
   const int block_row = blockIdx.x + blockIdx.y * gridDim.x;
   // unsigned int state = block_row + blockIdx.x * blockDim.x +

--- a/custom_ops/gpu_ops/moe/moe_dispatch.cu
+++ b/custom_ops/gpu_ops/moe/moe_dispatch.cu
@@ -23,6 +23,7 @@
 #pragma GCC diagnostic pop
 
 #include "helper.h"
+#include "../cccl_compat.h"  // CCCL 3.0 compatibility
 
 // This kernel is specifically designed for w4afp8 optimizations
 // Uses CUB BlockReduce for efficient parallel reduction
@@ -47,7 +48,8 @@ __global__ void compute_max_tokens_from_prefix_sum_kernel(
   }
 
   // Use CUB BlockReduce to find maximum value across all threads
-  int64_t block_max = BlockReduceT(temp_storage).Reduce(local_max, cub::Max());
+  int64_t block_max =
+      BlockReduceT(temp_storage).Reduce(local_max, fd_cub_compat::Max());
 
   if (tid == 0) {
     *max_tokens_output = block_max;

--- a/custom_ops/gpu_ops/quantization/common.cu
+++ b/custom_ops/gpu_ops/quantization/common.cu
@@ -209,7 +209,8 @@ __global__ void dynamic_per_token_scaled_fp8_quant_kernel(
   using BlockReduce = cub::BlockReduce<float, 1024>;
   __shared__ typename BlockReduce::TempStorage reduceStorage;
   float const block_absmax_val_maybe =
-      BlockReduce(reduceStorage).Reduce(absmax_val, cub::Max{}, blockDim.x);
+      BlockReduce(reduceStorage)
+          .Reduce(absmax_val, fd_cub_compat::Max{}, blockDim.x);
   __shared__ float token_scale;
   if (tid == 0) {
     if (scale_ub > 0) {

--- a/custom_ops/gpu_ops/quantization/common.cuh
+++ b/custom_ops/gpu_ops/quantization/common.cuh
@@ -9,6 +9,8 @@
 #include <cub/cub.cuh>
 #include <cuda_runtime.h>
 
+#include "../cccl_compat.h"  // CCCL 3.0 compatibility
+
 namespace fastdeploy {
 
 // Vectorization containers

--- a/custom_ops/gpu_ops/sample_kernels/sampling.cuh
+++ b/custom_ops/gpu_ops/sample_kernels/sampling.cuh
@@ -27,10 +27,15 @@
 #include <numeric>
 
 #include "sample_kernels/utils.cuh"
+#include "../cccl_compat.h"  // CCCL 3.0 compatibility
 
 namespace sampling {
 
 using namespace cub;
+
+// Use fd_cub_compat for functors removed in CCCL 3.0
+using fd_cub_compat::Max;
+using fd_cub_compat::Min;
 
 #define DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, ...) \
   if (compute_capacity.first >= 8) {                                           \
@@ -317,7 +322,7 @@ __device__ __forceinline__ void DeviceSamplingFromProb(
   }
   int max_valid_index = BlockReduce<int, BLOCK_THREADS, REDUCE_ALGORITHM>(
                             temp_storage->block_prim.reduce_int)
-                            .Reduce(valid_index, cub::Max());
+                            .Reduce(valid_index, Max());
   if (tx == 0 && max_valid_index != -1) {
     temp_storage->last_valid_id = max_valid_index;
   }
@@ -636,12 +641,12 @@ __device__ __forceinline__ float GetMaxValue(float* in_data,
     max_val = max(max_val,
                   BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(
                       temp_storage.block_prim.reduce)
-                      .Reduce(in_data_, cub::Max()));
+                      .Reduce(in_data_, Max()));
 #else
     max_val = max(max_val,
                   BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(
                       temp_storage.block_prim.reduce)
-                      .Reduce<VEC_SIZE>(in_data_, cub::Max()));
+                      .Reduce<VEC_SIZE>(in_data_, Max()));
 #endif
     __syncthreads();
   }
@@ -837,11 +842,11 @@ __global__ void TopKRenormProbKernel(DType* probs,
       }
       min_gt_low = BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(
                        temp_storage.block_prim.reduce)
-                       .Reduce(min_gt_low, cub::Min());
+                       .Reduce(min_gt_low, Min());
       __syncthreads();
       max_le_high = BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(
                         temp_storage.block_prim.reduce)
-                        .Reduce(max_le_high, cub::Max());
+                        .Reduce(max_le_high, Max());
       if (tx == 0) {
         temp_storage.block_aggregate.pairs[0] = aggregate_gt_pivot_0;
         temp_storage.block_aggregate.pairs[1] = aggregate_gt_pivot_1;

--- a/custom_ops/gpu_ops/speculate_decoding/draft_model/mtp_step_paddle.cu
+++ b/custom_ops/gpu_ops/speculate_decoding/draft_model/mtp_step_paddle.cu
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "helper.h"  // NOLINT
+#include "helper.h"             // NOLINT
+#include "../../cccl_compat.h"  // CCCL 3.0 compatibility
 template <int NUM_THREADS, int MAX_BATCH_SIZE = 256>
 __global__ void mtp_free_and_dispatch_block(bool *base_model_stop_flags,
                                             bool *stop_flags,
@@ -110,7 +111,8 @@ __global__ void mtp_free_and_dispatch_block(bool *base_model_stop_flags,
     const int used_block_num =
         tid < bsz && !base_model_stop_flags[tid] ? used_list_len[tid] : 0;
     cub::KeyValuePair<int, int> kv_pair = {tid, used_block_num};
-    kv_pair = BlockReduce(temp_storage).Reduce(kv_pair, cub::ArgMax());
+    kv_pair =
+        BlockReduce(temp_storage).Reduce(kv_pair, fd_cub_compat::ArgMax());
 
     if (tid == 0) {
       const int encoder_block_len = encoder_block_lens[kv_pair.key];

--- a/custom_ops/gpu_ops/speculate_decoding/speculate_step.cu
+++ b/custom_ops/gpu_ops/speculate_decoding/speculate_step.cu
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "helper.h"  // NOLINT
+#include "helper.h"          // NOLINT
+#include "../cccl_compat.h"  // CCCL 3.0 compatibility
 
 // #define DEBUG_STEP
 
@@ -121,7 +122,8 @@ __global__ void speculate_free_and_dispatch_block(
             ? used_list_len[tid]
             : 0;
     cub::KeyValuePair<int, int> kv_pair = {tid, used_block_num};
-    kv_pair = BlockReduce(temp_storage).Reduce(kv_pair, cub::ArgMax());
+    kv_pair =
+        BlockReduce(temp_storage).Reduce(kv_pair, fd_cub_compat::ArgMax());
 
     if (tid == 0) {
       if (kv_pair.value == 0) {

--- a/custom_ops/gpu_ops/speculate_decoding/speculate_step_reschedule.cu
+++ b/custom_ops/gpu_ops/speculate_decoding/speculate_step_reschedule.cu
@@ -14,6 +14,7 @@
 
 #include "helper.h"
 #include "speculate_msg.h"
+#include "../cccl_compat.h"  // CCCL 3.0 compatibility
 
 #ifndef PD_BUILD_STATIC_OP
 #define PD_BUILD_STATIC_OP(name) PD_BUILD_OP(static_op_##name)
@@ -122,7 +123,8 @@ __global__ void speculate_free_and_reschedule(bool *stop_flags,
     // 调度block，根据used_list_len从大到小回收block，直到满足need_block_len，已解码到最后一个block的query不参与调度（马上就结束）
     const int used_block_num = tid < bsz ? used_list_len[tid] : 0;
     cub::KeyValuePair<int, int> kv_pair = {tid, used_block_num};
-    kv_pair = BlockReduce(temp_storage).Reduce(kv_pair, cub::ArgMax());
+    kv_pair =
+        BlockReduce(temp_storage).Reduce(kv_pair, fd_cub_compat::ArgMax());
     if (tid == 0) {
       if (kv_pair.value == 0) {
         step_max_block_flag = true;

--- a/custom_ops/gpu_ops/step.cu
+++ b/custom_ops/gpu_ops/step.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "helper.h"
+#include "cccl_compat.h"  // CCCL 3.0 compatibility
 
 __device__ bool in_need_block_list(const int &qid,
                                    int *need_block_list,
@@ -116,7 +117,8 @@ __global__ void free_and_dispatch_block(bool *stop_flags,
             ? used_list_len[tid]
             : 0;
     cub::KeyValuePair<int, int> kv_pair = {tid, used_block_num};
-    kv_pair = BlockReduce(temp_storage).Reduce(kv_pair, cub::ArgMax());
+    kv_pair =
+        BlockReduce(temp_storage).Reduce(kv_pair, fd_cub_compat::ArgMax());
 
     if (tid == 0) {
       if (kv_pair.value == 0) {

--- a/custom_ops/gpu_ops/step_reschedule.cu
+++ b/custom_ops/gpu_ops/step_reschedule.cu
@@ -14,6 +14,7 @@
 
 #include "helper.h"
 #include "save_with_output_msg.h"
+#include "cccl_compat.h"  // CCCL 3.0 compatibility
 
 #define RECOVERY_STOP_SIGNAL -3
 
@@ -115,7 +116,8 @@ __global__ void free_and_reschedule(bool *stop_flags,
     // 调度block，根据used_list_len从大到小回收block，直到满足need_block_len，已解码到最后一个block的query不参与调度（马上就结束）
     const int used_block_num = tid < bsz ? used_list_len[tid] : 0;
     cub::KeyValuePair<int, int> kv_pair = {tid, used_block_num};
-    kv_pair = BlockReduce(temp_storage).Reduce(kv_pair, cub::ArgMax());
+    kv_pair =
+        BlockReduce(temp_storage).Reduce(kv_pair, fd_cub_compat::ArgMax());
     if (tid == 0) {
       if (kv_pair.value == 0) {
         step_max_block_flag = true;

--- a/custom_ops/setup_ops.py
+++ b/custom_ops/setup_ops.py
@@ -368,6 +368,12 @@ elif paddle.is_compiled_with_cuda():
 
     nvcc_version = get_nvcc_version()
     print(f"nvcc_version = {nvcc_version}")
+
+    # CUDA 13.0+ (CCCL 3.0) changes the default -static-global-template-stub behavior
+    # Restore old linking behavior to allow kernel symbols to be visible in shared libraries
+    if nvcc_version >= 13.0:
+        nvcc_compile_args += ["-static-global-template-stub=false"]
+
     if nvcc_version >= 12.0:
         sources += ["gpu_ops/sample_kernels/air_top_p_sampling.cu"]
     cc = max(get_sm_version(archs))


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

CUDA 13.0 升级了 CCCL (CUDA C++ Core Libraries) 库，其中包含一些不兼容的 API 变更，主要影响了 CUB 库中的 functor（如 `Sum`, `Max`, `Min`, `ArgMax`, `ArgMin`）以及链接器的行为。本PR对相关变更进行兼容，支持FastDeploy在cuda13.0下编译。

**相关链接：**
- [CCCL 文档](https://nvidia.github.io/cccl/)
- [CUDA 13.0 Release Notes](https://developer.nvidia.com/cuda-toolkit)


## Modifications
- 新增cccl适配文件：custom_ops/gpu_ops/cccl_compat.h （CCCL兼容层实现）
- custom_ops/gpu_ops 中涉及 cub::Max()、cub::Min()、cub::Sum()、cub::ArgMax等都更新为适配后的调用
- setup_ops.py 中针对cuda13.0 增加 -static-global-template-stub=false 编译选项，让链接器支持跨cu文件调用__global__声明的函数\结构体

<!-- Detail the changes made in this pull request. -->

## Usage or Command
无变更
<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests
不涉及

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
