### PR TITLE
[Cherry-Pick][CI] Adapt to codecov action changes for Node.js 24(#7064)

### DIFF
--- a/.github/workflows/_unit_test_coverage.yml
+++ b/.github/workflows/_unit_test_coverage.yml
@@ -405,7 +405,7 @@ jobs:
 
       - name: Upload diff coverage report
         if: always() && hashFiles('python_coverage_all.xml') != ''
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: ./python_coverage_all.xml
           flags: GPU


### PR DESCRIPTION
Cherry-pick of #7064 (authored by @EmmonsCurse) to `release/2.5`.

devPR:https://github.com/PaddlePaddle/FastDeploy/pull/7064 <!-- For pass CI -->

---

<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
Recent GitHub Actions updates have deprecated Node.js 20 runtime. Starting from June 2nd, 2026, all JavaScript actions will be forced to run on Node.js 24, and Node.js 20 will be fully removed from runners by September 16th, 2026.

The CI workflow started to emit warnings indicating that some actions are still running on Node.js 20 (e.g., `actions/github-script@60a0d8...`), which may lead to potential compatibility issues in the future.

To ensure forward compatibility with Node.js 24 and avoid future CI failures, an upgrade is required.

## Modifications

- Upgrade `codecov/codecov-action` from v5 to v6 to align with Node.js 24 runtime support
- Ensure CI workflow is compatible with the latest GitHub Actions runtime changes
- Eliminate Node.js 20 deprecation warnings in CI logs

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
- Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
- You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.