### PR TITLE
[CI] Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/CheckPRTemplate.yml
+++ b/.github/workflows/CheckPRTemplate.yml
@@ -33,7 +33,7 @@ jobs:
           git checkout -b test FETCH_HEAD
 
       - name: Setup Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/CheckPRTemplate.yml
+++ b/.github/workflows/CheckPRTemplate.yml
@@ -22,7 +22,7 @@ jobs:
           rm -rf * .[^.]*
 
       - name: Checkout base branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 1000

--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -32,7 +32,7 @@ jobs:
           git checkout -b test FETCH_HEAD
 
       - name: Setup python3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -21,7 +21,7 @@ jobs:
           rm -rf * .[^.]*
 
       - name: Checkout base repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 1000

--- a/.github/workflows/_clone_linux.yml
+++ b/.github/workflows/_clone_linux.yml
@@ -33,7 +33,7 @@ jobs:
       repo_archive_url: ${{ steps.set_output.outputs.repo_archive_url }}
     steps:
       - name: Clone FastDeploy
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'pull_request'
                 && github.event.pull_request.base.ref
@@ -60,8 +60,6 @@ jobs:
           AK: paddle
           SK: paddle
         run: |
-          git config --unset http.https://github.com/.extraheader
-          git submodule foreach --recursive sh -c "git config --local --unset-all 'http.https://github.com/.extraheader'"
           git submodule foreach --recursive sh -c "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
           echo "Current HEAD Log:"
           git log --oneline -n 5

--- a/.github/workflows/_clone_linux.yml
+++ b/.github/workflows/_clone_linux.yml
@@ -51,7 +51,7 @@ jobs:
           git merge --no-ff pr/${{ github.event.pull_request.number }}
           echo "PR Branch log "
           git log --oneline -n 5 pr/${{ github.event.pull_request.number }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Code Info Show and Upload

--- a/.github/workflows/_unit_test_coverage.yml
+++ b/.github/workflows/_unit_test_coverage.yml
@@ -387,7 +387,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Download diff coverage file

--- a/.github/workflows/_unit_test_coverage.yml
+++ b/.github/workflows/_unit_test_coverage.yml
@@ -403,7 +403,7 @@ jobs:
 
       - name: Upload diff coverage report
         if: always() && hashFiles('python_coverage_all.xml') != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./python_coverage_all.xml
           flags: GPU

--- a/.github/workflows/_unit_test_coverage.yml
+++ b/.github/workflows/_unit_test_coverage.yml
@@ -384,7 +384,7 @@ jobs:
       all_cov_file_url: ${{ needs.run_tests_with_coverage.outputs.all_cov_file_url }}
     steps:
       - name: Clone FastDeploy
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v5

--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -19,7 +19,7 @@ jobs:
       BRANCH: ${{ github.event.pull_request.base.ref }}
     steps:
       - name: Checkout base repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 1000

--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -33,7 +33,7 @@ jobs:
           git fetch upstream $BRANCH
 
       - name: Setup python3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/ce_job.yml
+++ b/.github/workflows/ce_job.yml
@@ -105,7 +105,7 @@ jobs:
           fetch-depth: 1000
 
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Code Info Show and Upload
@@ -214,7 +214,7 @@ jobs:
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8090.outputs.wheel_path }}
       COMPILE_ARCH: "80,90"
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Wheel Info Show and Upload
@@ -264,7 +264,7 @@ jobs:
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8090_rl.outputs.wheel_path_rl }}
       COMPILE_ARCH: "80,90"
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Wheel Info Show and Upload
@@ -310,7 +310,7 @@ jobs:
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8689.outputs.wheel_path }}
       COMPILE_ARCH: "86,89"
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Wheel Info Show and Upload

--- a/.github/workflows/ce_job.yml
+++ b/.github/workflows/ce_job.yml
@@ -96,7 +96,7 @@ jobs:
       repo_archive_url: ${{ steps.set_output.outputs.repo_archive_url }}
     steps:
       - name: Clone FastDeploy
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'pull_request'
                 && github.event.pull_request.base.ref
@@ -114,8 +114,6 @@ jobs:
           AK: ${{ secrets.BOS_AK }}
           SK: ${{ secrets.BOS_SK }}
         run: |
-          git config --unset http.https://github.com/.extraheader
-          git submodule foreach --recursive sh -c "git config --local --unset-all 'http.https://github.com/.extraheader'"
           git submodule foreach --recursive sh -c "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
           echo "Current HEAD Log:"
           git log --oneline -n 5

