### PR TITLE
feat(scheduler): ratio-based decode reservation, chunked prefill and retract preemption

### DIFF
--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -1965,8 +1965,8 @@ class FDConfig:
         """
         check the legality of config
         """
-        assert self.scheduler_config.max_num_seqs <= 256, (
-            "The parameter `max_num_seqs` is not allowed to exceed 256, "
+        assert self.scheduler_config.max_num_seqs <= 512, (
+            "The parameter `max_num_seqs` is not allowed to exceed 512, "
             f"but now it's {self.scheduler_config.max_num_seqs}."
         )
         assert self.nnode >= 1, f"nnode: {self.nnode} should no less than 1"

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -901,6 +901,11 @@ class ResourceManagerV1(ResourceManager):
             # rem_input_tokens: total input budget (SGLang's max_prefill_tokens - mixed_with_decode_tokens)
             rem_input_tokens = envs.FD_REM_INPUT_TOKENS - running_decode_count
 
+            # Compute running decode reservation once per schedule() call (shared by RUNNING & WAITING loops)
+            cached_running_decode_reserved = self._calculate_decode_reserved_tokens_by_ratio()
+            # Track decode reservations accumulated within this cycle (RUNNING + WAITING)
+            scheduled_new_decode_reserved_tokens: float = 0.0
+
             # First, schedule the RUNNING requests.
             req_index = 0
             num_decoding_req_nums = 0
@@ -1029,8 +1034,15 @@ class ResourceManagerV1(ResourceManager):
                         continue
                     num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
                     num_new_block = self.get_new_block_nums(request, num_new_tokens)
+                    # Threshold check (same as WAITING loop): ensure enough free blocks for
+                    # current chunk + decode reservations
+                    can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
+                        request, num_new_block,
+                        scheduled_new_decode_reserved_tokens,
+                        cached_running_decode_reserved,
+                    )
                     # Allocate blocks to prefill
-                    if self.cache_manager.can_allocate_gpu_blocks(num_new_block):
+                    if self.cache_manager.can_allocate_gpu_blocks(can_schedule_block_num_threshold):
                         request.block_tables.extend(
                             self.cache_manager.allocate_gpu_blocks(num_new_block, request.request_id)
                         )
@@ -1048,6 +1060,14 @@ class ResourceManagerV1(ResourceManager):
                     has_scheduled_prefill = True
                     rem_input_tokens -= num_new_tokens
                     rem_chunk_tokens -= num_new_tokens
+
+                    # Track decode reservation for last-chunk requests in RUNNING loop
+                    remaining_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
+                    is_last_chunk = remaining_to_prefill <= num_new_tokens
+                    if is_last_chunk:
+                        max_new = getattr(request, 'max_new_tokens', self.clip_max_new_tokens_estimation)
+                        scheduled_new_decode_reserved_tokens += min(max_new, self.clip_max_new_tokens_estimation)
+
                     request.num_computed_tokens += num_new_tokens
                     if self.config.cache_config.enable_prefix_caching:
                         self.cache_manager.update_cache_blocks(
@@ -1057,11 +1077,6 @@ class ResourceManagerV1(ResourceManager):
 
             # Second, schedule the WAITING requests.
             if not preempted_reqs:
-                # Compute running decode reservation once per schedule() call
-                cached_running_decode_reserved = self._calculate_decode_reserved_tokens_by_ratio()
-                # Track decode reservations accumulated within this cycle's waiting loop
-                scheduled_new_decode_reserved_tokens: float = 0.0
-
                 skip_requests: list[Request] = []
                 while self.waiting and rem_input_tokens > 0 and rem_chunk_tokens > 0:
                     if len(self.running) == self.max_num_seqs:

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -1207,7 +1207,7 @@ class ResourceManagerV1(ResourceManager):
                             rem_input_tokens -= num_new_tokens
                             if is_last_chunk:
                                 max_new = min(_get_request_max_new_tokens(request), self.clip_max_new_tokens_estimation)
-                                scheduled_new_decode_reserved_tokens += min(max_new, self.clip_max_new_tokens_estimation)
+                                scheduled_new_decode_reserved_tokens += max_new
                             else:
                                 rem_chunk_tokens -= num_new_tokens
                                 # SGLang: after admitting one chunked waiting request, break.
@@ -1281,7 +1281,7 @@ class ResourceManagerV1(ResourceManager):
                             rem_input_tokens -= num_new_tokens
                             if is_last_chunk:
                                 max_new = min(_get_request_max_new_tokens(request), self.clip_max_new_tokens_estimation)
-                                scheduled_new_decode_reserved_tokens += min(max_new, self.clip_max_new_tokens_estimation)
+                                scheduled_new_decode_reserved_tokens += max_new
                             else:
                                 rem_chunk_tokens -= num_new_tokens
                                 chunked_request_admitted_this_step = True

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -532,6 +532,7 @@ class ResourceManagerV1(ResourceManager):
         self,
         request,
         num_chunk_new_block,
+        is_last_chunk: bool,
         new_decode_reserved_tokens: float = 0.0,
         cached_running_decode_reserved: float = 0.0,
     ):
@@ -550,10 +551,6 @@ class ResourceManagerV1(ResourceManager):
 
         # 1. Current chunk blocks
         current_chunk_tokens = num_chunk_new_block * block_size
-
-        # Determine if this is the last chunk (needed for decode reservation)
-        remaining_tokens_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
-        is_last_chunk = remaining_tokens_to_prefill <= num_chunk_new_block * block_size
 
         # 2. Only reserve max_new_tokens for the LAST chunk
         max_new_tokens_for_request = 0
@@ -683,15 +680,22 @@ class ResourceManagerV1(ResourceManager):
         return matched_token_num
 
     def _get_num_new_tokens(self, request, rem_chunk_tokens, rem_input_tokens):
-        # SGLang-aligned: num_new_tokens = min(remaining, rem_chunk_tokens, rem_input_tokens)
+        # SGLang-aligned:
+        # - All admitted prefills share rem_input_tokens.
+        # - When chunk budget is enabled, requests that do not fit in the remaining
+        #   chunk budget are truncated to a chunk-sized prefill.
         remaining = request.need_prefill_tokens - request.num_computed_tokens
-        num_new_tokens = min(remaining, rem_chunk_tokens, rem_input_tokens)
+        num_new_tokens = min(remaining, rem_input_tokens)
 
         block_size = self.config.cache_config.block_size
         is_truncated = num_new_tokens < remaining
 
+        if rem_chunk_tokens is not None and remaining > rem_chunk_tokens:
+            num_new_tokens = min(num_new_tokens, rem_chunk_tokens)
+            is_truncated = True
+
         if current_platform.is_intel_hpu():
-            if is_truncated and min(rem_chunk_tokens, rem_input_tokens) > block_size:
+            if is_truncated and min(rem_input_tokens, rem_chunk_tokens or rem_input_tokens) > block_size:
                 num_new_tokens = num_new_tokens // block_size * block_size
         elif block_size > 1 and is_truncated:
             # SGLang-aligned: floor-align truncated chunk to block boundary
@@ -865,6 +869,10 @@ class ResourceManagerV1(ResourceManager):
 
         # Compatible with scenarios without images and videos.
         return num_new_tokens
+
+    def _is_last_prefill_chunk(self, request, num_new_tokens: int) -> bool:
+        remaining_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
+        return num_new_tokens >= remaining_to_prefill
 
     def exist_mm_prefill(self, scheduled_reqs):
         for request in scheduled_reqs:
@@ -1092,10 +1100,12 @@ class ResourceManagerV1(ResourceManager):
                 ) and not get_enough_request(request, scheduled_reqs) and rem_chunk_tokens > 0:
                     num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
                     if num_new_tokens > 0:
+                        is_last_chunk = self._is_last_prefill_chunk(request, num_new_tokens)
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
                         can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
                             request,
                             num_new_block,
+                            is_last_chunk,
                             scheduled_new_decode_reserved_tokens,
                             cached_running_decode_reserved,
                         )
@@ -1108,8 +1118,7 @@ class ResourceManagerV1(ResourceManager):
                             has_scheduled_running_prefill = True
                             rem_input_tokens -= num_new_tokens
                             rem_chunk_tokens -= num_new_tokens
-                            remaining_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
-                            if remaining_to_prefill <= num_new_tokens:
+                            if is_last_chunk:
                                 max_new = min(
                                     _get_request_max_new_tokens(request), self.clip_max_new_tokens_estimation
                                 )
@@ -1130,8 +1139,9 @@ class ResourceManagerV1(ResourceManager):
             # entirely this step. Otherwise admit at most one new request from WAITING.
             if not preempted_reqs and not has_scheduled_running_prefill and self.active_chunked_prefill_req is None:
                 skip_requests: list[Request] = []
-                # SGLang-aligned: only admit ONE chunked (long) request per step.
-                # Short requests continue to be admitted without consuming rem_chunk_tokens.
+                # SGLang-aligned: waiting requests share a single chunk budget.
+                # Requests that fit in the remaining budget are admitted in full;
+                # otherwise they are truncated into one chunk for this step.
                 chunked_request_admitted_this_step = False
                 while self.waiting and rem_input_tokens > 0 and rem_chunk_tokens > 0:
                     if self.available_batch() == 0:
@@ -1180,10 +1190,12 @@ class ResourceManagerV1(ResourceManager):
                         num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
                         if num_new_tokens <= 0:
                             break
+                        is_last_chunk = self._is_last_prefill_chunk(request, num_new_tokens)
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
                         can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
                             request,
                             num_new_block,
+                            is_last_chunk,
                             scheduled_new_decode_reserved_tokens,
                             cached_running_decode_reserved,
                         )
@@ -1198,19 +1210,15 @@ class ResourceManagerV1(ResourceManager):
                             self._ensure_request_slot_allocated(request)
                             scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
                             has_scheduled_prefill = True
-                            # Track decode reservation for last-chunk requests
-                            remaining_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
-                            is_last_chunk = remaining_to_prefill <= num_new_tokens
 
-                            # Every prefill chunk consumes total input budget. Chunked requests also
-                            # consume the per-step chunk budget.
+                            # SGLang-aligned: every admitted prefill chunk consumes both
+                            # the total input budget and the shared per-step chunk budget.
                             rem_input_tokens -= num_new_tokens
+                            rem_chunk_tokens -= num_new_tokens
                             if is_last_chunk:
                                 max_new = min(_get_request_max_new_tokens(request), self.clip_max_new_tokens_estimation)
                                 scheduled_new_decode_reserved_tokens += max_new
                             else:
-                                rem_chunk_tokens -= num_new_tokens
-                                # SGLang: after admitting one chunked waiting request, break.
                                 chunked_request_admitted_this_step = True
 
                             request.num_computed_tokens += num_new_tokens
@@ -1224,7 +1232,6 @@ class ResourceManagerV1(ResourceManager):
                             else:
                                 self.active_chunked_prefill_req = request
                             # SGLang-aligned: after admitting one chunked waiting request, break.
-                            # Short (non-chunked) requests continue to be admitted.
                             if chunked_request_admitted_this_step:
                                 break
                         else:
@@ -1254,10 +1261,12 @@ class ResourceManagerV1(ResourceManager):
                         num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
                         if num_new_tokens <= 0:
                             break
+                        is_last_chunk = self._is_last_prefill_chunk(request, num_new_tokens)
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
                         can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
                             request,
                             num_new_block,
+                            is_last_chunk,
                             scheduled_new_decode_reserved_tokens,
                             cached_running_decode_reserved,
                         )
@@ -1272,18 +1281,15 @@ class ResourceManagerV1(ResourceManager):
                             self._ensure_request_slot_allocated(request)
                             scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
                             has_scheduled_prefill = True
-                            # Track decode reservation for last-chunk requests
-                            remaining_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
-                            is_last_chunk = remaining_to_prefill <= num_new_tokens
 
-                            # Every prefill chunk consumes total input budget. Chunked requests also
-                            # consume the per-step chunk budget.
+                            # SGLang-aligned: every admitted prefill chunk consumes both
+                            # the total input budget and the shared per-step chunk budget.
                             rem_input_tokens -= num_new_tokens
+                            rem_chunk_tokens -= num_new_tokens
                             if is_last_chunk:
                                 max_new = min(_get_request_max_new_tokens(request), self.clip_max_new_tokens_estimation)
                                 scheduled_new_decode_reserved_tokens += max_new
                             else:
-                                rem_chunk_tokens -= num_new_tokens
                                 chunked_request_admitted_this_step = True
 
                             request.num_computed_tokens += num_new_tokens

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -901,11 +901,6 @@ class ResourceManagerV1(ResourceManager):
             # rem_input_tokens: total input budget (SGLang's max_prefill_tokens - mixed_with_decode_tokens)
             rem_input_tokens = envs.FD_REM_INPUT_TOKENS - running_decode_count
 
-            # Compute running decode reservation once per schedule() call (shared by RUNNING & WAITING loops)
-            cached_running_decode_reserved = self._calculate_decode_reserved_tokens_by_ratio()
-            # Track decode reservations accumulated within this cycle (RUNNING + WAITING)
-            scheduled_new_decode_reserved_tokens: float = 0.0
-
             # First, schedule the RUNNING requests.
             req_index = 0
             num_decoding_req_nums = 0
@@ -1034,15 +1029,8 @@ class ResourceManagerV1(ResourceManager):
                         continue
                     num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
                     num_new_block = self.get_new_block_nums(request, num_new_tokens)
-                    # Threshold check (same as WAITING loop): ensure enough free blocks for
-                    # current chunk + decode reservations
-                    can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
-                        request, num_new_block,
-                        scheduled_new_decode_reserved_tokens,
-                        cached_running_decode_reserved,
-                    )
                     # Allocate blocks to prefill
-                    if self.cache_manager.can_allocate_gpu_blocks(can_schedule_block_num_threshold):
+                    if self.cache_manager.can_allocate_gpu_blocks(num_new_block):
                         request.block_tables.extend(
                             self.cache_manager.allocate_gpu_blocks(num_new_block, request.request_id)
                         )
@@ -1057,27 +1045,31 @@ class ResourceManagerV1(ResourceManager):
                         )
                         # Prepare prefill task
                         scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
+                    # SGLang-aligned: only continue ONE chunked prefill per step, then break.
+                    # Multiple running prefills share rem_chunk_tokens → fragmented slow progress.
+                    # SGLang: single chunked_req per step gets the full budget.
                     has_scheduled_prefill = True
-                    rem_input_tokens -= num_new_tokens
                     rem_chunk_tokens -= num_new_tokens
-
-                    # Track decode reservation for last-chunk requests in RUNNING loop
-                    remaining_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
-                    is_last_chunk = remaining_to_prefill <= num_new_tokens
-                    if is_last_chunk:
-                        max_new = getattr(request, 'max_new_tokens', self.clip_max_new_tokens_estimation)
-                        scheduled_new_decode_reserved_tokens += min(max_new, self.clip_max_new_tokens_estimation)
-
                     request.num_computed_tokens += num_new_tokens
                     if self.config.cache_config.enable_prefix_caching:
                         self.cache_manager.update_cache_blocks(
                             request, self.config.cache_config.block_size, request.num_computed_tokens
                         )
+                    break  # ← only 1 running chunked prefill per step
+
                 req_index += 1
 
             # Second, schedule the WAITING requests.
             if not preempted_reqs:
+                # Compute running decode reservation once per schedule() call
+                cached_running_decode_reserved = self._calculate_decode_reserved_tokens_by_ratio()
+                # Track decode reservations accumulated within this cycle's waiting loop
+                scheduled_new_decode_reserved_tokens: float = 0.0
+
                 skip_requests: list[Request] = []
+                # SGLang-aligned: only admit ONE chunked (long) request per step.
+                # Short requests continue to be admitted without consuming rem_chunk_tokens.
+                chunked_request_admitted_this_step = False
                 while self.waiting and rem_input_tokens > 0 and rem_chunk_tokens > 0:
                     if len(self.running) == self.max_num_seqs:
                         break
@@ -1140,15 +1132,20 @@ class ResourceManagerV1(ResourceManager):
                             self.running.append(request)
                             scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
                             has_scheduled_prefill = True
-                            rem_input_tokens -= num_new_tokens
-                            rem_chunk_tokens -= num_new_tokens
-
                             # Track decode reservation for last-chunk requests
                             remaining_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
                             is_last_chunk = remaining_to_prefill <= num_new_tokens
+
+                            # SGLang-aligned: chunked requests consume rem_chunk_tokens;
+                            # non-chunked (last) requests consume rem_input_tokens (NOT rem_chunk_tokens).
                             if is_last_chunk:
+                                rem_input_tokens -= num_new_tokens
                                 max_new = getattr(request, 'max_new_tokens', self.clip_max_new_tokens_estimation)
                                 scheduled_new_decode_reserved_tokens += min(max_new, self.clip_max_new_tokens_estimation)
+                            else:
+                                rem_chunk_tokens -= num_new_tokens
+                                # SGLang: after admitting one chunked waiting request, break.
+                                chunked_request_admitted_this_step = True
 
                             request.num_computed_tokens += num_new_tokens
                             if self.config.cache_config.enable_prefix_caching:
@@ -1163,6 +1160,10 @@ class ResourceManagerV1(ResourceManager):
                                 self.stop_flags[allocated_position] = False
                                 self.req_dict[request.request_id] = allocated_position
                                 llm_logger.debug(f"req_id:{request.request_id} allocate pos end")
+                            # SGLang-aligned: after admitting one chunked waiting request, break.
+                            # Short (non-chunked) requests continue to be admitted.
+                            if chunked_request_admitted_this_step:
+                                break
                         else:
                             if self.config.cache_config.enable_prefix_caching:
                                 self._free_blocks(request)
@@ -1205,15 +1206,19 @@ class ResourceManagerV1(ResourceManager):
                             self.running.append(request)
                             scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
                             has_scheduled_prefill = True
-                            rem_input_tokens -= num_new_tokens
-                            rem_chunk_tokens -= num_new_tokens
-
                             # Track decode reservation for last-chunk requests
                             remaining_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
                             is_last_chunk = remaining_to_prefill <= num_new_tokens
+
+                            # SGLang-aligned: chunked requests consume rem_chunk_tokens;
+                            # non-chunked (last) requests consume rem_input_tokens (NOT rem_chunk_tokens).
                             if is_last_chunk:
