### PR TITLE
[Cherry-Pick][BugFix] prevent requests from entering running state without a slot (#7141)

### DIFF
--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -1091,8 +1091,7 @@ class EngineService:
                     time.sleep(0.005)
 
             except RuntimeError as e:
-                if "cannot schedule new futures after shutdown" in str(e):
-                    break
+                raise e
             except Exception as e:
                 err_msg = "Error happend while insert task to engine: {}, {}.".format(e, str(traceback.format_exc()))
                 self.llm_logger.error(err_msg)

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -885,7 +885,7 @@ class ResourceManagerV1(ResourceManager):
             if not preempted_reqs:
                 skip_requests: list[Request] = []
                 while self.waiting and token_budget > 0:
-                    if len(self.running) == self.max_num_seqs:
+                    if len(self.running) + len(self.to_be_rescheduled_request_id_set) >= self.max_num_seqs:
                         break
 
                     request = self.waiting[0]

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -885,7 +885,12 @@ class ResourceManagerV1(ResourceManager):
             if not preempted_reqs:
                 skip_requests: list[Request] = []
                 while self.waiting and token_budget > 0:
-                    if len(self.running) + len(self.to_be_rescheduled_request_id_set) >= self.max_num_seqs:
+                    if (
+                        len(self.running)
+                        + len(self.to_be_rescheduled_request_id_set)
+                        + len(self.to_be_aborted_req_id_set)
+                        >= self.max_num_seqs
+                    ):
                         break
 
                     request = self.waiting[0]

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -889,6 +889,7 @@ class ResourceManagerV1(ResourceManager):
                         len(self.running)
                         + len(self.to_be_rescheduled_request_id_set)
                         + len(self.to_be_aborted_req_id_set)
+                        + sum([req.status == RequestStatus.PREEMPTED for req in self.waiting])
                         >= self.max_num_seqs
                     ):
                         break


### PR DESCRIPTION
## Motivation

Cherry-pick the scheduler slot-accounting fixes from develop PR #7141 to `release/2.5`.

This keeps scheduler occupancy consistent on the release branch when requests are running, pending abort, pending reschedule, or already preempted back into the waiting queue.

## Modifications

- Cherry-pick `ea3854523f9a69b01e4194e51bc1e2d037e71d23`: prevent requests from entering running state without a slot.
- Cherry-pick `3e4360b2553391850467b544757022ab02f99c3c`: fix abort-set counting.
- Cherry-pick `dc46505dbf06f3f95c565d53e57fb459e224a87b`: count preempted tasks in the waiting list.
- Applied cleanly on top of `upstream/release/2.5` in branch `release/2.5+20260402_fix_schedule`.

## Usage or Command

Bugfix validation command not run in this session.

Suggested reproduction:
- Run a workload where requests are frequently rescheduled, aborted, or preempted while the scheduler is near `max_num_seqs`.
- Verify that no request enters `running` when the effective occupied slots have already reached capacity.

## Accuracy Tests

This cherry-pick does not change model forward, kernel logic, or numerical computation paths.

No accuracy impact is expected.

## Checklist

- [x] Add at least a tag in the PR title.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. No new unit tests were added in this cherry-pick.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
