### PR TITLE
[Cherry-Pick][BugFix] prevent requests from entering running state without a slot(#7141)

### DIFF
--- a/fastdeploy/cache_manager/transfer_factory/mooncake_store/mooncake_store.py
+++ b/fastdeploy/cache_manager/transfer_factory/mooncake_store/mooncake_store.py
@@ -111,6 +111,9 @@ class MooncakeStore(KVCacheStorage):
         host_ip = get_host_ip()
         os.environ["MC_TCP_BIND_ADDRESS"] = host_ip
         logger.info(f"Set MC_TCP_BIND_ADDRESS to {host_ip}")
+        if os.environ.get("MC_MAX_MR_SIZE") is None:
+            os.environ["MC_MAX_MR_SIZE"] = str(4 * 1024**3)  # 4GB
+            logger.info("MC_MAX_MR_SIZE is not set, default to 4GB.")
 
         try:
             from mooncake.store import MooncakeDistributedStore

--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -1152,8 +1152,7 @@ class EngineService:
                     time.sleep(0.005)
 
             except RuntimeError as e:
-                if "cannot schedule new futures after shutdown" in str(e):
-                    break
+                raise e
             except Exception as e:
                 err_msg = "Error happened while insert task to engine: {}, {}.".format(e, str(traceback.format_exc()))
                 self.llm_logger.error(err_msg)

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -945,6 +945,7 @@ class ResourceManagerV1(ResourceManager):
                         len(self.running)
                         + len(self.to_be_rescheduled_request_id_set)
                         + len(self.to_be_aborted_req_id_set)
+                        + sum([req.status == RequestStatus.PREEMPTED for req in self.waiting])
                         >= self.max_num_seqs
                     ):
                         break

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -941,7 +941,7 @@ class ResourceManagerV1(ResourceManager):
             if not preempted_reqs:
                 skip_requests: list[Request] = []
                 while self.waiting and token_budget > 0:
-                    if len(self.running) == self.max_num_seqs:
+                    if len(self.running) + len(self.to_be_rescheduled_request_id_set) >= self.max_num_seqs:
                         break
 
                     request = self.waiting[0]

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -941,7 +941,12 @@ class ResourceManagerV1(ResourceManager):
             if not preempted_reqs:
                 skip_requests: list[Request] = []
                 while self.waiting and token_budget > 0:
-                    if len(self.running) + len(self.to_be_rescheduled_request_id_set) >= self.max_num_seqs:
+                    if (
+                        len(self.running)
+                        + len(self.to_be_rescheduled_request_id_set)
+                        + len(self.to_be_aborted_req_id_set)
+                        >= self.max_num_seqs
+                    ):
                         break
 
                     request = self.waiting[0]


### PR DESCRIPTION
## Motivation

Cherry-pick the waiting-list preempted-task counting fix from develop PR #7141 into release/2.6.

This cherry-pick keeps the release branch aligned with the scheduler slot-accounting fix that prevents requests from being admitted when effective occupied slots have already reached max_num_seqs.

## Modifications

- Update fastdeploy/engine/sched/resource_manager_v1.py
- Count RequestStatus.PREEMPTED requests in self.waiting when checking max_num_seqs
- Preserve the existing release/2.6 slot accounting for running, abort-pending, and reschedule-pending requests

## Usage or Command

No new usage is introduced.

Validation performed during git cherry-pick --continue via pre-commit hooks:
- black
- isort
- flake8
- ruff
- check for merge conflicts
- fix end of files
- trim trailing whitespace
- detect private key
- check for added large files

## Accuracy Tests

This change only affects scheduler accounting logic and does not change model forward, kernel logic, or numerical outputs.

No accuracy impact is expected.

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run pre-commit before commit.
- [ ] Add unit tests. No dedicated unit test is added because this is a targeted scheduler guard fix being cherry-picked to the release branch.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the release branch, make sure the PR has been submitted to the develop branch, then cherry-pick it to the release branch with the [Cherry-Pick] PR tag.