### PR TITLE
[CI] Sync _log_softmax_batch_invariant with paddle update

### DIFF
--- a/fastdeploy/model_executor/layers/batch_invariant_ops/batch_invariant_ops.py
+++ b/fastdeploy/model_executor/layers/batch_invariant_ops/batch_invariant_ops.py
@@ -682,8 +682,13 @@ def addmm_batch_invariant(
     return result
 
 
-def _log_softmax_batch_invariant(x: paddle.Tensor, axis: int = -1) -> paddle.Tensor:
-    return log_softmax(input=x, axis=axis)
+def _log_softmax_batch_invariant(x: paddle.Tensor, axis: int = -1, out=None) -> paddle.Tensor:
+    result = log_softmax(input=x, axis=axis)
+    # Handle out parameter if provided
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
 
 
 def mean_batch_invariant(

--- a/scripts/unittest_requirement.txt
+++ b/scripts/unittest_requirement.txt
@@ -8,3 +8,4 @@ partial_json_parser
 jsonschema
 aistudio_sdk==0.3.5
 pandas
+use_triton_in_paddle

--- a/tests/cov_pytest.ini
+++ b/tests/cov_pytest.ini
@@ -12,4 +12,3 @@ addopts =
     --ignore=tests/e2e/golang_router
     --ignore=tests/v1/test_schedule_output.py
     --ignore=tests/graph_optimization/test_cuda_graph_dynamic_subgraph.py
-    --ignore=tests/batch_invariant/test_batch_invariance_op_logsoftmax.py


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
Adapt to the API change of `paddle.nn.functional.log_softmax` introduced in https://github.com/PaddlePaddle/Paddle/pull/78220, where a new implementation is aligned and `paddle.compact.nn.functional.log_softmax` is introduced.  
The previous `_log_softmax_batch_invariant` implementation in FastDeploy did not fully align with the updated behavior, leading to potential incompatibility with the latest Paddle nightly version.

## Modifications

- Updated `_log_softmax_batch_invariant` to align with the latest `log_softmax` API behavior.
- Added support for the optional `out` parameter to maintain consistency with Paddle interfaces.
- Kept the original computation logic unchanged while ensuring compatibility with new Paddle updates.
- Ensured CI passes with the latest Paddle nightly builds.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.