### PR TITLE
⚡ Bolt: Optimize RequestMetrics & SpeculateMetrics Serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2025-02-23 - Avoid dataclasses.asdict in Hot Paths
+**Learning:** `dataclasses.asdict` does recursive deepcopy internally and is incredibly slow for large dataclasses or objects instantiated frequently. In FastDeploy, it was used in `RequestMetrics.to_dict()`, creating significant overhead.
+**Action:** When defining `to_dict()` or custom serialization methods for fast/frequent dataclasses, avoid `asdict`. Instead, iterate through `self.__dataclass_fields__` with `getattr` and do shallow copying for basic types (`int`, `float`, `str`, `bool`, `type(None)`). For nested dataclasses, ensure they also implement their own `to_dict()` method to skip the `asdict` recursive penalty.

--- a/fastdeploy/engine/request.py
+++ b/fastdeploy/engine/request.py
@@ -897,7 +897,26 @@ class RequestMetrics:
         """
         Convert the RequestMetrics object to a dictionary.
         """
-        return {k: v for k, v in asdict(self).items()}
+        import dataclasses
+
+        res = {}
+        for k in self.__dataclass_fields__:
+            v = getattr(self, k)
+            if type(v) in (int, float, str, bool, type(None)):
+                res[k] = v
+            elif isinstance(v, list):
+                res[k] = list(v)
+            elif isinstance(v, dict):
+                res[k] = dict(v)
+            else:
+                if dataclasses.is_dataclass(v):
+                    if hasattr(v, "to_dict"):
+                        res[k] = v.to_dict()
+                    else:
+                        res[k] = dataclasses.asdict(v)
+                else:
+                    res[k] = v
+        return res
 
     def record_recv_first_token(self):
         cur_time = time.time()

--- a/fastdeploy/worker/output.py
+++ b/fastdeploy/worker/output.py
@@ -164,6 +164,20 @@ class SpeculateMetrics:
     """
     accept_ratio_per_head: list[float]
 
+    def to_dict(self):
+        return {
+            "accepted_tokens": self.accepted_tokens,
+            "rejected_tokens": self.rejected_tokens,
+            "accept_ratio": self.accept_ratio,
+            "average_accept_length": self.average_accept_length,
+            "accepted_tokens_per_head": (
+                list(self.accepted_tokens_per_head) if self.accepted_tokens_per_head is not None else None
+            ),
+            "accept_ratio_per_head": (
+                list(self.accept_ratio_per_head) if self.accept_ratio_per_head is not None else None
+            ),
+        }
+
 
 @dataclass
 class SamplerOutput:


### PR DESCRIPTION
## Motivation
`dataclasses.asdict()` relies heavily on `deepcopy` recursively, which becomes incredibly slow for high-throughput execution paths. In `fastdeploy/engine/request.py`, `RequestMetrics.to_dict()` is called constantly (per-request execution trace tracking), causing undue serialization overhead.

## Modifications
* **`fastdeploy/engine/request.py`**: Refactored `RequestMetrics.to_dict()` to iterate explicitly over `__dataclass_fields__` with `getattr`. Basic scalar types (`int`, `float`, `str`, `bool`) and simple built-in dicts/lists skip deepcopy overhead entirely and use shallow/explicit copy methods instead. It only falls back to recursive methods when absolutely necessary.
* **`fastdeploy/worker/output.py`**: Added an explicit `to_dict()` method to `SpeculateMetrics` so nested dataclass parsing skips the deepcopy penalty.
* **`.jules/bolt.md`**: Created bolt journal entry outlining this lesson.

## Usage or Command
*This optimization is strictly internal and operates transparently on `RequestMetrics` and `SpeculateMetrics` usage.*

## Accuracy Tests
Ran local unit tests in `pytest tests/engine/test_request.py` (30/30 passed) and ran `flake8`/`black`/`isort` to ensure formatting logic complies.

## Checklist
- [x] I have read the guidelines.
- [x] I have checked my code and tests.
- [x] I have considered performance impact.

---
*PR created automatically by Jules for task [10751143528886952738](https://jules.google.com/task/10751143528886952738) started by @ZeyuChen*