### PR TITLE
[Others]Add model format detection based on `source` field in model_config

### DIFF
--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -408,14 +408,17 @@ class ModelConfig:
                 logger.info("The model format is Hugging Face Torch")
             elif "dtype" in self.model_config:
                 # https://github.com/huggingface/transformers/releases/tag/v4.56.0  Transformers 4.56.0 version deprecated torch_dtype
-                if "transformers_version" in self.model_config and parse_version(
-                    self.model_config["transformers_version"]
-                ) > parse_version("4.56.0"):
-                    self.model_format = "torch"
-                    logger.info("The model format is Hugging Face Torch")
-                else:
+                if "source" in self.model_config and self.model_config["source"] == "paddle":
                     self.model_format = "paddle"
-                    logger.info("The model format is Paddle")
+                else:
+                    if "transformers_version" in self.model_config and parse_version(
+                        self.model_config["transformers_version"]
+                    ) > parse_version("4.56.0"):
+                        self.model_format = "torch"
+                        logger.info("The model format is Hugging Face Torch")
+                    else:
+                        self.model_format = "paddle"
+                        logger.info("The model format is Paddle")
             elif (
                 "quantization_config" in self.model_config
                 and "quant_method" in self.model_config["quantization_config"]
@@ -424,11 +427,11 @@ class ModelConfig:
                 self.model_format = "torch"
                 logger.info("The model format is Hugging Face")
             else:
-                raise ValueError(
-                    "Unknown model format. Please ensure your config.json contains "
-                    "either 'torch_dtype' (for Hugging Face models) or 'dtype' (for Paddle models) field. "
-                    f"Config file path: {config_path}"
-                )
+                if "source" in self.model_config and self.model_config["source"] == "paddle":
+                    self.model_format = "paddle"
+                else:
+                    self.model_format = "torch"
+                logger.info("The model format is Hugging Face")
 
     def _get_default_runner_type(
         self,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications

<!-- Detail the changes made in this pull request. -->
paddle格式的权重额外增加source:"paddle"的字段，
FD新增该字段适配，用于识别paddle 格式权重
## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
