### PR TITLE
[CI] Fix test_communication.py and add port cleanup

### DIFF
--- a/tests/cov_pytest.ini
+++ b/tests/cov_pytest.ini
@@ -12,4 +12,3 @@ addopts =
     --ignore=tests/e2e/golang_router
     --ignore=tests/v1/test_schedule_output.py
     --ignore=tests/graph_optimization/test_cuda_graph_dynamic_subgraph.py
-    --ignore=tests/distributed/test_communication.py

--- a/tests/distributed/test_communication.py
+++ b/tests/distributed/test_communication.py
@@ -52,7 +52,7 @@ class TestCommunicationBasic(unittest.TestCase):
         communication.use_custom_allreduce()
 
         self.assertIsNotNone(communication._TP_AR)
-        mock_custom_ar.assert_called_once_with(fake_group, 64 * 1024 * 1024)
+        mock_custom_ar.assert_called_once_with(fake_group, 8 * 1024 * 1024)
 
     def test_custom_ar_clear_ipc_handles(self):
         mock_tp_ar = MagicMock()

--- a/tests/engine/test_async_llm.py
+++ b/tests/engine/test_async_llm.py
@@ -16,9 +16,14 @@
 
 import asyncio
 import os
+import sys
 import unittest
 import uuid
 import weakref
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."))
+
+from e2e.utils.serving_utils import clean_ports
 
 from fastdeploy.engine.args_utils import EngineArgs
 from fastdeploy.engine.async_llm import AsyncLLM
@@ -42,6 +47,10 @@ class TestAsyncLLMEngine(unittest.TestCase):
     def setUpClass(cls):
         """Set up AsyncLLM for testing"""
         try:
+            # Clean ports before starting the engine
+            print("Pre-test port cleanup...")
+            clean_ports()
+
             # Use unique ports to avoid conflicts
             base_port = int(os.getenv("FD_ENGINE_QUEUE_PORT", "6778"))
             cache_port = int(os.getenv("FD_CACHE_QUEUE_PORT", "6779"))

--- a/tests/engine/test_common_engine.py
+++ b/tests/engine/test_common_engine.py
@@ -16,14 +16,18 @@
 
 import asyncio
 import os
+import sys
 import threading
 import time
 import types
 import unittest
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."))
+
 import numpy as np
 import paddle
+from e2e.utils.serving_utils import clean_ports
 
 if not hasattr(paddle, "compat"):
 
@@ -82,6 +86,10 @@ class TestCommonEngine(unittest.TestCase):
     def setUpClass(cls):
         """Set up EngineService for testing"""
         try:
+            # Clean ports before starting the engine
+            print("Pre-test port cleanup...")
+            clean_ports()
+
             # Create engine args for testing
             engine_args = EngineArgs(
                 model=MODEL_NAME,

--- a/tests/engine/test_resource_manager_v1.py
+++ b/tests/engine/test_resource_manager_v1.py
@@ -13,12 +13,16 @@
 # limitations under the License.
 
 import os
+import sys
 import unittest
 from unittest.mock import Mock
 
 from fastdeploy.engine.args_utils import EngineArgs
 from fastdeploy.engine.request import Request, RequestStatus
 from fastdeploy.engine.sched.resource_manager_v1 import ResourceManagerV1
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."))
+from e2e.utils.serving_utils import clean_ports
 
 MODEL_NAME = os.getenv("MODEL_PATH", "/path/to/models") + "/ERNIE-4.5-0.3B-Paddle"
 
@@ -28,6 +32,9 @@ class TestResourceManagerV1(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
+        # Clean ports before each test
+        clean_ports()
+
         engine_args = EngineArgs(
             model=MODEL_NAME,
             max_model_len=8192,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

- The default value of `FD_CUSTOM_AR_MAX_SIZE_MB` was changed from 64 to 8, which caused mismatches with existing test expectations.
- Some CI failures were caused by ports not being released when previous tasks exited abnormally, leading to port conflicts in subsequent runs.
- These issues affected CI stability, especially in distributed and communication-related tests.

## Modifications

- Updated test expectations in `test_communication.py` to align with the new default value of `FD_CUSTOM_AR_MAX_SIZE_MB` (64 → 8).
- Added port cleanup logic to ensure ports are properly released before test execution.
- Synchronized updates across related test files, including communication, engine, and resource manager tests.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.