### PR TITLE
[Cherry-Pick][Optimization] Skip compat guard when torch is not installed(#6913)

### DIFF
--- a/fastdeploy/model_executor/ops/triton_ops/triton_utils.py
+++ b/fastdeploy/model_executor/ops/triton_ops/triton_utils.py
@@ -18,6 +18,7 @@ import inspect
 import os
 import re
 import sys
+from importlib.metadata import PackageNotFoundError, distribution
 
 import paddle
 import triton
@@ -30,7 +31,19 @@ link_file = triton.__path__[0] + "/tools/link.py"
 python_path = sys.executable
 
 
+def _is_package_installed(dist_name: str) -> bool:
+    try:
+        distribution(dist_name)
+        return True
+    except PackageNotFoundError:
+        return False
+
+
 def enable_compat_on_triton_kernel(triton_kernel):
+    # When torch is not installed, this decorator does not do anything, just return the original triton kernel.
+    if not _is_package_installed("torch"):
+        return triton_kernel
+
     class WrappedTritonKernel:
         def __init__(self, kernel):
             self.kernel = kernel


### PR DESCRIPTION
Cherry-pick of #6913 (authored by @SigureMo) to `release/2.5`.

devPR:https://github.com/PaddlePaddle/FastDeploy/pull/6913 <!-- For pass CI -->

---

<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

在不混合 torch 环境下，直接返回原始 triton kernel，不包装，零运行时开销

## Modifications

<!-- Detail the changes made in this pull request. -->

未安装 torch 时下不使用 compat guard

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

无

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

无

## Checklist

- [x] Add at least a tag in the PR title.
- Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
- You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.