### PR TITLE
[Cherry-Pick] Add clear_grpah_opt_backend method to Qwen3VL(#7086)

### DIFF
--- a/fastdeploy/model_executor/models/qwen3_vl/qwen3_vl.py
+++ b/fastdeploy/model_executor/models/qwen3_vl/qwen3_vl.py
@@ -381,6 +381,10 @@ class Qwen3VLForConditionalGeneration(ModelForCasualLM):
 
         return hidden_states
 
+    def clear_grpah_opt_backend(self):
+        """Clear graph optimization backend, the captured cuda graph will be cleaned"""
+        self.model.clear_grpah_opt_backend(fd_config=self.fd_config)
+
 
 class Qwen3VLPretrainedModel(PretrainedModel):
     """Utilities for tensor-parallel weight splitting."""


### PR DESCRIPTION
## Motivation

Cherry-pick from develop branch.

Add `clear_grpah_opt_backend` method to `Qwen3VLForConditionalGeneration` to support clearing cuda graph optimization backend, enabling proper cleanup when switching inference backends.

## Modifications

- Add `clear_grpah_opt_backend` method in `Qwen3VLForConditionalGeneration` that delegates to the underlying model to clear cuda graph optimization backend.

## Usage or Command

N/A

## Accuracy Tests

No model output changes involved.

## Checklist
- [x] Add unit tests. 仅新增一个委托方法，暂不添加单测。
- [x] Documentation(README/CNAME/Doxyfile) modified or not. No
- [x] Usage/AutoTest modified or not. No
- [x] Accuracy test modified or not. No
- [x] FastDeploy library interface modified or not. No
- [x] Other modified or not. No