### PR TITLE
[RL][Optimization] Support chunked part files loading in IPC snapshot to avoid memory spike

### DIFF
--- a/fastdeploy/rl/dynamic_weight_manager.py
+++ b/fastdeploy/rl/dynamic_weight_manager.py
@@ -205,8 +205,8 @@ class DynamicWeightManager:
         """Update using IPC snapshot strategy for elastic recovery.
 
         Loading priority:
-          1. Chunked part files  (model_state.tpR{id}.part{N}.pdparams)
-          2. Single full file    (model_state.tpR{id}.pdparams)
+          1. Chunked part files  (model_state.tp{rank}{id}.part{N}.pdparams)
+          2. Single full file    (model_state.tp{rank}{id}.pdparams)
           3. Shared fallback dir (/shared_ipc_meta/...)
         """
         model_dir = self.fd_config.model_config.model

--- a/fastdeploy/rl/dynamic_weight_manager.py
+++ b/fastdeploy/rl/dynamic_weight_manager.py
@@ -205,12 +205,14 @@ class DynamicWeightManager:
         """Update using IPC snapshot strategy for elastic recovery.
 
         Loading priority:
-          1. Chunked part files  (model_state.tp{rank}{id}.part{N}.pdparams)
-          2. Single full file    (model_state.tp{rank}{id}.pdparams)
-          3. Shared fallback dir (/shared_ipc_meta/...)
+          1. Chunked part files  (model_state.tp{rank}.{id}.part{N}.pdparams)
+          2. Single full file    (model_state.tp{rank}.{id}.pdparams)
+          3. Legacy format       (model_state.tp0{id}.pdparams)
+          4. Shared fallback dir (/shared_ipc_meta/...)
         """
         model_dir = self.fd_config.model_config.model
-        base_name = f"model_state.tp{paddle.distributed.get_rank()}{self.meta_src_id}"
+        base_name = f"model_state.tp{paddle.distributed.get_rank()}.{self.meta_src_id}"
+        legacy_base_name = f"model_state.tp0{self.meta_src_id}"
 
         # --- Priority 1: load from chunked part files to avoid memory spike ---
         part_pattern = os.path.join(model_dir, f"{base_name}.part*.pdparams")
@@ -230,7 +232,7 @@ class DynamicWeightManager:
             logger.info(f"IPC snapshot update completed from {len(part_files)} part files under {model_dir}")
             return
 
-        # --- Priority 2: single full pdparams file (legacy) ---
+        # --- Priority 2: single full pdparams file ---
         model_path = os.path.join(model_dir, f"{base_name}.pdparams")
         if os.path.exists(model_path):
             ipc_state_dict = paddle.load(model_path, safetensors=True)
@@ -238,10 +240,20 @@ class DynamicWeightManager:
             logger.info(f"IPC snapshot update completed from {model_path}")
             return
 
-        # --- Priority 3: shared directory fallback (oldest legacy path) ---
+        # --- Priority 3: legacy format (model_state.tp0{id}.pdparams) ---
+        legacy_path = os.path.join(model_dir, f"{legacy_base_name}.pdparams")
+        if os.path.exists(legacy_path):
+            ipc_state_dict = paddle.load(legacy_path, safetensors=True)
+            self._update_model_from_state(ipc_state_dict, "snapshot")
+            logger.info(f"IPC snapshot update completed from legacy format {legacy_path}")
+            return
+
+        # --- Priority 4: shared directory fallback ---
         fallback_path = f"/shared_ipc_meta/{base_name}.pdparams"
         if not os.path.exists(fallback_path):
-            raise FileNotFoundError(f"No snapshot found for {base_name}: " f"checked {model_dir} and {fallback_path}")
+            raise FileNotFoundError(
+                f"No snapshot found for {base_name}: " f"checked {model_dir} (new/legacy) and {fallback_path}"
+            )
         logger.info(f"No local snapshot in {model_dir}, fallback to {fallback_path}")
         ipc_state_dict = paddle.load(fallback_path)
         self._update_model_from_state(ipc_state_dict, "snapshot")

