### PR TITLE
[BugFix] Validate feature shape to reject mismatched Encode versions

### DIFF
--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -935,6 +935,35 @@ class ResourceManagerV1(ResourceManager):
                     return error_msg
             return result_list
 
+        def check_result_shape(features):
+            """Check if all features in the result list have consistent shape dimension.
+            Valid: all 2D or all 4D. Invalid: mixed 2D and 4D, or any other dimension.
+            Returns True if valid, otherwise sets error and returns None.
+            """
+            dims = set()
+            for i, feature in enumerate(features):
+                if not isinstance(feature, np.ndarray) or len(feature.shape) not in (2, 4):
+                    shape_info = feature.shape if isinstance(feature, np.ndarray) else type(feature).__name__
+                    error_msg = (
+                        f"request {request.request_id} feature shape check failed: "
+                        f"feature[{i}] has shape {shape_info}, expected 2D or 4D"
+                    )
+                    llm_logger.error(error_msg)
+                    request.error_message = error_msg
+                    request.error_code = 530
+                    return None
+                dims.add(len(feature.shape))
+            if len(dims) > 1:
+                error_msg = (
+                    f"request {request.request_id} feature shape check failed: "
+                    f"mixed dimensions {dims} in feature list, expected all 2D or all 4D"
+                )
+                llm_logger.error(error_msg)
+                request.error_message = error_msg
+                request.error_code = 530
+                return None
+            return True
+
         if not self._has_features_info(request):
             return None
 
@@ -948,12 +977,16 @@ class ResourceManagerV1(ResourceManager):
                 request.error_message = result
                 request.error_code = 530
                 return None
+            if check_result_shape(result) is None:
+                return None
             inputs["video_features"] = result
         if inputs.get("image_feature_urls") is not None and len(inputs["image_feature_urls"]) > 0:
             result = download_bos_features(self.bos_client, inputs["image_feature_urls"])
             if isinstance(result, str):  # download error
                 request.error_message = result
                 request.error_code = 530
+                return None
+            if check_result_shape(result) is None:
                 return None
             inputs["image_features"] = result
         if inputs.get("audio_feature_urls") is not None and len(inputs["audio_feature_urls"]) > 0:

--- a/tests/v1/test_resource_manager_v1.py
+++ b/tests/v1/test_resource_manager_v1.py
@@ -157,6 +157,80 @@ class TestResourceManagerV1(unittest.TestCase):
         )
         self.assertEqual(self.request.error_code, 530)
 
