### PR TITLE
[CI] Align with Paddle layer_norm kernel update

### DIFF
--- a/tests/cov_pytest.ini
+++ b/tests/cov_pytest.ini
@@ -12,4 +12,3 @@ addopts =
     --ignore=tests/e2e/golang_router
     --ignore=tests/v1/test_schedule_output.py
     --ignore=tests/graph_optimization/test_cuda_graph_dynamic_subgraph.py
-    --ignore=tests/e2e/test_Qwen3VLMoe_serving.py

--- a/tests/e2e/test_Qwen3VLMoe_serving.py
+++ b/tests/e2e/test_Qwen3VLMoe_serving.py
@@ -173,7 +173,7 @@ def test_consistency_between_runs(api_url, headers, consistent_payload):
     content1 = result1["choices"][0]["message"]["content"]
 
     # base result
-    content2 = "根据您提供的视频片段，我们可以观"
+    content2 = "根据您提供的视频帧，我们可以观"
 
     # Verify that result is same as the base result
     assert content1.startswith(content2), content1


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
https://github.com/PaddlePaddle/Paddle/pull/78321 introduces an accuracy-compatible `layer_norm` kernel, which changes numerical behavior (e.g., epsilon precision and mean/variance computation). This leads to observable accuracy drift in `Qwen3VLMoe` tests within FD CI.

This change is required to keep FastDeploy aligned with upstream Paddle behavior and maintain CI stability.

## Modifications
- Adapt Qwen3VLMoe test baselines to match the updated `layer_norm` behavior;
- Update related CI checks to avoid false failures caused by upstream accuracy changes;
- Ensure consistency with Paddle’s accuracy-compatible kernel implementation.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.