### PR TITLE
[BugFix] reset exist tasks signal in clear_data

### DIFF
--- a/fastdeploy/inter_communicator/engine_worker_queue.py
+++ b/fastdeploy/inter_communicator/engine_worker_queue.py
@@ -837,6 +837,10 @@ class EngineWorkerQueue:
         self.lock.acquire()
         self.tasks[:] = list()
         self.client_read_flag[:] = [1] * self.num_client
+        if self.is_single_node:
+            self.exist_tasks_intra_signal.value[0] = 0
+        else:
+            self.exist_tasks_inter_signal.set(0)
         self.lock.release()
         llm_logger.info("clear data for engine worker queue")
 

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -549,7 +549,6 @@ class PaddleDisWorkerProc:
                             f"Rank: {self.local_rank} has updated parameters. {self.model_weights_status.value[0]}"
                         )
                         self.model_weights_signal[0] = ModelWeightsStatus.NORMAL
-                        continue
                     elif self.model_weights_signal[0] == ModelWeightsStatus.CLEARING:
                         logger.info(
                             f"Rank: {self.local_rank} has cleared parameters. {self.model_weights_status.value[0]}"
@@ -568,7 +567,7 @@ class PaddleDisWorkerProc:
                             self.model_weights_status.value[0] = (
                                 ModelWeightsStatus.UPDATING
                             )  # 所有 Rank 已同步唤醒，启动权重更新流程
-                            continue
+                    continue
 
             if self.exist_task_signal.value[0] == ExistTaskStatus.EXIST or self.task_queue.read_finish_flag.get() == 1:
                 logger.debug(f"Rank: {self.local_rank} Detected new requests.")

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -549,6 +549,7 @@ class PaddleDisWorkerProc:
                             f"Rank: {self.local_rank} has updated parameters. {self.model_weights_status.value[0]}"
                         )
                         self.model_weights_signal[0] = ModelWeightsStatus.NORMAL
+                        continue
                     elif self.model_weights_signal[0] == ModelWeightsStatus.CLEARING:
                         logger.info(
                             f"Rank: {self.local_rank} has cleared parameters. {self.model_weights_status.value[0]}"

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -571,7 +571,7 @@ class PaddleDisWorkerProc:
                             continue
 
             if self.exist_task_signal.value[0] == ExistTaskStatus.EXIST or self.task_queue.read_finish_flag.get() == 1:
-                logger.info(f"Rank: {self.local_rank} Detected new requests.")
+                logger.debug(f"Rank: {self.local_rank} Detected new requests.")
                 self.engine_forward_signal.value[0] = 1
                 tasks, read_finish = self.task_queue.get_tasks()
                 # Only one of all tp_size client will get read_finish == True.


### PR DESCRIPTION
  ## Motivation

  `EngineWorkerQueue.clear_data()` cleared queued tasks and reset `client_read_flag`, but it did not reset the `exist_task` signal.

  This could leave the queue in an inconsistent state where `exist_tasks()` still returned `true` after the task payload had already been cleared. In that case, workers could still enter the `get_tasks()` path and observe
  an empty task list, which may trigger downstream assertion failures.

  This PR fixes the queue state inconsistency by resetting the `exist_task` signal together with queue cleanup.

  ## Modifications

  - Update `EngineWorkerQueue.clear_data()` to reset the `exist_task` signal when clearing the queue
  - Keep queue payload state and task-existence state consistent during cleanup
  - Prevent workers from observing stale queue-available state after forced clear operations

  ## Usage or Command

  This PR is a bug fix. No new usage is introduced.

  ## Accuracy Tests

  This change does not modify model forward logic, kernel behavior, or output generation semantics.

  Accuracy impact: none expected.

  ## Checklist

  - [x] Add at least a tag in the PR title.
  - [ ] Format your code, run pre-commit before commit.
  - [ ] Add unit tests. Please write the reason in this PR if no unit tests.
  - [x] Provide accuracy results.
  - [x] If the current PR is submitting to the release branch, make sure the PR has been submitted to the develop branch, then cherry-pick it to the release branch with the [Cherry-Pick] PR tag.