### PR TITLE
[FDConfig] Reduce FD_CUSTOM_AR_MAX_SIZE_MB default from 64 to 8

### DIFF
--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -225,10 +225,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "FD_WORKER_ALIVE_TIMEOUT": lambda: int(os.getenv("FD_WORKER_ALIVE_TIMEOUT", "30")),
     # File path for file storage backend
     "FILE_BACKEND_STORAGE_DIR": lambda: str(os.getenv("FILE_BACKEND_STORAGE_DIR", "/tmp/fastdeploy")),
-    # Custom all-reduce max buffer size in MB (default 64MB).
+    # Custom all-reduce max buffer size in MB (default 8MB).
     # Increase this to avoid NCCL fallback for large tensors in deterministic mode.
     # E.g. FD_CUSTOM_AR_MAX_SIZE_MB=128 for 128MB.
-    "FD_CUSTOM_AR_MAX_SIZE_MB": lambda: int(os.getenv("FD_CUSTOM_AR_MAX_SIZE_MB", "64")),
+    "FD_CUSTOM_AR_MAX_SIZE_MB": lambda: int(os.getenv("FD_CUSTOM_AR_MAX_SIZE_MB", "8")),
     # Enable deterministic inference mode for chunked prefill alignment
     "FD_DETERMINISTIC_MODE": lambda: bool(int(os.getenv("FD_DETERMINISTIC_MODE", "0"))),
     # Split KV block size for deterministic alignment (must be power of 2 and > 0, default 16)

--- a/tests/e2e/4cards_cases/test_determinism_long.py
+++ b/tests/e2e/4cards_cases/test_determinism_long.py
@@ -143,7 +143,7 @@ def _module_env():
         {
             "CUDA_VISIBLE_DEVICES": os.environ.get("CUDA_VISIBLE_DEVICES", "0,1,2,3"),
             "FD_DETERMINISTIC_MODE": "1",
-            "FD_CUSTOM_AR_MAX_SIZE_MB": os.environ.get("FD_CUSTOM_AR_MAX_SIZE_MB", "57"),
+            "FD_CUSTOM_AR_MAX_SIZE_MB": os.environ.get("FD_CUSTOM_AR_MAX_SIZE_MB", "64"),
             "FLAGS_max_partition_size": _CHUNK_SIZE_FOR_TEST,
         }
     ):


### PR DESCRIPTION
## Motivation

The default `FD_CUSTOM_AR_MAX_SIZE_MB` of 64MB is unnecessarily large for most single-GPU and small-model deployments. Reducing it to 8MB lowers shared memory allocation overhead. Multi-GPU or large-model scenarios that need bigger buffers can set the env var explicitly.

## Modifications

- **`fastdeploy/envs.py`**: Change default value from `64` to `8`, update comment accordingly.
- **`tests/e2e/4cards_cases/test_determinism_long.py`**: Explicitly set `FD_CUSTOM_AR_MAX_SIZE_MB=64` (was using `57` as fallback; now aligned with other test files).

## Usage or Command

```bash
# Use default 8MB buffer
python -m fastdeploy.entrypoints.openai.api_server ...

# Override for multi-GPU with large tensors
export FD_CUSTOM_AR_MAX_SIZE_MB=64
```

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. No new unit tests needed — this is a config default change; existing e2e tests cover the behavior.
- [ ] Provide accuracy results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)