+                                rem_input_tokens -= num_new_tokens
                                 max_new = getattr(request, 'max_new_tokens', self.clip_max_new_tokens_estimation)
                                 scheduled_new_decode_reserved_tokens += min(max_new, self.clip_max_new_tokens_estimation)
+                            else:
+                                rem_chunk_tokens -= num_new_tokens
+                                chunked_request_admitted_this_step = True
 
                             request.num_computed_tokens += num_new_tokens
                             if self.config.cache_config.enable_prefix_caching:
@@ -1221,6 +1226,9 @@ class ResourceManagerV1(ResourceManager):
                                     request, self.config.cache_config.block_size, request.num_computed_tokens
                                 )
                             request.status = RequestStatus.RUNNING
+                            # SGLang-aligned: after admitting one chunked waiting request, break.
+                            if chunked_request_admitted_this_step:
+                                break
                         else:
                             if self.config.cache_config.enable_prefix_caching:
                                 self._free_blocks(request)

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -919,38 +919,88 @@ class ResourceManagerV1(ResourceManager):
                         continue
                     if request.num_total_tokens > request.need_prefill_tokens:  # has generated tokens
                         request.num_computed_tokens = request.num_total_tokens - 1
-                    if (
-                        self.allocated_slots(request) - request.num_total_tokens
-                        <= self.config.cache_config.prealloc_dec_block_slot_num_threshold
-                    ):
-                        # Allocation for next decoding blocks
-                        if self.cache_manager.can_allocate_gpu_blocks(self.config.cache_config.enc_dec_block_num):
+                    # SGLang-aligned: dynamically calculate how many blocks are needed for next decode
+                    # Similar to SGLang's new_page_count_next_decode:
+                    # If (num_total_tokens - 1) % block_size == 0, need 1 more block
+                    block_size = self.config.cache_config.block_size
+                    num_new_blocks_needed = 1 if (request.num_total_tokens - 1) % block_size == 0 else 0
+
+                    # SGLang-aligned: schedule decode task without threshold check
+                    # The pre-allocation is decoupled from scheduling
+                    if num_new_blocks_needed > 0:
+                        # Need to allocate new blocks, check if we can allocate
+                        if self.cache_manager.can_allocate_gpu_blocks(num_new_blocks_needed):
                             llm_logger.debug(
                                 f"schedule decoding task: {request} request.num_total_tokens {request.num_total_tokens} request.num_computed_tokens {request.num_computed_tokens}"
                             )
                             request.block_tables.extend(
                                 self.cache_manager.allocate_gpu_blocks(
-                                    self.config.cache_config.enc_dec_block_num, request.request_id
+                                    num_new_blocks_needed, request.request_id
                                 )
                             )
                             # Prepare decoding task
                             scheduled_reqs.append(self._prepare_decode_task(request))
                         else:
-                            # Not enough blocks to allocate, trigger preemption
-                            can_schedule = self._trigger_preempt(
-                                request, self.config.cache_config.enc_dec_block_num, preempted_reqs, scheduled_reqs
-                            )
-                            if not can_schedule:
-                                break
-                            # Allocation for next decoding blocks
-                            request.block_tables.extend(
-                                self.cache_manager.allocate_gpu_blocks(
-                                    self.config.cache_config.enc_dec_block_num, request.request_id
+                            # Not enough blocks, trigger preemption
+                            # SGLang-aligned: first try to evict decode KV cache
+                            self._evict_decode_kv_cache(len(self.running))
+
+                            # Check again after eviction
+                            if self.cache_manager.can_allocate_gpu_blocks(num_new_blocks_needed):
+                                request.block_tables.extend(
+                                    self.cache_manager.allocate_gpu_blocks(
+                                        num_new_blocks_needed, request.request_id
+                                    )
                                 )
-                            )
-                            # Prepare decoding task
-                            scheduled_reqs.append(self._prepare_decode_task(request))
-                        num_decoding_req_nums += 1
+                                scheduled_reqs.append(self._prepare_decode_task(request))
+                            else:
+                                # Cannot allocate even after preemption, use SGLang-aligned behavior
+                                # Try to preempt other requests
+                                can_schedule = self._trigger_preempt(
+                                    request, num_new_blocks_needed, preempted_reqs, scheduled_reqs
+                                )
+                                if not can_schedule:
+                                    # Cannot preempt any other request to free space for this decode request.
+                                    # This happens when only 1 decode request remains.
+                                    # The only safe action is to preempt THIS request itself:
+                                    # remove it from running, free its KV blocks, and put it back in
+                                    # waiting so it can re-prefill later when memory is available.
+                                    # - Using `break` here causes a livelock: the request stays at
+                                    #   running[0] and blocks all subsequent decode/prefill every cycle.
+                                    # - Using `continue` (old bug) left it as a zombie that never gets
+                                    #   a decode step and never produces EOS.
+                                    llm_logger.warning(
+                                        f"Cannot allocate {num_new_blocks_needed} blocks "
+                                        f"for decode request {request.request_id} (idx={request.idx}) "
+                                        f"even after preemption attempt. Self-preempting this request."
+                                    )
+                                    self.running.remove(request)
+                                    request.status = RequestStatus.PREEMPTED
+                                    request.num_computed_tokens = 0
+                                    self._free_blocks(request)
+                                    request.num_cached_blocks = 0
+                                    self.to_be_rescheduled_request_id_set.add(request.request_id)
+                                    preempted_reqs.append(request)
+                                    scheduled_reqs.append(self._prepare_preempt_task(request))
+                                    # Do NOT increment req_index: after remove(), the next request
+                                    # has shifted to the current index position.
+                                    continue
+
+                                # Allocation for next decoding blocks after preemption
+                                request.block_tables.extend(
+                                    self.cache_manager.allocate_gpu_blocks(
+                                        num_new_blocks_needed, request.request_id
+                                    )
+                                )
+                                # Prepare decoding task
+                                scheduled_reqs.append(self._prepare_decode_task(request))
+
+                    # No new blocks needed (num_new_blocks_needed == 0), but still schedule decode task
+                    # SGLang-aligned: decode does NOT consume token_budget, only checks memory
+                    else:
+                        scheduled_reqs.append(self._prepare_decode_task(request))
+
+                    num_decoding_req_nums += 1
                     if (
                         request.use_extend_tables
                         and request.request_id not in self.using_extend_tables_req_id
@@ -1036,15 +1086,17 @@ class ResourceManagerV1(ResourceManager):
                         )
                         # Prepare prefill task
                         scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
-                    else:  # Not enough blocks to allocate, trigger preemption
-                        can_schedule = self._trigger_preempt(request, num_new_block, preempted_reqs, scheduled_reqs)
-                        if not can_schedule:
-                            break
-                        request.block_tables.extend(
-                            self.cache_manager.allocate_gpu_blocks(num_new_block, request.request_id)
+                    else:
+                        # SGLang-aligned: when running prefill cannot get blocks, skip this request
+                        # (it stays in running queue and retries next cycle). No preemption.
+                        # SGLang default behavior (enable_priority_scheduling=False) never preempts
+                        # for running prefill resource shortage.
+                        llm_logger.debug(
+                            f"Running prefill cannot get enough blocks for {request.request_id}, "
+                            f"skipping this cycle. (SGLang default: no preemption)"
                         )
-                        # Prepare prefill task
-                        scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
+                        req_index += 1
+                        continue
                     # SGLang-aligned: only continue ONE chunked prefill per step, then break.
                     # Multiple running prefills share rem_chunk_tokens → fragmented slow progress.
                     # SGLang: single chunked_req per step gets the full budget.

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -305,11 +305,20 @@ class ResourceManagerV1(ResourceManager):
     def preempted_all(self):
         with self.lock:
             preempted_reqs = []
-            for i in range(len(self.running)):
-                req = self.running.pop()
+            reqs_to_preempt = []
+            if self.active_chunked_prefill_req is not None:
+                reqs_to_preempt.append(self.active_chunked_prefill_req)
+                self.active_chunked_prefill_req = None
+            for _ in range(len(self.running)):
+                reqs_to_preempt.append(self.running.pop())
+
+            for req in reqs_to_preempt:
                 # txt2image: req.use_extend_tables is True, req can not be preempted. txt2image is not used in RL.
                 if req.use_extend_tables:
-                    self.running.insert(0, req)
+                    if req.num_computed_tokens < req.need_prefill_tokens and self.active_chunked_prefill_req is None:
+                        self.active_chunked_prefill_req = req
+                    else:
+                        self.running.insert(0, req)
                     continue
                 req.status = RequestStatus.PREEMPTED
                 req.num_computed_tokens = 0
@@ -323,7 +332,11 @@ class ResourceManagerV1(ResourceManager):
         count = 0
         while count < timeout * 1000:
             # wait ongoing running and rescheduled requests finished in worker
-            running_reqs_count = len(self.to_be_rescheduled_request_id_set) + len(self.running)
+            running_reqs_count = (
+                len(self.to_be_rescheduled_request_id_set)
+                + len(self.running)
+                + (1 if self.active_chunked_prefill_req is not None else 0)
+            )
             if running_reqs_count == 0:
                 break
 
@@ -524,32 +537,6 @@ class ResourceManagerV1(ResourceManager):
 
         return total_reserved_tokens
 
-    def _calculate_decode_batch_block_pressure(self) -> int:
-        """
-        Estimate how many new KV blocks the current decode batch will need this step.
-        This is a lightweight batch-level pressure check before entering the per-request
-        decode loop, so we can retract first instead of waiting for a single request to
-        fail at the block boundary.
-        """
-        block_size = self.config.cache_config.block_size
-        total_needed_blocks = 0
-
-        for req in self.running:
-            if req.num_computed_tokens < req.need_prefill_tokens:
-                continue
-            if self.config.scheduler_config.splitwise_role == "prefill":
-                continue
-            if (req.num_total_tokens - 1) % block_size == 0:
-                total_needed_blocks += 1
-
-        if total_needed_blocks > 0:
-            llm_logger.debug(
-                f"Decode batch block pressure: need={total_needed_blocks}, "
-                f"free={self.cache_manager.get_num_free_gpu_blocks()}, running={len(self.running)}"
-            )
-
-        return total_needed_blocks
-
     def _calculate_decode_reserved_tokens_for_new_requests(self, new_decode_reserved_tokens: float):
         """Return pre-computed reserved tokens for NEW decode requests in this cycle."""
         return new_decode_reserved_tokens
@@ -715,13 +702,25 @@ class ResourceManagerV1(ResourceManager):
 
         return -(-num_new_tokens // block_size) * block_size
 
-    def _get_num_new_tokens(self, request, rem_chunk_tokens, rem_input_tokens):
+    def _get_num_new_tokens(
+        self,
+        request,
+        rem_chunk_tokens,
+        rem_input_tokens,
+        *,
+        existing_prefill_in_batch: bool = False,
+    ):
         # SGLang-aligned:
-        # - First compute this round's candidate prefill length.
-        # - Then judge whether the paged input length can fit in rem_chunk_tokens.
-        # - If it does not fit, truncate to one page-aligned chunk.
+        # - rem_input_tokens is a hard stop only after some prefill has already
+        #   been admitted into this batch.
         remaining = request.need_prefill_tokens - request.num_computed_tokens
-        if remaining <= 0 or rem_input_tokens <= 0:
+        if remaining <= 0:
+            return 0
+
+        if rem_input_tokens <= 0:
+            return 0
+
+        if existing_prefill_in_batch and self._get_paged_prefill_tokens(remaining) >= rem_input_tokens:
             return 0
 
         block_size = self.config.cache_config.block_size
@@ -742,11 +741,14 @@ class ResourceManagerV1(ResourceManager):
             is_truncated = True
 
         if current_platform.is_intel_hpu():
-            if is_truncated and min(rem_input_tokens, rem_chunk_tokens or rem_input_tokens) > block_size:
+            hpu_budget = min(rem_input_tokens, rem_chunk_tokens or rem_input_tokens)
+            if is_truncated and hpu_budget > block_size:
                 num_new_tokens = num_new_tokens // block_size * block_size
         elif block_size > 1 and is_truncated:
             # SGLang-aligned: floor-align truncated chunk to block boundary
             num_new_tokens = num_new_tokens // block_size * block_size
+        if num_new_tokens <= 0:
+            return 0
         request.with_image = False
 
         if not self.config.model_config.enable_mm:
@@ -996,26 +998,6 @@ class ResourceManagerV1(ResourceManager):
 
             def _schedule_decode_requests():
                 nonlocal num_decoding_req_nums
-                decode_batch_block_pressure = self._calculate_decode_batch_block_pressure()
-                if decode_batch_block_pressure > 0 and not self.cache_manager.can_allocate_gpu_blocks(
-                    decode_batch_block_pressure
-                ):
-                    first_decode_request = next(
-                        (
-                            req
-                            for req in self.running
-                            if req.num_computed_tokens >= req.need_prefill_tokens
-                        ),
-                        None,
-                    )
-                    if first_decode_request is not None:
-                        self._trigger_preempt(
-                            first_decode_request,
-                            decode_batch_block_pressure,
-                            preempted_reqs,
-                            scheduled_reqs,
-                        )
-
                 req_index = 0
                 while req_index < len(self.running):
                     request = self.running[req_index]
@@ -1202,10 +1184,11 @@ class ResourceManagerV1(ResourceManager):
 
             # Second, schedule the WAITING requests.
             # Priority: in-flight prefill (RUNNING) > new prefill (WAITING) > decode.
-            # Only ONE prefill is scheduled per step total. If RUNNING already scheduled
-            # an in-flight prefill chunk (has_scheduled_running_prefill=True), skip WAITING
-            # entirely this step. Otherwise admit at most one new request from WAITING.
-            if not preempted_reqs and not has_scheduled_running_prefill and self.active_chunked_prefill_req is None:
+            # If an in-flight chunked prefill was admitted this round, continue filling
+            # the same batch from WAITING under the same shared budgets and threshold
+            # checks. We still preserve the invariant that at most one unfinished
+            # chunked prefill remains active after this scheduling step.
+            if not preempted_reqs and (has_scheduled_running_prefill or self.active_chunked_prefill_req is None):
                 skip_requests: list[Request] = []
                 # SGLang-aligned: waiting requests share a single chunk budget.
                 # Requests that fit in the remaining budget are admitted in full;
@@ -1255,10 +1238,17 @@ class ResourceManagerV1(ResourceManager):
                         ):
                             continue
                         # Allocate blocks for the tokens that does not hit cache
-                        num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
+                        num_new_tokens = self._get_num_new_tokens(
+                            request,
+                            rem_chunk_tokens,
+                            rem_input_tokens,
+                            existing_prefill_in_batch=has_scheduled_prefill,
+                        )
                         if num_new_tokens <= 0:
                             break
                         is_last_chunk = self._is_last_prefill_chunk(request, num_new_tokens)
+                        if self.active_chunked_prefill_req is not None and not is_last_chunk:
+                            break
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
                         can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
                             request,
@@ -1327,10 +1317,17 @@ class ResourceManagerV1(ResourceManager):
                                 break
 
                         # Allocate blocks for the tokens that does not hit cache
-                        num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
+                        num_new_tokens = self._get_num_new_tokens(
+                            request,
+                            rem_chunk_tokens,
+                            rem_input_tokens,
+                            existing_prefill_in_batch=has_scheduled_prefill,
+                        )
                         if num_new_tokens <= 0:
                             break
                         is_last_chunk = self._is_last_prefill_chunk(request, num_new_tokens)
+                        if self.active_chunked_prefill_req is not None and not is_last_chunk:
+                            break
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
                         can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
                             request,

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -939,6 +939,140 @@ class ResourceManagerV1(ResourceManager):
                     return request.sampling_params.max_tokens
                 return self.config.model_config.max_model_len - request.need_prefill_tokens
 
+            def _schedule_decode_requests():
+                nonlocal num_decoding_req_nums
+                req_index = 0
+                while req_index < len(self.running):
+                    request = self.running[req_index]
+                    need_block_num = self.need_block_num_signal.value[request.idx]
+                    if need_block_num != 0:
+                        self.need_block_num_map[request.request_id] = SignalConsumer(need_block_num, 1)
+                        self.need_block_num_signal.value[request.idx] = 0
+
+                    if request.num_computed_tokens >= request.need_prefill_tokens:  # to be decoding
+                        if self.config.scheduler_config.splitwise_role == "prefill":
+                            req_index += 1
+                            continue
+                        if request.num_total_tokens > request.need_prefill_tokens:
+                            request.num_computed_tokens = request.num_total_tokens - 1
+
+                        block_size = self.config.cache_config.block_size
+                        num_new_blocks_needed = 1 if (request.num_total_tokens - 1) % block_size == 0 else 0
+
+                        if num_new_blocks_needed > 0:
+                            if self.cache_manager.can_allocate_gpu_blocks(num_new_blocks_needed):
+                                llm_logger.debug(
+                                    f"schedule decoding task: {request} request.num_total_tokens {request.num_total_tokens} request.num_computed_tokens {request.num_computed_tokens}"
+                                )
+                                request.block_tables.extend(
+                                    self.cache_manager.allocate_gpu_blocks(
+                                        num_new_blocks_needed, request.request_id
+                                    )
+                                )
+                                scheduled_reqs.append(self._prepare_decode_task(request))
+                            else:
+                                self._evict_decode_kv_cache(len(self.running))
+
+                                if self.cache_manager.can_allocate_gpu_blocks(num_new_blocks_needed):
+                                    request.block_tables.extend(
+                                        self.cache_manager.allocate_gpu_blocks(
+                                            num_new_blocks_needed, request.request_id
+                                        )
+                                    )
+                                    scheduled_reqs.append(self._prepare_decode_task(request))
+                                else:
+                                    can_schedule = self._trigger_preempt(
+                                        request, num_new_blocks_needed, preempted_reqs, scheduled_reqs
+                                    )
+                                    if not can_schedule:
+                                        llm_logger.warning(
+                                            f"Cannot allocate {num_new_blocks_needed} blocks "
+                                            f"for decode request {request.request_id} (idx={request.idx}) "
+                                            f"even after preemption attempt. Self-preempting this request."
+                                        )
+                                        self.running.remove(request)
+                                        request.status = RequestStatus.PREEMPTED
+                                        request.num_computed_tokens = 0
+                                        self._free_blocks(request)
+                                        request.num_cached_blocks = 0
+                                        self.to_be_rescheduled_request_id_set.add(request.request_id)
+                                        preempted_reqs.append(request)
+                                        scheduled_reqs.append(self._prepare_preempt_task(request))
+                                        continue
+
+                                    request.block_tables.extend(
+                                        self.cache_manager.allocate_gpu_blocks(
+                                            num_new_blocks_needed, request.request_id
+                                        )
+                                    )
+                                    scheduled_reqs.append(self._prepare_decode_task(request))
+                        else:
+                            scheduled_reqs.append(self._prepare_decode_task(request))
+
+                        num_decoding_req_nums += 1
+                        if (
+                            request.use_extend_tables
+                            and request.request_id not in self.using_extend_tables_req_id
+                            and self.need_block_num_map[request.request_id].watch() > 0
+                        ):
+
+                            def _allocate_decode_and_extend():
+                                allocate_block_num = self.need_block_num_map[request.request_id].consume()
+                                request.block_tables.extend(
+                                    self.cache_manager.allocate_gpu_blocks(allocate_block_num, request.request_id)
+                                )
+                                scheduled_reqs.append(self._prepare_decode_task(request))
+
+                                reuse_block_num = request.num_total_tokens // self.config.cache_config.block_size
+                                llm_logger.info(
+                                    f"req {request.request_id} at batch id {request.idx} with reuse_block_num {reuse_block_num} is going to enable extend tables,"
+                                    f"need_block_num {allocate_block_num}"
+                                )
+                                self.using_extend_tables_req_id.add(request.request_id)
+                                self.reuse_block_num_map[request.request_id] = reuse_block_num
+
+                                request.extend_block_tables = request.block_tables[:reuse_block_num]
+                                request.extend_block_tables.extend(
+                                    self.cache_manager.allocate_gpu_blocks(allocate_block_num, request.request_id)
+                                )
+                                scheduled_reqs.append(
+                                    ScheduledExtendBlocksTask(
+                                        idx=request.idx,
+                                        request_id=request.request_id,
+                                        extend_block_tables=request.extend_block_tables,
+                                    )
+                                )
+                                llm_logger.debug(f"extend blocks is {request.extend_block_tables}")
+
+                            if self.cache_manager.can_allocate_gpu_blocks(
+                                2 * self.need_block_num_map[request.request_id].watch()
+                            ):
+                                _allocate_decode_and_extend()
+                            else:
+                                llm_logger.info(
+                                    f"{request.idx} using extend block need {2 * self.need_block_num_map[request.request_id].watch()} blocks but got not enough blocks, ready to preempt"
+                                )
+                                can_schedule = self._trigger_preempt(
+                                    request,
+                                    2 * self.need_block_num_map[request.request_id].watch(),
+                                    preempted_reqs,
+                                    scheduled_reqs,
+                                )
+
+                                if can_schedule:
+                                    _allocate_decode_and_extend()
+                                else:
+                                    break
+                    else:
+                        if self.active_chunked_prefill_req is None:
+                            self.active_chunked_prefill_req = request
+                            self.running.pop(req_index)
+                            continue
+                        req_index += 1
+                        continue
+
+                    req_index += 1
+
             # First, schedule the single active chunked prefill request (if any).
             num_decoding_req_nums = 0
             has_scheduled_running_prefill = False
@@ -989,156 +1123,6 @@ class ResourceManagerV1(ResourceManager):
                                 self.active_chunked_prefill_req = None
                                 self.running.append(request)
 
-            # Second, schedule decode requests in self.running.
-            if not has_scheduled_running_prefill:
-                req_index = 0
-                while req_index < len(self.running):
-                    request = self.running[req_index]
-                    need_block_num = self.need_block_num_signal.value[request.idx]
-                    if need_block_num != 0:
-                        self.need_block_num_map[request.request_id] = SignalConsumer(need_block_num, 1)
-                        self.need_block_num_signal.value[request.idx] = 0
-
-                    if request.num_computed_tokens >= request.need_prefill_tokens:  # to be decoding
-                        if (
-                            self.config.scheduler_config.splitwise_role == "prefill"
-                        ):  # do not need to schedule for decoding
-                            req_index += 1
-                            continue
-                        if request.num_total_tokens > request.need_prefill_tokens:  # has generated tokens
-                            request.num_computed_tokens = request.num_total_tokens - 1
-                        # SGLang-aligned: dynamically calculate how many blocks are needed for next decode
-                        # Similar to SGLang's new_page_count_next_decode:
-                        # If (num_total_tokens - 1) % block_size == 0, need 1 more block
-                        block_size = self.config.cache_config.block_size
-                        num_new_blocks_needed = 1 if (request.num_total_tokens - 1) % block_size == 0 else 0
-
-                        # SGLang-aligned: schedule decode task without threshold check
-                        # The pre-allocation is decoupled from scheduling
-                        if num_new_blocks_needed > 0:
-                            # Need to allocate new blocks, check if we can allocate
-                            if self.cache_manager.can_allocate_gpu_blocks(num_new_blocks_needed):
-                                llm_logger.debug(
-                                    f"schedule decoding task: {request} request.num_total_tokens {request.num_total_tokens} request.num_computed_tokens {request.num_computed_tokens}"
-                                )
-                                request.block_tables.extend(
-                                    self.cache_manager.allocate_gpu_blocks(
-                                        num_new_blocks_needed, request.request_id
-                                    )
-                                )
-                                # Prepare decoding task
-                                scheduled_reqs.append(self._prepare_decode_task(request))
-                            else:
-                                # Not enough blocks, trigger preemption
-                                # SGLang-aligned: first try to evict decode KV cache
-                                self._evict_decode_kv_cache(len(self.running))
-
-                                # Check again after eviction
-                                if self.cache_manager.can_allocate_gpu_blocks(num_new_blocks_needed):
-                                    request.block_tables.extend(
-                                        self.cache_manager.allocate_gpu_blocks(
-                                            num_new_blocks_needed, request.request_id
-                                        )
-                                    )
-                                    scheduled_reqs.append(self._prepare_decode_task(request))
-                                else:
-                                    # Cannot allocate even after preemption, use SGLang-aligned behavior
-                                    # Try to preempt other requests
-                                    can_schedule = self._trigger_preempt(
-                                        request, num_new_blocks_needed, preempted_reqs, scheduled_reqs
-                                    )
-                                    if not can_schedule:
-                                        llm_logger.warning(
-                                            f"Cannot allocate {num_new_blocks_needed} blocks "
-                                            f"for decode request {request.request_id} (idx={request.idx}) "
-                                            f"even after preemption attempt. Self-preempting this request."
-                                        )
-                                        self.running.remove(request)
-                                        request.status = RequestStatus.PREEMPTED
-                                        request.num_computed_tokens = 0
-                                        self._free_blocks(request)
-                                        request.num_cached_blocks = 0
-                                        self.to_be_rescheduled_request_id_set.add(request.request_id)
-                                        preempted_reqs.append(request)
-                                        scheduled_reqs.append(self._prepare_preempt_task(request))
-                                        continue
-
-                                    request.block_tables.extend(
-                                        self.cache_manager.allocate_gpu_blocks(
-                                            num_new_blocks_needed, request.request_id
-                                        )
-                                    )
-                                    scheduled_reqs.append(self._prepare_decode_task(request))
-
-                        else:
-                            scheduled_reqs.append(self._prepare_decode_task(request))
-
-                        num_decoding_req_nums += 1
-                        if (
-                            request.use_extend_tables
-                            and request.request_id not in self.using_extend_tables_req_id
-                            and self.need_block_num_map[request.request_id].watch() > 0
-                        ):
-
-                            def _allocate_decode_and_extend():
-                                allocate_block_num = self.need_block_num_map[request.request_id].consume()
-                                # Prepare decoding task
-                                request.block_tables.extend(
-                                    self.cache_manager.allocate_gpu_blocks(allocate_block_num, request.request_id)
-                                )
-                                scheduled_reqs.append(self._prepare_decode_task(request))
-
-                                # Prepare extend task
-                                reuse_block_num = request.num_total_tokens // self.config.cache_config.block_size
-                                llm_logger.info(
-                                    f"req {request.request_id} at batch id {request.idx} with reuse_block_num {reuse_block_num} is going to enable extend tables,"
-                                    f"need_block_num {allocate_block_num}"
-                                )
-                                self.using_extend_tables_req_id.add(request.request_id)
-                                self.reuse_block_num_map[request.request_id] = reuse_block_num
-
-                                request.extend_block_tables = request.block_tables[:reuse_block_num]
-                                request.extend_block_tables.extend(
-                                    self.cache_manager.allocate_gpu_blocks(allocate_block_num, request.request_id)
-                                )
-                                scheduled_reqs.append(
-                                    ScheduledExtendBlocksTask(
-                                        idx=request.idx,
-                                        request_id=request.request_id,
-                                        extend_block_tables=request.extend_block_tables,
-                                    )
-                                )
-                                llm_logger.debug(f"extend blocks is {request.extend_block_tables}")
-
-                            if self.cache_manager.can_allocate_gpu_blocks(
-                                2 * self.need_block_num_map[request.request_id].watch()
-                            ):
-                                _allocate_decode_and_extend()
-                            else:
-                                llm_logger.info(
-                                    f"{request.idx} using extend block need {2 * self.need_block_num_map[request.request_id].watch()} blocks but got not enough blocks, ready to preempt"
-                                )
-                                can_schedule = self._trigger_preempt(
-                                    request,
-                                    2 * self.need_block_num_map[request.request_id].watch(),
-                                    preempted_reqs,
-                                    scheduled_reqs,
-                                )
-
-                                if can_schedule:
-                                    _allocate_decode_and_extend()
-                                else:
-                                    break
-                    else:  # Legacy unfinished prefill should not stay in self.running.
-                        if self.active_chunked_prefill_req is None:
-                            self.active_chunked_prefill_req = request
-                            self.running.pop(req_index)
-                            continue
-                        req_index += 1
-                        continue
-
-                    req_index += 1
-
             # Second, schedule the WAITING requests.
             # Priority: in-flight prefill (RUNNING) > new prefill (WAITING) > decode.
             # Only ONE prefill is scheduled per step total. If RUNNING already scheduled
@@ -1149,14 +1133,7 @@ class ResourceManagerV1(ResourceManager):
                 # SGLang-aligned: only admit ONE chunked (long) request per step.
                 # Short requests continue to be admitted without consuming rem_chunk_tokens.
                 chunked_request_admitted_this_step = False
-                # WAITING loop uses its own chunk budget, separate from what RUNNING in-flight
-                # prefills consumed. If RUNNING already used the full rem_chunk_tokens, new
-                # waiting requests still get a fresh budget = chunked_prefill_size.
-                # This mirrors SGLang's PrefillAdder where RUNNING chunked continuation and
-                # WAITING new admission are independent; RUNNING consuming its chunk must NOT
-                # starve new requests from ever entering the waiting loop.
-                rem_chunk_tokens_waiting = chunked_prefill_size
-                while self.waiting and rem_input_tokens > 0 and rem_chunk_tokens_waiting > 0:
+                while self.waiting and rem_input_tokens > 0 and rem_chunk_tokens > 0:
                     if self.available_batch() == 0:
                         break
 
@@ -1200,7 +1177,7 @@ class ResourceManagerV1(ResourceManager):
                         ):
                             continue
                         # Allocate blocks for the tokens that does not hit cache
-                        num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens_waiting, rem_input_tokens)
+                        num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
                         if num_new_tokens <= 0:
                             break
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
@@ -1232,7 +1209,7 @@ class ResourceManagerV1(ResourceManager):
                                 max_new = min(_get_request_max_new_tokens(request), self.clip_max_new_tokens_estimation)
                                 scheduled_new_decode_reserved_tokens += min(max_new, self.clip_max_new_tokens_estimation)
                             else:
