### PR TITLE
[RL][Feature] Support chunked snapshot loading in _update_ipc_snapshot

### DIFF
--- a/fastdeploy/rl/dynamic_weight_manager.py
+++ b/fastdeploy/rl/dynamic_weight_manager.py
@@ -14,8 +14,11 @@
 # limitations under the License.
 """
 
+import gc
+import glob
 import io
 import os
+import re
 import time
 from multiprocessing.shared_memory import SharedMemory
 from typing import Any, Dict, List
@@ -199,20 +202,55 @@ class DynamicWeightManager:
         # step6: update weight status signal
 
     def _update_ipc_snapshot(self):
-        """Update using IPC snapshot strategy for elastic recovery."""
-        model_path = os.path.join(
-            self.fd_config.model_config.model,
-            f"model_state.tp0{self.meta_src_id}.pdparams",
+        """Update using IPC snapshot strategy for elastic recovery.
+
+        Loading priority:
+          1. Chunked part files  (model_state.tpR{id}.part{N}.pdparams)
+          2. Single full file    (model_state.tpR{id}.pdparams)
+          3. Shared fallback dir (/shared_ipc_meta/...)
+        """
+        model_dir = self.fd_config.model_config.model
+        base_name = f"model_state.tp{paddle.distributed.get_rank()}{self.meta_src_id}"
+
+        # --- Priority 1: load from chunked part files to avoid memory spike ---
+        part_pattern = os.path.join(model_dir, f"{base_name}.part*.pdparams")
+        part_files = sorted(
+            glob.glob(part_pattern),
+            key=lambda p: int(re.search(r"\.part(\d+)\.", p).group(1)),
         )
 
-        try:
-            ipc_state_dict = paddle.load(model_path, safetensors=True)
-        except FileNotFoundError:
-            fallback_path = f"/shared_ipc_meta/model_state.tp0{self.meta_src_id}.pdparams"
-            ipc_state_dict = paddle.load(fallback_path)
+        if part_files:
+            logger.info(f"Found {len(part_files)} snapshot part files for {base_name}")
+            for idx, part_path in enumerate(part_files, start=1):
+                logger.info(f"Loading snapshot part {idx}/{len(part_files)} from {part_path}")
+                ipc_state_dict = paddle.load(part_path, safetensors=True)
+                self._update_model_from_state(ipc_state_dict, f"snapshot-part{idx}")
+                del ipc_state_dict
+                gc.collect()
+            logger.info(
+                f"IPC snapshot update completed from {len(part_files)} part files under {model_dir}"
+            )
+            return
 
+        # --- Priority 2: single full pdparams file (legacy) ---
+        model_path = os.path.join(model_dir, f"{base_name}.pdparams")
+        if os.path.exists(model_path):
+            ipc_state_dict = paddle.load(model_path, safetensors=True)
+            self._update_model_from_state(ipc_state_dict, "snapshot")
+            logger.info(f"IPC snapshot update completed from {model_path}")
+            return
+
+        # --- Priority 3: shared directory fallback (oldest legacy path) ---
+        fallback_path = f"/shared_ipc_meta/{base_name}.pdparams"
+        if not os.path.exists(fallback_path):
+            raise FileNotFoundError(
+                f"No snapshot found for {base_name}: "
+                f"checked {model_dir} and {fallback_path}"
+            )
+        logger.info(f"No local snapshot in {model_dir}, fallback to {fallback_path}")
+        ipc_state_dict = paddle.load(fallback_path)
         self._update_model_from_state(ipc_state_dict, "snapshot")
-        logger.info(f"IPC snapshot update parameters completed from {model_path}")
+        logger.info(f"IPC snapshot update completed from {fallback_path}")
 
     def _update_ipc(self):
         """Update using standard IPC strategy (requires Training Worker)."""


### PR DESCRIPTION
## Motivation
Loading full model snapshot files in one shot causes large memory spikes during elastic recovery. This change introduces chunked part-file loading to reduce peak memory usage.

## Modifications
Refactor `_update_ipc_snapshot` to load weights in priority order:
1. Chunked part files (`model_state.tpR{id}.part{N}.pdparams`): load and apply weights incrementally, calling `gc.collect()` after each part to release memory promptly.
2. Single full pdparams file (legacy path).
3. Shared fallback directory (`/shared_ipc_meta/...`) as last resort.

Additional fixes:
- Use `paddle.distributed.get_rank()` instead of hardcoded `tp0` for proper rank awareness in multi-process scenarios.
- Raise explicit `FileNotFoundError` with a descriptive message when no snapshot file is found under any of the three paths.
