### PR TITLE
[Cherry-Pick][CI] Sync develop fix and optimizations to 2.4(#6975)

### DIFF
--- a/.github/workflows/CheckPRTemplate.yml
+++ b/.github/workflows/CheckPRTemplate.yml
@@ -22,7 +22,7 @@ jobs:
           rm -rf * .[^.]*
 
       - name: Checkout base branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 1000
@@ -33,7 +33,7 @@ jobs:
           git checkout -b test FETCH_HEAD
 
       - name: Setup Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -21,7 +21,7 @@ jobs:
           rm -rf * .[^.]*
 
       - name: Checkout base repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 1000
@@ -32,7 +32,7 @@ jobs:
           git checkout -b test FETCH_HEAD
 
       - name: Setup python3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/_base_test.yml
+++ b/.github/workflows/_base_test.yml
@@ -27,10 +27,22 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      github-token:
+        required: true
 
 jobs:
+  check_bypass:
+    uses: ./.github/workflows/check-bypass.yml
+    secrets:
+      github-token: ${{ secrets.github-token }}
+    with:
+      workflow-name: base_test
+
   base_tests:
     runs-on: [self-hosted, GPU-h20-1Cards]
+    needs: check_bypass
+    if: ${{ inputs.FASTDEPLOY_WHEEL_URL != '' && needs.check_bypass.outputs.can-skip != 'true' }}
     timeout-minutes: 60
     steps:
       - name: Code Prepare

--- a/.github/workflows/_build_linux.yml
+++ b/.github/workflows/_build_linux.yml
@@ -66,6 +66,8 @@ jobs:
 
   fd-build:
     runs-on: [self-hosted, GPU-Build]
+    needs: check_bypass
+    if: ${{ needs.check_bypass.outputs.can-skip != 'true' }}
     timeout-minutes: 360
     outputs:
       wheel_path: ${{ steps.set_output.outputs.wheel_path }}

--- a/.github/workflows/_build_linux.yml
+++ b/.github/workflows/_build_linux.yml
@@ -52,7 +52,18 @@ on:
       wheel_path:
         description: "Output path of the generated wheel"
         value: ${{ jobs.fd-build.outputs.wheel_path }}
+    secrets:
+      github-token:
+        required: true
+
 jobs:
+  check_bypass:
+    uses: ./.github/workflows/check-bypass.yml
+    secrets:
+      github-token: ${{ secrets.github-token }}
+    with:
+      workflow-name: build_gpu
+
   fd-build:
     runs-on: [self-hosted, GPU-Build]
     timeout-minutes: 360

--- a/.github/workflows/_clone_linux.yml
+++ b/.github/workflows/_clone_linux.yml
@@ -12,15 +12,28 @@ on:
       repo_archive_url:
         description: "Compressed source code archive."
         value: ${{ jobs.code-clone.outputs.repo_archive_url }}
+    secrets:
+      github-token:
+        required: true
+
 jobs:
+  check_bypass:
+    uses: ./.github/workflows/check-bypass.yml
+    secrets:
+      github-token: ${{ secrets.github-token }}
+    with:
+      workflow-name: code_clone
+
   code-clone:
     runs-on:
       group: HK-Clone
+    needs: check_bypass
+    if: ${{ needs.check_bypass.outputs.can-skip != 'true' }}
     outputs:
       repo_archive_url: ${{ steps.set_output.outputs.repo_archive_url }}
     steps:
       - name: Clone FastDeploy
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'pull_request'
                 && github.event.pull_request.base.ref
@@ -38,7 +51,7 @@ jobs:
           git merge --no-ff pr/${{ github.event.pull_request.number }}
           echo "PR Branch log "
           git log --oneline -n 5 pr/${{ github.event.pull_request.number }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Code Info Show and Upload
@@ -47,8 +60,6 @@ jobs:
           AK: paddle
           SK: paddle
         run: |
-          git config --unset http.https://github.com/.extraheader
-          git submodule foreach --recursive sh -c "git config --local --unset-all 'http.https://github.com/.extraheader'"
           git submodule foreach --recursive sh -c "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
           echo "Current HEAD Log:"
           git log --oneline -n 5

--- a/.github/workflows/_gpu_4cards_case_test.yml
+++ b/.github/workflows/_gpu_4cards_case_test.yml
@@ -32,8 +32,17 @@ on:
         required: true
 
 jobs:
+  check_bypass:
+    uses: ./.github/workflows/check-bypass.yml
+    secrets:
+      github-token: ${{ secrets.github-token }}
+    with:
+      workflow-name: gpu_4cards_test
+
   run_4_cards_tests:
     runs-on: [self-hosted, GPU-h20-4Cards]
+    needs: check_bypass
+    if: ${{ inputs.FASTDEPLOY_WHEEL_URL != '' && needs.check_bypass.outputs.can-skip != 'true' }}
     timeout-minutes: 30
     steps:
       - name: Code Prepare

--- a/.github/workflows/_logprob_test_linux.yml
+++ b/.github/workflows/_logprob_test_linux.yml
@@ -28,10 +28,22 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      github-token:
+        required: true
 
 jobs:
+  check_bypass:
+    uses: ./.github/workflows/check-bypass.yml
+    secrets:
+      github-token: ${{ secrets.github-token }}
+    with:
+      workflow-name: logprob_test
+
   run_tests_logprob:
     runs-on: [self-hosted, GPU-h20-1Cards]
+    needs: check_bypass
+    if: ${{ inputs.FASTDEPLOY_WHEEL_URL != '' && needs.check_bypass.outputs.can-skip != 'true' }}
     timeout-minutes: 60
     steps:
       - name: Code Prepare

--- a/.github/workflows/_pre_ce_test.yml
+++ b/.github/workflows/_pre_ce_test.yml
@@ -26,10 +26,22 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      github-token:
+        required: true
 
 jobs:
+  check_bypass:
+    uses: ./.github/workflows/check-bypass.yml
+    secrets:
+      github-token: ${{ secrets.github-token }}
+    with:
+      workflow-name: pre_ce_test
+
   run_ce_cases:
     runs-on: [self-hosted, PRE_CE_RUN_2Card]
+    needs: check_bypass
+    if: ${{ inputs.FASTDEPLOY_WHEEL_URL != '' && needs.check_bypass.outputs.can-skip != 'true' }}
     timeout-minutes: 60
     steps:
       - name: Print current runner name

--- a/.github/workflows/_stable_test.yml
+++ b/.github/workflows/_stable_test.yml
@@ -27,10 +27,22 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      github-token:
+        required: true
 
 jobs:
+  check_bypass:
+    uses: ./.github/workflows/check-bypass.yml
+    secrets:
+      github-token: ${{ secrets.github-token }}
+    with:
+      workflow-name: stable_test
+
   stable_tests:
-    runs-on: [self-hosted, GPU-h1z1-2Cards]
+    runs-on: [self-hosted, GPU-h20-2Cards]
+    needs: check_bypass
+    if: ${{ inputs.FASTDEPLOY_WHEEL_URL != '' && needs.check_bypass.outputs.can-skip != 'true' }}
     timeout-minutes: 60
     steps:
       - name: Code Prepare

--- a/.github/workflows/_unit_test_coverage.yml
+++ b/.github/workflows/_unit_test_coverage.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: [self-hosted, GPU-h1z1-2Cards]
     timeout-minutes: 90
     needs: check_cov_skip
-    if: needs.check_cov_skip.outputs.can-skip != 'true'
+    if: ${{ inputs.FASTDEPLOY_WHEEL_URL != '' && needs.check_cov_skip.outputs.can-skip != 'true' }}
     outputs:
       all_cov_file_url: ${{ steps.cov_upload.outputs.all_cov_file_url }}
       unittest_failed_url: ${{ steps.cov_upload.outputs.unittest_failed_url }}
@@ -389,10 +389,10 @@ jobs:
       all_cov_file_url: ${{ needs.run_tests_with_coverage.outputs.all_cov_file_url }}
     steps:
       - name: Clone FastDeploy
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Download diff coverage file
@@ -408,7 +408,7 @@ jobs:
 
       - name: Upload diff coverage report
         if: always() && hashFiles('python_coverage_all.xml') != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: ./python_coverage_all.xml
           flags: GPU

--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -19,7 +19,7 @@ jobs:
       BRANCH: ${{ github.event.pull_request.base.ref }}
     steps:
       - name: Checkout base repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 1000
@@ -33,7 +33,7 @@ jobs:
           git fetch upstream $BRANCH
 
       - name: Setup python3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/ce_job.yml
+++ b/.github/workflows/ce_job.yml
@@ -96,7 +96,7 @@ jobs:
       repo_archive_url: ${{ steps.set_output.outputs.repo_archive_url }}
     steps:
       - name: Clone FastDeploy
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'pull_request'
                 && github.event.pull_request.base.ref
@@ -105,7 +105,7 @@ jobs:
           fetch-depth: 1000
 
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Code Info Show and Upload
@@ -114,8 +114,6 @@ jobs:
           AK: ${{ secrets.BOS_AK }}
           SK: ${{ secrets.BOS_SK }}
         run: |
-          git config --unset http.https://github.com/.extraheader
-          git submodule foreach --recursive sh -c "git config --local --unset-all 'http.https://github.com/.extraheader'"
           git submodule foreach --recursive sh -c "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
           echo "Current HEAD Log:"
           git log --oneline -n 5
@@ -155,6 +153,8 @@ jobs:
       WITH_NIGHTLY_BUILD: OFF
       FD_VERSION: 0.0.0
       PADDLE_WHL_URL: ${{ needs.ce_job_pre_check.outputs.compile_use_paddle_whl_url }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build_sm8090_rl:
     name: BUILD_SM8090_RL
@@ -181,6 +181,8 @@ jobs:
       WITH_NIGHTLY_BUILD: OFF
       FD_VERSION: 0.0.0
       PADDLE_WHL_URL: ${{ needs.ce_job_pre_check.outputs.compile_use_paddle_whl_url }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   ce_upload_sm8090:
     environment: CodeSync
@@ -193,7 +195,7 @@ jobs:
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8090.outputs.wheel_path }}
       COMPILE_ARCH: "80,90"
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Wheel Info Show and Upload
@@ -243,7 +245,7 @@ jobs:
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8090_rl.outputs.wheel_path_rl }}
       COMPILE_ARCH: "80,90"
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Wheel Info Show and Upload
@@ -289,7 +291,7 @@ jobs:
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8689.outputs.wheel_path }}
       COMPILE_ARCH: "86,89"
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Wheel Info Show and Upload