-                                rem_chunk_tokens_waiting -= num_new_tokens
+                                rem_chunk_tokens -= num_new_tokens
                                 # SGLang: after admitting one chunked waiting request, break.
                                 chunked_request_admitted_this_step = True
 
@@ -1274,7 +1251,7 @@ class ResourceManagerV1(ResourceManager):
                                 break
 
                         # Allocate blocks for the tokens that does not hit cache
-                        num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens_waiting, rem_input_tokens)
+                        num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
                         if num_new_tokens <= 0:
                             break
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
@@ -1306,7 +1283,7 @@ class ResourceManagerV1(ResourceManager):
                                 max_new = min(_get_request_max_new_tokens(request), self.clip_max_new_tokens_estimation)
                                 scheduled_new_decode_reserved_tokens += min(max_new, self.clip_max_new_tokens_estimation)
                             else:
-                                rem_chunk_tokens_waiting -= num_new_tokens
+                                rem_chunk_tokens -= num_new_tokens
                                 chunked_request_admitted_this_step = True
 
                             request.num_computed_tokens += num_new_tokens
@@ -1332,6 +1309,10 @@ class ResourceManagerV1(ResourceManager):
                 for req in skip_requests:
                     # move waiting request to end of the deque
                     self.waiting.append(req)
+
+            # Finally, only when no prefill was admitted this round, schedule decode.
+            if not has_scheduled_prefill and not preempted_reqs:
+                _schedule_decode_requests()
 
             if scheduled_reqs:
                 llm_logger.debug(f"schedued_reqs: {scheduled_reqs}")

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -524,6 +524,32 @@ class ResourceManagerV1(ResourceManager):
 
         return total_reserved_tokens
 
+    def _calculate_decode_batch_block_pressure(self) -> int:
+        """
+        Estimate how many new KV blocks the current decode batch will need this step.
+        This is a lightweight batch-level pressure check before entering the per-request
+        decode loop, so we can retract first instead of waiting for a single request to
+        fail at the block boundary.
+        """
+        block_size = self.config.cache_config.block_size
+        total_needed_blocks = 0
+
+        for req in self.running:
+            if req.num_computed_tokens < req.need_prefill_tokens:
+                continue
+            if self.config.scheduler_config.splitwise_role == "prefill":
+                continue
+            if (req.num_total_tokens - 1) % block_size == 0:
+                total_needed_blocks += 1
+
+        if total_needed_blocks > 0:
+            llm_logger.debug(
+                f"Decode batch block pressure: need={total_needed_blocks}, "
+                f"free={self.cache_manager.get_num_free_gpu_blocks()}, running={len(self.running)}"
+            )
+
+        return total_needed_blocks
+
     def _calculate_decode_reserved_tokens_for_new_requests(self, new_decode_reserved_tokens: float):
         """Return pre-computed reserved tokens for NEW decode requests in this cycle."""
         return new_decode_reserved_tokens
@@ -679,19 +705,40 @@ class ResourceManagerV1(ResourceManager):
                 break
         return matched_token_num
 
-    def _get_num_new_tokens(self, request, rem_chunk_tokens, rem_input_tokens):
-        # SGLang-aligned:
-        # - All admitted prefills share rem_input_tokens.
-        # - When chunk budget is enabled, requests that do not fit in the remaining
-        #   chunk budget are truncated to a chunk-sized prefill.
-        remaining = request.need_prefill_tokens - request.num_computed_tokens
-        num_new_tokens = min(remaining, rem_input_tokens)
+    def _get_paged_prefill_tokens(self, num_new_tokens: int) -> int:
+        if num_new_tokens <= 0:
+            return 0
 
         block_size = self.config.cache_config.block_size
