### PR TITLE
[CI] Replace ipc=host with shm-size and sysctl configuration

### DIFF
--- a/.github/workflows/_base_test.yml
+++ b/.github/workflows/_base_test.yml
@@ -182,7 +182,10 @@ jobs:
             docker rm -f ${runner_name} || true
           fi
 
-          docker run --rm --ipc=host --pid=host --net=host \
+          docker run --rm --net=host \
+          --shm-size=64g \
+          --sysctl kernel.msgmax=1048576 \
+          --sysctl kernel.msgmnb=268435456 \
           --name ${runner_name} \
           -v $(pwd):/workspace \
           -w /workspace \

--- a/.github/workflows/_gpu_4cards_case_test.yml
+++ b/.github/workflows/_gpu_4cards_case_test.yml
@@ -166,7 +166,10 @@ jobs:
             docker rm -f ${runner_name} || true
           fi
 
-          docker run --rm --ipc=host --net=host \
+          docker run --rm --net=host \
+          --shm-size=64g \
+          --sysctl kernel.msgmax=1048576 \
+          --sysctl kernel.msgmnb=268435456 \
           --name ${runner_name} \
           -v $(pwd):/workspace -w /workspace \
           -v "${CACHE_DIR}/gitconfig:/etc/gitconfig:ro" \

--- a/.github/workflows/_logprob_test_linux.yml
+++ b/.github/workflows/_logprob_test_linux.yml
@@ -152,7 +152,11 @@ jobs:
             echo "Removing stale container: ${runner_name}"
             docker rm -f ${runner_name} || true
           fi
-          docker run --rm --ipc=host --pid=host --net=host \
+
+          docker run --rm --net=host \
+          --shm-size=64g \
+          --sysctl kernel.msgmax=1048576 \
+          --sysctl kernel.msgmnb=268435456 \
           --name ${runner_name} \
           -v $(pwd):/workspace \
           -w /workspace \

--- a/.github/workflows/_pre_ce_test.yml
+++ b/.github/workflows/_pre_ce_test.yml
@@ -163,6 +163,7 @@ jobs:
           fi
 
           docker run --rm --net=host \
+          --shm-size=64G \
           --name ${runner_name} \
           -v $(pwd):/workspace \
           -w /workspace \

--- a/.github/workflows/_stable_test.yml
+++ b/.github/workflows/_stable_test.yml
@@ -160,6 +160,7 @@ jobs:
           fi
 
           docker run --rm --net=host \
+          --shm-size=64G \
           --name ${runner_name} \
           -v $(pwd):/workspace \
           -w /workspace \


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
- Removing `--ipc=host` exposed shared memory related issues (e.g., IPC/SHM allocation failures)
- Default Docker `/dev/shm` (64MB) is insufficient for multi-process / multi-GPU tests
- Need a safer and more isolated configuration without relying on host IPC

## Modifications
- Remove `--ipc=host` to avoid cross-task interference
- Add `--shm-size=64g` to ensure sufficient shared memory for model serving
- Add `--sysctl kernel.msgmax` and `kernel.msgmnb` to support larger IPC message queues
- Keep container-level isolation while ensuring stability for multi-GPU workloads

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.