--- a/.github/workflows/check-bypass.yml
+++ b/.github/workflows/check-bypass.yml
@@ -11,6 +11,9 @@ on:
       can-skip:
         description: "Whether the workflow can be skipped."
         value: ${{ jobs.check-bypass.outputs.can-skip }}
+      can-skip-docs:
+        description: "Whether the workflow can be skipped due to docs-only change."
+        value: ${{ jobs.check-bypass.outputs.can-skip-docs }}
 
 jobs:
   check-bypass:
@@ -19,9 +22,10 @@ jobs:
     permissions:
       contents: read
     env:
-      CI_TEAM_MEMBERS: '["yuanlehome","YuanRisheng","Jiang-Jia-Jun","DDDivano","XieYunshen","EmmonsCurse","CSWYF3634076"]'
+      CI_TEAM_MEMBERS: '["yuanlehome","YuanRisheng","Jiang-Jia-Jun","DDDivano","XieYunshen","EmmonsCurse","CSWYF3634076","plusNew001"]'
     outputs:
-      can-skip: ${{ steps.check-bypass.outputs.can-skip }}
+      can-skip: ${{ steps.final-output.outputs.can-skip }}
+      can-skip-docs: ${{ steps.final-output.outputs.can-skip-docs }}
     steps:
       - name: Cleanup
         run: |