+        if block_size <= 1:
+            return num_new_tokens
+
+        return -(-num_new_tokens // block_size) * block_size
+
+    def _get_num_new_tokens(self, request, rem_chunk_tokens, rem_input_tokens):
+        # SGLang-aligned:
+        # - First compute this round's candidate prefill length.
+        # - Then judge whether the paged input length can fit in rem_chunk_tokens.
+        # - If it does not fit, truncate to one page-aligned chunk.
+        remaining = request.need_prefill_tokens - request.num_computed_tokens
+        if remaining <= 0 or rem_input_tokens <= 0:
+            return 0
+
+        block_size = self.config.cache_config.block_size
+        num_new_tokens = min(remaining, rem_input_tokens)
         is_truncated = num_new_tokens < remaining
 
-        if rem_chunk_tokens is not None and remaining > rem_chunk_tokens:
-            num_new_tokens = min(num_new_tokens, rem_chunk_tokens)
+        paged_input_tokens = self._get_paged_prefill_tokens(num_new_tokens)
+        if rem_chunk_tokens is not None and paged_input_tokens > rem_chunk_tokens:
+            if block_size > 1:
+                trunc_len = (rem_chunk_tokens // block_size) * block_size
+            else:
+                trunc_len = rem_chunk_tokens
+
+            if trunc_len <= 0:
+                return 0
+
+            num_new_tokens = min(num_new_tokens, trunc_len)
             is_truncated = True
 
         if current_platform.is_intel_hpu():
@@ -949,6 +996,26 @@ class ResourceManagerV1(ResourceManager):
 
             def _schedule_decode_requests():
                 nonlocal num_decoding_req_nums
+                decode_batch_block_pressure = self._calculate_decode_batch_block_pressure()
+                if decode_batch_block_pressure > 0 and not self.cache_manager.can_allocate_gpu_blocks(
+                    decode_batch_block_pressure
+                ):
+                    first_decode_request = next(
+                        (
+                            req
+                            for req in self.running
+                            if req.num_computed_tokens >= req.need_prefill_tokens
+                        ),
+                        None,
+                    )
+                    if first_decode_request is not None:
+                        self._trigger_preempt(
+                            first_decode_request,
+                            decode_batch_block_pressure,
+                            preempted_reqs,
+                            scheduled_reqs,
+                        )
+
                 req_index = 0
                 while req_index < len(self.running):
                     request = self.running[req_index]
@@ -1116,8 +1183,9 @@ class ResourceManagerV1(ResourceManager):
                             scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
                             has_scheduled_prefill = True
                             has_scheduled_running_prefill = True
-                            rem_input_tokens -= num_new_tokens
-                            rem_chunk_tokens -= num_new_tokens
+                            budgeted_prefill_tokens = self._get_paged_prefill_tokens(num_new_tokens)
+                            rem_input_tokens -= budgeted_prefill_tokens
+                            rem_chunk_tokens -= budgeted_prefill_tokens
                             if is_last_chunk:
                                 max_new = min(
                                     _get_request_max_new_tokens(request), self.clip_max_new_tokens_estimation
@@ -1213,8 +1281,9 @@ class ResourceManagerV1(ResourceManager):
 
                             # SGLang-aligned: every admitted prefill chunk consumes both
                             # the total input budget and the shared per-step chunk budget.
-                            rem_input_tokens -= num_new_tokens
-                            rem_chunk_tokens -= num_new_tokens
+                            budgeted_prefill_tokens = self._get_paged_prefill_tokens(num_new_tokens)
+                            rem_input_tokens -= budgeted_prefill_tokens
+                            rem_chunk_tokens -= budgeted_prefill_tokens
                             if is_last_chunk:
                                 max_new = min(_get_request_max_new_tokens(request), self.clip_max_new_tokens_estimation)
                                 scheduled_new_decode_reserved_tokens += max_new
@@ -1284,8 +1353,9 @@ class ResourceManagerV1(ResourceManager):
 
                             # SGLang-aligned: every admitted prefill chunk consumes both
                             # the total input budget and the shared per-step chunk budget.
-                            rem_input_tokens -= num_new_tokens
-                            rem_chunk_tokens -= num_new_tokens
+                            budgeted_prefill_tokens = self._get_paged_prefill_tokens(num_new_tokens)
+                            rem_input_tokens -= budgeted_prefill_tokens
+                            rem_chunk_tokens -= budgeted_prefill_tokens
                             if is_last_chunk:
                                 max_new = min(_get_request_max_new_tokens(request), self.clip_max_new_tokens_estimation)
                                 scheduled_new_decode_reserved_tokens += max_new

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -709,6 +709,7 @@ class ResourceManagerV1(ResourceManager):
         rem_input_tokens,
         *,
         existing_prefill_in_batch: bool = False,
+        ignore_rem_input_budget: bool = False,
     ):
         # SGLang-aligned:
         # - rem_input_tokens is a hard stop only after some prefill has already
@@ -717,14 +718,18 @@ class ResourceManagerV1(ResourceManager):
         if remaining <= 0:
             return 0
 
-        if rem_input_tokens <= 0:
+        if not ignore_rem_input_budget and rem_input_tokens <= 0:
             return 0
 
-        if existing_prefill_in_batch and self._get_paged_prefill_tokens(remaining) >= rem_input_tokens:
+        if (
+            not ignore_rem_input_budget
+            and existing_prefill_in_batch
+            and self._get_paged_prefill_tokens(remaining) >= rem_input_tokens
+        ):
             return 0
 
         block_size = self.config.cache_config.block_size
-        num_new_tokens = min(remaining, rem_input_tokens)
+        num_new_tokens = remaining if ignore_rem_input_budget else min(remaining, rem_input_tokens)
         is_truncated = num_new_tokens < remaining
 
         paged_input_tokens = self._get_paged_prefill_tokens(num_new_tokens)
@@ -741,7 +746,8 @@ class ResourceManagerV1(ResourceManager):
             is_truncated = True
 
         if current_platform.is_intel_hpu():
-            hpu_budget = min(rem_input_tokens, rem_chunk_tokens or rem_input_tokens)
+            hpu_input_budget = num_new_tokens if ignore_rem_input_budget else rem_input_tokens
+            hpu_budget = min(hpu_input_budget, rem_chunk_tokens or hpu_input_budget)
             if is_truncated and hpu_budget > block_size:
                 num_new_tokens = num_new_tokens // block_size * block_size
         elif block_size > 1 and is_truncated:
@@ -1147,7 +1153,12 @@ class ResourceManagerV1(ResourceManager):
                     >= self.config.cache_config.block_size
                     and rem_input_tokens < self.config.cache_config.block_size
                 ) and not get_enough_request(request, scheduled_reqs) and rem_chunk_tokens > 0:
-                    num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
+                    num_new_tokens = self._get_num_new_tokens(
+                        request,
+                        rem_chunk_tokens,
+                        rem_input_tokens,
+                        ignore_rem_input_budget=True,
+                    )
                     if num_new_tokens > 0:
                         is_last_chunk = self._is_last_prefill_chunk(request, num_new_tokens)
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
@@ -1247,8 +1258,6 @@ class ResourceManagerV1(ResourceManager):
                         if num_new_tokens <= 0:
                             break
                         is_last_chunk = self._is_last_prefill_chunk(request, num_new_tokens)
-                        if self.active_chunked_prefill_req is not None and not is_last_chunk:
-                            break
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
                         can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
                             request,
@@ -1326,8 +1335,6 @@ class ResourceManagerV1(ResourceManager):
                         if num_new_tokens <= 0:
                             break
                         is_last_chunk = self._is_last_prefill_chunk(request, num_new_tokens)
-                        if self.active_chunked_prefill_req is not None and not is_last_chunk:
-                            break
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
                         can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
                             request,

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -1295,13 +1295,19 @@ class ResourceManagerV1(ResourceManager):
             if scheduled_reqs:
                 llm_logger.debug(f"schedued_reqs: {scheduled_reqs}")
 
-            # SGLang-aligned: decay new_token_ratio only when no prefill was actually scheduled
-            # this round and there are decode requests running.
+            # SGLang-aligned: decay new_token_ratio only when:
+            # - There are decode requests running
+            # - No running chunked prefill (has_running_prefill = False)
+            # - No waiting queue (bool(self.waiting) = False)
+            # - No prefill was scheduled this round (has_scheduled_prefill = False)
+            # - No preemption occurred this round (not preempted_reqs)
+            # This matches SGLang's is_extend_mode = has_running_prefill or bool(self.waiting)
             if (
-                scheduled_reqs
+                has_decode_requests
+                and not has_running_prefill
+                and not self.waiting
                 and not has_scheduled_prefill
                 and not preempted_reqs
-                and has_decode_requests
                 and self.current_new_token_ratio > self.min_new_token_ratio
             ):
                 self.current_new_token_ratio = max(

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -167,6 +167,9 @@ class ResourceManagerV1(ResourceManager):
         # Priority queues for requests.
         self.waiting: deque[Request] = deque()
         self.running: list[Request] = []
+        # SGLang-aligned chunked_req: keep at most one unfinished chunked prefill
+        # outside self.running until its final chunk completes.
+        self.active_chunked_prefill_req: Request | None = None
         self.preallocated_reqs: dict[str, Request] = {}
         self.enable_max_prefill = envs.FD_ENABLE_MAX_PREFILL
         self.finish_execution_pool = ThreadPoolExecutor(max_workers=1)
@@ -248,6 +251,27 @@ class ResourceManagerV1(ResourceManager):
 
     def _prepare_preempt_task(self, request):
         return ScheduledPreemptTask(idx=request.idx, request_id=request.request_id)
+
+    def _ensure_request_slot_allocated(self, request: Request):
+        if self.config.scheduler_config.splitwise_role != "mixed":
+            return
+        if (
+            request.idx is not None
+            and 0 <= request.idx < len(self.tasks_list)
+            and self.tasks_list[request.idx] is request
+            and not self.stop_flags[request.idx]
+        ):
+            self.req_dict[request.request_id] = request.idx
+            return
+
+        allocated_position = self.get_available_position()
+        request.idx = allocated_position
+        self.tasks_list[allocated_position] = request
+        self.stop_flags[allocated_position] = False
+        self.req_dict[request.request_id] = allocated_position
+
+    def _num_active_running_requests(self) -> int:
+        return len(self.running) + (1 if self.active_chunked_prefill_req is not None else 0)
 
     def reschedule_preempt_task(self, request_id, process_func=None):
         with self.lock:
@@ -877,18 +901,23 @@ class ResourceManagerV1(ResourceManager):
             preempted_reqs: list[Request] = []
             error_reqs: list[tuple[str, str]] = []
 
-            # Single-pass over self.running: compute running_decode_count, has_running_prefill,
-            # has_decode_requests
+            # Keep the single unfinished chunked prefill outside self.running, like
+            # SGLang's chunked_req. If older code left one in self.running, migrate the
+            # first unfinished request out.
+            if self.active_chunked_prefill_req is None:
+                for i, req in enumerate(self.running):
+                    if req.num_computed_tokens < req.need_prefill_tokens:
+                        self.active_chunked_prefill_req = self.running.pop(i)
+                        break
+
+            # Single-pass over self.running: compute running decode state only.
             _block_size = self.config.cache_config.block_size
             running_decode_count = 0
-            has_running_prefill = False
             has_decode_requests = False
             for _r in self.running:
                 if _r.num_computed_tokens >= _r.need_prefill_tokens:
                     running_decode_count += 1
                     has_decode_requests = True
-                else:
-                    has_running_prefill = True
 
             # Track whether any prefill was actually scheduled this round (for decay condition)
             has_scheduled_prefill = False
@@ -900,103 +929,98 @@ class ResourceManagerV1(ResourceManager):
             rem_chunk_tokens = chunked_prefill_size
             # rem_input_tokens: total input budget (SGLang's max_prefill_tokens - mixed_with_decode_tokens)
             rem_input_tokens = envs.FD_REM_INPUT_TOKENS - running_decode_count
+            # Compute running decode reservation once per schedule() call and accumulate
+            # last-chunk requests admitted within this cycle on top of it.
+            cached_running_decode_reserved = self._calculate_decode_reserved_tokens_by_ratio()
+            scheduled_new_decode_reserved_tokens: float = 0.0
 
-            # First, schedule the RUNNING requests.
-            # Priority: move any in-progress chunked prefill request to the front so it is
-            # processed before decode requests and gets priority access to available KV blocks.
-            # A partially-prefilled request already holds KV cache for computed chunks and must
-            # be allowed to complete its prefill without starvation.
-            if has_running_prefill:
-                for i in range(1, len(self.running)):
-                    if self.running[i].num_computed_tokens < self.running[i].need_prefill_tokens:
-                        self.running.insert(0, self.running.pop(i))
-                        break
-            req_index = 0
+            def _get_request_max_new_tokens(request: Request) -> int:
+                if request.sampling_params and request.sampling_params.max_tokens is not None:
+                    return request.sampling_params.max_tokens
+                return self.config.model_config.max_model_len - request.need_prefill_tokens
+
+            # First, schedule the single active chunked prefill request (if any).
             num_decoding_req_nums = 0
-            has_scheduled_running_prefill = False  # guard: only schedule ONE in-flight prefill per step
-            while req_index < len(self.running):
-                request = self.running[req_index]
+            has_scheduled_running_prefill = False
+            active_chunked_prefill_req = self.active_chunked_prefill_req
+            if active_chunked_prefill_req is not None:
+                request = active_chunked_prefill_req
                 need_block_num = self.need_block_num_signal.value[request.idx]
                 if need_block_num != 0:
                     self.need_block_num_map[request.request_id] = SignalConsumer(need_block_num, 1)
                     self.need_block_num_signal.value[request.idx] = 0
 
-                if request.num_computed_tokens >= request.need_prefill_tokens:  # to be decoding
-                    if (
-                        self.config.scheduler_config.splitwise_role == "prefill"
-                    ):  # do not need to schedule for decoding
-                        req_index += 1
-                        continue
-                    if request.num_total_tokens > request.need_prefill_tokens:  # has generated tokens
-                        request.num_computed_tokens = request.num_total_tokens - 1
-                    # SGLang-aligned: dynamically calculate how many blocks are needed for next decode
-                    # Similar to SGLang's new_page_count_next_decode:
-                    # If (num_total_tokens - 1) % block_size == 0, need 1 more block
-                    block_size = self.config.cache_config.block_size
-                    num_new_blocks_needed = 1 if (request.num_total_tokens - 1) % block_size == 0 else 0
-
-                    # SGLang-aligned: schedule decode task without threshold check
-                    # The pre-allocation is decoupled from scheduling
-                    if num_new_blocks_needed > 0:
-                        # Need to allocate new blocks, check if we can allocate
-                        if self.cache_manager.can_allocate_gpu_blocks(num_new_blocks_needed):
-                            llm_logger.debug(
-                                f"schedule decoding task: {request} request.num_total_tokens {request.num_total_tokens} request.num_computed_tokens {request.num_computed_tokens}"
-                            )
+                if not (
+                    current_platform.is_intel_hpu()
+                    and request.need_prefill_tokens - request.num_computed_tokens
+                    >= self.config.cache_config.block_size
+                    and rem_input_tokens < self.config.cache_config.block_size
+                ) and not get_enough_request(request, scheduled_reqs) and rem_chunk_tokens > 0:
+                    num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
+                    if num_new_tokens > 0:
+                        num_new_block = self.get_new_block_nums(request, num_new_tokens)
+                        can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
+                            request,
+                            num_new_block,
+                            scheduled_new_decode_reserved_tokens,
+                            cached_running_decode_reserved,
+                        )
+                        if self.cache_manager.can_allocate_gpu_blocks(can_schedule_block_num_threshold):
                             request.block_tables.extend(
-                                self.cache_manager.allocate_gpu_blocks(
-                                    num_new_blocks_needed, request.request_id
-                                )
+                                self.cache_manager.allocate_gpu_blocks(num_new_block, request.request_id)
                             )
-                            # Prepare decoding task
-                            scheduled_reqs.append(self._prepare_decode_task(request))
-                        else:
-                            # Not enough blocks, trigger preemption
-                            # SGLang-aligned: first try to evict decode KV cache
-                            self._evict_decode_kv_cache(len(self.running))
+                            scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
+                            has_scheduled_prefill = True
+                            has_scheduled_running_prefill = True
+                            rem_input_tokens -= num_new_tokens
+                            rem_chunk_tokens -= num_new_tokens
+                            remaining_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
+                            if remaining_to_prefill <= num_new_tokens:
+                                max_new = min(
+                                    _get_request_max_new_tokens(request), self.clip_max_new_tokens_estimation
+                                )
+                                scheduled_new_decode_reserved_tokens += max_new
+                            request.num_computed_tokens += num_new_tokens
+                            if self.config.cache_config.enable_prefix_caching:
+                                self.cache_manager.update_cache_blocks(
+                                    request, self.config.cache_config.block_size, request.num_computed_tokens
+                                )
+                            if request.num_computed_tokens >= request.need_prefill_tokens:
+                                self.active_chunked_prefill_req = None
+                                self.running.append(request)
 
-                            # Check again after eviction
+            # Second, schedule decode requests in self.running.
+            if not has_scheduled_running_prefill:
+                req_index = 0
+                while req_index < len(self.running):
+                    request = self.running[req_index]
+                    need_block_num = self.need_block_num_signal.value[request.idx]
+                    if need_block_num != 0:
+                        self.need_block_num_map[request.request_id] = SignalConsumer(need_block_num, 1)
+                        self.need_block_num_signal.value[request.idx] = 0
+
+                    if request.num_computed_tokens >= request.need_prefill_tokens:  # to be decoding
+                        if (
+                            self.config.scheduler_config.splitwise_role == "prefill"
+                        ):  # do not need to schedule for decoding
+                            req_index += 1
+                            continue
+                        if request.num_total_tokens > request.need_prefill_tokens:  # has generated tokens
+                            request.num_computed_tokens = request.num_total_tokens - 1
+                        # SGLang-aligned: dynamically calculate how many blocks are needed for next decode
+                        # Similar to SGLang's new_page_count_next_decode:
+                        # If (num_total_tokens - 1) % block_size == 0, need 1 more block
+                        block_size = self.config.cache_config.block_size
+                        num_new_blocks_needed = 1 if (request.num_total_tokens - 1) % block_size == 0 else 0
+
+                        # SGLang-aligned: schedule decode task without threshold check
+                        # The pre-allocation is decoupled from scheduling
+                        if num_new_blocks_needed > 0:
+                            # Need to allocate new blocks, check if we can allocate
                             if self.cache_manager.can_allocate_gpu_blocks(num_new_blocks_needed):
-                                request.block_tables.extend(
-                                    self.cache_manager.allocate_gpu_blocks(
-                                        num_new_blocks_needed, request.request_id
-                                    )
+                                llm_logger.debug(
+                                    f"schedule decoding task: {request} request.num_total_tokens {request.num_total_tokens} request.num_computed_tokens {request.num_computed_tokens}"
                                 )
-                                scheduled_reqs.append(self._prepare_decode_task(request))
-                            else:
-                                # Cannot allocate even after preemption, use SGLang-aligned behavior
-                                # Try to preempt other requests
-                                can_schedule = self._trigger_preempt(
-                                    request, num_new_blocks_needed, preempted_reqs, scheduled_reqs
-                                )
-                                if not can_schedule:
-                                    # Cannot preempt any other request to free space for this decode request.
-                                    # This happens when only 1 decode request remains.
-                                    # The only safe action is to preempt THIS request itself:
-                                    # remove it from running, free its KV blocks, and put it back in
-                                    # waiting so it can re-prefill later when memory is available.
-                                    # - Using `break` here causes a livelock: the request stays at
-                                    #   running[0] and blocks all subsequent decode/prefill every cycle.
-                                    # - Using `continue` (old bug) left it as a zombie that never gets
-                                    #   a decode step and never produces EOS.
-                                    llm_logger.warning(
-                                        f"Cannot allocate {num_new_blocks_needed} blocks "
-                                        f"for decode request {request.request_id} (idx={request.idx}) "
-                                        f"even after preemption attempt. Self-preempting this request."
-                                    )
-                                    self.running.remove(request)
-                                    request.status = RequestStatus.PREEMPTED
-                                    request.num_computed_tokens = 0
-                                    self._free_blocks(request)
-                                    request.num_cached_blocks = 0
-                                    self.to_be_rescheduled_request_id_set.add(request.request_id)
-                                    preempted_reqs.append(request)
-                                    scheduled_reqs.append(self._prepare_preempt_task(request))
-                                    # Do NOT increment req_index: after remove(), the next request
-                                    # has shifted to the current index position.
-                                    continue
-
-                                # Allocation for next decoding blocks after preemption
                                 request.block_tables.extend(
                                     self.cache_manager.allocate_gpu_blocks(
                                         num_new_blocks_needed, request.request_id
@@ -1004,144 +1028,123 @@ class ResourceManagerV1(ResourceManager):
                                 )
                                 # Prepare decoding task
                                 scheduled_reqs.append(self._prepare_decode_task(request))
+                            else:
+                                # Not enough blocks, trigger preemption
+                                # SGLang-aligned: first try to evict decode KV cache
+                                self._evict_decode_kv_cache(len(self.running))
 
-                    # No new blocks needed (num_new_blocks_needed == 0), but still schedule decode task
-                    # SGLang-aligned: decode does NOT consume token_budget, only checks memory
-                    else:
-                        scheduled_reqs.append(self._prepare_decode_task(request))
+                                # Check again after eviction
+                                if self.cache_manager.can_allocate_gpu_blocks(num_new_blocks_needed):
+                                    request.block_tables.extend(
+                                        self.cache_manager.allocate_gpu_blocks(
+                                            num_new_blocks_needed, request.request_id
+                                        )
+                                    )
+                                    scheduled_reqs.append(self._prepare_decode_task(request))
+                                else:
+                                    # Cannot allocate even after preemption, use SGLang-aligned behavior
+                                    # Try to preempt other requests
+                                    can_schedule = self._trigger_preempt(
+                                        request, num_new_blocks_needed, preempted_reqs, scheduled_reqs
+                                    )
+                                    if not can_schedule:
+                                        llm_logger.warning(
+                                            f"Cannot allocate {num_new_blocks_needed} blocks "
+                                            f"for decode request {request.request_id} (idx={request.idx}) "
+                                            f"even after preemption attempt. Self-preempting this request."
+                                        )
+                                        self.running.remove(request)
+                                        request.status = RequestStatus.PREEMPTED
+                                        request.num_computed_tokens = 0
+                                        self._free_blocks(request)
+                                        request.num_cached_blocks = 0
+                                        self.to_be_rescheduled_request_id_set.add(request.request_id)
+                                        preempted_reqs.append(request)
+                                        scheduled_reqs.append(self._prepare_preempt_task(request))
+                                        continue
 
-                    num_decoding_req_nums += 1
-                    if (
-                        request.use_extend_tables
-                        and request.request_id not in self.using_extend_tables_req_id
-                        and self.need_block_num_map[request.request_id].watch() > 0
-                    ):
+                                    request.block_tables.extend(
+                                        self.cache_manager.allocate_gpu_blocks(
+                                            num_new_blocks_needed, request.request_id
+                                        )
+                                    )
+                                    scheduled_reqs.append(self._prepare_decode_task(request))
 
-                        def _allocate_decode_and_extend():
-                            allocate_block_num = self.need_block_num_map[request.request_id].consume()
-                            # Prepare decoding task
-                            request.block_tables.extend(
-                                self.cache_manager.allocate_gpu_blocks(allocate_block_num, request.request_id)
-                            )
+                        else:
                             scheduled_reqs.append(self._prepare_decode_task(request))
 
-                            # Prepare extend task
-                            reuse_block_num = request.num_total_tokens // self.config.cache_config.block_size
-                            llm_logger.info(
-                                f"req {request.request_id} at batch id {request.idx} with reuse_block_num {reuse_block_num} is going to enable extend tables,"
-                                f"need_block_num {allocate_block_num}"
-                            )
-                            self.using_extend_tables_req_id.add(request.request_id)
-                            self.reuse_block_num_map[request.request_id] = reuse_block_num
-
-                            request.extend_block_tables = request.block_tables[:reuse_block_num]  # copy prompt cache
-                            request.extend_block_tables.extend(
-                                self.cache_manager.allocate_gpu_blocks(allocate_block_num, request.request_id)
-                            )
-                            scheduled_reqs.append(
-                                ScheduledExtendBlocksTask(
-                                    idx=request.idx,
-                                    request_id=request.request_id,
-                                    extend_block_tables=request.extend_block_tables,
-                                )
-                            )
-                            llm_logger.debug(f"extend blocks is {request.extend_block_tables}")
-
-                        if self.cache_manager.can_allocate_gpu_blocks(
-                            2 * self.need_block_num_map[request.request_id].watch()
+                        num_decoding_req_nums += 1
+                        if (
+                            request.use_extend_tables
+                            and request.request_id not in self.using_extend_tables_req_id
+                            and self.need_block_num_map[request.request_id].watch() > 0
                         ):
-                            _allocate_decode_and_extend()
-                        else:
-                            llm_logger.info(
-                                f"{request.idx} using extend block need {2 * self.need_block_num_map[request.request_id].watch()} blocks but got not enough blocks, ready to preempt"
-                            )
-                            can_schedule = self._trigger_preempt(
-                                request,
-                                2 * self.need_block_num_map[request.request_id].watch(),
-                                preempted_reqs,
-                                scheduled_reqs,
-                            )
 
-                            if can_schedule:
+                            def _allocate_decode_and_extend():
+                                allocate_block_num = self.need_block_num_map[request.request_id].consume()
+                                # Prepare decoding task
+                                request.block_tables.extend(
+                                    self.cache_manager.allocate_gpu_blocks(allocate_block_num, request.request_id)
+                                )
+                                scheduled_reqs.append(self._prepare_decode_task(request))
+
+                                # Prepare extend task
+                                reuse_block_num = request.num_total_tokens // self.config.cache_config.block_size
+                                llm_logger.info(
+                                    f"req {request.request_id} at batch id {request.idx} with reuse_block_num {reuse_block_num} is going to enable extend tables,"
+                                    f"need_block_num {allocate_block_num}"
+                                )
+                                self.using_extend_tables_req_id.add(request.request_id)
+                                self.reuse_block_num_map[request.request_id] = reuse_block_num
+
+                                request.extend_block_tables = request.block_tables[:reuse_block_num]
+                                request.extend_block_tables.extend(
+                                    self.cache_manager.allocate_gpu_blocks(allocate_block_num, request.request_id)
+                                )
+                                scheduled_reqs.append(
+                                    ScheduledExtendBlocksTask(
+                                        idx=request.idx,
+                                        request_id=request.request_id,
+                                        extend_block_tables=request.extend_block_tables,
+                                    )
+                                )
+                                llm_logger.debug(f"extend blocks is {request.extend_block_tables}")
+
+                            if self.cache_manager.can_allocate_gpu_blocks(
+                                2 * self.need_block_num_map[request.request_id].watch()
+                            ):
                                 _allocate_decode_and_extend()
                             else:
-                                break
-                else:  # need to prefill
-                    # Only ONE in-flight prefill is scheduled per step.
-                    # The priority reorder above moved it to running[0]; all other
-                    # in-flight prefill requests at later indices must wait until the
-                    # next schedule() call (they remain in self.running).
-                    if has_scheduled_running_prefill:
-                        req_index += 1
-                        continue
-                    llm_logger.debug(
-                        f"scheduler prefill task in running queue: {request.request_id}, "
-                        f"request.need_prefill_tokens {request.need_prefill_tokens},"
-                        f"request.num_computed_tokens {request.num_computed_tokens}"
-                    )
-                    if (
-                        current_platform.is_intel_hpu()
-                        and request.need_prefill_tokens - request.num_computed_tokens
-                        >= self.config.cache_config.block_size
-                        and rem_input_tokens < self.config.cache_config.block_size
-                    ):
-                        req_index += 1
-                        continue
-                    if get_enough_request(request, scheduled_reqs):
-                        req_index += 1
-                        continue
-                    # Apply rem_chunk_tokens batch-level constraint for running prefills too
-                    if rem_chunk_tokens <= 0:
-                        req_index += 1
-                        continue
-                    num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
-                    num_new_block = self.get_new_block_nums(request, num_new_tokens)
-                    # Allocate blocks to prefill
-                    if self.cache_manager.can_allocate_gpu_blocks(num_new_block):
-                        request.block_tables.extend(
-                            self.cache_manager.allocate_gpu_blocks(num_new_block, request.request_id)
-                        )
-                        # Prepare prefill task
-                        scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
-                    else:
-                        # In-progress chunked prefill is already at the front of the RUNNING queue
-                        # (moved there by the priority reorder above). If it still can't get blocks,
-                        # memory is genuinely exhausted this step — stop the RUNNING loop entirely.
-                        # Do NOT skip-and-continue: that would leave the request stuck indefinitely.
-                        llm_logger.debug(
-                            f"Running prefill cannot get enough blocks for {request.request_id}, "
-                            f"stopping RUNNING loop this cycle."
-                        )
-                        break
-                    # Priority: in-flight prefill > prefill > decode.
-                    # After scheduling this prefill chunk, continue the RUNNING loop
-                    # so that decode requests still get scheduled this step.
-                    # The priority reorder above ensures at most one in-flight prefill is at
-                    # index 0; req_index += 1 will move on to decode requests after it.
-                    has_scheduled_prefill = True
-                    has_scheduled_running_prefill = True  # block subsequent in-flight prefills this step
-                    rem_chunk_tokens -= num_new_tokens
-                    request.num_computed_tokens += num_new_tokens
-                    if self.config.cache_config.enable_prefix_caching:
-                        self.cache_manager.update_cache_blocks(
-                            request, self.config.cache_config.block_size, request.num_computed_tokens
-                        )
-                    req_index += 1  # continue to decode requests, do NOT break
-                    continue  # skip the shared req_index += 1 below
+                                llm_logger.info(
+                                    f"{request.idx} using extend block need {2 * self.need_block_num_map[request.request_id].watch()} blocks but got not enough blocks, ready to preempt"
+                                )
+                                can_schedule = self._trigger_preempt(
+                                    request,
+                                    2 * self.need_block_num_map[request.request_id].watch(),
+                                    preempted_reqs,
+                                    scheduled_reqs,
+                                )
 
-                req_index += 1
+                                if can_schedule:
+                                    _allocate_decode_and_extend()
+                                else:
+                                    break
+                    else:  # Legacy unfinished prefill should not stay in self.running.
+                        if self.active_chunked_prefill_req is None:
+                            self.active_chunked_prefill_req = request
+                            self.running.pop(req_index)
+                            continue
+                        req_index += 1
+                        continue
+
+                    req_index += 1
 
             # Second, schedule the WAITING requests.
             # Priority: in-flight prefill (RUNNING) > new prefill (WAITING) > decode.
             # Only ONE prefill is scheduled per step total. If RUNNING already scheduled
             # an in-flight prefill chunk (has_scheduled_running_prefill=True), skip WAITING
             # entirely this step. Otherwise admit at most one new request from WAITING.
-            if not preempted_reqs and not has_scheduled_running_prefill:
-                # Compute running decode reservation once per schedule() call
-                cached_running_decode_reserved = self._calculate_decode_reserved_tokens_by_ratio()
-                # Track decode reservations accumulated within this cycle's waiting loop
-                scheduled_new_decode_reserved_tokens: float = 0.0
-
+            if not preempted_reqs and not has_scheduled_running_prefill and self.active_chunked_prefill_req is None:
                 skip_requests: list[Request] = []
                 # SGLang-aligned: only admit ONE chunked (long) request per step.
                 # Short requests continue to be admitted without consuming rem_chunk_tokens.
@@ -1154,7 +1157,7 @@ class ResourceManagerV1(ResourceManager):
                 # starve new requests from ever entering the waiting loop.
                 rem_chunk_tokens_waiting = chunked_prefill_size
                 while self.waiting and rem_input_tokens > 0 and rem_chunk_tokens_waiting > 0:
-                    if len(self.running) == self.max_num_seqs:
+                    if self.available_batch() == 0:
                         break
 
                     request = self.waiting[0]
@@ -1198,9 +1201,12 @@ class ResourceManagerV1(ResourceManager):
                             continue
                         # Allocate blocks for the tokens that does not hit cache
                         num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens_waiting, rem_input_tokens)
+                        if num_new_tokens <= 0:
+                            break
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
                         can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
-                            request, num_new_block,
+                            request,
+                            num_new_block,
                             scheduled_new_decode_reserved_tokens,
                             cached_running_decode_reserved,
                         )
@@ -1212,18 +1218,18 @@ class ResourceManagerV1(ResourceManager):
                                 )
                                 request.block_tables.extend(extra_gpu_block_ids)
                             self.waiting.popleft()
-                            self.running.append(request)
+                            self._ensure_request_slot_allocated(request)
                             scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
                             has_scheduled_prefill = True
                             # Track decode reservation for last-chunk requests
                             remaining_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
                             is_last_chunk = remaining_to_prefill <= num_new_tokens
 
-                            # SGLang-aligned: chunked requests consume rem_chunk_tokens_waiting;
-                            # non-chunked (last) requests consume rem_input_tokens (NOT rem_chunk_tokens_waiting).
+                            # Every prefill chunk consumes total input budget. Chunked requests also
+                            # consume the per-step chunk budget.
+                            rem_input_tokens -= num_new_tokens
                             if is_last_chunk:
-                                rem_input_tokens -= num_new_tokens
-                                max_new = getattr(request, 'max_new_tokens', self.clip_max_new_tokens_estimation)
+                                max_new = min(_get_request_max_new_tokens(request), self.clip_max_new_tokens_estimation)
                                 scheduled_new_decode_reserved_tokens += min(max_new, self.clip_max_new_tokens_estimation)
                             else:
                                 rem_chunk_tokens_waiting -= num_new_tokens
@@ -1236,13 +1242,10 @@ class ResourceManagerV1(ResourceManager):
                                     request, self.config.cache_config.block_size, request.num_computed_tokens
                                 )
                             request.status = RequestStatus.RUNNING
