### PR TITLE
[Cherry-Pick][Optimization] Use a separate driver when using Triton with Paddle (#6897)

### DIFF
--- a/fastdeploy/__init__.py
+++ b/fastdeploy/__init__.py
@@ -14,59 +14,7 @@
 # limitations under the License.
 """
 
-import logging
 import os
-from contextlib import contextmanager
-
-# Create standard format (without color)
-_root_formatter = logging.Formatter(
-    "%(levelname)-8s %(asctime)s %(process)-5s %(filename)s[line:%(lineno)d] %(message)s"
-)
-
-# Save original getLogger before any patching
-_original_getLogger = logging.getLogger
-
-
-@contextmanager
-def _intercept_paddle_loggers():
-    """Intercept and configure paddle loggers during import."""
-
-    def _patched(name=None):
-        if name and str(name).startswith("paddle"):
-            # Configure paddle logger immediately on first access
-            return _configure_logger(name)
-        return _original_getLogger(name)
-
-    logging.getLogger = _patched
-    try:
-        yield
-    finally:
-        logging.getLogger = _original_getLogger
-
-
-def _configure_logger(name=None):
-    """Configure logger with unified format.
-
-    Args:
-        name: Logger name. If None, configures root logger.
-    """
-    # Use original getLogger to avoid recursion when interceptor is active
-    logger = _original_getLogger(name)
-    logger.setLevel(logging.DEBUG if envs.FD_DEBUG else logging.INFO)
-    for handler in logger.handlers[:]:
-        logger.removeHandler(handler)
-    handler = logging.StreamHandler()
-    handler.setFormatter(_root_formatter)
-    logger.addHandler(handler)
-    logger.propagate = False
-    return logger
-
-
-from fastdeploy.utils import _is_package_installed, envs
-
-# Configure root logger
-_configure_logger()
-
 import uuid
 
 # suppress warning log from paddlepaddle
@@ -99,7 +47,13 @@ from paddleformers.utils.log import logger as pf_logger
 
 from fastdeploy.engine.sampling_params import SamplingParams
 from fastdeploy.entrypoints.llm import LLM
-from fastdeploy.utils import console_logger, current_package_version, get_version_info
+from fastdeploy.utils import (
+    _is_package_installed,
+    console_logger,
+    current_package_version,
+    envs,
+    get_version_info,
+)
 
 # We can use enable_compat only when torch is not installed, otherwise it will
 # cause some unexpected issues in triton kernels. We use enable_compat_on_triton_kernel

--- a/fastdeploy/__init__.py
+++ b/fastdeploy/__init__.py
@@ -14,7 +14,59 @@
 # limitations under the License.
 """
 
+import logging
 import os
+from contextlib import contextmanager
+
+# Create standard format (without color)
+_root_formatter = logging.Formatter(
+    "%(levelname)-8s %(asctime)s %(process)-5s %(filename)s[line:%(lineno)d] %(message)s"
+)
+
+# Save original getLogger before any patching
+_original_getLogger = logging.getLogger
+
+
+@contextmanager
+def _intercept_paddle_loggers():
+    """Intercept and configure paddle loggers during import."""
+
+    def _patched(name=None):
+        if name and str(name).startswith("paddle"):
+            # Configure paddle logger immediately on first access
+            return _configure_logger(name)
+        return _original_getLogger(name)
+
+    logging.getLogger = _patched
+    try:
+        yield
+    finally:
+        logging.getLogger = _original_getLogger
+
+
+def _configure_logger(name=None):
+    """Configure logger with unified format.
+
+    Args:
+        name: Logger name. If None, configures root logger.
+    """
+    # Use original getLogger to avoid recursion when interceptor is active
+    logger = _original_getLogger(name)
+    logger.setLevel(logging.DEBUG if envs.FD_DEBUG else logging.INFO)
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+    handler = logging.StreamHandler()
+    handler.setFormatter(_root_formatter)
+    logger.addHandler(handler)
+    logger.propagate = False
+    return logger
+
+
+from fastdeploy.utils import _is_package_installed, envs
+
+# Configure root logger
+_configure_logger()
+
 import uuid
 
 # suppress warning log from paddlepaddle
@@ -47,23 +99,13 @@ from paddleformers.utils.log import logger as pf_logger
 
 from fastdeploy.engine.sampling_params import SamplingParams
 from fastdeploy.entrypoints.llm import LLM
-from fastdeploy.utils import (
-    console_logger,
-    current_package_version,
-    envs,
-    get_version_info,
-)
+from fastdeploy.utils import console_logger, current_package_version, get_version_info
 
-paddle.compat.enable_torch_proxy(scope={"triton"})
-# paddle.compat.enable_torch_proxy(scope={"triton"}) enables the torch proxy
-# specifically for the 'triton' module. This means `import torch` inside 'triton'
-# will actually import paddle's compatibility layer (acting as torch).
-#
-# 'scope' acts as an allowlist. To add other modules, you can do:
-# paddle.compat.enable_torch_proxy(scope={"triton", "new_module"})
-#
-# Note: Ensure that any torch APIs used in 'new_module' are already implemented in Paddle.
-
+# We can use enable_compat only when torch is not installed, otherwise it will
+# cause some unexpected issues in triton kernels. We use enable_compat_on_triton_kernel
+# for these cases.
+if not _is_package_installed("torch"):
+    paddle.enable_compat(scope={"triton"})
 
 if envs.FD_DEBUG != 1:
     import logging

--- a/fastdeploy/model_executor/guided_decoding/kernels/xgrammar_apply_token_bitmask.py
+++ b/fastdeploy/model_executor/guided_decoding/kernels/xgrammar_apply_token_bitmask.py
@@ -23,10 +23,15 @@ import paddle
 try:
     import triton
     import triton.language as tl
+
+    from fastdeploy.model_executor.ops.triton_ops.triton_utils import (
+        enable_compat_on_triton_kernel,
+    )
 except ImportError as err:
     raise ImportError("Triton is not installed") from err
 
 
+@enable_compat_on_triton_kernel
 @triton.jit
 def apply_token_bitmask_inplace_kernel(
     logits_ptr,

--- a/fastdeploy/model_executor/layers/backends/dcu/triton_moe_kernels.py
+++ b/fastdeploy/model_executor/layers/backends/dcu/triton_moe_kernels.py
@@ -17,7 +17,12 @@
 import triton
 import triton.language as tl
 
+from fastdeploy.model_executor.ops.triton_ops.triton_utils import (
+    enable_compat_on_triton_kernel,
+)
 
+
+@enable_compat_on_triton_kernel
 @triton.jit
 def fused_moe_kernel_paddle(
     a_ptr,

--- a/fastdeploy/model_executor/layers/backends/metax/moe/triton_moe_kernels.py
+++ b/fastdeploy/model_executor/layers/backends/metax/moe/triton_moe_kernels.py
@@ -15,7 +15,12 @@
 import triton
 import triton.language as tl
 
+from fastdeploy.model_executor.ops.triton_ops.triton_utils import (
+    enable_compat_on_triton_kernel,
+)
 
+
+@enable_compat_on_triton_kernel
 @triton.jit()
 def fused_moe_kernel_paddle(
     a_ptr,

--- a/fastdeploy/model_executor/layers/batch_invariant_ops/batch_invariant_ops.py
+++ b/fastdeploy/model_executor/layers/batch_invariant_ops/batch_invariant_ops.py
@@ -6,16 +6,13 @@ from collections import namedtuple
 from collections.abc import Callable
 from typing import Any, Dict
 
-from fastdeploy.model_executor.ops.triton_ops.triton_utils import (
-    enable_compat_on_triton_kernel,
-)
-from fastdeploy.utils import get_logger
-
-logger = get_logger("worker_process", "worker_process.log")
-
 import paddle
 import triton
 import triton.language as tl
+
+from fastdeploy.model_executor.ops.triton_ops.triton_utils import (
+    enable_compat_on_triton_kernel,
+)
 
 __all__ = [
     "set_batch_invariant_mode",
@@ -518,6 +515,8 @@ def mean_batch_invariant(
         return out
     return result
 
+
+_original_ops = {"mm": None, "addmm": None, "_log_softmax": None, "mean_dim": None}
 
 _batch_invariant_MODE = False
 

--- a/fastdeploy/model_executor/layers/batch_invariant_ops/batch_invariant_ops.py
+++ b/fastdeploy/model_executor/layers/batch_invariant_ops/batch_invariant_ops.py
@@ -6,6 +6,13 @@ from collections import namedtuple
 from collections.abc import Callable
 from typing import Any, Dict
 
+from fastdeploy.model_executor.ops.triton_ops.triton_utils import (
+    enable_compat_on_triton_kernel,
+)
+from fastdeploy.utils import get_logger
+
+logger = get_logger("worker_process", "worker_process.log")
+
 import paddle
 import triton
 import triton.language as tl
@@ -33,6 +40,7 @@ def _matmul_launch_metadata(grid: Callable[..., Any], kernel: Any, args: Dict[st
     return ret
 
 
+@enable_compat_on_triton_kernel
 @triton.jit
 def _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS):
     group_id = tile_id // num_pid_in_group
@@ -43,6 +51,7 @@ def _compute_pid(tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, NUM_SMS):
     return pid_m, pid_n
 
 
+@enable_compat_on_triton_kernel
 @triton.jit(launch_metadata=_matmul_launch_metadata)
 def matmul_kernel_persistent(
     a_ptr,
@@ -220,6 +229,7 @@ def matmul_persistent(a: paddle.Tensor, b: paddle.Tensor, bias: paddle.Tensor | 
     return c
 
 
+@enable_compat_on_triton_kernel
 @triton.jit
 def _log_softmax_kernel(
     input_ptr,
@@ -324,6 +334,7 @@ def log_softmax(input: paddle.Tensor, axis: int = -1) -> paddle.Tensor:
     return output.reshape(original_shape)
 
 
+@enable_compat_on_triton_kernel
 @triton.jit
 def mean_kernel(
     input_ptr,
@@ -507,8 +518,6 @@ def mean_batch_invariant(
         return out
     return result
 
-
-_original_ops = {"mm": None, "addmm": None, "_log_softmax": None, "mean_dim": None}
 
 _batch_invariant_MODE = False
 

--- a/fastdeploy/model_executor/layers/moe/triton_moe_kernels.py
+++ b/fastdeploy/model_executor/layers/moe/triton_moe_kernels.py
@@ -17,7 +17,12 @@
 import triton
 import triton.language as tl
 
+from fastdeploy.model_executor.ops.triton_ops.triton_utils import (
+    enable_compat_on_triton_kernel,
+)
 
+
+@enable_compat_on_triton_kernel
 @triton.jit()
 def fused_moe_kernel_paddle(
     a_ptr,

--- a/fastdeploy/model_executor/layers/sample/logprobs.py
+++ b/fastdeploy/model_executor/layers/sample/logprobs.py
@@ -18,9 +18,13 @@ import paddle
 import triton
 import triton.language as tl
 
+from fastdeploy.model_executor.ops.triton_ops.triton_utils import (
+    enable_compat_on_triton_kernel,
+)
 from fastdeploy.platforms import current_platform
 
 
+@enable_compat_on_triton_kernel
 @triton.jit
 def count_greater_kernel(
     x_ptr,  # [num_tokens, n_elements]

--- a/fastdeploy/model_executor/ops/triton_ops/repetition_early_stop_kernel.py
+++ b/fastdeploy/model_executor/ops/triton_ops/repetition_early_stop_kernel.py
@@ -17,7 +17,12 @@
 import triton
 import triton.language as tl
 
+from fastdeploy.model_executor.ops.triton_ops.triton_utils import (
+    enable_compat_on_triton_kernel,
+)
 
+
+@enable_compat_on_triton_kernel
 @triton.jit
 def repetition_early_stopper_kernel(
     trunc_ptr,  # float32[B, W]

--- a/fastdeploy/model_executor/ops/triton_ops/triton_utils.py
+++ b/fastdeploy/model_executor/ops/triton_ops/triton_utils.py
@@ -18,29 +18,42 @@ import inspect
 import os
 import re
 import sys
-from importlib.metadata import PackageNotFoundError, distribution
 
 import paddle
 import triton
 from paddle.base.framework import OpProtoHolder
 
 from fastdeploy import envs
+from fastdeploy.utils import _is_package_installed
 
 compile_file = triton.__path__[0] + "/tools/compile.py"
 link_file = triton.__path__[0] + "/tools/link.py"
 python_path = sys.executable
 
+if _is_package_installed("torch"):
+    with paddle.use_compat_guard(enable=True, silent=True):
+        from triton.runtime.driver import _create_driver
 
-def _is_package_installed(dist_name: str) -> bool:
-    try:
-        distribution(dist_name)
-        return True
-    except PackageNotFoundError:
-        return False
+        paddle_driver = _create_driver()
+
+
+def swap_driver_guard(fn):
+    from triton.runtime.driver import driver
+
+    # A lightweight wrapper to enable compatibility for triton kernel
+    def wrapped_fn(*args, **kwargs):
+        driver.set_active(paddle_driver)
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            driver.reset_active()
+
+    return wrapped_fn
 
 
 def enable_compat_on_triton_kernel(triton_kernel):
     # When torch is not installed, this decorator does not do anything, just return the original triton kernel.
+    # Because the `paddle.enable_compat(scope={"triton"})` already enabled in `__init__.py`, it will take zero runtime overhead.
     if not _is_package_installed("torch"):
         return triton_kernel
 
@@ -49,7 +62,7 @@ def enable_compat_on_triton_kernel(triton_kernel):
             self.kernel = kernel
 
         def __getitem__(self, index):
-            return paddle.use_compat_guard(enable=True, silent=True)(self.kernel[index])
+            return swap_driver_guard(self.kernel[index])
 
     return WrappedTritonKernel(triton_kernel)
 

--- a/fastdeploy/utils.py
+++ b/fastdeploy/utils.py
@@ -33,6 +33,7 @@ import time
 import traceback
 from datetime import datetime
 from enum import Enum
+from functools import cache
 from http import HTTPStatus
 from importlib.metadata import PackageNotFoundError, distribution
 from logging.handlers import BaseRotatingHandler
@@ -1278,6 +1279,15 @@ def do_nothing(*args, **kwargs):
         return func
 
     return decorator
+
+
+@cache
+def _is_package_installed(dist_name: str) -> bool:
+    try:
+        distribution(dist_name)
+        return True
+    except PackageNotFoundError:
+        return False
 
 
 def fill_paddle_tensor(shared_inputs_object, key, value):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

Cherry-pick of #6897

解决在混合 torch 场景使用的 compat guard 过重导致性能下降的问题

## Modifications

<!-- Detail the changes made in this pull request. -->

将在 Paddle 下使用 triton kernel 的方式分为两种

1. 不混合 PyTorch 的场景，仍然直接开启 `enable_compat(scope={"triton"})`，后面和普通用法一样使用，如 https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/custom_op/cross_ecosystem_custom_op/user_guide_cn.html 中所述，零运行时开销
2. 在混合 PyTorch 的场景，为保证在运行 kernel 时所使用的 driver 里的 `torch` API 被替换为了 Paddle API，需要在 kernel 上加一个装饰器 `enable_compat_on_triton_kernel`

   ```python
   @enable_compat_on_triton_kernel
   @triton.jit
   def triton_kernel_xxx(a, b, c):
       ...
   ```

   这会在跑这个 triton kernel 前将 triton 使用的 driver 切成 Paddle 专用的 driver，确保其中使用的 API 都是 Paddle 的，在运行结束后再切回原来默认的，确保在 Paddle 环境下的 triton kernel 和在 torch 环境下的 triton kernel 都使用正确的 API，有极小的运行时开销

为了确保 FD 中两种场景都能正确执行，在 `enable_compat_on_triton_kernel` 里会根据环境是否安装 torch 来 dispatch 到上述两种逻辑

**这里本质问题是，PyTorch 和 Paddle 的 triton kernel 抢 triton 模块里一个 driver 的问题**，当然，实际上之前出现的问题还混合了在 enable compat 下，PyTorch 和 Paddle 抢 `sys.modules["torch.*"]` 的问题，不过现在在混合 PyTorch 场景下不再全局开，该问题规避掉了

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

后续所有 FD 里在 Paddle 下跑的 triton kernel 都应在 `@triton.jit` 上额外装饰 `@enable_compat_on_triton_kernel`，支持 PyTorch 和 Paddle 混用

```python
import triton
import torch
import paddle
from fastdeploy.model_executor.ops.triton_ops.triton_utils import (
    enable_compat_on_triton_kernel,
)

@triton.jit
def kernel_for_torch(x, y):
    ...

@enable_compat_on_triton_kernel
@triton.jit
def kernel_for_paddle(x, y):
    ...

kernel_for_torch(torch.tensor(1), torch.tensor(2))
kernel_for_paddle(paddle.tensor(1), paddle.tensor(2))
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

无

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