--- a/fastdeploy/rl/dynamic_weight_manager.py
+++ b/fastdeploy/rl/dynamic_weight_manager.py
@@ -14,8 +14,11 @@
 # limitations under the License.
 """
 
+import gc
+import glob
 import io
 import os
+import re
 import time
 from multiprocessing.shared_memory import SharedMemory
 from typing import Any, Dict, List
@@ -199,20 +202,50 @@ class DynamicWeightManager:
         # step6: update weight status signal
 
     def _update_ipc_snapshot(self):
-        """Update using IPC snapshot strategy for elastic recovery."""
-        model_path = os.path.join(
-            self.fd_config.model_config.model,
-            f"model_state.tp0{self.meta_src_id}.pdparams",
+        """Update using IPC snapshot strategy for elastic recovery.
+
+        Loading priority:
+          1. Chunked part files  (model_state.tpR{id}.part{N}.pdparams)
+          2. Single full file    (model_state.tpR{id}.pdparams)
+          3. Shared fallback dir (/shared_ipc_meta/...)
+        """
+        model_dir = self.fd_config.model_config.model
+        base_name = f"model_state.tp{paddle.distributed.get_rank()}{self.meta_src_id}"
+
+        # --- Priority 1: load from chunked part files to avoid memory spike ---
+        part_pattern = os.path.join(model_dir, f"{base_name}.part*.pdparams")
+        part_files = sorted(
+            glob.glob(part_pattern),
+            key=lambda p: int(re.search(r"\.part(\d+)\.", p).group(1)),
         )
 
-        try:
-            ipc_state_dict = paddle.load(model_path, safetensors=True)
-        except FileNotFoundError:
-            fallback_path = f"/shared_ipc_meta/model_state.tp0{self.meta_src_id}.pdparams"
-            ipc_state_dict = paddle.load(fallback_path)
+        if part_files:
+            logger.info(f"Found {len(part_files)} snapshot part files for {base_name}")
+            for idx, part_path in enumerate(part_files, start=1):
+                logger.info(f"Loading snapshot part {idx}/{len(part_files)} from {part_path}")
+                ipc_state_dict = paddle.load(part_path, safetensors=True)
+                self._update_model_from_state(ipc_state_dict, f"snapshot-part{idx}")
+                del ipc_state_dict
+                gc.collect()
+            logger.info(f"IPC snapshot update completed from {len(part_files)} part files under {model_dir}")
+            return
 
+        # --- Priority 2: single full pdparams file (legacy) ---
+        model_path = os.path.join(model_dir, f"{base_name}.pdparams")
+        if os.path.exists(model_path):
+            ipc_state_dict = paddle.load(model_path, safetensors=True)
+            self._update_model_from_state(ipc_state_dict, "snapshot")
+            logger.info(f"IPC snapshot update completed from {model_path}")
+            return
+
+        # --- Priority 3: shared directory fallback (oldest legacy path) ---
+        fallback_path = f"/shared_ipc_meta/{base_name}.pdparams"
+        if not os.path.exists(fallback_path):
+            raise FileNotFoundError(f"No snapshot found for {base_name}: " f"checked {model_dir} and {fallback_path}")
+        logger.info(f"No local snapshot in {model_dir}, fallback to {fallback_path}")
+        ipc_state_dict = paddle.load(fallback_path)
         self._update_model_from_state(ipc_state_dict, "snapshot")
-        logger.info(f"IPC snapshot update parameters completed from {model_path}")
+        logger.info(f"IPC snapshot update completed from {fallback_path}")
 
     def _update_ipc(self):
         """Update using standard IPC strategy (requires Training Worker)."""


### PR DESCRIPTION
## Motivation

When using IPC snapshot strategy for elastic recovery in RL training, loading a single large `.pdparams` file at once causes a significant memory spike — the entire state dict must reside in memory simultaneously alongside the live model weights. This PR refactors `_update_ipc_snapshot` to support loading chunked (sharded) part files sequentially, releasing memory between each chunk to avoid the spike.

Additionally, the original implementation hardcoded `tp0` as the rank ID in the file path, which is incorrect in multi-rank scenarios. This PR fixes it to use the actual rank via `paddle.distributed.get_rank()`.

## Modifications

Refactored `_update_ipc_snapshot` in `fastdeploy/rl/dynamic_weight_manager.py` with a three-level loading priority:

1. **Chunked part files** (`model_state.tp{rank}{src_id}.part{N}.pdparams`):
   Load multiple smaller shards sequentially. After each shard is applied to the model, the state dict is deleted and `gc.collect()` is called to release memory immediately, avoiding memory spike.

2. **Single full file** (`model_state.tp{rank}{src_id}.pdparams`):
   Legacy single-file loading path, preserved for backward compatibility.

3. **Shared fallback directory** (`/shared_ipc_meta/model_state.tp{rank}{src_id}.pdparams`):
   Oldest legacy fallback path, preserved for backward compatibility. Raises a clear `FileNotFoundError` if none of the above exist.

Other changes:
- Fixed hardcoded `tp0` → `tp{paddle.distributed.get_rank()}` in the snapshot file name pattern.
- Added `gc`, `glob`, `re` imports.
- Improved log messages to show progress (e.g., `Loading snapshot part 1/3 from ...`).

## Usage or Command

No API changes. The behavior is backward compatible — if no part files exist, it falls back to the previous single-file or shared-directory path automatically.

To produce chunked part files on the training side, split the state dict and save as:
`model_state.tp{rank}{src_id}.part0.pdparams`
`model_state.tp{rank}{src_id}.part1.pdparams`
`...`

## Accuracy Tests

This PR only changes the weight loading path (data loading logic), not the model forward computation or kernel. The loaded weights are identical regardless of whether they are loaded from a single file or multiple part files. No accuracy regression is expected.

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests. (Unit test for snapshot loading path requires a distributed training environment setup; will be tracked separately.)
- [x] Provide accuracy results. (N/A — no model forward code changed.)
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
