### PR TITLE
[BugFix] Add lock to avoid generating nan when using storage cache

### DIFF
--- a/fastdeploy/cache_manager/prefix_cache_manager.py
+++ b/fastdeploy/cache_manager/prefix_cache_manager.py
@@ -1251,20 +1251,18 @@ class PrefixCacheManager:
 
         assert is_sync, "Only support is_sync=True for now."
         self._acquire_kvcache_lock()
+        try:
+            if len(task.keys) != len(task.gpu_block_ids):
+                err_msg = f"write_back_storage error: hash_keys({len(task.keys)}) != gpu_block_ids({len(task.gpu_block_ids)})"
+                logger.error(err_msg)
+                raise ValueError(err_msg)
 
-        if len(task.keys) != len(task.gpu_block_ids):
-            err_msg = (
-                f"write_back_storage error: hash_keys({len(task.keys)}) != gpu_block_ids({len(task.gpu_block_ids)})"
-            )
-            logger.error(err_msg)
-            raise ValueError(err_msg)
-
-        self.task_write_back_event[task.task_id] = Event()
-        self.cache_task_queue.put_transfer_task((CacheStatus.GPU2STORAGE, task))
-        if is_sync:
-            self.wait_write_storage_task(task.task_id)
-
-        self._release_kvcache_lock()
+            self.task_write_back_event[task.task_id] = Event()
+            self.cache_task_queue.put_transfer_task((CacheStatus.GPU2STORAGE, task))
+            if is_sync:
+                self.wait_write_storage_task(task.task_id)
+        finally:
+            self._release_kvcache_lock()
 
     def wait_write_storage_task(self, req_id):
         """
@@ -1284,14 +1282,15 @@ class PrefixCacheManager:
         assert is_sync, "Only support is_sync=True for now."
         self._acquire_kvcache_lock()
 
-        storage_block_ids = []
-        self.task_prefetch_event[task.task_id] = Event()
-        # issue task to cache_transfer_manager
-        self.cache_task_queue.put_transfer_task((CacheStatus.STORAGE2GPU, task))
-        if is_sync:
-            storage_block_ids = self.wait_prefetch_storage_task(task.task_id)
-
-        self._release_kvcache_lock()
+        try:
+            storage_block_ids = []
+            self.task_prefetch_event[task.task_id] = Event()
+            # issue task to cache_transfer_manager
+            self.cache_task_queue.put_transfer_task((CacheStatus.STORAGE2GPU, task))
+            if is_sync:
+                storage_block_ids = self.wait_prefetch_storage_task(task.task_id)
+        finally:
+            self._release_kvcache_lock()
         return storage_block_ids
 
     def wait_prefetch_storage_task(self, req_id):

--- a/fastdeploy/cache_manager/prefix_cache_manager.py
+++ b/fastdeploy/cache_manager/prefix_cache_manager.py
@@ -1249,6 +1249,9 @@ class PrefixCacheManager:
         if self.kvcache_storage_backend is None:
             return
 
+        assert is_sync, "Only support is_sync=True for now."
+        self._acquire_kvcache_lock()
+
         if len(task.keys) != len(task.gpu_block_ids):
             err_msg = (
                 f"write_back_storage error: hash_keys({len(task.keys)}) != gpu_block_ids({len(task.gpu_block_ids)})"
@@ -1260,6 +1263,8 @@ class PrefixCacheManager:
         self.cache_task_queue.put_transfer_task((CacheStatus.GPU2STORAGE, task))
         if is_sync:
             self.wait_write_storage_task(task.task_id)
+
+        self._release_kvcache_lock()
 
     def wait_write_storage_task(self, req_id):
         """
@@ -1276,12 +1281,17 @@ class PrefixCacheManager:
         if self.kvcache_storage_backend is None:
             return []
 
+        assert is_sync, "Only support is_sync=True for now."
+        self._acquire_kvcache_lock()
+
         storage_block_ids = []
         self.task_prefetch_event[task.task_id] = Event()
         # issue task to cache_transfer_manager
         self.cache_task_queue.put_transfer_task((CacheStatus.STORAGE2GPU, task))
         if is_sync:
             storage_block_ids = self.wait_prefetch_storage_task(task.task_id)
+
+        self._release_kvcache_lock()
         return storage_block_ids
 
     def wait_prefetch_storage_task(self, req_id):

--- a/fastdeploy/cache_manager/transfer_factory/mooncake_store/mooncake_store.py
+++ b/fastdeploy/cache_manager/transfer_factory/mooncake_store/mooncake_store.py
@@ -150,13 +150,12 @@ class MooncakeStore(KVCacheStorage):
 
     def warmup(self):
         warmup_key = "fastdeploy_mooncake_store_warmup_key" + str(uuid.uuid4())
-        warmup_value = bytes(1 * 1024 * 1024)  # 1 MB
+        warmup_value = bytes(4 * 1024)  # 4 kb
         rc = self.store.put(warmup_key, warmup_value)
         assert rc == 0, f"Failed to put warmup key, key:{warmup_key}, error code: {rc}"
         rc = self.store.is_exist(warmup_key)
         assert rc == 1, f"Failed to check existence, key:{warmup_key}, error code: {rc}"
         self.store.get(warmup_key)
-        self.store.remove(warmup_key)
 
     def register_buffer(self, buffer_ptr, buffer_size) -> None:
         try:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
Add lock to avoid generating nan when using storage cache
<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications
fastdeploy/cache_manager/prefix_cache_manager.py

<!-- Detail the changes made in this pull request. -->

## Usage or Command
none
<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests
none
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