-                            if self.config.scheduler_config.splitwise_role == "mixed":
-                                allocated_position = self.get_available_position()
-                                request.idx = allocated_position
-                                self.tasks_list[allocated_position] = request
-                                self.stop_flags[allocated_position] = False
-                                self.req_dict[request.request_id] = allocated_position
-                                llm_logger.debug(f"req_id:{request.request_id} allocate pos end")
+                            if is_last_chunk:
+                                self.running.append(request)
+                            else:
+                                self.active_chunked_prefill_req = request
                             # SGLang-aligned: after admitting one chunked waiting request, break.
                             # Short (non-chunked) requests continue to be admitted.
                             if chunked_request_admitted_this_step:
@@ -1272,9 +1275,12 @@ class ResourceManagerV1(ResourceManager):
 
                         # Allocate blocks for the tokens that does not hit cache
                         num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens_waiting, rem_input_tokens)
+                        if num_new_tokens <= 0:
+                            break
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
                         can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
-                            request, num_new_block,
+                            request,
+                            num_new_block,
                             scheduled_new_decode_reserved_tokens,
                             cached_running_decode_reserved,
                         )
@@ -1286,18 +1292,18 @@ class ResourceManagerV1(ResourceManager):
                                 )
                                 request.block_tables.extend(extra_gpu_block_ids)
                             self.waiting.popleft()
-                            self.running.append(request)
+                            self._ensure_request_slot_allocated(request)
                             scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
                             has_scheduled_prefill = True
                             # Track decode reservation for last-chunk requests
                             remaining_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
                             is_last_chunk = remaining_to_prefill <= num_new_tokens
 
-                            # SGLang-aligned: chunked requests consume rem_chunk_tokens_waiting;
-                            # non-chunked (last) requests consume rem_input_tokens (NOT rem_chunk_tokens_waiting).
+                            # Every prefill chunk consumes total input budget. Chunked requests also
+                            # consume the per-step chunk budget.
+                            rem_input_tokens -= num_new_tokens
                             if is_last_chunk:
-                                rem_input_tokens -= num_new_tokens
-                                max_new = getattr(request, 'max_new_tokens', self.clip_max_new_tokens_estimation)
+                                max_new = min(_get_request_max_new_tokens(request), self.clip_max_new_tokens_estimation)
                                 scheduled_new_decode_reserved_tokens += min(max_new, self.clip_max_new_tokens_estimation)
                             else:
                                 rem_chunk_tokens_waiting -= num_new_tokens
@@ -1309,6 +1315,10 @@ class ResourceManagerV1(ResourceManager):
                                     request, self.config.cache_config.block_size, request.num_computed_tokens
                                 )
                             request.status = RequestStatus.RUNNING
+                            if is_last_chunk:
+                                self.running.append(request)
+                            else:
+                                self.active_chunked_prefill_req = request
                             # SGLang-aligned: after admitting one chunked waiting request, break.
                             if chunked_request_admitted_this_step:
                                 break
@@ -1328,7 +1338,6 @@ class ResourceManagerV1(ResourceManager):
 
             # Decay new_token_ratio when:
             # - There are decode requests running
-            # - No running chunked prefill (has_running_prefill = False)
             # - No prefill was scheduled this round (has_scheduled_prefill = False)
             # - No preemption occurred this round (not preempted_reqs)
             # NOTE: do NOT gate on "not self.waiting". When self.waiting is large,
@@ -1336,7 +1345,6 @@ class ResourceManagerV1(ResourceManager):
             # no waiting request can ever be admitted → queue never drains (屯土地).
             if (
                 has_decode_requests
-                and not has_running_prefill
                 and not has_scheduled_prefill
                 and not preempted_reqs
                 and self.current_new_token_ratio > self.min_new_token_ratio
@@ -1355,9 +1363,9 @@ class ResourceManagerV1(ResourceManager):
                 total_blocks = self.total_block_number()
                 free_blocks = self.available_block_num()
                 used_blocks = max(total_blocks - free_blocks, 0)
+                tokens_used = used_blocks * self.config.cache_config.block_size
                 token_usage = used_blocks / total_blocks if total_blocks > 0 else 0.0
-                running_cnt = len(self.running)
-                running_prefill_count = running_cnt - running_decode_count
+                running_cnt = self._num_active_running_requests()
                 queue_cnt = len(self.waiting)
 
                 prefill_reqs = [
@@ -1367,9 +1375,9 @@ class ResourceManagerV1(ResourceManager):
 
                 self.scheduler_metrics_logger.log_prefill_batch(
                     prefill_reqs=prefill_reqs,
-                    running_decode_cnt=running_decode_count,
-                    running_prefill_cnt=running_prefill_count,
+                    running_cnt=running_cnt,
                     queue_cnt=queue_cnt,
+                    tokens_used=tokens_used,
                     token_usage=token_usage,
                 )
                 if has_decode:
@@ -1391,9 +1399,9 @@ class ResourceManagerV1(ResourceManager):
                         )
                     )
                     self.scheduler_metrics_logger.log_decode_batch(
-                        running_decode_cnt=running_decode_count,
-                        running_prefill_cnt=running_prefill_count,
+                        running_cnt=running_cnt,
                         queue_cnt=queue_cnt,
+                        tokens_used=tokens_used,
                         token_usage=token_usage,
                         use_cudagraph=use_decode_cudagraph,
                     )
@@ -1602,6 +1610,8 @@ class ResourceManagerV1(ResourceManager):
             if request_id not in self.requests:
                 return
             req = self.requests[request_id]