+    def test_check_result_shape_all_2d_success(self):
+        """Test check_result_shape passes when all features are 2D"""
+        mock_client = MagicMock()
+        mock_client.get_object_as_string.side_effect = [
+            pickle.dumps(np.array([[1, 2, 3]], dtype=np.float32)),
+            pickle.dumps(np.array([[4, 5, 6]], dtype=np.float32)),
+        ]
+
+        self.request.multimodal_inputs = {
+            "video_feature_urls": ["bos://bucket-name/path/to/obj1", "bos://bucket-name/path/to/obj2"]
+        }
+
+        self.manager.bos_client = mock_client
+        result = self.manager._download_features(self.request)
+        self.assertIsNone(result)
+        self.assertIn("video_features", self.request.multimodal_inputs)
+        self.assertEqual(len(self.request.multimodal_inputs["video_features"]), 2)
+        self.assertFalse(hasattr(self.request, "error_code") and self.request.error_code == 530)
+
+    def test_check_result_shape_all_4d_success(self):
+        """Test check_result_shape passes when all features are 4D"""
+        mock_client = MagicMock()
+        mock_client.get_object_as_string.side_effect = [
+            pickle.dumps(np.ones((1, 3, 224, 224), dtype=np.float32)),
+            pickle.dumps(np.ones((2, 3, 112, 112), dtype=np.float32)),
+        ]
+
+        self.request.multimodal_inputs = {
+            "image_feature_urls": ["bos://bucket-name/path/to/obj1", "bos://bucket-name/path/to/obj2"]
+        }
+
+        self.manager.bos_client = mock_client
+        result = self.manager._download_features(self.request)
+        self.assertIsNone(result)
+        self.assertIn("image_features", self.request.multimodal_inputs)
+        self.assertEqual(len(self.request.multimodal_inputs["image_features"]), 2)
+
+    def test_check_result_shape_mixed_2d_4d_fails(self):
+        """Test check_result_shape fails when 2D and 4D features are mixed"""
+        mock_client = MagicMock()
+        mock_client.get_object_as_string.side_effect = [
+            pickle.dumps(np.array([[1, 2, 3]], dtype=np.float32)),           # 2D
+            pickle.dumps(np.ones((1, 3, 224, 224), dtype=np.float32)),       # 4D
+        ]
+
+        self.request.multimodal_inputs = {
+            "video_feature_urls": ["bos://bucket-name/path/to/obj1", "bos://bucket-name/path/to/obj2"]
+        }
+
+        self.manager.bos_client = mock_client
+        result = self.manager._download_features(self.request)
+        self.assertIsNone(result)
+        self.assertIn("feature shape check failed", self.request.error_message)
+        self.assertIn("mixed dimensions", self.request.error_message)
+        self.assertEqual(self.request.error_code, 530)
+
+    def test_check_result_shape_1d_fails(self):
+        """Test check_result_shape fails when feature is 1D"""
+        mock_client = MagicMock()
+        mock_client.get_object_as_string.side_effect = [
+            pickle.dumps(np.array([1, 2, 3], dtype=np.float32)),             # 1D
+        ]
+
+        self.request.multimodal_inputs = {
+            "video_feature_urls": ["bos://bucket-name/path/to/obj1"]
+        }
+
+        self.manager.bos_client = mock_client
+        result = self.manager._download_features(self.request)
+        self.assertIsNone(result)
+        self.assertIn("feature shape check failed", self.request.error_message)
+        self.assertIn("expected 2D or 4D", self.request.error_message)
+        self.assertEqual(self.request.error_code, 530)
+
     def test_download_features_retry(self):
         """Test image feature download with error"""
         mock_client = MagicMock()


### PR DESCRIPTION
## Motivation

在多模态推理场景中，特征下载后需要确保形状维度的一致性。当前代码在下载 BOS 特征时，缺少对特征形状维度的验证，可能导致混合维度（如同时存在 2D 和 4D 特征）或非法维度（如 1D 特征）的输入进入后续处理流程，引发潜在的运行时错误。

本 PR 通过添加特征形状检查逻辑，在特征下载完成后立即验证形状维度的合法性，提前拦截不合规的请求并返回明确的错误信息。

## Modifications

### 1. 新增 `check_result_shape()` 函数 (`resource_manager_v1.py`)

- 验证所有特征必须是 2D 或 4D 形状
- 确保同一批特征中的维度一致（不允许混合 2D 和 4D）
- 对非法维度或不一致的情况，设置错误码 530 并记录详细错误信息
- 错误消息包含具体的特征索引和形状信息，便于问题定位

### 2. 特征下载流程增强

在以下特征下载完成后调用 `check_result_shape()` 进行验证：
- `video_features` 下载后
- `image_features` 下载后

### 3. 单元测试覆盖 (`test_resource_manager_v1.py`)

新增 4 个测试用例：
- `test_check_result_shape_all_2d_success` - 验证所有 2D 特征通过
- `test_check_result_shape_all_4d_success` - 验证所有 4D 特征通过
- `test_check_result_shape_mixed_2d_4d_fails` - 验证混合维度被拦截
- `test_check_result_shape_1d_fails` - 验证非法维度被拦截

## Usage or Command

无需额外命令，该修复自动应用于多模态特征下载流程。

## Accuracy Tests

本 PR 不涉及模型内核或前向传播代码的修改，仅增加输入验证逻辑，不影响模型输出的准确性。

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag: `[BugFix]`
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results. (N/A - no model output changes)
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