@@ -29,7 +33,7 @@ jobs:
 
       - id: check-bypass
         name: Check Bypass
-        uses: PFCCLab/ci-bypass@v1
+        uses: PFCCLab/ci-bypass@v2
         with:
           github-token: ${{ secrets.github-token }}
           non-pull-request-event-strategy: 'never-skipped'
@@ -49,3 +53,51 @@ jobs:
                 }
               ]
             }
+
+      - id: check-only-docs
+        name: Check if only Docs files changed
+        env:
+          GITHUB_TOKEN: ${{ secrets.github-token }}
+        run: |
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "can-skip-docs=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          files=$(gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json files --jq '.files[].path')
+          echo "$files"
+
+          can_skip_docs=true
+          for f in $files; do
+            if [[ ! "$f" =~ \.(md|txt|yaml|go)$ ]]; then
+              can_skip_docs=false
+              break
+            fi
+          done
+
+          echo "can-skip-docs=$can_skip_docs" >> "$GITHUB_OUTPUT"
+
+      - id: final-output
+        name: Final can-skip result
+        run: |
+          if [[ "${{ steps.check-only-docs.outputs['can-skip-docs'] }}" == "true" ]]; then
+            echo "can-skip=true" >> "$GITHUB_OUTPUT"
+            echo "can-skip-docs=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${{ steps.check-bypass.outputs['can-skip'] }}" == "true" ]]; then
+            echo "can-skip=true" >> "$GITHUB_OUTPUT"
+            echo "can-skip-docs=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "can-skip=false" >> "$GITHUB_OUTPUT"
+          echo "can-skip-docs=false" >> "$GITHUB_OUTPUT"
+
+      - id: print-final-output
+        name: Print final result
+        run: |
+          echo "===== Final can-skip result ====="
+          echo "can-skip=${{ steps.final-output.outputs['can-skip'] }}"
+          echo "can-skip-docs=${{ steps.final-output.outputs['can-skip-docs'] }}"