+            if req is self.active_chunked_prefill_req:
+                self.active_chunked_prefill_req = None
             self.tasks_list[req.idx] = None
             self.stop_flags[req.idx] = True
             self._free_blocks(req)
@@ -1795,6 +1805,11 @@ class ResourceManagerV1(ResourceManager):
                         self.running.remove(request)
                         request.status = RequestStatus.FINISHED
                         need_postprocess_reqs.append(request)
+                    elif request is self.active_chunked_prefill_req:
+                        llm_logger.info(f"finish active chunked prefill request: {req_id}")
+                        self.active_chunked_prefill_req = None
+                        request.status = RequestStatus.FINISHED
+                        need_postprocess_reqs.append(request)
                     if request.request_id in self.to_be_rescheduled_request_id_set:
                         # finished after preempted, blocks have been recycled.
                         llm_logger.info(f"finish preempeted request: {req_id}")
@@ -1824,12 +1839,14 @@ class ResourceManagerV1(ResourceManager):
 
     def clear_data(self):
         self.waiting: deque[Request] = deque()
+        self.active_chunked_prefill_req = None
         self.to_be_rescheduled_request_id_set = set()
         self.update_metrics(verbose=True)
 
     def update_metrics(self, verbose=False):
         # Update metrics
         num_tasks = sum([1 if task else 0 for task in self.tasks_list])
+        active_running_reqs = self._num_active_running_requests()
         blocks_used_by_tasks = set()
         for task in self.tasks_list:
             if task is not None:
@@ -1837,16 +1854,17 @@ class ResourceManagerV1(ResourceManager):
         main_process_metrics.available_gpu_block_num.set(self.total_block_number() - len(blocks_used_by_tasks))
         main_process_metrics.batch_size.set(self.max_num_seqs - self.available_batch())
         main_process_metrics.gpu_cache_usage_perc.set(self.get_gpu_cache_usage_perc())
-        main_process_metrics.num_requests_running.set(len(self.running))
-        main_process_metrics.num_requests_waiting.set(num_tasks - len(self.running))
+        main_process_metrics.num_requests_running.set(active_running_reqs)
+        main_process_metrics.num_requests_waiting.set(num_tasks - active_running_reqs)
         if verbose:
-            llm_logger.info(f"update metrics: running={len(self.running)}, waiting={num_tasks - len(self.running)}")
+            llm_logger.info(f"update metrics: running={active_running_reqs}, waiting={num_tasks - active_running_reqs}")
 
     def log_status(self):
         llm_logger.info(
             f"ResourceManagerV1( "
             f"waiting={len(self.waiting)}, "
             f"running={len(self.running)}, "
+            f"active_chunked_prefill_req={getattr(self.active_chunked_prefill_req, 'request_id', None)}, "
             f"preempted={len(self.to_be_rescheduled_request_id_set)}, "
             f"tasks_list={self.tasks_list}, "
             f"stop_flags={self.stop_flags}, "

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -902,8 +902,18 @@ class ResourceManagerV1(ResourceManager):
             rem_input_tokens = envs.FD_REM_INPUT_TOKENS - running_decode_count
 
             # First, schedule the RUNNING requests.
+            # Priority: move any in-progress chunked prefill request to the front so it is
+            # processed before decode requests and gets priority access to available KV blocks.
+            # A partially-prefilled request already holds KV cache for computed chunks and must
+            # be allowed to complete its prefill without starvation.
+            if has_running_prefill:
+                for i in range(1, len(self.running)):
+                    if self.running[i].num_computed_tokens < self.running[i].need_prefill_tokens:
+                        self.running.insert(0, self.running.pop(i))
+                        break
             req_index = 0
             num_decoding_req_nums = 0
+            has_scheduled_running_prefill = False  # guard: only schedule ONE in-flight prefill per step
             while req_index < len(self.running):
                 request = self.running[req_index]
                 need_block_num = self.need_block_num_signal.value[request.idx]
@@ -1057,6 +1067,13 @@ class ResourceManagerV1(ResourceManager):
                             else:
                                 break
                 else:  # need to prefill
+                    # Only ONE in-flight prefill is scheduled per step.
+                    # The priority reorder above moved it to running[0]; all other
+                    # in-flight prefill requests at later indices must wait until the
+                    # next schedule() call (they remain in self.running).
+                    if has_scheduled_running_prefill:
+                        req_index += 1
+                        continue
                     llm_logger.debug(
                         f"scheduler prefill task in running queue: {request.request_id}, "
                         f"request.need_prefill_tokens {request.need_prefill_tokens},"
@@ -1087,32 +1104,39 @@ class ResourceManagerV1(ResourceManager):
                         # Prepare prefill task
                         scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
                     else:
-                        # SGLang-aligned: when running prefill cannot get blocks, skip this request
-                        # (it stays in running queue and retries next cycle). No preemption.
-                        # SGLang default behavior (enable_priority_scheduling=False) never preempts
-                        # for running prefill resource shortage.
+                        # In-progress chunked prefill is already at the front of the RUNNING queue
+                        # (moved there by the priority reorder above). If it still can't get blocks,
+                        # memory is genuinely exhausted this step — stop the RUNNING loop entirely.
+                        # Do NOT skip-and-continue: that would leave the request stuck indefinitely.
                         llm_logger.debug(
                             f"Running prefill cannot get enough blocks for {request.request_id}, "
-                            f"skipping this cycle. (SGLang default: no preemption)"
+                            f"stopping RUNNING loop this cycle."
                         )
-                        req_index += 1
-                        continue
-                    # SGLang-aligned: only continue ONE chunked prefill per step, then break.
-                    # Multiple running prefills share rem_chunk_tokens → fragmented slow progress.
-                    # SGLang: single chunked_req per step gets the full budget.
+                        break
+                    # Priority: in-flight prefill > prefill > decode.
+                    # After scheduling this prefill chunk, continue the RUNNING loop
+                    # so that decode requests still get scheduled this step.
+                    # The priority reorder above ensures at most one in-flight prefill is at
+                    # index 0; req_index += 1 will move on to decode requests after it.
                     has_scheduled_prefill = True
+                    has_scheduled_running_prefill = True  # block subsequent in-flight prefills this step
                     rem_chunk_tokens -= num_new_tokens
                     request.num_computed_tokens += num_new_tokens
                     if self.config.cache_config.enable_prefix_caching:
                         self.cache_manager.update_cache_blocks(
                             request, self.config.cache_config.block_size, request.num_computed_tokens
                         )
-                    break  # ← only 1 running chunked prefill per step
+                    req_index += 1  # continue to decode requests, do NOT break
+                    continue  # skip the shared req_index += 1 below
 
                 req_index += 1
 
             # Second, schedule the WAITING requests.
-            if not preempted_reqs:
+            # Priority: in-flight prefill (RUNNING) > new prefill (WAITING) > decode.
+            # Only ONE prefill is scheduled per step total. If RUNNING already scheduled
+            # an in-flight prefill chunk (has_scheduled_running_prefill=True), skip WAITING
+            # entirely this step. Otherwise admit at most one new request from WAITING.
+            if not preempted_reqs and not has_scheduled_running_prefill:
                 # Compute running decode reservation once per schedule() call
                 cached_running_decode_reserved = self._calculate_decode_reserved_tokens_by_ratio()
                 # Track decode reservations accumulated within this cycle's waiting loop
@@ -1122,7 +1146,14 @@ class ResourceManagerV1(ResourceManager):
                 # SGLang-aligned: only admit ONE chunked (long) request per step.
                 # Short requests continue to be admitted without consuming rem_chunk_tokens.
                 chunked_request_admitted_this_step = False
-                while self.waiting and rem_input_tokens > 0 and rem_chunk_tokens > 0:
+                # WAITING loop uses its own chunk budget, separate from what RUNNING in-flight
+                # prefills consumed. If RUNNING already used the full rem_chunk_tokens, new
+                # waiting requests still get a fresh budget = chunked_prefill_size.
+                # This mirrors SGLang's PrefillAdder where RUNNING chunked continuation and
+                # WAITING new admission are independent; RUNNING consuming its chunk must NOT
+                # starve new requests from ever entering the waiting loop.
+                rem_chunk_tokens_waiting = chunked_prefill_size
+                while self.waiting and rem_input_tokens > 0 and rem_chunk_tokens_waiting > 0:
                     if len(self.running) == self.max_num_seqs:
                         break
 
@@ -1166,7 +1197,7 @@ class ResourceManagerV1(ResourceManager):
                         ):
                             continue
                         # Allocate blocks for the tokens that does not hit cache
-                        num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
+                        num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens_waiting, rem_input_tokens)
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
                         can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
                             request, num_new_block,
@@ -1188,14 +1219,14 @@ class ResourceManagerV1(ResourceManager):
                             remaining_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
                             is_last_chunk = remaining_to_prefill <= num_new_tokens
 
-                            # SGLang-aligned: chunked requests consume rem_chunk_tokens;
-                            # non-chunked (last) requests consume rem_input_tokens (NOT rem_chunk_tokens).
+                            # SGLang-aligned: chunked requests consume rem_chunk_tokens_waiting;
+                            # non-chunked (last) requests consume rem_input_tokens (NOT rem_chunk_tokens_waiting).
                             if is_last_chunk:
                                 rem_input_tokens -= num_new_tokens
                                 max_new = getattr(request, 'max_new_tokens', self.clip_max_new_tokens_estimation)
                                 scheduled_new_decode_reserved_tokens += min(max_new, self.clip_max_new_tokens_estimation)
                             else:
-                                rem_chunk_tokens -= num_new_tokens
+                                rem_chunk_tokens_waiting -= num_new_tokens
                                 # SGLang: after admitting one chunked waiting request, break.
                                 chunked_request_admitted_this_step = True
 
@@ -1240,7 +1271,7 @@ class ResourceManagerV1(ResourceManager):
                                 break
 
                         # Allocate blocks for the tokens that does not hit cache
-                        num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
+                        num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens_waiting, rem_input_tokens)
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
                         can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
                             request, num_new_block,
@@ -1262,14 +1293,14 @@ class ResourceManagerV1(ResourceManager):
                             remaining_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
                             is_last_chunk = remaining_to_prefill <= num_new_tokens
 
-                            # SGLang-aligned: chunked requests consume rem_chunk_tokens;
-                            # non-chunked (last) requests consume rem_input_tokens (NOT rem_chunk_tokens).
+                            # SGLang-aligned: chunked requests consume rem_chunk_tokens_waiting;
+                            # non-chunked (last) requests consume rem_input_tokens (NOT rem_chunk_tokens_waiting).
                             if is_last_chunk:
                                 rem_input_tokens -= num_new_tokens
                                 max_new = getattr(request, 'max_new_tokens', self.clip_max_new_tokens_estimation)
                                 scheduled_new_decode_reserved_tokens += min(max_new, self.clip_max_new_tokens_estimation)
                             else:
-                                rem_chunk_tokens -= num_new_tokens
+                                rem_chunk_tokens_waiting -= num_new_tokens
                                 chunked_request_admitted_this_step = True
 
                             request.num_computed_tokens += num_new_tokens
@@ -1295,17 +1326,17 @@ class ResourceManagerV1(ResourceManager):
             if scheduled_reqs:
                 llm_logger.debug(f"schedued_reqs: {scheduled_reqs}")
 
-            # SGLang-aligned: decay new_token_ratio only when:
+            # Decay new_token_ratio when:
             # - There are decode requests running
             # - No running chunked prefill (has_running_prefill = False)
-            # - No waiting queue (bool(self.waiting) = False)
             # - No prefill was scheduled this round (has_scheduled_prefill = False)
             # - No preemption occurred this round (not preempted_reqs)
-            # This matches SGLang's is_extend_mode = has_running_prefill or bool(self.waiting)
+            # NOTE: do NOT gate on "not self.waiting". When self.waiting is large,
+            # ratio would never decay → block reservation threshold stays high →
+            # no waiting request can ever be admitted → queue never drains (屯土地).
             if (
                 has_decode_requests
                 and not has_running_prefill
-                and not self.waiting
                 and not has_scheduled_prefill
                 and not preempted_reqs
                 and self.current_new_token_ratio > self.min_new_token_ratio
@@ -1324,9 +1355,9 @@ class ResourceManagerV1(ResourceManager):
                 total_blocks = self.total_block_number()
                 free_blocks = self.available_block_num()
                 used_blocks = max(total_blocks - free_blocks, 0)
-                tokens_used = used_blocks * self.config.cache_config.block_size
                 token_usage = used_blocks / total_blocks if total_blocks > 0 else 0.0
                 running_cnt = len(self.running)
+                running_prefill_count = running_cnt - running_decode_count
                 queue_cnt = len(self.waiting)
 
                 prefill_reqs = [
@@ -1336,9 +1367,9 @@ class ResourceManagerV1(ResourceManager):
 
                 self.scheduler_metrics_logger.log_prefill_batch(
                     prefill_reqs=prefill_reqs,
-                    running_cnt=running_cnt,
+                    running_decode_cnt=running_decode_count,
+                    running_prefill_cnt=running_prefill_count,
                     queue_cnt=queue_cnt,
-                    tokens_used=tokens_used,
                     token_usage=token_usage,
                 )
                 if has_decode:
@@ -1360,9 +1391,9 @@ class ResourceManagerV1(ResourceManager):
                         )
                     )
                     self.scheduler_metrics_logger.log_decode_batch(
-                        running_cnt=running_cnt,
+                        running_decode_cnt=running_decode_count,
+                        running_prefill_cnt=running_prefill_count,
                         queue_cnt=queue_cnt,
-                        tokens_used=tokens_used,
                         token_usage=token_usage,
                         use_cudagraph=use_decode_cudagraph,
                     )

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -202,18 +202,28 @@ class ResourceManagerV1(ResourceManager):
         self.bos_client = None
         self.async_preprocess_pool = ThreadPoolExecutor(max_workers=4)
 
-        self.init_reserve_output_block_num = (
-            envs.FD_RESERVE_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL
-        )  # int
-        self.decay_output_block_num = (
-            envs.FD_RESERVE_DECAY_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL
-        )  # float
-        self.min_reserve_output_block_num = (
-            envs.FD_RESERVE_MIN_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL
-        )  # int
-        self.current_reserve_output_block_num = self.init_reserve_output_block_num
-        self.current_reserve_output_block_num_float = self.init_reserve_output_block_num
-        self.can_relax_prefill_strategy = True
+        # New token ratio mechanism for dynamic decode reservation (inspired by SGLang)
+        # This replaces the fixed per-request block reservation with a ratio-based approach
+        schedule_conservativeness = 1.0  # Can be made configurable via SchedulerConfig later
+        self.init_new_token_ratio = min(
+            envs.FD_INIT_NEW_TOKEN_RATIO * schedule_conservativeness,
+            1.0,
+        )
+        self.min_new_token_ratio = min(
+            self.init_new_token_ratio * envs.FD_MIN_NEW_TOKEN_RATIO_FACTOR,
+            1.0,
+        )
+        self.new_token_ratio_decay = (
+            self.init_new_token_ratio - self.min_new_token_ratio
+        ) / envs.FD_NEW_TOKEN_RATIO_DECAY_STEPS
+        self.current_new_token_ratio = self.init_new_token_ratio
+        self.clip_max_new_tokens_estimation = envs.FD_CLIP_MAX_NEW_TOKENS_ESTIMATION
+
+        llm_logger.info(
+            f"NewTokenRatio initialized: init={self.init_new_token_ratio:.3f}, "
+            f"min={self.min_new_token_ratio:.3f}, decay_per_step={self.new_token_ratio_decay:.6f}, "
+            f"clip_max_tokens={self.clip_max_new_tokens_estimation}"
+        )
 
     def allocated_slots(self, request: Request):
         return len(request.block_tables) * self.config.cache_config.block_size
@@ -246,8 +256,8 @@ class ResourceManagerV1(ResourceManager):
                 request = self.requests[request_id]
                 if process_func is not None:
                     process_func(request)
-                llm_logger.debug(f"self.waiting append request:{request.request_id},req.type:{request.status}")
-                self.waiting.appendleft(request)
+                llm_logger.debug(f"self.waiting append request to end:{request.request_id},req.type:{request.status}")
+                self.waiting.append(request)  # Append to end of queue (FIFO order)
                 self.to_be_rescheduled_request_id_set.remove(request_id)
 
     def _info_each_block(self):
@@ -303,64 +313,264 @@ class ResourceManagerV1(ResourceManager):
 
     def _trigger_preempt(self, request, num_new_blocks, preempted_reqs, scheduled_reqs):
         """
-        If the request cannot be scheduled, preempt the running request one by one until it can be scheduled. Last in, first out.
+        SGLang-aligned retract_decode: when a decode request cannot get enough blocks,
+        evict prefix cache first, then kick out other decode requests one by one
+        (shortest output / longest input first) until there is enough memory,
+        always keeping at least 1 request.
+
+        Mirrors SGLang's release_req flow:
+          _free_blocks(req)  →  evict remaining * RETRACT_DECODE_STEPS tokens  →  check again
         """
-        can_schedule = False
-        while self._can_preempt():
-            if not self.cache_manager.can_allocate_gpu_blocks(num_new_blocks):
-                preempted_req = self.running.pop()
-                if preempted_req.use_extend_tables:
-                    self.running.insert(0, preempted_req)
-                    continue
-                preempted_req.status = RequestStatus.PREEMPTED
-                preempted_req.num_computed_tokens = 0
-                if self.config.scheduler_config.splitwise_role == "decode":
-                    self.tasks_list[preempted_req.idx] = None
-                    self.stop_flags[preempted_req.idx] = True
-                    if preempted_req.request_id in self.requests:
-                        del self.requests[preempted_req.request_id]
-                    if preempted_req.request_id in self.req_dict:
-                        del self.req_dict[preempted_req.request_id]
-                    self._free_blocks(preempted_req)
-                    llm_logger.info(f"Preemption is triggered! Preempted request id: {preempted_req.request_id}")
-                else:
-                    self._free_blocks(preempted_req)
-                    preempted_req.num_cached_blocks = 0
-                    self.to_be_rescheduled_request_id_set.add(preempted_req.request_id)
-                    llm_logger.info(f"Preemption is triggered! Preempted request id: {preempted_req.request_id}")
-                preempted_reqs.append(preempted_req)
-                scheduled_reqs.append(self._prepare_preempt_task(preempted_req))
+        # Collect decode requests sorted: shorter output / longer input popped first
+        # (reverse=True so pop() removes the last element = shortest output)
+        decode_requests = [
+            req for req in self.running
+            if req.num_computed_tokens >= req.need_prefill_tokens
+        ]
+        decode_requests.sort(
+            key=lambda r: (len(r.output_token_ids), -r.prompt_token_ids_len),
+            reverse=True,
+        )
 
