### PR TITLE
[Docs] Remove Python-only mode (BUILD_WHEEL=2) from installation guides

### DIFF
--- a/docs/get_started/installation/kunlunxin_xpu.md
+++ b/docs/get_started/installation/kunlunxin_xpu.md
@@ -110,44 +110,6 @@ bash build.sh
 
 The compiled outputs will be located in the ```FastDeploy/dist``` directory.
 
-## 4. Python-only Quick Install (For Development)
-
-If you have already completed a full build (`bash build.sh 1`) and only modified Python files, you can use the python-only mode to quickly sync changes to `site-packages` **without recompiling C++ Custom Ops or rebuilding the wheel**.
-
-### Prerequisites
-
-A full build must have been completed at least once:
-
-```bash
-bash build.sh 1
-```
-
-### Usage
-
-```bash
-# Argument 1: Must be 2 to enable python-only mode
-# Argument 2 (optional): Python interpreter path (default: python)
-
-# Use default python
-bash build.sh 2
-
-# Use a specific python interpreter
-bash build.sh 2 python3
-
-# Use an absolute path to the interpreter
-bash build.sh 2 /path/to/your/python
-```
-
-This command syncs `.py` files from the source tree directly into the installed `site-packages/fastdeploy/` directory via `rsync`. Compiled artifacts (`.so` files) are preserved.
-
-### When to Use
-
-| Scenario | Recommended Command |
-|---|---|
-| Only modified Python files | `bash build.sh 2` |
-| Modified C++/CUDA code | `bash build.sh 1` |
-| First-time build | `bash build.sh 1` |
-
 ## Installation verification
 
 ```bash

--- a/docs/get_started/installation/nvidia_gpu.md
+++ b/docs/get_started/installation/nvidia_gpu.md
@@ -125,44 +125,6 @@ After the build completes, the operator binaries can be found in `FastDeploy/fas
 > - For custom architectures or modified operator logic, please use **source compilation (Section 4)**.
 > - You can check whether the precompiled wheel for a specific commit has been successfully built on the [FastDeploy CI Build Status Page](https://github.com/PaddlePaddle/FastDeploy/actions/workflows/ci_image_update.yml).
 
-## 6. Python-only Quick Install (For Development)
-
-If you have already completed a full build (`bash build.sh 1 ...`) and only modified Python files, you can use the python-only mode to quickly sync changes to `site-packages` **without recompiling C++ Custom Ops or rebuilding the wheel**.
-
-### Prerequisites
-
-A full build must have been completed at least once:
-
-```shell
-bash build.sh 1 python false [80,90]
-```
-
-### Usage
-
-```shell
-# Argument 1: Must be 2 to enable python-only mode
-# Argument 2 (optional): Python interpreter path (default: python)
-
-# Use default python
-bash build.sh 2
-
-# Use a specific python interpreter
-bash build.sh 2 python3
-
-# Use an absolute path to the interpreter
-bash build.sh 2 /path/to/your/python
-```
-
-This command syncs `.py` files from the source tree directly into the installed `site-packages/fastdeploy/` directory via `rsync`. Compiled artifacts (`.so` files) are preserved.
-
-### When to Use
-
-| Scenario | Recommended Command |
-|---|---|
-| Only modified Python files | `bash build.sh 2` |
-| Modified C++/CUDA code | `bash build.sh 1 python false [80,90]` |
-| First-time build | `bash build.sh 1 python false [80,90]` |
-
 ## Environment Verification
 
 After installation, verify the environment with this Python code:

--- a/docs/zh/get_started/installation/kunlunxin_xpu.md
+++ b/docs/zh/get_started/installation/kunlunxin_xpu.md
@@ -111,40 +111,6 @@ bash build.sh
 
 编译后的产物在 ```FastDeploy/dist``` 目录下。
 
-## 4. Python-only 快速安装
-
-如果你已经完成过一次完整编译安装，后续仅修改了 Python 代码，可以使用 Python-only 模式将 Python 文件快速同步到 `site-packages`，**跳过 C++ 算子编译和 Wheel 打包**。
-
-### 前提条件
-
-必须先完成过一次完整编译安装（即执行过 `bash build.sh 1 ...`），确保 `site-packages` 中已有编译产物（`.so` 文件）。
-
-### 使用方式
-
-```bash
-# 使用默认 python
-bash build.sh 2
-
-# 指定 Python 解释器
-bash build.sh 2 python3
-
-# 使用完整路径指定 Python 解释器
-bash build.sh 2 /path/to/your/python
-```
-
-- 第 1 个参数 `2`：表示使用 Python-only 模式
-- 第 2 个参数（可选）：Python 解释器路径或命令名，默认为 `python`
-
-### 适用场景
-
-| 场景 | 推荐方式 |
-|------|----------|
-| 仅修改 Python 文件 | `bash build.sh 2` |
-| 修改了 C++/CUDA 代码 | `bash build.sh 1 ...`（完整编译） |
-| 首次编译 | `bash build.sh 1 ...`（完整编译） |
-
-> **注意：** 该模式需要系统安装 `rsync`，若未安装请先执行 `apt-get install rsync` 或 `yum install rsync`。
-
 ## 验证是否安装成功
 
 ```python

--- a/docs/zh/get_started/installation/nvidia_gpu.md
+++ b/docs/zh/get_started/installation/nvidia_gpu.md
@@ -131,40 +131,6 @@ bash build.sh 1 python false [90] 1 8a9e7b53af4a98583cab65e4b44e3265a93e56d2
 > - 若希望自定义架构或修改算子逻辑，请使用 **源码编译方式（第4节）**。
 > - 您可以在 FastDeploy CI 构建状态页面查看对应 commit 的预编译 whl 是否已构建成功。
 
-## 6. Python-only 快速安装
-
-如果你已经完成过一次完整编译安装，后续仅修改了 Python 代码，可以使用 Python-only 模式将 Python 文件快速同步到 `site-packages`，**跳过 C++ 算子编译和 Wheel 打包**。
-
-### 前提条件
-
-必须先完成过一次完整编译安装（即执行过 `bash build.sh 1 ...`），确保 `site-packages` 中已有编译产物（`.so` 文件）。
-
-### 使用方式
-
-```bash
-# 使用默认 python
-bash build.sh 2
-
-# 指定 Python 解释器
-bash build.sh 2 python3
-
-# 使用完整路径指定 Python 解释器
-bash build.sh 2 /path/to/your/python
-```
-
-- 第 1 个参数 `2`：表示使用 Python-only 模式
-- 第 2 个参数（可选）：Python 解释器路径或命令名，默认为 `python`
-
-### 适用场景
-
-| 场景 | 推荐方式 |
-|------|----------|
-| 仅修改 Python 文件 | `bash build.sh 2` |
-| 修改了 C++/CUDA 代码 | `bash build.sh 1 python false "[80,90]"` |
-| 首次编译 | `bash build.sh 1 python false "[80,90]"` |
-
-> **注意：** 该模式需要系统安装 `rsync`，若未安装请先执行 `apt-get install rsync` 或 `yum install rsync`。
-
 ## 环境检查
 
 在安装 FastDeploy 后，通过如下 Python 代码检查环境的可用性


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

## Motivation

`BUILD_WHEEL=2` (Python-only quick install) mode has been removed from `build.sh` (see #6781). The corresponding documentation sections in installation guides should be removed accordingly.

## Modifications

Remove the Python-only quick install sections from 4 docs:
- `docs/zh/get_started/installation/nvidia_gpu.md` (Section 6)
- `docs/get_started/installation/nvidia_gpu.md` (Section 6)
- `docs/zh/get_started/installation/kunlunxin_xpu.md` (Section 4)
- `docs/get_started/installation/kunlunxin_xpu.md` (Section 4)

## Usage or Command

N/A - documentation cleanup only.

## Accuracy Tests

N/A - no code changes.

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. No unit tests needed — documentation only.
- [ ] Provide accuracy results. N/A.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.