### PR TITLE
[RL][Qwen3VL] Add clear_grpah_opt_backend method to Qwen3VLForConditional…

### DIFF
--- a/fastdeploy/model_executor/models/qwen3_vl/qwen3_vl.py
+++ b/fastdeploy/model_executor/models/qwen3_vl/qwen3_vl.py
@@ -382,6 +382,10 @@ class Qwen3VLForConditionalGeneration(ModelForCasualLM):
 
         return hidden_states
 
+    def clear_grpah_opt_backend(self):
+        """Clear graph optimization backend, the captured cuda graph will be cleaned"""
+        self.model.clear_grpah_opt_backend(fd_config=self.fd_config)
+
 
 class Qwen3VLPretrainedModel(PretrainedModel):
     """Utilities for tensor-parallel weight splitting."""


### PR DESCRIPTION
## Motivation

`Qwen3VLForConditionalGeneration` 缺少 `clear_grpah_opt_backend` 方法，导致上层无法通过统一接口清理 Qwen3VL 模型的 CUDA Graph 缓存。

## Modifications

为 `Qwen3VLForConditionalGeneration` 新增 `clear_grpah_opt_backend` 方法，将调用委托给底层 `self.model`，与其他模型保持接口一致。

## Usage or Command

N/A

## Accuracy Tests

不涉及模型前向计算逻辑，无需精度测试。

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. 仅新增一个委托方法，暂不添加单测。
- [x] Provide accuracy results. 不涉及模型输出，无需提供。