### PR TITLE
[Cherry-Pick][Refactor] Replace --skip-mm-profiling with --deploy-modality text(#7048)

### DIFF
--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -2209,7 +2209,7 @@ class FDConfig:
                 num_tokens = self.scheduler_config.max_num_seqs
         else:
             num_tokens = self.scheduler_config.max_num_batched_tokens
-            if mm_max_tokens_per_item is not None:
+            if mm_max_tokens_per_item is not None and self.deploy_modality != DeployModality.TEXT:
                 max_mm_tokens = max(
                     mm_max_tokens_per_item.get("image", 0),
                     mm_max_tokens_per_item.get("video", 0),


### PR DESCRIPTION
Cherry-pick of #7048 (authored by @kevincheng2) to `release/2.5`.

devPR:https://github.com/PaddlePaddle/FastDeploy/pull/7048 <!-- For pass CI -->

---

## Motivation

原 `--skip-mm-profiling` 参数与已有的 `--deploy-modality` 参数功能存在语义重叠：
当以纯文本模式（`--deploy-modality text`）部署时，本就不需要为多模态 token 预留显存。
引入独立参数增加了配置复杂度，复用 `deploy_modality` 更加直观和一致。

## Modifications

- `fastdeploy/engine/args_utils.py`：删除 `EngineArgs.skip_mm_profiling` 字段及
`--skip-mm-profiling` 启动参数
- `fastdeploy/config.py`：删除 `ModelConfig.__init__` 中的 `self.skip_mm_profiling = False`；
`FDConfig.get_max_chunk_tokens` 中将条件改为
`self.deploy_modality != DeployModality.TEXT`，
当 deploy_modality 为 text 时直接返回 `max_num_batched_tokens`，跳过 mm token 叠加

## Usage or Command

```bash
# 以文本模式部署，跳过 mm token profiling 开销（替代原 --skip-mm-profiling）
python -m fastdeploy.entrypoints.openai.api_server \
--deploy-modality text \
--model /path/to/model \
...
```

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. 本次为参数重构，逻辑等价替换，已有 config 单元测试覆盖。