### PR TITLE
[BugFix][KVCache] Add enc_dec_block_num to prefill_kvcache_block_num check

### DIFF
--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -1379,9 +1379,11 @@ class CacheConfig:
                 self.prefill_kvcache_block_num = self.total_block_num
             else:
                 self.prefill_kvcache_block_num = int(self.total_block_num * self.kv_cache_ratio)
-            assert (
-                self.prefill_kvcache_block_num >= self.max_block_num_per_seq
-            ), f"current block number :{self.prefill_kvcache_block_num} should be greater than or equal to current model len needed minimum block number :{self.max_block_num_per_seq}"
+            assert self.prefill_kvcache_block_num >= self.max_block_num_per_seq + self.enc_dec_block_num, (
+                f"prefill_kvcache_block_num: {self.prefill_kvcache_block_num} should be larger "
+                f"than or equal to {self.max_block_num_per_seq + self.enc_dec_block_num}, please reduce "
+                "the max_model_len or increase num_gpu_blocks_override"
+            )
         else:
             length = num_total_tokens // number_of_tasks
             block_num = (length + self.block_size - 1 + self.dec_token_num) // self.block_size
@@ -1402,9 +1404,11 @@ class CacheConfig:
             f"Reset block num, the total_block_num:{self.total_block_num},"
             f" prefill_kvcache_block_num:{self.prefill_kvcache_block_num}"
         )
-        assert (
-            self.prefill_kvcache_block_num >= self.max_block_num_per_seq
-        ), f"current block number :{self.prefill_kvcache_block_num} should be greater than or equal to current model len needed minimum block number :{self.max_block_num_per_seq}"
+        assert self.prefill_kvcache_block_num >= self.max_block_num_per_seq + self.enc_dec_block_num, (
+            f"current device block num: {self.prefill_kvcache_block_num} "
+            f"should be larger than or equal to {self.max_block_num_per_seq + self.enc_dec_block_num}, please reduce "
+            "the max_model_len or replace the machine with larger GPU cards"
+        )
 
     def print(self):
         """


### PR DESCRIPTION
## Motivation

Cherry-pick from release/2.5: the original assertion only checked
`prefill_kvcache_block_num >= max_block_num_per_seq`, but for
encoder-decoder models the kvcache must also reserve blocks for the
encoder side (`enc_dec_block_num`). Without this check, the service
could silently allocate insufficient blocks for enc-dec sequences.

## Modifications

- `CacheConfig.postprocess`: tighten assertion to
  `prefill_kvcache_block_num >= max_block_num_per_seq + enc_dec_block_num`,
  error message guides user to reduce `max_model_len` or increase
  `num_gpu_blocks_override`
- `CacheConfig.reset`: same tightening, error message guides user to
  reduce `max_model_len` or replace with larger GPU cards (override
  is not applicable here)

## Usage or Command

No change to launch command. If the assertion fires, adjust:

```bash
# Option 1: reduce max_model_len
python -m fastdeploy.entrypoints.openai.api_server \
  --max-model-len <smaller_value> ...

# Option 2 (postprocess only): increase GPU block count
python -m fastdeploy.entrypoints.openai.api_server \
  --num-gpu-blocks-override <larger_value> ...
```

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. No new logic introduced, only assertion tightened.
- [ ] Provide accuracy results. Not applicable.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.