### PR TITLE
[Cherry-Pick] [BugFix] remove all gather ep group control requests in normal cases (#7026)

### DIFF
--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -604,7 +604,7 @@ class PaddleDisWorkerProc:
                     self.worker.preprocess_new_task(req_dicts, max_occupied_batch_index)
 
             # Let the ep group run control method synchronically
-            if self.parallel_config.use_ep:
+            if envs.FD_ENABLE_V1_UPDATE_WEIGHTS and self.parallel_config.use_ep:
                 pendings = all_gather_values(len(self.cached_control_reqs), self.parallel_config.ep_group)
                 if all([p > 0 for p in pendings]):
                     logger.info(f"Rank: {self.local_rank} Detected all ep ranks have pending control tasks.")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

In normal EP execution paths, worker control requests do not need to trigger EP-group `all_gather` synchronization. The current logic performs this synchronization whenever `use_ep` is enabled, which makes the control path broader than necessary.

This PR narrows the synchronization condition so that EP-group control `all_gather` is only triggered when `FD_ENABLE_V1_UPDATE_WEIGHTS` is enabled, matching the intended V1 update-weights flow and avoiding unnecessary control synchronization in normal cases.

## Modifications

For verification, compare behavior under the following environments:
- `FD_ENABLE_V1_UPDATE_WEIGHTS=1`: keep the existing EP control synchronization path.
- `FD_ENABLE_V1_UPDATE_WEIGHTS=0`: skip the EP control `all_gather` in normal cases.

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

N/A. This PR does not change model forward computation or model outputs.

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