--- a/.github/workflows/ci_image_update.yml
+++ b/.github/workflows/ci_image_update.yml
@@ -21,7 +21,7 @@ jobs:
       repo_archive_url: ${{ steps.set_output.outputs.repo_archive_url }}
     steps:
       - name: Clone FastDeploy
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
           submodules: 'recursive'
@@ -37,8 +37,6 @@ jobs:
           AK: ${{ secrets.BOS_AK }}
           SK: ${{ secrets.BOS_SK }}
         run: |
-          git config --unset http.https://github.com/.extraheader
-          git submodule foreach --recursive sh -c "git config --local --unset-all 'http.https://github.com/.extraheader'"
           git submodule foreach --recursive sh -c "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
           echo "Current HEAD Log:"
           git log --oneline -n 5

--- a/.github/workflows/ci_image_update.yml
+++ b/.github/workflows/ci_image_update.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 1000
 
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Code Info Show and Upload

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - run: pip install mkdocs-material mkdocs-get-deps mkdocs-material-extensions mkdocs-multilang mkdocs-static-i18n

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x

--- a/.github/workflows/publish_job.yml
+++ b/.github/workflows/publish_job.yml
@@ -125,7 +125,7 @@ jobs:
       repo_archive_url: ${{ steps.set_output.outputs.repo_archive_url }}
     steps:
       - name: Clone FastDeploy
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
           submodules: 'recursive'
@@ -141,8 +141,6 @@ jobs:
           AK: ${{ secrets.BOS_AK }}
           SK: ${{ secrets.BOS_SK }}
         run: |
-          git config --unset http.https://github.com/.extraheader
-          git submodule foreach --recursive sh -c "git config --local --unset-all 'http.https://github.com/.extraheader'"
           git submodule foreach --recursive sh -c "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
           echo "Current HEAD Log:"
           git log --oneline -n 5

--- a/.github/workflows/publish_job.yml
+++ b/.github/workflows/publish_job.yml
@@ -132,7 +132,7 @@ jobs:
           fetch-depth: 1000
 
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Code Info Show and Upload
@@ -241,7 +241,7 @@ jobs:
       SK: ${{ secrets.BOS_SK }}
       FD_ROUTER_URL: ${{ needs.build_fd_router.outputs.fd_router_path }}
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Fd-Router Info Show and Upload
@@ -297,7 +297,7 @@ jobs:
       SK: ${{ secrets.BOS_SK }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_cu126.outputs.wheel_path }}
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Wheel Info Show and Upload
@@ -329,7 +329,7 @@ jobs:
       SK: ${{ secrets.BOS_SK }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_cu129.outputs.wheel_path_cu129 }}
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Wheel Info Show and Upload
@@ -361,7 +361,7 @@ jobs:
       SK: ${{ secrets.BOS_SK }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_cu130.outputs.wheel_path_cu130 }}
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Wheel Info Show and Upload

--- a/.github/workflows/remove-skip-ci-labels.yml
+++ b/.github/workflows/remove-skip-ci-labels.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Get PR labels
         id: get-labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -34,7 +34,7 @@ jobs:
 
       - name: Remove skip-ci labels
         if: steps.get-labels.outputs.has-skip-ci-labels == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -14,7 +14,7 @@ jobs:
           rm -rf * .[^.]*
 
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Rerun all failed jobs
         if: ${{ contains(github.event.comment.body, 'all-failed') }}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

This change is aligned with the following PRs from the Paddle main repository:

- https://github.com/PaddlePaddle/Paddle/pull/78079
- https://github.com/PaddlePaddle/Paddle/pull/78080

The primary goal is to upgrade GitHub Actions to ensure compatibility with the upcoming default switch of GitHub Actions runners to Node 24, while also aligning with the latest major versions of several commonly used actions.

FastDeploy workflows still use multiple outdated action versions, which may lead to compatibility issues. Therefore, minimal necessary updates are required. In addition, after upgrading to `actions/checkout@v6`, the legacy workaround for cleaning `extraheader` in the clone step is no longer needed and should be removed.

---

## Modifications

- Upgrade GitHub Actions versions:
  - `actions/checkout`: v4 → v6
  - `actions/setup-python`: v5 → v6
  - `actions/github-script`: v7 → v8
  - `codecov/codecov-action`: v4 → v5

- Remove legacy `extraheader` cleanup logic in the clone step, which is no longer required after upgrading `actions/checkout`.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.