### PR TITLE
[BugFix] prevent requests from entering running state without a slot

### DIFF
--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -1120,8 +1120,7 @@ class EngineService:
                     time.sleep(0.005)
 
             except RuntimeError as e:
-                if "cannot schedule new futures after shutdown" in str(e):
-                    break
+                raise e
             except Exception as e:
                 err_msg = "Error happened while insert task to engine: {}, {}.".format(e, str(traceback.format_exc()))
                 self.llm_logger.error(err_msg)

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -935,7 +935,7 @@ class ResourceManagerV1(ResourceManager):
             if not preempted_reqs:
                 skip_requests: list[Request] = []
                 while self.waiting and token_budget > 0:
-                    if len(self.running) == self.max_num_seqs:
+                    if len(self.running) + len(self.to_be_rescheduled_request_id_set) >= self.max_num_seqs:
                         break
 
                     request = self.waiting[0]

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -939,6 +939,7 @@ class ResourceManagerV1(ResourceManager):
                         len(self.running)
                         + len(self.to_be_rescheduled_request_id_set)
                         + len(self.to_be_aborted_req_id_set)
+                        + sum([req.status == RequestStatus.PREEMPTED for req in self.waiting])
                         >= self.max_num_seqs
                     ):
                         break

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -935,7 +935,12 @@ class ResourceManagerV1(ResourceManager):
             if not preempted_reqs:
                 skip_requests: list[Request] = []
                 while self.waiting and token_budget > 0:
-                    if len(self.running) + len(self.to_be_rescheduled_request_id_set) >= self.max_num_seqs:
+                    if (
+                        len(self.running)
+                        + len(self.to_be_rescheduled_request_id_set)
+                        + len(self.to_be_aborted_req_id_set)
+                        >= self.max_num_seqs
+                    ):
                         break
 
                     request = self.waiting[0]


### PR DESCRIPTION
## Motivation

Fix scheduler slot-accounting inconsistencies when requests are running, pending abort, pending reschedule, or already preempted back into the waiting queue.

Without these fixes, the scheduler may over-admit requests and move them into `running` even though the effective occupied slots have already reached `max_num_seqs`.

## Modifications

- Update `fastdeploy/engine/sched/resource_manager_v1.py`
  - Count pending abort requests in slot accounting during scheduling.
  - Count preempted requests that have already returned to the waiting queue in slot accounting.
  - Prevent new requests from entering `running` unless a real execution slot is available.

- Update `fastdeploy/engine/common_engine.py`
  - Stop swallowing `RuntimeError("cannot schedule new futures after shutdown")`.
  - Re-raise the runtime error so shutdown and scheduling failures are surfaced explicitly.

## Usage or Command

Reproduce with a workload where requests are frequently rescheduled, aborted, or preempted while the scheduler is near `max_num_seqs`.

Expected result after this fix:
- no new request enters `running` when the effective occupied slots have already reached capacity
- scheduler occupancy stays consistent across running, abort-pending, reschedule-pending, and preempted-waiting requests
- shutdown-related scheduling errors are exposed instead of being silently skipped

## Accuracy Tests

This PR does not change model forward, kernel logic, or numerical computation paths.

No accuracy impact is expected.

## Checklist

- [x] Add at least a tag in the PR title.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. No dedicated unit test is added in this PR because the change is a scheduler state guard fix.
- [x] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