-                llm_logger.debug(
-                    f"preempt {preempted_req.request_id} in idx {preempted_req.idx} with generated ids {preempted_req.output_token_ids}"
-                )
-                llm_logger.debug(self.info())
-                self._info_each_block()
+        # First: try evicting prefix cache only (SGLang's evict_from_tree_cache before retract loop)
+        self._evict_decode_kv_cache(len(decode_requests))
+        if self.cache_manager.can_allocate_gpu_blocks(num_new_blocks):
+            return True
 
-                if preempted_req == request:
-                    # No more request to preempt.
-                    can_schedule = False
-                    break
-            else:
-                # The request can be scheduled.
-                can_schedule = True
+        # Need at least 2 decode requests to be able to kick one out
+        if len(decode_requests) <= 1:
+            return False
+
+        preempted_count = 0
+        # SGLang while loop: kick one, re-check, until memory is enough or only 1 left
+        while not self.cache_manager.can_allocate_gpu_blocks(num_new_blocks):
+            if len(decode_requests) <= 1:
                 break
-        self.current_reserve_output_block_num = self.init_reserve_output_block_num
-        self.current_reserve_output_block_num_float = self.init_reserve_output_block_num
-        self.can_relax_prefill_strategy = False
-        return can_schedule
 
-    def _get_can_schedule_prefill_threshold_block(self, request, num_chunk_new_block):
-        if self.can_relax_prefill_strategy:
-            can_schedule_block_num_threshold = num_chunk_new_block
-        else:
-            can_schedule_block_num_threshold = (
-                request.need_prefill_tokens + self.config.cache_config.block_size - 1
-            ) // self.config.cache_config.block_size + len(self.running) * self.current_reserve_output_block_num
-            if self.config.speculative_config.method is not None:
-                can_schedule_block_num_threshold = min(
-                    can_schedule_block_num_threshold + 1, self.config.cache_config.max_block_num_per_seq
+            preempted_req = decode_requests.pop()  # shortest output first
+
+            # Remove from running list and release KV (sync, FD style via _free_blocks)
+            self.running.remove(preempted_req)
+            preempted_req.status = RequestStatus.PREEMPTED
+            preempted_req.num_computed_tokens = 0
+            preempted_req.is_retracted = True
+
+            if self.config.scheduler_config.splitwise_role == "decode":
+                self.tasks_list[preempted_req.idx] = None
+                self.stop_flags[preempted_req.idx] = True
+                if preempted_req.request_id in self.requests:
+                    del self.requests[preempted_req.request_id]
+                if preempted_req.request_id in self.req_dict:
+                    del self.req_dict[preempted_req.request_id]
+                self._free_blocks(preempted_req)
+            else:
+                self._free_blocks(preempted_req)
+                preempted_req.num_cached_blocks = 0
+                self.to_be_rescheduled_request_id_set.add(preempted_req.request_id)
+
+            preempted_reqs.append(preempted_req)
+            scheduled_reqs.append(self._prepare_preempt_task(preempted_req))
+            preempted_count += 1
+
+            llm_logger.info(
+                f"Preemption triggered: {preempted_req.request_id} "
+                f"(output_len={len(preempted_req.output_token_ids)}, "
+                f"input_len={preempted_req.prompt_token_ids_len}, "
+                f"running={len(self.running)}, waiting={len(self.waiting)}, "
+                f"ratio={self.current_new_token_ratio:.4f})"
+            )
+
+            # SGLang: after each retraction evict remaining * RETRACT_DECODE_STEPS tokens
+            self._evict_decode_kv_cache(len(decode_requests))
+
+        if preempted_count > 0:
+            llm_logger.debug(self.info())
+            self._info_each_block()
+            self._update_new_token_ratio_after_preemption()
+
+        return self.cache_manager.can_allocate_gpu_blocks(num_new_blocks)
+
+    def _evict_decode_kv_cache(self, remaining_req_count: int):
+        """
+        Evict KV cache from tree cache after retracting a decode request.
+        SGLang-aligned: each retraction triggers eviction of retract_decode_steps * remaining_req_count tokens.
+        """
+        retract_decode_steps = getattr(self, 'retract_decode_steps', 20)
+        num_tokens_to_evict = remaining_req_count * retract_decode_steps
+
+        if self.cache_manager is not None:
+            block_size = self.config.cache_config.block_size
+            num_blocks_to_evict = (num_tokens_to_evict + block_size - 1) // block_size
+            llm_logger.debug(
+                f"Evicting {num_blocks_to_evict} blocks "
+                f"(={num_tokens_to_evict} tokens) from GPU cache"
+            )
+            self.cache_manager.free_block_ids(num_blocks_to_evict)
+
+    def _update_new_token_ratio_after_preemption(self):
+        """
+        Update current_new_token_ratio based on remaining running decode requests.
+        SGLang's formula: new_ratio = (total_decoded + retract_decode_steps * num_reqs) / (total_max_new + 1)
+        """
+        decode_reqs = [
+            req for req in self.running
+            if req.num_computed_tokens >= req.need_prefill_tokens
+        ]
+
+        if len(decode_reqs) == 0:
+            llm_logger.debug(
+                f"No decode requests after preemption, keeping current_new_token_ratio={self.current_new_token_ratio:.3f}"
+            )
+            return
+
+        total_decoded_tokens = 0
+        total_max_new_tokens = 0
+
+        for req in decode_reqs:
+            already_decoded = len(req.output_token_ids)
+            total_decoded_tokens += already_decoded
+
+            if req.sampling_params and req.sampling_params.max_tokens is not None:
+                max_new_tokens = req.sampling_params.max_tokens
+            else:
+                max_new_tokens = self.config.model_config.max_model_len - req.need_prefill_tokens
+            total_max_new_tokens += max_new_tokens
+
+        retract_decode_steps = getattr(self, 'retract_decode_steps', 20)
+        num_decode_reqs = len(decode_reqs)
+
+        new_ratio = (
+            total_decoded_tokens + retract_decode_steps * num_decode_reqs
+        ) / (total_max_new_tokens + 1)
+
+        # SGLang-aligned: clamp to (0, 1.0] only, NO min_new_token_ratio floor.
+        new_ratio = min(1.0, max(new_ratio, 1e-6))
+
+        llm_logger.info(
+            f"Update new_token_ratio after preemption: "
+            f"decode_reqs={num_decode_reqs}, decoded={total_decoded_tokens}, "
+            f"max_new={total_max_new_tokens}, ratio={new_ratio:.4f} "
+            f"(was {self.current_new_token_ratio:.4f})"
+        )
+
+        self.current_new_token_ratio = new_ratio
+
+    def reset_new_token_ratio_on_idle(self):
+        """Reset new_token_ratio when system is completely idle (SGLang self_check_during_idle)."""
+        if len(self.running) == 0 and len(self.waiting) == 0:
+            if self.current_new_token_ratio != self.init_new_token_ratio:
+                llm_logger.debug(
+                    f"System completely idle, resetting new_token_ratio "
+                    f"from {self.current_new_token_ratio:.3f} to {self.init_new_token_ratio:.3f}"
                 )
+                self.current_new_token_ratio = self.init_new_token_ratio
+
+    def _calculate_decode_reserved_tokens_by_ratio(self):
+        """
+        Calculate total reserved tokens for all running decode requests based on current_new_token_ratio.
+        SGLang-aligned: only count requests in decode phase.
+        """
+        total_reserved_tokens = 0
+        num_decode_reqs = 0
+
+        for req in self.running:
+            if req.num_computed_tokens < req.need_prefill_tokens:
+                continue  # Still in prefill, skip
+
+            num_decode_reqs += 1
+
+            if req.sampling_params and req.sampling_params.max_tokens is not None:
+                max_new_tokens = req.sampling_params.max_tokens
+            else:
+                max_new_tokens = self.config.model_config.max_model_len - req.need_prefill_tokens
+
+            already_decoded = len(req.output_token_ids)
+            remaining_tokens = min(
+                max_new_tokens - already_decoded,
+                self.clip_max_new_tokens_estimation,
+            )
+
+            reserved_tokens = remaining_tokens * self.current_new_token_ratio
+            total_reserved_tokens += reserved_tokens
+
+        llm_logger.debug(
+            f"Decode reservation: {num_decode_reqs} decode reqs, "
+            f"{total_reserved_tokens:.1f} tokens, ratio={self.current_new_token_ratio:.3f}"
+        )
+
+        return total_reserved_tokens
+
+    def _calculate_decode_reserved_tokens_for_new_requests(self, new_decode_reserved_tokens: float):
+        """Return pre-computed reserved tokens for NEW decode requests in this cycle."""
+        return new_decode_reserved_tokens
+
+    def _get_can_schedule_prefill_threshold_block(
+        self,
+        request,
+        num_chunk_new_block,
+        new_decode_reserved_tokens: float = 0.0,
+        cached_running_decode_reserved: float = 0.0,
+    ):
+        """
+        Calculate the total blocks needed to safely admit a new prefill chunk.
+        SGLang-aligned: current chunk blocks + decode reservation (last chunk only).
+        The check is: free_blocks >= threshold.
+
+        Total includes:
+        1. Current chunk blocks (num_chunk_new_block) — blocks to allocate NOW
+        2. Decode reservation for THIS request (only if last chunk)
+        3. Decode reservation for ALL running decode requests
+        4. Decode reservation for NEW last-chunk requests admitted this cycle
+        """
+        block_size = self.config.cache_config.block_size
+
+        # 1. Current chunk blocks
+        current_chunk_tokens = num_chunk_new_block * block_size
+
+        # Determine if this is the last chunk (needed for decode reservation)
+        remaining_tokens_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
+        is_last_chunk = remaining_tokens_to_prefill <= num_chunk_new_block * block_size
+
+        # 2. Only reserve max_new_tokens for the LAST chunk
+        max_new_tokens_for_request = 0
+        if is_last_chunk:
+            if hasattr(request, 'sampling_params') and request.sampling_params and request.sampling_params.max_tokens:
+                max_new_tokens_for_request = request.sampling_params.max_tokens
+            else:
+                max_new_tokens_for_request = self.config.model_config.max_model_len - request.need_prefill_tokens
+            max_new_tokens_for_request = min(max_new_tokens_for_request, self.clip_max_new_tokens_estimation)
+
+        # 3. Tokens reserved for ALL running decode requests
+        running_decode_reserved_tokens = cached_running_decode_reserved
+
+        # 4. Tokens reserved for NEW decode requests in this cycle
+        cycle_new_decode_reserved = self._calculate_decode_reserved_tokens_for_new_requests(
+            new_decode_reserved_tokens
+        )
+
+        total_tokens = (
+            current_chunk_tokens
+            + max_new_tokens_for_request
+            + running_decode_reserved_tokens
+            + cycle_new_decode_reserved
+        )
+        can_schedule_block_num_threshold = (
+            total_tokens + block_size - 1
+        ) // block_size
+
+        if self.config.speculative_config.method is not None:
+            can_schedule_block_num_threshold = min(
+                can_schedule_block_num_threshold + 1, self.config.cache_config.max_block_num_per_seq
+            )
+
+        llm_logger.debug(
+            f"Prefill threshold: tokens={total_tokens:.1f} -> blocks={can_schedule_block_num_threshold} "
+            f"(chunk={current_chunk_tokens}, future_decode={max_new_tokens_for_request:.1f}, "
+            f"running_decode_reserved={running_decode_reserved_tokens:.1f}, "
+            f"new_decode_reserved={cycle_new_decode_reserved:.1f}, "
+            f"is_last_chunk={is_last_chunk})"
+        )
+
         return can_schedule_block_num_threshold
 
     def _update_mm_hashes(self, request):
@@ -448,16 +658,20 @@ class ResourceManagerV1(ResourceManager):
                 break
         return matched_token_num
 
-    def _get_num_new_tokens(self, request, token_budget):
-        # TODO: set condition to new _get_num_new_tokens
-        num_new_tokens = request.need_prefill_tokens - request.num_computed_tokens
-        num_new_tokens = min(num_new_tokens, token_budget)
-        if (
-            current_platform.is_intel_hpu()
-            and request.need_prefill_tokens - request.num_computed_tokens > token_budget
-            and token_budget > self.config.cache_config.block_size
-        ):
-            num_new_tokens = token_budget // self.config.cache_config.block_size * self.config.cache_config.block_size
+    def _get_num_new_tokens(self, request, rem_chunk_tokens, rem_input_tokens):
+        # SGLang-aligned: num_new_tokens = min(remaining, rem_chunk_tokens, rem_input_tokens)
+        remaining = request.need_prefill_tokens - request.num_computed_tokens
+        num_new_tokens = min(remaining, rem_chunk_tokens, rem_input_tokens)
+
+        block_size = self.config.cache_config.block_size
+        is_truncated = num_new_tokens < remaining
+
+        if current_platform.is_intel_hpu():
+            if is_truncated and min(rem_chunk_tokens, rem_input_tokens) > block_size:
+                num_new_tokens = num_new_tokens // block_size * block_size
+        elif block_size > 1 and is_truncated:
+            # SGLang-aligned: floor-align truncated chunk to block boundary
+            num_new_tokens = num_new_tokens // block_size * block_size
         request.with_image = False
 
         if not self.config.model_config.enable_mm:
@@ -662,12 +876,35 @@ class ResourceManagerV1(ResourceManager):
             scheduled_reqs: list[Request] = []
             preempted_reqs: list[Request] = []
             error_reqs: list[tuple[str, str]] = []
-            token_budget = self.config.scheduler_config.max_num_batched_tokens
+
+            # Single-pass over self.running: compute running_decode_count, has_running_prefill,
+            # has_decode_requests
+            _block_size = self.config.cache_config.block_size
+            running_decode_count = 0
+            has_running_prefill = False
+            has_decode_requests = False
+            for _r in self.running:
+                if _r.num_computed_tokens >= _r.need_prefill_tokens:
+                    running_decode_count += 1
+                    has_decode_requests = True
+                else:
+                    has_running_prefill = True
+
+            # Track whether any prefill was actually scheduled this round (for decay condition)
+            has_scheduled_prefill = False
+
+            # SGLang-aligned chunked_prefill_size
+            chunked_prefill_size = envs.FD_CHUNKED_PREFILL_SIZE
+
+            # rem_chunk_tokens: per-step chunk token budget (SGLang's chunked_prefill_size)
+            rem_chunk_tokens = chunked_prefill_size
+            # rem_input_tokens: total input budget (SGLang's max_prefill_tokens - mixed_with_decode_tokens)
+            rem_input_tokens = envs.FD_REM_INPUT_TOKENS - running_decode_count
 
             # First, schedule the RUNNING requests.
             req_index = 0
             num_decoding_req_nums = 0
-            while req_index < len(self.running) and token_budget > 0:
+            while req_index < len(self.running):
                 request = self.running[req_index]
                 need_block_num = self.need_block_num_signal.value[request.idx]
                 if need_block_num != 0:
@@ -714,7 +951,6 @@ class ResourceManagerV1(ResourceManager):
                             # Prepare decoding task
                             scheduled_reqs.append(self._prepare_decode_task(request))
                         num_decoding_req_nums += 1
-                    token_budget -= 1
                     if (
                         request.use_extend_tables
                         and request.request_id not in self.using_extend_tables_req_id
@@ -780,14 +1016,18 @@ class ResourceManagerV1(ResourceManager):
                         current_platform.is_intel_hpu()
                         and request.need_prefill_tokens - request.num_computed_tokens
                         >= self.config.cache_config.block_size
-                        and token_budget < self.config.cache_config.block_size
+                        and rem_input_tokens < self.config.cache_config.block_size
                     ):
                         req_index += 1
                         continue
                     if get_enough_request(request, scheduled_reqs):
                         req_index += 1
                         continue
-                    num_new_tokens = self._get_num_new_tokens(request, token_budget)
+                    # Apply rem_chunk_tokens batch-level constraint for running prefills too
+                    if rem_chunk_tokens <= 0:
+                        req_index += 1
+                        continue
+                    num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
                     num_new_block = self.get_new_block_nums(request, num_new_tokens)
                     # Allocate blocks to prefill
                     if self.cache_manager.can_allocate_gpu_blocks(num_new_block):
@@ -805,7 +1045,9 @@ class ResourceManagerV1(ResourceManager):
                         )
                         # Prepare prefill task
                         scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
-                    token_budget -= num_new_tokens
+                    has_scheduled_prefill = True
+                    rem_input_tokens -= num_new_tokens
+                    rem_chunk_tokens -= num_new_tokens
                     request.num_computed_tokens += num_new_tokens
                     if self.config.cache_config.enable_prefix_caching:
                         self.cache_manager.update_cache_blocks(
@@ -815,8 +1057,13 @@ class ResourceManagerV1(ResourceManager):
 
             # Second, schedule the WAITING requests.
             if not preempted_reqs:
+                # Compute running decode reservation once per schedule() call
+                cached_running_decode_reserved = self._calculate_decode_reserved_tokens_by_ratio()
+                # Track decode reservations accumulated within this cycle's waiting loop
+                scheduled_new_decode_reserved_tokens: float = 0.0
+
                 skip_requests: list[Request] = []
-                while self.waiting and token_budget > 0:
+                while self.waiting and rem_input_tokens > 0 and rem_chunk_tokens > 0:
                     if len(self.running) == self.max_num_seqs:
                         break
 
@@ -856,14 +1103,16 @@ class ResourceManagerV1(ResourceManager):
                             current_platform.is_intel_hpu()
                             and request.need_prefill_tokens - request.num_computed_tokens
                             >= self.config.cache_config.block_size
-                            and token_budget < self.config.cache_config.block_size
+                            and rem_input_tokens < self.config.cache_config.block_size
                         ):
                             continue
                         # Allocate blocks for the tokens that does not hit cache
-                        num_new_tokens = self._get_num_new_tokens(request, token_budget)
+                        num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
                         can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
-                            request, num_new_block
+                            request, num_new_block,
+                            scheduled_new_decode_reserved_tokens,
+                            cached_running_decode_reserved,
                         )
                         # Allocate blocks to prefill
                         if self.cache_manager.can_allocate_gpu_blocks(can_schedule_block_num_threshold):
