### PR TITLE
[RL][BugFix] Fix incorrect rank in IPC snapshot model path

### DIFF
--- a/fastdeploy/rl/dynamic_weight_manager.py
+++ b/fastdeploy/rl/dynamic_weight_manager.py
@@ -114,13 +114,13 @@ class DynamicWeightManager:
         """Update using IPC snapshot strategy for elastic recovery."""
         model_path = os.path.join(
             self.fd_config.model_config.model,
-            f"model_state.tp0{self.meta_src_id}.pdparams",
+            f"model_state.tp{paddle.distributed.get_rank()}{self.meta_src_id}.pdparams",
         )
 
         try:
             ipc_state_dict = paddle.load(model_path, safetensors=True)
         except FileNotFoundError:
-            fallback_path = f"/shared_ipc_meta/model_state.tp0{self.meta_src_id}.pdparams"
+            fallback_path = f"/shared_ipc_meta/model_state.tp{paddle.distributed.get_rank()}{self.meta_src_id}.pdparams"
             ipc_state_dict = paddle.load(fallback_path)
 
         self._update_model_from_state(ipc_state_dict, "snapshot")


### PR DESCRIPTION
## Motivation
During elastic recovery, each rank should load its own model shard.
The hardcoded `tp0` caused all ranks to load rank-0's shard, leading
to incorrect weight initialization in multi-process scenarios.

## Modifications
- Replace hardcoded `tp0` with `paddle.distributed.get_rank()` in both
  the primary model path and the fallback `/shared_ipc_meta/` path
  inside `_update_ipc_snapshot`, so each rank correctly loads its own
  shard during elastic recovery.