### PR TITLE
【Hackathon 10th Spring No.45】Add missing cpp_extensions.cc compile guards for SM70/SM75 -part

### DIFF
--- a/custom_ops/gpu_ops/cpp_extensions.cc
+++ b/custom_ops/gpu_ops/cpp_extensions.cc
@@ -1632,6 +1632,7 @@ PYBIND11_MODULE(fastdeploy_ops, m) {
         &GetPositionIdsAndMaskEncoderBatch,
         "get_position_ids_and_mask_encoder_batch function");
 
+#ifdef ENABLE_SM75_EXT_OPS
   /**
    * cutlass_scaled_mm.cu
    * cutlass_scaled_mm
@@ -1669,6 +1670,7 @@ PYBIND11_MODULE(fastdeploy_ops, m) {
         py::arg("input"),
         py::arg("scales"),
         py::arg("scale_ub"));
+#endif
 #ifdef ENABLE_SM80_EXT_OPS
   m.def("decode_mla_write_cache",
         &DecodeMLAWriteCacheKernel,
@@ -1885,6 +1887,7 @@ PYBIND11_MODULE(fastdeploy_ops, m) {
   m.def("custom_numpy_to_tensor",
         &CustomNumpyToTensor,
         "custom_numpy_to_tensor function");
+#ifdef ENABLE_SM80_EXT_OPS
   m.def("prefill_permute_to_masked_gemm",
         &PrefillPermuteToMaskedGemm,
         py::arg("x"),
@@ -1919,4 +1922,5 @@ PYBIND11_MODULE(fastdeploy_ops, m) {
   m.def("per_token_group_fp8_quant",
         &PerTokenGroupQuantFp8,
         "per_token_group_quant_fp8");
+#endif
 }


### PR DESCRIPTION
## Motivation

PR #6488 (merged as `-part`) introduced T4/V100 compile support but left two registration blocks in `cpp_extensions.cc` unguarded:

1. **5 cutlass/FP8 ops** (lines 1635–1673): `.cu` sources compile only at SM≥75, but registration is unconditional → linker error on V100 (SM70)
2. **7 tail MoE/MLA ops** (lines 1890–1925): sources compile only at SM≥80, registration unconditional → linker error on SM70/SM75

This is a **minimal, additive-only** fix — 4 lines added, 0 lines removed. See PR #6941 for a full wholesale replacement alternative.

## Modifications

- `custom_ops/gpu_ops/cpp_extensions.cc`: Add `#ifdef ENABLE_SM75_EXT_OPS` / `#endif` around 5 cutlass/FP8 ops. Add `#ifdef ENABLE_SM80_EXT_OPS` / `#endif` around 7 tail MoE ops.

No changes to `setup_ops.py` — keeps #6488's code as-is.

## Usage or Command

No user-facing changes. Build correctly gates ops per SM tier after this fix.

## Accuracy Tests

Guard macro verified in `setup_ops.py`: `ENABLE_SM75_EXT_OPS` and `ENABLE_SM80_EXT_OPS` are both in `cc_compile_args` (host compiler visibility — required for `.cc` files).

Wholesale version tested on **Baidu AI Studio V100** (pipeline `p-1051a228d3c7`).

## Checklist

- [x] 4 additive lines, 0 deletions — minimal diff
- [x] Pre-commit hooks pass (clang-format)
- [x] Guards use macros visible to host compiler (`cc_compile_args`)
- [x] Correct SM tier: cutlass→SM75, MoE→SM80
