### PR TITLE
[Refactor] Replace --skip-mm-profiling with --deploy-modality text

### DIFF
--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -233,7 +233,6 @@ class ModelConfig:
         self.partial_rotary_factor: float = 1.0
         self.num_nextn_predict_layers = 0
         self.mm_max_tokens_per_item = None
-        self.skip_mm_profiling = False
         for key, value in args.items():
             if hasattr(self, key) and value != "None":
                 setattr(self, key, value)
@@ -2393,7 +2392,7 @@ class FDConfig:
                 num_tokens = self.scheduler_config.max_num_seqs
         else:
             num_tokens = self.scheduler_config.max_num_batched_tokens
-            if mm_max_tokens_per_item is not None and not self.model_config.skip_mm_profiling:
+            if mm_max_tokens_per_item is not None and self.deploy_modality != DeployModality.TEXT:
                 max_mm_tokens = max(
                     mm_max_tokens_per_item.get("image", 0),
                     mm_max_tokens_per_item.get("video", 0),

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -233,6 +233,7 @@ class ModelConfig:
         self.partial_rotary_factor: float = 1.0
         self.num_nextn_predict_layers = 0
         self.mm_max_tokens_per_item = None
+        self.skip_mm_profiling = False
         for key, value in args.items():
             if hasattr(self, key) and value != "None":
                 setattr(self, key, value)
@@ -2392,7 +2393,7 @@ class FDConfig:
                 num_tokens = self.scheduler_config.max_num_seqs
         else:
             num_tokens = self.scheduler_config.max_num_batched_tokens
-            if mm_max_tokens_per_item is not None:
+            if mm_max_tokens_per_item is not None and not self.model_config.skip_mm_profiling:
                 max_mm_tokens = max(
                     mm_max_tokens_per_item.get("image", 0),
                     mm_max_tokens_per_item.get("video", 0),

--- a/fastdeploy/engine/args_utils.py
+++ b/fastdeploy/engine/args_utils.py
@@ -184,12 +184,6 @@ class EngineArgs:
     """
     Flags to enable multi-modal model
     """
-    skip_mm_profiling: bool = False
-    """
-    Skip multimodal token overhead when calculating max chunk tokens for profiling.
-    When enabled, get_max_chunk_tokens will not add extra mm tokens,
-    which avoids reserving extra GPU memory for multimodal inputs during profiling.
-    """
     speculative_config: Optional[Dict[str, Any]] = None
     """
     Configuration for speculative execution.
@@ -803,12 +797,6 @@ class EngineArgs:
             action=DeprecatedOptionWarning,
             default=EngineArgs.enable_mm,
             help="Flag to enable multi-modal model.",
-        )
-        model_group.add_argument(
-            "--skip-mm-profiling",
-            action="store_true",
-            default=EngineArgs.skip_mm_profiling,
-            help="Skip multimodal token overhead when calculating max chunk tokens for profiling.",
         )
         model_group.add_argument(
             "--reasoning-parser",

--- a/fastdeploy/engine/args_utils.py
+++ b/fastdeploy/engine/args_utils.py
@@ -184,6 +184,12 @@ class EngineArgs:
     """
     Flags to enable multi-modal model
     """
+    skip_mm_profiling: bool = False
+    """
+    Skip multimodal token overhead when calculating max chunk tokens for profiling.
+    When enabled, get_max_chunk_tokens will not add extra mm tokens,
+    which avoids reserving extra GPU memory for multimodal inputs during profiling.
+    """
     speculative_config: Optional[Dict[str, Any]] = None
     """
     Configuration for speculative execution.
@@ -797,6 +803,12 @@ class EngineArgs:
             action=DeprecatedOptionWarning,
             default=EngineArgs.enable_mm,
             help="Flag to enable multi-modal model.",
+        )
+        model_group.add_argument(
+            "--skip-mm-profiling",
+            action="store_true",
+            default=EngineArgs.skip_mm_profiling,
+            help="Skip multimodal token overhead when calculating max chunk tokens for profiling.",
         )
         model_group.add_argument(
             "--reasoning-parser",


### PR DESCRIPTION
## Motivation

原 `--skip-mm-profiling` 参数与已有的 `--deploy-modality` 参数功能存在语义重叠：
当以纯文本模式（`--deploy-modality text`）部署时，本就不需要为多模态 token 预留显存。
引入独立参数增加了配置复杂度，复用 `deploy_modality` 更加直观和一致。

## Modifications

- `fastdeploy/engine/args_utils.py`：删除 `EngineArgs.skip_mm_profiling` 字段及
  `--skip-mm-profiling` 启动参数
- `fastdeploy/config.py`：删除 `ModelConfig.__init__` 中的 `self.skip_mm_profiling = False`；
  `FDConfig.get_max_chunk_tokens` 中将条件改为
  `self.deploy_modality != DeployModality.TEXT`，
  当 deploy_modality 为 text 时直接返回 `max_num_batched_tokens`，跳过 mm token 叠加

## Usage or Command

```bash
# 以文本模式部署，跳过 mm token profiling 开销（替代原 --skip-mm-profiling）
python -m fastdeploy.entrypoints.openai.api_server \
  --deploy-modality text \
  --model /path/to/model \
  ...
```

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. 本次为参数重构，逻辑等价替换，已有 config 单元测试覆盖。