--- a/.github/workflows/ci_iluvatar.yml
+++ b/.github/workflows/ci_iluvatar.yml
@@ -19,7 +19,7 @@ jobs:
           echo "Current runner name: ${{ runner.name }}"
       # Because the system version is lower than 2.23, the checkout cannot be used.
       # - name: Checkout code
-      #   uses: actions/checkout@v4
+      #   uses: actions/checkout@v6
 
       - name: Code Checkout
         env:

--- a/.github/workflows/ci_image_update.yml
+++ b/.github/workflows/ci_image_update.yml
@@ -21,14 +21,14 @@ jobs:
       repo_archive_url: ${{ steps.set_output.outputs.repo_archive_url }}
     steps:
       - name: Clone FastDeploy
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
           submodules: 'recursive'
           fetch-depth: 1000
 
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Code Info Show and Upload
@@ -37,8 +37,6 @@ jobs:
           AK: ${{ secrets.BOS_AK }}
           SK: ${{ secrets.BOS_SK }}
         run: |
-          git config --unset http.https://github.com/.extraheader
-          git submodule foreach --recursive sh -c "git config --local --unset-all 'http.https://github.com/.extraheader'"
           git submodule foreach --recursive sh -c "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
           echo "Current HEAD Log:"
           git log --oneline -n 5
@@ -93,7 +91,8 @@ jobs:
       FD_VERSION: ${{ needs.publish_pre_check.outputs.fd_version }}
       PADDLEVERSION: ${{ needs.publish_pre_check.outputs.compile_use_paddle_version }}
       PADDLE_WHL_URL: ${{ needs.publish_pre_check.outputs.compile_use_paddle_whl_url }}
-
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   unittest_coverage:
     name: Run FastDeploy Unit Tests and Coverage
@@ -116,6 +115,8 @@ jobs:
       PADDLETEST_ARCHIVE_URL: "https://xly-devops.bj.bcebos.com/PaddleTest/PaddleTest.tar.gz"
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8090.outputs.wheel_path }}
       MODEL_CACHE_DIR: "/ssd2/actions-runner/ModelData"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   pre_ce_test:
     name: Extracted partial CE model tasks to run in CI.
