### PR TITLE
[BugFix] Set MC_TCP_BIND_ADDRESS for mooncake store

### DIFF
--- a/fastdeploy/cache_manager/transfer_factory/mooncake_store/mooncake_store.py
+++ b/fastdeploy/cache_manager/transfer_factory/mooncake_store/mooncake_store.py
@@ -28,6 +28,7 @@ from fastdeploy.cache_manager.transfer_factory.kvcache_storage import (
 )
 from fastdeploy.cache_manager.transfer_factory.utils import get_rdma_nics
 from fastdeploy.platforms import current_platform
+from fastdeploy.utils import get_host_ip
 
 DEFAULT_GLOBAL_SEGMENT_SIZE = 1024 * 1024 * 1024  # 1 GiB
 DEFAULT_LOCAL_BUFFER_SIZE = 128 * 1024 * 1024  # 128MB
@@ -48,9 +49,10 @@ class MooncakeStoreConfig:
         """Load the config from a JSON file or environment variables."""
         config = {}
         file_path = os.getenv("MOONCAKE_CONFIG_PATH")
+        host_ip = get_host_ip()
 
         if file_path is None:
-            local_hostname = os.environ.get("MOONCAKE_LOCAL_HOSTNAME", "localhost")
+            local_hostname = os.environ.get("MOONCAKE_LOCAL_HOSTNAME", host_ip)
             metadata_server = os.environ.get("MOONCAKE_METADATA_SERVER")
             global_segment_size = int(os.environ.get("MOONCAKE_GLOBAL_SEGMENT_SIZE", DEFAULT_GLOBAL_SEGMENT_SIZE))
             local_buffer_size = int(os.environ.get("MOONCAKE_LOCAL_BUFFER_SIZE", DEFAULT_LOCAL_BUFFER_SIZE))
@@ -63,7 +65,7 @@ class MooncakeStoreConfig:
             with open(file_path) as fin:
                 config = json.load(fin)
 
-            local_hostname = config.get("local_hostname", "localhost")
+            local_hostname = config.get("local_hostname", host_ip)
             metadata_server = config.get("metadata_server")
             global_segment_size = int(config.get("global_segment_size", DEFAULT_GLOBAL_SEGMENT_SIZE))
             local_buffer_size = int(config.get("local_buffer_size", DEFAULT_LOCAL_BUFFER_SIZE))
@@ -99,6 +101,11 @@ class MooncakeStore(KVCacheStorage):
     def __init__(self, tp_rank=None):
         super().__init__()
         self.tp_rank = tp_rank
+
+        # Set MC_TCP_BIND_ADDRESS for mooncake store to bind to the correct host IP
+        host_ip = get_host_ip()
+        os.environ["MC_TCP_BIND_ADDRESS"] = host_ip
+        logger.info(f"Set MC_TCP_BIND_ADDRESS to {host_ip}")
 
         try:
             from mooncake.store import MooncakeDistributedStore
@@ -139,8 +146,10 @@ class MooncakeStore(KVCacheStorage):
     def warmup(self):
         warmup_key = "fastdeploy_mooncake_store_warmup_key" + str(uuid.uuid4())
         warmup_value = bytes(1 * 1024 * 1024)  # 1 MB
-        self.store.put(warmup_key, warmup_value)
-        assert self.store.is_exist(warmup_key) == 1
+        rc = self.store.put(warmup_key, warmup_value)
+        assert rc == 0, f"Failed to put warmup key, key:{warmup_key}, error code: {rc}"
+        rc = self.store.is_exist(warmup_key)
+        assert rc == 1, f"Failed to check existence, key:{warmup_key}, error code: {rc}"
         self.store.get(warmup_key)
         self.store.remove(warmup_key)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Fix error in using mooncake store

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications
Set MC_TCP_BIND_ADDRESS for mooncake store

<!-- Detail the changes made in this pull request. -->

## Usage or Command
None
<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests
None
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
