### PR TITLE
[Cherry-Pick] [BugFix] resolve get_save_output_v1 socket name conflicts between multiple instances (#6758)

### DIFF
--- a/fastdeploy/output/token_processor.py
+++ b/fastdeploy/output/token_processor.py
@@ -69,7 +69,7 @@ class TokenProcessor:
         self.split_connector = split_connector
 
         if envs.FD_USE_GET_SAVE_OUTPUT_V1:
-            port = self.cfg.parallel_config.engine_worker_queue_port
+            port = self.cfg.parallel_config.engine_worker_queue_port[self.cfg.parallel_config.local_data_parallel_id]
             llm_logger.debug(
                 f"create zmq get_save_output_rank{self.cfg.parallel_config.local_data_parallel_id}_{port}"
             )

--- a/fastdeploy/output/token_processor.py
+++ b/fastdeploy/output/token_processor.py
@@ -69,9 +69,12 @@ class TokenProcessor:
         self.split_connector = split_connector
 
         if envs.FD_USE_GET_SAVE_OUTPUT_V1:
-            llm_logger.debug(f"create zmq get_save_output_rank{self.cfg.parallel_config.local_data_parallel_id}")
+            port = self.cfg.parallel_config.local_engine_worker_queue_port
+            llm_logger.debug(
+                f"create zmq get_save_output_rank{self.cfg.parallel_config.local_data_parallel_id}_{port}"
+            )
             self.zmq_server = ZmqIpcServer(
-                name=f"get_save_output_rank{self.cfg.parallel_config.local_data_parallel_id}", mode=zmq.PULL
+                name=f"get_save_output_rank{self.cfg.parallel_config.local_data_parallel_id}_{port}", mode=zmq.PULL
             )
 
         self.speculative_decoding = self.cfg.speculative_config.method is not None

--- a/fastdeploy/output/token_processor.py
+++ b/fastdeploy/output/token_processor.py
@@ -69,7 +69,7 @@ class TokenProcessor:
         self.split_connector = split_connector
 
         if envs.FD_USE_GET_SAVE_OUTPUT_V1:
-            port = self.cfg.parallel_config.local_engine_worker_queue_port
+            port = self.cfg.parallel_config.engine_worker_queue_port
             llm_logger.debug(
                 f"create zmq get_save_output_rank{self.cfg.parallel_config.local_data_parallel_id}_{port}"
             )

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -224,7 +224,7 @@ class GPUModelRunner(ModelRunnerBase):
         self.zmq_client = None
         self.async_output_queue = None
         if envs.FD_USE_GET_SAVE_OUTPUT_V1:
-            port = self.fd_config.parallel_config.local_engine_worker_queue_port
+            port = self.fd_config.parallel_config.engine_worker_queue_port
             logger.info(f"zmq client get_save_output_rank{local_rank}_{port}")
             self.zmq_client = ZmqIpcClient(name=f"get_save_output_rank{local_rank}_{port}", mode=zmq.PUSH)
             self.zmq_client.connect()

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -224,8 +224,9 @@ class GPUModelRunner(ModelRunnerBase):
         self.zmq_client = None
         self.async_output_queue = None
         if envs.FD_USE_GET_SAVE_OUTPUT_V1:
-            logger.info(f"zmq client get_save_output_rank{local_rank}")
-            self.zmq_client = ZmqIpcClient(name=f"get_save_output_rank{local_rank}", mode=zmq.PUSH)
+            port = self.fd_config.parallel_config.local_engine_worker_queue_port
+            logger.info(f"zmq client get_save_output_rank{local_rank}_{port}")
+            self.zmq_client = ZmqIpcClient(name=f"get_save_output_rank{local_rank}_{port}", mode=zmq.PUSH)
             self.zmq_client.connect()
             self.zmq_client.socket.SNDTIMEO = 3000
             self.async_output_queue: queue.Queue = queue.Queue()

--- a/fastdeploy/worker/metax_model_runner.py
+++ b/fastdeploy/worker/metax_model_runner.py
@@ -157,7 +157,7 @@ class MetaxModelRunner(ModelRunnerBase):
         self.zmq_client = None
         self.async_output_queue = None
         if envs.FD_USE_GET_SAVE_OUTPUT_V1:
-            port = self.fd_config.parallel_config.local_engine_worker_queue_port
+            port = self.fd_config.parallel_config.engine_worker_queue_port
             logger.info(f"zmq client get_save_output_rank{local_rank}_{port}")
             self.zmq_client = ZmqIpcClient(name=f"get_save_output_rank{local_rank}_{port}", mode=zmq.PUSH)
             self.zmq_client.connect()

--- a/fastdeploy/worker/metax_model_runner.py
+++ b/fastdeploy/worker/metax_model_runner.py
@@ -157,8 +157,9 @@ class MetaxModelRunner(ModelRunnerBase):
         self.zmq_client = None
         self.async_output_queue = None
         if envs.FD_USE_GET_SAVE_OUTPUT_V1:
-            logger.info(f"zmq client get_save_output_rank{local_rank}")
-            self.zmq_client = ZmqIpcClient(name=f"get_save_output_rank{local_rank}", mode=zmq.PUSH)
+            port = self.fd_config.parallel_config.local_engine_worker_queue_port
+            logger.info(f"zmq client get_save_output_rank{local_rank}_{port}")
+            self.zmq_client = ZmqIpcClient(name=f"get_save_output_rank{local_rank}_{port}", mode=zmq.PUSH)
             self.zmq_client.connect()
             self.zmq_client.socket.SNDTIMEO = 3000
             self.async_output_queue: queue.Queue = queue.Queue()

--- a/fastdeploy/worker/xpu_model_runner.py
+++ b/fastdeploy/worker/xpu_model_runner.py
@@ -163,8 +163,9 @@ class XPUModelRunner(ModelRunnerBase):
         self.zmq_client = None
         self.async_output_queue = None
         if envs.FD_USE_GET_SAVE_OUTPUT_V1:
-            logger.info(f"zmq client get_save_output_rank{local_rank}")
-            self.zmq_client = ZmqIpcClient(name=f"get_save_output_rank{local_rank}", mode=zmq.PUSH)
+            port = self.fd_config.parallel_config.local_engine_worker_queue_port
+            logger.info(f"zmq client get_save_output_rank{local_rank}_{port}")
+            self.zmq_client = ZmqIpcClient(name=f"get_save_output_rank{local_rank}_{port}", mode=zmq.PUSH)
             self.zmq_client.connect()
             self.zmq_client.socket.SNDTIMEO = 3000
             self.async_output_queue: queue.Queue = queue.Queue()

--- a/fastdeploy/worker/xpu_model_runner.py
+++ b/fastdeploy/worker/xpu_model_runner.py
@@ -163,7 +163,7 @@ class XPUModelRunner(ModelRunnerBase):
         self.zmq_client = None
         self.async_output_queue = None
         if envs.FD_USE_GET_SAVE_OUTPUT_V1:
-            port = self.fd_config.parallel_config.local_engine_worker_queue_port
+            port = self.fd_config.parallel_config.engine_worker_queue_port
             logger.info(f"zmq client get_save_output_rank{local_rank}_{port}")
             self.zmq_client = ZmqIpcClient(name=f"get_save_output_rank{local_rank}_{port}", mode=zmq.PUSH)
             self.zmq_client.connect()

--- a/tests/output/test_get_save_output_v1.py
+++ b/tests/output/test_get_save_output_v1.py
@@ -36,6 +36,7 @@ class MockConfig:
         local_data_parallel_id = 0
         enable_expert_parallel = False
         data_parallel_size = 1
+        local_engine_worker_queue_port = 1200
 
     class SpeculativeConfig:
         method = None
@@ -120,8 +121,9 @@ class TestGetSaveOutputV1(unittest.TestCase):
         model_runner.zmq_client = None
         model_runner.async_output_queue = None
         if envs.FD_USE_GET_SAVE_OUTPUT_V1:
+            port = cfg.parallel_config.local_engine_worker_queue_port
             model_runner.zmq_client = ZmqIpcClient(
-                name=f"get_save_output_rank{cfg.parallel_config.local_data_parallel_id}", mode=zmq.PUSH
+                name=f"get_save_output_rank{cfg.parallel_config.local_data_parallel_id}_{port}", mode=zmq.PUSH
             )
             model_runner.zmq_client.connect()
             model_runner.zmq_client.socket.SNDTIMEO = 3000

--- a/tests/output/test_get_save_output_v1.py
+++ b/tests/output/test_get_save_output_v1.py
@@ -36,7 +36,7 @@ class MockConfig:
         local_data_parallel_id = 0
         enable_expert_parallel = False
         data_parallel_size = 1
-        local_engine_worker_queue_port = 1200
+        engine_worker_queue_port = 1200
 
     class SpeculativeConfig:
         method = None
@@ -121,7 +121,7 @@ class TestGetSaveOutputV1(unittest.TestCase):
         model_runner.zmq_client = None
         model_runner.async_output_queue = None
         if envs.FD_USE_GET_SAVE_OUTPUT_V1:
-            port = cfg.parallel_config.local_engine_worker_queue_port
+            port = cfg.parallel_config.engine_worker_queue_port
             model_runner.zmq_client = ZmqIpcClient(
                 name=f"get_save_output_rank{cfg.parallel_config.local_data_parallel_id}_{port}", mode=zmq.PUSH
             )


### PR DESCRIPTION

<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

When `FD_USE_GET_SAVE_OUTPUT_V1` is enabled, the ZMQ socket name is currently derived only from `local_data_parallel_id`. In multi-instance deployments on the same machine, different instances can end up using the same socket name, which may cause IPC

## Modifications

  - Updated the `get_save_output_v1` socket naming rule to include `local_engine_worker_queue_port` in addition to `local_data_parallel_id`
  - Aligned both server and client socket names across:
    - `token_processor`
    - `gpu_model_runner`
    - `metax_model_runner`
    - `xpu_model_runner`
  - Updated `tests/output/test_get_save_output_v1.py` to reflect the new socket naming logic

## Usage or Command

As usual

## Accuracy Tests

No side effect on accuracy

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
