### PR TITLE
[Optimization] Use triton kernel of qk_rmsnorm_fused in both Prefill and Decode.

### DIFF
--- a/fastdeploy/model_executor/layers/normalization.py
+++ b/fastdeploy/model_executor/layers/normalization.py
@@ -340,28 +340,16 @@ class QKRMSNorm(nn.Layer):
         qkv_out,
         forward_meta,
     ) -> paddle.Tensor:
-        if self.qk_norm_fused and forward_meta.step_use_cudagraph:
-            qkv_out = qk_rmsnorm_fused(
-                qkv_out,
-                self.q_norm.weight,
-                self.k_norm.weight,
-                self.eps,
-                self.q_size,
-                self.kv_size,
-                self.head_dim,
-            )
-        else:
-            q, k, v = qkv_out.split([self.q_size, self.kv_size, self.kv_size], axis=-1)
 
-            q_by_head = q.reshape([*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim])
-            q_by_head = self.q_norm(q_by_head)[0]
-            q = q_by_head.reshape(q.shape)
-
-            k_by_head = k.reshape([*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim])
-            k_by_head = self.k_norm(k_by_head)[0]
-            k = k_by_head.reshape(k.shape)
-
-            qkv_out = paddle.concat([q, k, v], axis=-1)
+        qkv_out = qk_rmsnorm_fused(
+            qkv_out,
+            self.q_norm.weight,
+            self.k_norm.weight,
+            self.eps,
+            self.q_size,
+            self.kv_size,
+            self.head_dim,
+        )
         return qkv_out
 
 

--- a/fastdeploy/model_executor/ops/triton_ops/qk_rmsnorm_fused_kernel.py
+++ b/fastdeploy/model_executor/ops/triton_ops/qk_rmsnorm_fused_kernel.py
@@ -17,13 +17,9 @@
 import triton
 import triton.language as tl
 
-from fastdeploy.model_executor.ops.triton_ops.triton_utils import (
-    enable_compat_on_triton_kernel,
-)
 from fastdeploy.utils import ceil_div
 
 
-@enable_compat_on_triton_kernel
 @triton.jit
 def qk_rmsnorm_fused_kernel(
     x_ptr,


### PR DESCRIPTION
## Motivation
Prefill 阶段使用QKRMSNorm融合算子. 部分模型 单Kernel部分加速2～7倍. Prefill 空泡较大的模型单次Forward可加速2倍左右. 
NOTE：必须移除enable_compat_on_triton_kernel装饰器，否则在Kernel launch 存在巨大异常耗时，导致优化无效. 

## Modifications

使用QKRMSNorm 替代paddle 散Op

## Usage or Command

## Accuracy Tests


## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