@@ -875,7 +1124,17 @@ class ResourceManagerV1(ResourceManager):
                             self.waiting.popleft()
                             self.running.append(request)
                             scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
-                            token_budget -= num_new_tokens
+                            has_scheduled_prefill = True
+                            rem_input_tokens -= num_new_tokens
+                            rem_chunk_tokens -= num_new_tokens
+
+                            # Track decode reservation for last-chunk requests
+                            remaining_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
+                            is_last_chunk = remaining_to_prefill <= num_new_tokens
+                            if is_last_chunk:
+                                max_new = getattr(request, 'max_new_tokens', self.clip_max_new_tokens_estimation)
+                                scheduled_new_decode_reserved_tokens += min(max_new, self.clip_max_new_tokens_estimation)
+
                             request.num_computed_tokens += num_new_tokens
                             if self.config.cache_config.enable_prefix_caching:
                                 self.cache_manager.update_cache_blocks(
@@ -913,10 +1172,12 @@ class ResourceManagerV1(ResourceManager):
                                 break
 
                         # Allocate blocks for the tokens that does not hit cache
-                        num_new_tokens = self._get_num_new_tokens(request, token_budget)
+                        num_new_tokens = self._get_num_new_tokens(request, rem_chunk_tokens, rem_input_tokens)
                         num_new_block = self.get_new_block_nums(request, num_new_tokens)
                         can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
-                            request, num_new_block
+                            request, num_new_block,
+                            scheduled_new_decode_reserved_tokens,
+                            cached_running_decode_reserved,
                         )
                         # Allocate blocks to prefill
                         if self.cache_manager.can_allocate_gpu_blocks(can_schedule_block_num_threshold):
@@ -928,7 +1189,17 @@ class ResourceManagerV1(ResourceManager):
                             self.waiting.popleft()
                             self.running.append(request)
                             scheduled_reqs.append(self._prepare_prefill_task(request, num_new_tokens))
-                            token_budget -= num_new_tokens
+                            has_scheduled_prefill = True
+                            rem_input_tokens -= num_new_tokens
+                            rem_chunk_tokens -= num_new_tokens
+
+                            # Track decode reservation for last-chunk requests
+                            remaining_to_prefill = request.need_prefill_tokens - request.num_computed_tokens
+                            is_last_chunk = remaining_to_prefill <= num_new_tokens
+                            if is_last_chunk:
+                                max_new = getattr(request, 'max_new_tokens', self.clip_max_new_tokens_estimation)
+                                scheduled_new_decode_reserved_tokens += min(max_new, self.clip_max_new_tokens_estimation)
+
                             request.num_computed_tokens += num_new_tokens
                             if self.config.cache_config.enable_prefix_caching:
                                 self.cache_manager.update_cache_blocks(
@@ -948,14 +1219,21 @@ class ResourceManagerV1(ResourceManager):
 
             if scheduled_reqs:
                 llm_logger.debug(f"schedued_reqs: {scheduled_reqs}")
-                self.current_reserve_output_block_num_float -= self.decay_output_block_num
-                self.current_reserve_output_block_num = max(
-                    int(self.current_reserve_output_block_num_float),
-                    self.min_reserve_output_block_num,
-                    0,
+
+            # SGLang-aligned: decay new_token_ratio only when no prefill was actually scheduled
+            # this round and there are decode requests running.
+            if (
+                scheduled_reqs
+                and not has_scheduled_prefill
+                and not preempted_reqs
+                and has_decode_requests
+                and self.current_new_token_ratio > self.min_new_token_ratio
+            ):
+                self.current_new_token_ratio = max(
+                    self.current_new_token_ratio - self.new_token_ratio_decay,
+                    self.min_new_token_ratio,
                 )
-                if self.current_reserve_output_block_num == 0:
-                    self.can_relax_prefill_strategy = True
+                llm_logger.info(f"Decayed new_token_ratio to {self.current_new_token_ratio:.4f}")
 
             if (
                 hasattr(self, "scheduler_metrics_logger")

--- a/fastdeploy/engine/sched/scheduler_metrics_logger.py
+++ b/fastdeploy/engine/sched/scheduler_metrics_logger.py
@@ -27,7 +27,7 @@ class SchedulerMetricsLogger:
     Lightweight console logger for scheduler-level prefill/decode metrics.
     """
 
-    DEFAULT_DECODE_LOG_INTERVAL = 5
+    DEFAULT_DECODE_LOG_INTERVAL = 1
 
     def __init__(self, enabled: bool = True, dp_rank: int = 0) -> None:
         self.enabled = enabled
@@ -37,7 +37,6 @@ class SchedulerMetricsLogger:
             decode_log_interval = self.DEFAULT_DECODE_LOG_INTERVAL
         self._lock = threading.Lock()
         self._decode_log_interval = decode_log_interval
-        self._decode_batch_count = 0
         self._last_decode_tic = time.perf_counter()
         self._decode_tokens_since_last = 0
         self._logger = self._get_logger()
@@ -111,11 +110,10 @@ class SchedulerMetricsLogger:
         if not self.enabled:
             return
         with self._lock:
-            self._decode_batch_count += 1
-            if self._decode_batch_count % self._decode_log_interval != 0:
-                return
             now = time.perf_counter()
             elapsed = now - self._last_decode_tic
+            if elapsed < self._decode_log_interval:
+                return
             if elapsed > 0:
                 throughput = self._decode_tokens_since_last / elapsed
             else:

--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -192,16 +192,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "FD_XPU_ENABLE_MIXED_EP_MODE": lambda: bool(int(os.getenv("FD_XPU_ENABLE_MIXED_EP_MODE", "0"))),
     # Whether to use phi FP8 quantization,if 1,use paddle default.
     "FD_USE_PHI_FP8_QUANT": lambda: bool(int(os.getenv("FD_USE_PHI_FP8_QUANT", "1"))),
-    # Reserve output blocks for decoding requests when schedule new prefill requests
-    "FD_RESERVE_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL": lambda: int(
-        os.getenv("FD_RESERVE_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL", "16")
-    ),
-    "FD_RESERVE_DECAY_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL": lambda: float(
-        os.getenv("FD_RESERVE_DECAY_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL", "0.025")
-    ),
-    "FD_RESERVE_MIN_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL": lambda: int(
-        os.getenv("FD_RESERVE_MIN_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL", "0")
-    ),
+    # Token-ratio-based decode reservation (SGLang-aligned)
+    "FD_INIT_NEW_TOKEN_RATIO": lambda: float(os.getenv("FD_INIT_NEW_TOKEN_RATIO", "0.7")),
+    "FD_MIN_NEW_TOKEN_RATIO_FACTOR": lambda: float(os.getenv("FD_MIN_NEW_TOKEN_RATIO_FACTOR", "0.14")),
+    "FD_NEW_TOKEN_RATIO_DECAY_STEPS": lambda: int(os.getenv("FD_NEW_TOKEN_RATIO_DECAY_STEPS", "600")),
+    "FD_RETRACT_DECODE_STEPS": lambda: int(os.getenv("FD_RETRACT_DECODE_STEPS", "20")),
+    "FD_CLIP_MAX_NEW_TOKENS_ESTIMATION": lambda: int(os.getenv("FD_CLIP_MAX_NEW_TOKENS_ESTIMATION", "4096")),
+    # Chunked prefill size: per-request chunk token limit (similar to SGLang's rem_chunk_tokens)
+    "FD_CHUNKED_PREFILL_SIZE": lambda: int(os.getenv("FD_CHUNKED_PREFILL_SIZE", "8192")),
+    # Rem input tokens: batch-level total prefill input budget (similar to SGLang's rem_input_tokens)
+    "FD_REM_INPUT_TOKENS": lambda: int(os.getenv("FD_REM_INPUT_TOKENS", "16384")),
     # Timeout for worker process health check in seconds
     "FD_WORKER_ALIVE_TIMEOUT": lambda: int(os.getenv("FD_WORKER_ALIVE_TIMEOUT", "30")),
     # File path for file storage backend

--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -194,7 +194,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "FD_USE_PHI_FP8_QUANT": lambda: bool(int(os.getenv("FD_USE_PHI_FP8_QUANT", "1"))),
     # Token-ratio-based decode reservation (SGLang-aligned)
     "FD_INIT_NEW_TOKEN_RATIO": lambda: float(os.getenv("FD_INIT_NEW_TOKEN_RATIO", "0.7")),
-    "FD_MIN_NEW_TOKEN_RATIO_FACTOR": lambda: float(os.getenv("FD_MIN_NEW_TOKEN_RATIO_FACTOR", "0.14")),
+    "FD_MIN_NEW_TOKEN_RATIO_FACTOR": lambda: float(os.getenv("FD_MIN_NEW_TOKEN_RATIO_FACTOR", "0.30")),
     "FD_NEW_TOKEN_RATIO_DECAY_STEPS": lambda: int(os.getenv("FD_NEW_TOKEN_RATIO_DECAY_STEPS", "600")),
     "FD_RETRACT_DECODE_STEPS": lambda: int(os.getenv("FD_RETRACT_DECODE_STEPS", "20")),
     "FD_CLIP_MAX_NEW_TOKENS_ESTIMATION": lambda: int(os.getenv("FD_CLIP_MAX_NEW_TOKENS_ESTIMATION", "4096")),

--- a/fastdeploy/scheduler/local_scheduler.py
+++ b/fastdeploy/scheduler/local_scheduler.py
@@ -266,32 +266,16 @@ class LocalScheduler:
             )
 
             requests: List[Request] = []
-            required_total_blocks = 0
-            current_prefill_tokens = 0
-            long_partial_requests, short_partial_requests = 0, 0
             for request_id in batch_ids:
                 request = self.requests[request_id]
-                required_input_blocks = self.calc_required_blocks(request.prompt_tokens_ids_len, block_size)
-                current_prefill_tokens += request.prompt_tokens_ids_len
-                required_total_blocks += required_input_blocks + reserved_output_blocks
-                if required_total_blocks > available_blocks:
-                    break
-
+                # No block accumulation check here - resource_manager_v1 handles
+                # actual scheduling with chunked prefill and proper admission control
                 if not envs.FD_ENABLE_MAX_PREFILL:
                     if self.enable_chunked_prefill:
                         if request.prompt_tokens_ids_len > self.long_prefill_token_threshold:
-                            # 长请求
-                            long_partial_requests += 1
-                            if long_partial_requests > self.max_long_partial_prefills:
-                                break
-                        else:
-                            short_partial_requests += 1
-
-                        if short_partial_requests + long_partial_requests > self.max_num_partial_prefills:
-                            break
+                            pass  # long request tracking removed - handled by resource_manager
                     else:
-                        if current_prefill_tokens > max_num_batched_tokens and len(requests) > 0:
-                            break
+                        pass  # non-chunked limit removed - handled by resource_manager
                 requests.append(request.raw)
 
             self.ids_read_cursor += len(requests)


### PR DESCRIPTION
 Scheduler Refactor (ResourceManagerV1): Ratio-based Decode Reservation, Chunked Prefill, and Retract-style Preemption

## Changed Files

- `fastdeploy/engine/sched/resource_manager_v1.py`
- `fastdeploy/envs.py`
- `fastdeploy/scheduler/local_scheduler.py`
- `fastdeploy/engine/sched/scheduler_metrics_logger.py`

---

## 1) `resource_manager_v1.py`: Core Implementation Changes

### 1.1 Introduce `active_chunked_prefill_req` (single active chunked prefill)

- Added state:
  - `self.active_chunked_prefill_req: Request | None = None`
- Added helpers:
  - `_num_active_running_requests()` (counts `active_chunked_prefill_req` into running metrics)
  - `_ensure_request_slot_allocated(request)` (ensures `tasks_list/stop_flags/req_dict` slot correctness in mixed mode)
- Integrated `active_chunked_prefill_req` handling into lifecycle paths:
  - `preempted_all()`
  - `wait_worker_inflight_requests_finish()`
  - `pre_recycle_resource()`
  - `finish_requests()`
  - `clear_data()`
  - `update_metrics()` and `log_status()` (running/waiting counters updated)

---

### 1.2 Decode reservation: replace fixed block reservation with `new_token_ratio` (ratio-based)

- Removed the fixed per-request block reservation mechanism (`reserve_output_block_num` family):
  - `init_reserve_output_block_num / decay_output_block_num / min_reserve_output_block_num`
  - `current_reserve_output_block_num / current_reserve_output_block_num_float`
  - `can_relax_prefill_strategy`
- Added ratio-based reservation fields:
  - `init_new_token_ratio`
  - `min_new_token_ratio`
  - `new_token_ratio_decay`
  - `current_new_token_ratio`
  - `clip_max_new_tokens_estimation`
- Added/updated functions:
  - `_calculate_decode_reserved_tokens_by_ratio()` (ratio-based reserved token estimation for running decode-phase requests)
  - `_calculate_decode_reserved_tokens_for_new_requests(new_decode_reserved_tokens)` (per-cycle accumulation for newly admitted last-chunk requests)
  - `_update_new_token_ratio_after_preemption()` (update ratio after preemption based on remaining decode state)
  - `reset_new_token_ratio_on_idle()` (reset ratio back to init when system is fully idle)
- Prefill admission threshold refactor:
  - `_get_can_schedule_prefill_threshold_block(...)` signature extended with:
    - `is_last_chunk`
    - `new_decode_reserved_tokens`
    - `cached_running_decode_reserved`
  - Threshold now accounts for:
    - current chunk tokens/blocks
    - future decode tokens for last chunk
    - reserved tokens from running decode requests (ratio-based)
    - reserved tokens from newly admitted last-chunk requests in the same cycle

---

### 1.3 Chunked prefill scheduling and budgets (SGLang-aligned)

- Added per-step chunk budget and batch input budget:
  - `chunked_prefill_size = envs.FD_CHUNKED_PREFILL_SIZE`
  - `rem_chunk_tokens = chunked_prefill_size`
  - `rem_input_tokens = envs.FD_REM_INPUT_TOKENS - running_decode_count`
- Added utilities:
  - `_get_paged_prefill_tokens(num_new_tokens)` (align prefill budget to `block_size`)
  - `_is_last_prefill_chunk(request, num_new_tokens)`
- Reworked `_get_num_new_tokens(...)`:
  - Signature changed from `(request, token_budget)` to:
    - `(request, rem_chunk_tokens, rem_input_tokens, existing_prefill_in_batch, ignore_rem_input_budget)`
  - Supports:
    - truncation under `rem_chunk_tokens` with block-aligned chunk sizing
    - `rem_input_tokens` gating (more strict once a prefill chunk is already admitted in the same cycle)
    - existing HPU alignment logic adapted to the new budget model
- `schedule()` main flow changes:
  - If an unfinished prefill exists in `running`, migrate one into `active_chunked_prefill_req` (enforce single active unfinished chunked prefill)
  - Schedule one chunk for `active_chunked_prefill_req` first (if admission threshold passes)
  - Then schedule `waiting` under shared `rem_chunk_tokens/rem_input_tokens` budgets
  - If a `waiting` request becomes a non-last chunk (i.e., chunked), admit it and **break** (at most one newly chunked waiting request per cycle)

---

### 1.4 Preemption refactor: retract-style decode preemption + eviction

- Completely rewrote `_trigger_preempt()`:
  - Preemption candidates restricted to decode-phase requests
  - Selection order changed to:
    - shortest output first + longest input first
    - sorted by `(len(output_token_ids), -prompt_token_ids_len)` and popped
  - Added cache eviction during preemption:
    - `_evict_decode_kv_cache(remaining_req_count)`
    - eviction executed before attempting retraction, and again after each retraction
  - After retraction:
    - `preempted_req.is_retracted = True`
    - `_update_new_token_ratio_after_preemption()` is invoked
- Updated `preempted_all()` to include:
  - preempting `active_chunked_prefill_req` together with `running`
  - special handling of `use_extend_tables` requests to reinsert into `active_chunked_prefill_req` or `running` as appropriate

---

### 1.5 Scheduling order and decode scheduling gate

- Added internal `_schedule_decode_requests()` to handle decode-phase scheduling and block allocation/extend logic
- Enforced scheduling order:
  1) active/running prefill (chunk)
  2) waiting prefill (budget + admission threshold controlled)
  3) decode: only scheduled when **no prefill** was admitted in this cycle and **no preemption** occurred
- Ratio decay condition updated:
  - when decode requests exist, and no prefill is scheduled, and no preemption occurs, `current_new_token_ratio` decays linearly

---

### 1.6 Queue behavior change for rescheduled (preempted) requests

- `reschedule_preempt_task()`:
  - changed from `waiting.appendleft(request)` to `waiting.append(request)` (FIFO append)

---

## 2) `envs.py`: Environment Variables Update

- Removed fixed block reservation envs:
  - `FD_RESERVE_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL`
  - `FD_RESERVE_DECAY_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL`
  - `FD_RESERVE_MIN_OUTPUT_BLOCK_NUM_FOR_DECODE_WHEN_SCHEDULE_NEW_PREFILL`
- Added ratio-based decode reservation + chunked prefill + budget envs:
  - `FD_INIT_NEW_TOKEN_RATIO` (default `0.7`)
  - `FD_MIN_NEW_TOKEN_RATIO_FACTOR` (default `0.30`)
  - `FD_NEW_TOKEN_RATIO_DECAY_STEPS` (default `600`)
  - `FD_RETRACT_DECODE_STEPS` (default `20`)
  - `FD_CLIP_MAX_NEW_TOKENS_ESTIMATION` (default `4096`)
  - `FD_CHUNKED_PREFILL_SIZE` (default `8192`)
  - `FD_REM_INPUT_TOKENS` (default `16384`)

---

## 3) `local_scheduler.py`: Remove block-accumulation admission filtering

- In `get_requests()`, removed:
  - `required_total_blocks/current_prefill_tokens` accumulation and `available_blocks` break logic
  - long/short partial prefill counters and limits
- Kept:
  - basic request selection (`requests.append(request.raw)`), leaving admission control and chunking to `resource_manager_v1`

---

## 4) `scheduler_metrics_logger.py`: Decode logging interval change

- `DEFAULT_DECODE_LOG_INTERVAL`: `5 -> 1`
- Decode logging trigger changed from:
  - batch-count modulo
  - to elapsed-time threshold check