@@ -126,6 +127,8 @@ jobs:
       FASTDEPLOY_ARCHIVE_URL: ${{ needs.clone.outputs.repo_archive_url }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8090.outputs.wheel_path }}
       MODEL_CACHE_DIR: "/ssd2/actions-runner/ModelData"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   base_test:
     name: Run Base Tests
@@ -136,6 +139,8 @@ jobs:
       FASTDEPLOY_ARCHIVE_URL: ${{ needs.clone.outputs.repo_archive_url }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8090.outputs.wheel_path }}
       MODEL_CACHE_DIR: "/ssd2/actions-runner/ModelData"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   stable_test:
     name: Run Stable Tests
@@ -146,6 +151,8 @@ jobs:
       FASTDEPLOY_ARCHIVE_URL: ${{ needs.clone.outputs.repo_archive_url }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8090.outputs.wheel_path }}
       MODEL_CACHE_DIR: "/ssd2/actions-runner/ModelData"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   publish_pre_check:
     name: Publish Docker Images Pre Check

--- a/.github/workflows/ci_xpu.yml
+++ b/.github/workflows/ci_xpu.yml
@@ -24,7 +24,7 @@ jobs:
           echo "Current runner name: ${{ runner.name }}"
       # Because the system version is lower than 2.23, the checkout cannot be used.
       # - name: Checkout code
-      #   uses: actions/checkout@v4
+      #   uses: actions/checkout@v6
 
       - name: Code Checkout
         env:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,8 +11,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - run: pip install mkdocs-material mkdocs-get-deps mkdocs-material-extensions mkdocs-multilang mkdocs-static-i18n

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -13,6 +13,8 @@ jobs:
   clone:
     name: FD-Clone-Linux
     uses: ./.github/workflows/_clone_linux.yml
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     name: FD-Build-Linux
@@ -24,6 +26,8 @@ jobs:
       COMPILE_ARCH: "90"
       WITH_NIGHTLY_BUILD: "OFF"
       FD_VERSION: "0.0.0"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   resultshow:
     name: Use Build Output
@@ -67,6 +71,8 @@ jobs:
       PADDLETEST_ARCHIVE_URL: "https://xly-devops.bj.bcebos.com/PaddleTest/PaddleTest.tar.gz"
       FASTDEPLOY_WHEEL_URL: ${{ needs.build.outputs.wheel_path }}
       MODEL_CACHE_DIR: "/ssd2/actions-runner/ModelData"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   pre_ce_test:
     name: Extracted partial CE model tasks to run in CI.
@@ -77,6 +83,8 @@ jobs:
       FASTDEPLOY_ARCHIVE_URL: ${{ needs.clone.outputs.repo_archive_url }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build.outputs.wheel_path }}
       MODEL_CACHE_DIR: "/ssd2/actions-runner/ModelData"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   base_test:
     name: Run Base Tests
@@ -87,6 +95,8 @@ jobs:
       FASTDEPLOY_ARCHIVE_URL: ${{ needs.clone.outputs.repo_archive_url }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build.outputs.wheel_path }}
       MODEL_CACHE_DIR: "/ssd2/actions-runner/ModelData"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   stable_test:
     name: Run Stable Tests
@@ -97,3 +107,5 @@ jobs:
       FASTDEPLOY_ARCHIVE_URL: ${{ needs.clone.outputs.repo_archive_url }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build.outputs.wheel_path }}
       MODEL_CACHE_DIR: "/ssd2/actions-runner/ModelData"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_job.yml
+++ b/.github/workflows/publish_job.yml
@@ -125,14 +125,14 @@ jobs:
       repo_archive_url: ${{ steps.set_output.outputs.repo_archive_url }}
     steps:
       - name: Clone FastDeploy
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
           submodules: 'recursive'
           fetch-depth: 1000
 
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Code Info Show and Upload
@@ -141,8 +141,6 @@ jobs:
           AK: ${{ secrets.BOS_AK }}
           SK: ${{ secrets.BOS_SK }}
         run: |
-          git config --unset http.https://github.com/.extraheader
-          git submodule foreach --recursive sh -c "git config --local --unset-all 'http.https://github.com/.extraheader'"
           git submodule foreach --recursive sh -c "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
           echo "Current HEAD Log:"
           git log --oneline -n 5
