### PR TITLE
[BugFix] Cap nvcc -t threads to avoid compilation failures on high-co…

### DIFF
--- a/custom_ops/setup_ops.py
+++ b/custom_ops/setup_ops.py
@@ -365,7 +365,7 @@ elif paddle.is_compiled_with_cuda():
     ]
     # Limit nvcc internal threads to avoid resource exhaustion when Paddle's
     # ThreadPoolExecutor also launches many parallel compilations.
-    # Total threads ≈ MAX_JOBS × nvcc_threads, so cap nvcc_threads at 4.
+    # Total threads ≈ (number of parallel compile jobs) × nvcc_threads, so cap nvcc_threads at 4.
     nvcc_threads = min(os.cpu_count() or 1, 4)
     nvcc_compile_args += ["-t", str(nvcc_threads)]
 

--- a/custom_ops/setup_ops.py
+++ b/custom_ops/setup_ops.py
@@ -363,8 +363,11 @@ elif paddle.is_compiled_with_cuda():
         "-Igpu_ops",
         "-Ithird_party/nlohmann_json/include",
     ]
-    worker_threads = os.cpu_count()
-    nvcc_compile_args += ["-t", str(worker_threads)]
+    # Limit nvcc internal threads to avoid resource exhaustion when Paddle's
+    # ThreadPoolExecutor also launches many parallel compilations.
+    # Total threads ≈ MAX_JOBS × nvcc_threads, so cap nvcc_threads at 4.
+    nvcc_threads = min(os.cpu_count() or 1, 4)
+    nvcc_compile_args += ["-t", str(nvcc_threads)]
 
     nvcc_version = get_nvcc_version()
     print(f"nvcc_version = {nvcc_version}")


### PR DESCRIPTION
## Motivation

On machines with many CPU cores (e.g. 192), the first `bash build.sh` fails at link stage with errors like:

```
/bin/ld: cannot find .../gpu_ops/append_attention.cu.o: No such file or directory
/bin/ld: cannot find .../gpu_ops/machete/generated/machete_mm_impl_part1.cu.o: No such file or directory
```

A second build succeeds without any code change.

Two factors combine to cause this:

1. **Thread explosion**: `nvcc -t` was set to `os.cpu_count()` (e.g. 192). Paddle `ThreadPoolExecutor` also launches up to `cpu_count()` parallel workers. This creates up to 192 x 192 = 36K threads, causing resource exhaustion (OOM / process killed).

2. **Silent compilation failures in Paddle**: In `paddle.utils.cpp_extension`, `unix_custom_compile_single_file` catches exceptions and only prints them without re-raising (`cpp_extension.py:571-572`). When nvcc processes are killed, their `.o` files are never created, but the build continues to the link stage where the linker fails.

The second build succeeds because already-compiled `.o` files are cached and skipped, reducing resource pressure.

## Modifications

Cap `nvcc -t` at 4 instead of `os.cpu_count()`. `nvcc -t` controls internal threads per nvcc process for parallelizing compilation stages within a single `.cu` file. With Paddle already launching many parallel workers externally, 4 is sufficient. Total parallelism = Paddle workers x 4.

## Usage or Command

```bash
bash build.sh 0 python false "[90]"
```

No change in usage. Can also set `MAX_JOBS` to further control Paddle parallel workers:

```bash
MAX_JOBS=32 bash build.sh 0 python false "[90]"
```

## Accuracy Tests

N/A — build configuration only, no model output change.

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. No unit test needed — this is a build configuration fix with no runtime behavior change.
- [x] Provide accuracy results.