### PR TITLE
[BugFix] Fix promblem where DEBUG logs were lossed

### DIFF
--- a/fastdeploy/__init__.py
+++ b/fastdeploy/__init__.py
@@ -17,6 +17,7 @@
 # Configure root logger first to unify log formats
 # This must be done before importing any modules that may use the logger
 import logging
+import os
 from contextlib import contextmanager
 
 # Create standard format (without color)
@@ -53,7 +54,7 @@ def _configure_logger(name=None):
     """
     # Use original getLogger to avoid recursion when interceptor is active
     logger = _original_getLogger(name)
-    logger.setLevel(logging.INFO)
+    logger.setLevel(logging.DEBUG if envs.FD_DEBUG else logging.INFO)
     for handler in logger.handlers[:]:
         logger.removeHandler(handler)
     handler = logging.StreamHandler()
@@ -63,10 +64,11 @@ def _configure_logger(name=None):
     return logger
 
 
+from fastdeploy.utils import envs
+
 # Configure root logger
 _configure_logger()
 
-import os
 import uuid
 
 # suppress warning log from paddlepaddle
@@ -107,12 +109,7 @@ if hasattr(pf_logger, "logger") and isinstance(pf_logger.logger, logging.Logger)
 
 from fastdeploy.engine.sampling_params import SamplingParams
 from fastdeploy.entrypoints.llm import LLM
-from fastdeploy.utils import (
-    console_logger,
-    current_package_version,
-    envs,
-    get_version_info,
-)
+from fastdeploy.utils import console_logger, current_package_version, get_version_info
 
 paddle.compat.enable_torch_proxy(scope={"triton"})
 # paddle.compat.enable_torch_proxy(scope={"triton"}) enables the torch proxy

--- a/fastdeploy/logger/logger.py
+++ b/fastdeploy/logger/logger.py
@@ -238,7 +238,7 @@ def intercept_paddle_loggers():
             formatter = logging.Formatter(
                 "%(levelname)-8s %(asctime)s %(process)-5s %(filename)s[line:%(lineno)d] %(message)s"
             )
-            logger.setLevel(logging.INFO)
+            logger.setLevel(logging.DEBUG if envs.FD_DEBUG else logging.INFO)
             for handler in logger.handlers[:]:
                 logger.removeHandler(handler)
             stream_handler = logging.StreamHandler()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

There is an ongoing issue with DEBUG log loss in the current project.

## Modifications

<!-- Detail the changes made in this pull request. -->

Resolve issue where logger handlers overrode level settings to INFO.

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