@@ -188,6 +186,8 @@ jobs:
       FD_VERSION: ${{ needs.publish_pre_check.outputs.fd_version }}
       PADDLEVERSION: ${{ needs.publish_pre_check.outputs.compile_use_paddle_version }}
       PADDLE_WHL_URL: ${{ needs.publish_pre_check.outputs.compile_use_paddle_whl_url }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build_sm8689:
     name: BUILD_SM8689
@@ -201,6 +201,8 @@ jobs:
       FD_VERSION: ${{ needs.publish_pre_check.outputs.fd_version }}
       PADDLEVERSION: ${{ needs.publish_pre_check.outputs.compile_use_paddle_version }}
       PADDLE_WHL_URL: ${{ needs.publish_pre_check.outputs.compile_use_paddle_whl_url }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   paddle_pypi_upload_sm8090:
     environment: PaddleSourceUpload
@@ -213,7 +215,7 @@ jobs:
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8090.outputs.wheel_path }}
       COMPILE_ARCH: "80,90"
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Wheel Info Show and Upload
@@ -246,7 +248,7 @@ jobs:
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8689.outputs.wheel_path }}
       COMPILE_ARCH: "86,89"
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Wheel Info Show and Upload
@@ -341,6 +343,8 @@ jobs:
       PADDLETEST_ARCHIVE_URL: "https://xly-devops.bj.bcebos.com/PaddleTest/PaddleTest.tar.gz"
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8090.outputs.wheel_path }}
       MODEL_CACHE_DIR: "/ssd2/actions-runner/ModelData"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   pre_ce_test:
     name: Extracted partial CE model tasks to run in CI.
@@ -351,6 +355,8 @@ jobs:
       FASTDEPLOY_ARCHIVE_URL: ${{ needs.clone.outputs.repo_archive_url }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8090.outputs.wheel_path }}
       MODEL_CACHE_DIR: "/ssd2/actions-runner/ModelData"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   base_test:
     name: Run Base Tests
@@ -361,6 +367,8 @@ jobs:
       FASTDEPLOY_ARCHIVE_URL: ${{ needs.clone.outputs.repo_archive_url }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8090.outputs.wheel_path }}
       MODEL_CACHE_DIR: "/ssd2/actions-runner/ModelData"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   accuracy_test:
     name: Run Accuracy Tests
@@ -381,3 +389,5 @@ jobs:
       FASTDEPLOY_ARCHIVE_URL: ${{ needs.clone.outputs.repo_archive_url }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8090.outputs.wheel_path }}
       MODEL_CACHE_DIR: "/ssd2/actions-runner/ModelData"
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/remove-skip-ci-labels.yml
+++ b/.github/workflows/remove-skip-ci-labels.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Remove skip-ci labels
         if: steps.get-labels.outputs.has-skip-ci-labels == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -14,7 +14,7 @@ jobs:
           rm -rf * .[^.]*
 
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Rerun all failed jobs
         if: ${{ contains(github.event.comment.body, 'all-failed') }}


### PR DESCRIPTION
Cherry-pick of #6975 #6958 #6939 #7064  to `release/2.4`.

devPR:#6975 #6958 #6939 #7064 
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
- Introduce a unified mechanism to skip unnecessary CI workflows
- Reduce resource usage and avoid running redundant jobs
- Upgrade GitHub Actions to ensure compatibility with the upcoming default switch of GitHub Actions runners to Node 24, while also aligning with the latest major versions of several commonly used actions.


## Modifications
- Refine `check-bypass` workflow to determine whether CI can be skipped
- Integrate skip logic into related workflows based on bypass results
- Upgrade GitHub Actions versions:
  - `actions/checkout`: v4 → v6
  - `actions/setup-python`: v5 → v6
  - `actions/github-script`: v7 → v8
  - `codecov/codecov-action`: v4 → v6

- Remove legacy `extraheader` cleanup logic in the clone step, which is no longer required after upgrading `actions/checkout`.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.