### PR TITLE
[Cherry-Pick][BugFix][RL] Fix RL OOM Bug, Optimize async weight loading and switch to yaml version file (#7171)

### DIFF
--- a/fastdeploy/rl/dynamic_weight_manager.py
+++ b/fastdeploy/rl/dynamic_weight_manager.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List
 
 import numpy as np
 import paddle
+import yaml
 from paddleformers.utils.log import logger
 
 from fastdeploy.config import FDConfig
@@ -67,8 +68,6 @@ class DynamicWeightManager:
         """Capture and store initial model parameters state."""
         for model in self.model_list:
             for name, param in model.state_dict().items():
-                if hasattr(param, "_is_initialized") and not param._is_initialized():
-                    param.initialize()
                 logger.info(f"Model param: {name}, shape={param.shape}, dtype={param.dtype}, place={param.place}")
                 self.state_dict[name] = param
 
@@ -93,17 +92,18 @@ class DynamicWeightManager:
                     )
             return is_valid
 
-        if version is None or version == "":
+        bootstrap_load = version is None or version == ""
+        if bootstrap_load:
             version = self.read_model_version_from_file()
         if version is None or version == "":
             raise Exception(
-                "rsync model version not set, please set it in 1) {model_version}/version.txt "
+                "rsync model version not set, please set it in 1) {model_version}/version.yaml "
                 "or 2) interface arguments 'version'"
             )
 
         logger.info(
             f"START rank:{self.local_rank}/{self.nranks} update_weights_by_rdma, "
-            f"version:{version}, verify_checksum:{verify_checksum}"
+            f"version:{version}, verify_checksum:{verify_checksum}, bootstrap_load:{bootstrap_load}"
         )
 
         if self.rdma_handle is None:
@@ -128,8 +128,14 @@ class DynamicWeightManager:
             raise ValueError(error_msg)
 
         update_start = time.perf_counter()
-        for name, param in old_state_dict.items():
-            param.set_value(new_state_dict[name])
+        for name, target_param in old_state_dict.items():
+            new_param = new_state_dict[name]
+            if bootstrap_load and not target_param._is_initialized():
+                new_param = new_param.cuda()
+                new_param._share_buffer_to(target_param)
+            else:
+                target_param.set_value(new_param)
+
         update_cost = time.perf_counter() - update_start
         logger.info(f"params set value cost {update_cost:.2f} seconds")
         total_cost = time.perf_counter() - sync_start
@@ -476,13 +482,23 @@ class DynamicWeightManager:
 
     def read_model_version_from_file(self):
         model_dir = self.fd_config.model_config.model
-        version_file = os.path.join(model_dir, "version.txt")
+        version_file = os.path.join(model_dir, "version.yaml")
         try:
             with open(version_file, "r", encoding="utf-8") as f:
-                version = f.read().strip()
-            return version
-        except (FileNotFoundError, OSError, IOError) as e:
-            logger.error(f"Failed to read model version file '{version_file}': {e}")
+                version_info = yaml.safe_load(f) or {}
+
+            if not isinstance(version_info, dict):
+                logger.error(f"Failed to read model step from '{version_file}': yaml content is not a mapping")
+                return None
+
+            step = version_info.get("step")
+            if step is None:
+                logger.error(f"Failed to read model step from '{version_file}': missing 'step' field")
+                return None
+
+            return str(step)
+        except (FileNotFoundError, OSError, IOError, yaml.YAMLError) as e:
+            logger.error(f"Failed to read model step from '{version_file}': {e}")
             return None
 
     @staticmethod


### PR DESCRIPTION
This PR cherry-picks #7171 to release/2.5.

💡 If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

💡 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Motivation

- `_capture_model_state` 预先调用 `param.initialize()` 初始化所有参数，本意是将初始params移植gpu place，方便后续异步权重设置，但实际会导致ipc权重加载路径出现OOM错误
- 原先的step信息从 `version.txt` 统一到 `version.yaml`文件，避免过多版本文件管理。

## Modifications

**`fastdeploy/rl/dynamic_weight_manager.py`**

1. **`_capture_model_state`**：移除对未初始化参数的 `param.initialize()` 调用，使其保持未初始化状态，避免OOM问题。
2. **`update_weights_by_rdma`**：新增 `bootstrap_load` 标志位（当未显式传入 `version` 时为 `True`）。在 bootstrap 路径下，对仍未初始化的参数（`_is_initialized() == False`），将接收到的权重移至 CUDA 后通过 `_share_buffer_to()` 直接共享底层 buffer，保证权重在GPU place后，后续继续通过原本的set_value进行设置。
3. **`read_model_version_from_file`**：版本文件格式从 `version.txt`（纯文本）切换为 `version.yaml`（YAML 格式）。使用 `yaml.safe_load()` 解析并提取 `step` 字段，增加对非法 YAML 内容和缺失 `step` 字段的校验。

## Usage or Command

无新增用户侧 API。版本文件格式变更需要将模型目录下的 `version.txt` 替换为 `version.yaml`：

## Accuracy Tests

本次改动仅影响权重加载路径（内存管理），不影响模型前向计算逻辑，无精度影响。

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.

