### PR TITLE
[CI] Improve Code Prepare stability and cleanup logic

### DIFF
--- a/.github/workflows/_accuracy_test.yml
+++ b/.github/workflows/_accuracy_test.yml
@@ -44,38 +44,88 @@ jobs:
           FULL_REPO="${{ github.repository }}"
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
+
           docker pull ${docker_image}
-          # Clean the repository directory before starting
-          docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
-          -e "REPO_NAME=${REPO_NAME}" \
-          ${docker_image} /bin/bash -c '
-            CLEAN_RETRIES=3
-            CLEAN_COUNT=0
 
-            while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* ..."
-              rm -rf "${REPO_NAME}"* || true
-              sleep 2
+          echo "=== Step 1: Cleanup on host (runner user) ==="
+          CLEAN_RETRIES=3
+          CLEAN_COUNT=0
+          while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+            echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* on host..."
+            rm -rf "${REPO_NAME}"* 2>/dev/null || true
+            sleep 1
 
-              # Check if anything matching ${REPO_NAME}* still exists
-              if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "All ${REPO_NAME}* removed successfully"
-                break
+            if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+              echo "All ${REPO_NAME}* removed successfully on host"
+              break
+            fi
+
+            ls -ld "${REPO_NAME}"* 2>/dev/null || true
+
+            CLEAN_COUNT=$((CLEAN_COUNT + 1))
+          done
+
+          if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+            echo "=== Step 2: Cleanup using Docker (root user) ==="
+
+            docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+            -e "REPO_NAME=${REPO_NAME}" \
+            ${docker_image} /bin/bash -c '
+              CLEAN_RETRIES=3
+              CLEAN_COUNT=0
+
+              while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+                echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
+                rm -rf "${REPO_NAME}"* 2>/dev/null || true
+                sleep 2
+
+                if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                  echo "All ${REPO_NAME}* removed successfully in container"
+                  break
+                fi
+
+                CLEAN_COUNT=$((CLEAN_COUNT + 1))
+              done
+
+              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+                echo "Directory info:"
+                ls -ld "${REPO_NAME}"* || true
+                echo "Attempting force cleanup with find..."
+                find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
+                exit 1
               fi
+            '
 
-              CLEAN_COUNT=$((CLEAN_COUNT + 1))
-            done
-
-            if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-              echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
-              ls -ld "${REPO_NAME}"*
+            FINAL_EXIT_CODE=$?
+            if [ $FINAL_EXIT_CODE -ne 0 ]; then
+              echo "ERROR: Container cleanup failed with exit code $FINAL_EXIT_CODE"
               exit 1
             fi
-          '
+          fi
 
-          wget -q --no-proxy ${fd_archive_url}
-          tar -xf FastDeploy.tar.gz
-          rm -rf FastDeploy.tar.gz
+          echo "=== Step 3: Extracting FastDeploy archive ==="
+
+          rm -f FastDeploy.tar.gz 2>/dev/null || true
+
+          wget -q --no-proxy ${fd_archive_url} || {
+            echo "ERROR: Failed to download archive from ${fd_archive_url}"
+            exit 1
+          }
+
+          if [ -d "FastDeploy" ]; then
+            echo "ERROR: FastDeploy directory still exists after cleanup!"
+            ls -ld FastDeploy
+            exit 1
+          fi
+
+          tar --no-same-owner -xf FastDeploy.tar.gz || {
+            echo "ERROR: Failed to extract archive"
+            exit 1
+          }
+
+          rm -f FastDeploy.tar.gz
+
           cd FastDeploy
           git config --global user.name "FastDeployCI"
           git config --global user.email "fastdeploy_ci@example.com"

--- a/.github/workflows/_accuracy_test.yml
+++ b/.github/workflows/_accuracy_test.yml
@@ -45,8 +45,7 @@ jobs:
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
           docker pull ${docker_image}
-
-          echo "=== Step 1: Cleanup using Docker (root user) ==="
+          # Clean the repository directory before starting
           docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
           -e "REPO_NAME=${REPO_NAME}" \
           ${docker_image} /bin/bash -c '
@@ -54,12 +53,13 @@ jobs:
             CLEAN_COUNT=0
 
             while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
-              rm -rf "${REPO_NAME}"* 2>/dev/null || true
+              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* ..."
+              rm -rf "${REPO_NAME}"* || true
               sleep 2
 
+              # Check if anything matching ${REPO_NAME}* still exists
               if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "All ${REPO_NAME}* removed successfully in container"
+                echo "All ${REPO_NAME}* removed successfully"
                 break
               fi
 
@@ -68,33 +68,29 @@ jobs:
 
             if ls "${REPO_NAME}"* >/dev/null 2>&1; then
               echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+              ls -ld "${REPO_NAME}"*
               echo "Attempting force cleanup with find..."
-              find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
-              exit 1
+              find /workspace -mindepth 1 -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
+              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "ERROR: Force cleanup still failed"
+                exit 1
+              else
+                echo "Force cleanup succeeded"
+              fi
             fi
           '
-
-          echo "=== Step 2: Extracting FastDeploy archive ==="
-          rm -f FastDeploy.tar.gz 2>/dev/null || true
 
           wget -q --no-proxy ${fd_archive_url} || {
             echo "ERROR: Failed to download archive from ${fd_archive_url}"
             exit 1
           }
 
-          if [ -d "FastDeploy" ]; then
-            echo "ERROR: FastDeploy directory still exists after cleanup!"
-            ls -ld FastDeploy
-            exit 1
-          fi
-
           tar --no-same-owner -xf FastDeploy.tar.gz || {
             echo "ERROR: Failed to extract archive"
             exit 1
           }
 
-          rm -f FastDeploy.tar.gz
-
+          rm -rf FastDeploy.tar.gz
           cd FastDeploy
           git config --global user.name "FastDeployCI"
           git config --global user.email "fastdeploy_ci@example.com"

--- a/.github/workflows/_accuracy_test.yml
+++ b/.github/workflows/_accuracy_test.yml
@@ -44,68 +44,37 @@ jobs:
           FULL_REPO="${{ github.repository }}"
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
-
           docker pull ${docker_image}
 
-          echo "=== Step 1: Cleanup on host (runner user) ==="
-          CLEAN_RETRIES=3
-          CLEAN_COUNT=0
-          while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-            echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* on host..."
-            rm -rf "${REPO_NAME}"* 2>/dev/null || true
-            sleep 1
+          echo "=== Step 1: Cleanup using Docker (root user) ==="
+          docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+          -e "REPO_NAME=${REPO_NAME}" \
+          ${docker_image} /bin/bash -c '
+            CLEAN_RETRIES=3
+            CLEAN_COUNT=0
 
-            if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-              echo "All ${REPO_NAME}* removed successfully on host"
-              break
-            fi
+            while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
+              rm -rf "${REPO_NAME}"* 2>/dev/null || true
+              sleep 2
 
-            ls -ld "${REPO_NAME}"* 2>/dev/null || true
-
-            CLEAN_COUNT=$((CLEAN_COUNT + 1))
-          done
-
-          if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-            echo "=== Step 2: Cleanup using Docker (root user) ==="
-
-            docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
-            -e "REPO_NAME=${REPO_NAME}" \
-            ${docker_image} /bin/bash -c '
-              CLEAN_RETRIES=3
-              CLEAN_COUNT=0
-
-              while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-                echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
-                rm -rf "${REPO_NAME}"* 2>/dev/null || true
-                sleep 2
-
-                if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                  echo "All ${REPO_NAME}* removed successfully in container"
-                  break
-                fi
-
-                CLEAN_COUNT=$((CLEAN_COUNT + 1))
-              done
-
-              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
-                echo "Directory info:"
-                ls -ld "${REPO_NAME}"* || true
-                echo "Attempting force cleanup with find..."
-                find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
-                exit 1
+              if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "All ${REPO_NAME}* removed successfully in container"
+                break
               fi
-            '
 
-            FINAL_EXIT_CODE=$?
-            if [ $FINAL_EXIT_CODE -ne 0 ]; then
-              echo "ERROR: Container cleanup failed with exit code $FINAL_EXIT_CODE"
+              CLEAN_COUNT=$((CLEAN_COUNT + 1))
+            done
+
+            if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+              echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+              echo "Attempting force cleanup with find..."
+              find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
               exit 1
             fi
-          fi
+          '
 
-          echo "=== Step 3: Extracting FastDeploy archive ==="
-
+          echo "=== Step 2: Extracting FastDeploy archive ==="
           rm -f FastDeploy.tar.gz 2>/dev/null || true
 
           wget -q --no-proxy ${fd_archive_url} || {

--- a/.github/workflows/_base_test.yml
+++ b/.github/workflows/_base_test.yml
@@ -56,68 +56,37 @@ jobs:
           FULL_REPO="${{ github.repository }}"
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
-
           docker pull ${docker_image}
 
-          echo "=== Step 1: Cleanup on host (runner user) ==="
-          CLEAN_RETRIES=3
-          CLEAN_COUNT=0
-          while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-            echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* on host..."
-            rm -rf "${REPO_NAME}"* 2>/dev/null || true
-            sleep 1
+          echo "=== Step 1: Cleanup using Docker (root user) ==="
+          docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+          -e "REPO_NAME=${REPO_NAME}" \
+          ${docker_image} /bin/bash -c '
+            CLEAN_RETRIES=3
+            CLEAN_COUNT=0
 
-            if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-              echo "All ${REPO_NAME}* removed successfully on host"
-              break
-            fi
+            while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
+              rm -rf "${REPO_NAME}"* 2>/dev/null || true
+              sleep 2
 
-            ls -ld "${REPO_NAME}"* 2>/dev/null || true
-
-            CLEAN_COUNT=$((CLEAN_COUNT + 1))
-          done
-
-          if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-            echo "=== Step 2: Cleanup using Docker (root user) ==="
-
-            docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
-            -e "REPO_NAME=${REPO_NAME}" \
-            ${docker_image} /bin/bash -c '
-              CLEAN_RETRIES=3
-              CLEAN_COUNT=0
-
-              while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-                echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
-                rm -rf "${REPO_NAME}"* 2>/dev/null || true
-                sleep 2
-
-                if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                  echo "All ${REPO_NAME}* removed successfully in container"
-                  break
-                fi
-
-                CLEAN_COUNT=$((CLEAN_COUNT + 1))
-              done
-
-              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
-                echo "Directory info:"
-                ls -ld "${REPO_NAME}"* || true
-                echo "Attempting force cleanup with find..."
-                find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
-                exit 1
+              if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "All ${REPO_NAME}* removed successfully in container"
+                break
               fi
-            '
 
-            FINAL_EXIT_CODE=$?
-            if [ $FINAL_EXIT_CODE -ne 0 ]; then
-              echo "ERROR: Container cleanup failed with exit code $FINAL_EXIT_CODE"
+              CLEAN_COUNT=$((CLEAN_COUNT + 1))
+            done
+
+            if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+              echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+              echo "Attempting force cleanup with find..."
+              find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
               exit 1
             fi
-          fi
+          '
 
-          echo "=== Step 3: Extracting FastDeploy archive ==="
-
+          echo "=== Step 2: Extracting FastDeploy archive ==="
           # Download with retry and validation
           MAX_RETRIES=3
           RETRY_COUNT=0

--- a/.github/workflows/_base_test.yml
+++ b/.github/workflows/_base_test.yml
@@ -57,36 +57,41 @@ jobs:
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
           docker pull ${docker_image}
-
-          echo "=== Step 1: Cleanup using Docker (root user) ==="
+          # Clean the repository directory before starting
           docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
           -e "REPO_NAME=${REPO_NAME}" \
           ${docker_image} /bin/bash -c '
-            CLEAN_RETRIES=3
-            CLEAN_COUNT=0
+              CLEAN_RETRIES=3
+              CLEAN_COUNT=0
 
-            while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
-              rm -rf "${REPO_NAME}"* 2>/dev/null || true
-              sleep 2
+              while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+                echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* ..."
+                rm -rf "${REPO_NAME}"* || true
+                sleep 2
 
-              if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "All ${REPO_NAME}* removed successfully in container"
-                break
+                # Check if anything matching ${REPO_NAME}* still exists
+                if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                  echo "All ${REPO_NAME}* removed successfully"
+                  break
+                fi
+
+                CLEAN_COUNT=$((CLEAN_COUNT + 1))
+              done
+
+              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+                ls -ld "${REPO_NAME}"*
+                echo "Attempting force cleanup with find..."
+                find /workspace -mindepth 1 -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
+                if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                  echo "ERROR: Force cleanup still failed"
+                  exit 1
+                else
+                  echo "Force cleanup succeeded"
+                fi
               fi
+            '
 
-              CLEAN_COUNT=$((CLEAN_COUNT + 1))
-            done
-
-            if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-              echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
-              echo "Attempting force cleanup with find..."
-              find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
-              exit 1
-            fi
-          '
-
-          echo "=== Step 2: Extracting FastDeploy archive ==="
           # Download with retry and validation
           MAX_RETRIES=3
           RETRY_COUNT=0
@@ -113,19 +118,12 @@ jobs:
             exit 1
           fi
 
-          if [ -d "FastDeploy" ]; then
-            echo "ERROR: FastDeploy directory still exists after cleanup!"
-            ls -ld FastDeploy
-            exit 1
-          fi
-
           tar --no-same-owner -xf FastDeploy.tar.gz || {
             echo "ERROR: Failed to extract archive"
             exit 1
           }
 
-          rm -f FastDeploy.tar.gz
-
+          rm -rf FastDeploy.tar.gz
           cd FastDeploy
           git config --global user.name "FastDeployCI"
           git config --global user.email "fastdeploy_ci@example.com"

--- a/.github/workflows/_base_test.yml
+++ b/.github/workflows/_base_test.yml
@@ -56,22 +56,43 @@ jobs:
           FULL_REPO="${{ github.repository }}"
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
+
           docker pull ${docker_image}
-          # Clean the repository directory before starting
-          docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
-          -e "REPO_NAME=${REPO_NAME}" \
-          ${docker_image} /bin/bash -c '
+
+          echo "=== Step 1: Cleanup on host (runner user) ==="
+          CLEAN_RETRIES=3
+          CLEAN_COUNT=0
+          while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+            echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* on host..."
+            rm -rf "${REPO_NAME}"* 2>/dev/null || true
+            sleep 1
+
+            if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+              echo "All ${REPO_NAME}* removed successfully on host"
+              break
+            fi
+
+            ls -ld "${REPO_NAME}"* 2>/dev/null || true
+
+            CLEAN_COUNT=$((CLEAN_COUNT + 1))
+          done
+
+          if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+            echo "=== Step 2: Cleanup using Docker (root user) ==="
+
+            docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+            -e "REPO_NAME=${REPO_NAME}" \
+            ${docker_image} /bin/bash -c '
               CLEAN_RETRIES=3
               CLEAN_COUNT=0
 
               while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-                echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* ..."
-                rm -rf "${REPO_NAME}"* || true
+                echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
+                rm -rf "${REPO_NAME}"* 2>/dev/null || true
                 sleep 2
 
-                # Check if anything matching ${REPO_NAME}* still exists
                 if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                  echo "All ${REPO_NAME}* removed successfully"
+                  echo "All ${REPO_NAME}* removed successfully in container"
                   break
                 fi
 
@@ -80,10 +101,22 @@ jobs:
 
               if ls "${REPO_NAME}"* >/dev/null 2>&1; then
                 echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
-                ls -ld "${REPO_NAME}"*
+                echo "Directory info:"
+                ls -ld "${REPO_NAME}"* || true
+                echo "Attempting force cleanup with find..."
+                find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
                 exit 1
               fi
             '
+
+            FINAL_EXIT_CODE=$?
+            if [ $FINAL_EXIT_CODE -ne 0 ]; then
+              echo "ERROR: Container cleanup failed with exit code $FINAL_EXIT_CODE"
+              exit 1
+            fi
+          fi
+
+          echo "=== Step 3: Extracting FastDeploy archive ==="
 
           # Download with retry and validation
           MAX_RETRIES=3
@@ -111,8 +144,19 @@ jobs:
             exit 1
           fi
 
-          tar -xf FastDeploy.tar.gz
-          rm -rf FastDeploy.tar.gz
+          if [ -d "FastDeploy" ]; then
+            echo "ERROR: FastDeploy directory still exists after cleanup!"
+            ls -ld FastDeploy
+            exit 1
+          fi
+
+          tar --no-same-owner -xf FastDeploy.tar.gz || {
+            echo "ERROR: Failed to extract archive"
+            exit 1
+          }
+
+          rm -f FastDeploy.tar.gz
+
           cd FastDeploy
           git config --global user.name "FastDeployCI"
           git config --global user.email "fastdeploy_ci@example.com"

--- a/.github/workflows/_golang_router_test.yml
+++ b/.github/workflows/_golang_router_test.yml
@@ -51,38 +51,88 @@ jobs:
           FULL_REPO="${{ github.repository }}"
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
+
           docker pull ${docker_image}
-          # Clean the repository directory before starting
-          docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
-          -e "REPO_NAME=${REPO_NAME}" \
-          ${docker_image} /bin/bash -c '
-            CLEAN_RETRIES=3
-            CLEAN_COUNT=0
 
-            while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* ..."
-              rm -rf "${REPO_NAME}"* || true
-              sleep 2
+          echo "=== Step 1: Cleanup on host (runner user) ==="
+          CLEAN_RETRIES=3
+          CLEAN_COUNT=0
+          while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+            echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* on host..."
+            rm -rf "${REPO_NAME}"* 2>/dev/null || true
+            sleep 1
 
-              # Check if anything matching ${REPO_NAME}* still exists
-              if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "All ${REPO_NAME}* removed successfully"
-                break
+            if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+              echo "All ${REPO_NAME}* removed successfully on host"
+              break
+            fi
+
+            ls -ld "${REPO_NAME}"* 2>/dev/null || true
+
+            CLEAN_COUNT=$((CLEAN_COUNT + 1))
+          done
+
+          if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+            echo "=== Step 2: Cleanup using Docker (root user) ==="
+
+            docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+            -e "REPO_NAME=${REPO_NAME}" \
+            ${docker_image} /bin/bash -c '
+              CLEAN_RETRIES=3
+              CLEAN_COUNT=0
+
+              while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+                echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
+                rm -rf "${REPO_NAME}"* 2>/dev/null || true
+                sleep 2
+
+                if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                  echo "All ${REPO_NAME}* removed successfully in container"
+                  break
+                fi
+
+                CLEAN_COUNT=$((CLEAN_COUNT + 1))
+              done
+
+              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+                echo "Directory info:"
+                ls -ld "${REPO_NAME}"* || true
+                echo "Attempting force cleanup with find..."
+                find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
+                exit 1
               fi
+            '
 
-              CLEAN_COUNT=$((CLEAN_COUNT + 1))
-            done
-
-            if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-              echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
-              ls -ld "${REPO_NAME}"*
+            FINAL_EXIT_CODE=$?
+            if [ $FINAL_EXIT_CODE -ne 0 ]; then
+              echo "ERROR: Container cleanup failed with exit code $FINAL_EXIT_CODE"
               exit 1
             fi
-          '
+          fi
 
-          wget -q --no-proxy ${fd_archive_url}
-          tar -xf FastDeploy.tar.gz
-          rm -rf FastDeploy.tar.gz
+          echo "=== Step 3: Extracting FastDeploy archive ==="
+
+          rm -f FastDeploy.tar.gz 2>/dev/null || true
+
+          wget -q --no-proxy ${fd_archive_url} || {
+            echo "ERROR: Failed to download archive from ${fd_archive_url}"
+            exit 1
+          }
+
+          if [ -d "FastDeploy" ]; then
+            echo "ERROR: FastDeploy directory still exists after cleanup!"
+            ls -ld FastDeploy
+            exit 1
+          fi
+
+          tar --no-same-owner -xf FastDeploy.tar.gz || {
+            echo "ERROR: Failed to extract archive"
+            exit 1
+          }
+
+          rm -f FastDeploy.tar.gz
+
           cd FastDeploy
           git config --global user.name "FastDeployCI"
           git config --global user.email "fastdeploy_ci@example.com"

--- a/.github/workflows/_golang_router_test.yml
+++ b/.github/workflows/_golang_router_test.yml
@@ -51,68 +51,37 @@ jobs:
           FULL_REPO="${{ github.repository }}"
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
-
           docker pull ${docker_image}
 
-          echo "=== Step 1: Cleanup on host (runner user) ==="
-          CLEAN_RETRIES=3
-          CLEAN_COUNT=0
-          while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-            echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* on host..."
-            rm -rf "${REPO_NAME}"* 2>/dev/null || true
-            sleep 1
+          echo "=== Step 1: Cleanup using Docker (root user) ==="
+          docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+          -e "REPO_NAME=${REPO_NAME}" \
+          ${docker_image} /bin/bash -c '
+            CLEAN_RETRIES=3
+            CLEAN_COUNT=0
 
-            if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-              echo "All ${REPO_NAME}* removed successfully on host"
-              break
-            fi
+            while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
+              rm -rf "${REPO_NAME}"* 2>/dev/null || true
+              sleep 2
 
-            ls -ld "${REPO_NAME}"* 2>/dev/null || true
-
-            CLEAN_COUNT=$((CLEAN_COUNT + 1))
-          done
-
-          if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-            echo "=== Step 2: Cleanup using Docker (root user) ==="
-
-            docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
-            -e "REPO_NAME=${REPO_NAME}" \
-            ${docker_image} /bin/bash -c '
-              CLEAN_RETRIES=3
-              CLEAN_COUNT=0
-
-              while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-                echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
-                rm -rf "${REPO_NAME}"* 2>/dev/null || true
-                sleep 2
-
-                if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                  echo "All ${REPO_NAME}* removed successfully in container"
-                  break
-                fi
-
-                CLEAN_COUNT=$((CLEAN_COUNT + 1))
-              done
-
-              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
-                echo "Directory info:"
-                ls -ld "${REPO_NAME}"* || true
-                echo "Attempting force cleanup with find..."
-                find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
-                exit 1
+              if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "All ${REPO_NAME}* removed successfully in container"
+                break
               fi
-            '
 
-            FINAL_EXIT_CODE=$?
-            if [ $FINAL_EXIT_CODE -ne 0 ]; then
-              echo "ERROR: Container cleanup failed with exit code $FINAL_EXIT_CODE"
+              CLEAN_COUNT=$((CLEAN_COUNT + 1))
+            done
+
+            if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+              echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+              echo "Attempting force cleanup with find..."
+              find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
               exit 1
             fi
-          fi
+          '
 
-          echo "=== Step 3: Extracting FastDeploy archive ==="
-
+          echo "=== Step 2: Extracting FastDeploy archive ==="
           rm -f FastDeploy.tar.gz 2>/dev/null || true
 
           wget -q --no-proxy ${fd_archive_url} || {

--- a/.github/workflows/_golang_router_test.yml
+++ b/.github/workflows/_golang_router_test.yml
@@ -52,8 +52,7 @@ jobs:
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
           docker pull ${docker_image}
-
-          echo "=== Step 1: Cleanup using Docker (root user) ==="
+          # Clean the repository directory before starting
           docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
           -e "REPO_NAME=${REPO_NAME}" \
           ${docker_image} /bin/bash -c '
@@ -61,12 +60,13 @@ jobs:
             CLEAN_COUNT=0
 
             while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
-              rm -rf "${REPO_NAME}"* 2>/dev/null || true
+              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* ..."
+              rm -rf "${REPO_NAME}"* || true
               sleep 2
 
+              # Check if anything matching ${REPO_NAME}* still exists
               if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "All ${REPO_NAME}* removed successfully in container"
+                echo "All ${REPO_NAME}* removed successfully"
                 break
               fi
 
@@ -75,33 +75,29 @@ jobs:
 
             if ls "${REPO_NAME}"* >/dev/null 2>&1; then
               echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+              ls -ld "${REPO_NAME}"*
               echo "Attempting force cleanup with find..."
-              find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
-              exit 1
+              find /workspace -mindepth 1 -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
+              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "ERROR: Force cleanup still failed"
+                exit 1
+              else
+                echo "Force cleanup succeeded"
+              fi
             fi
           '
-
-          echo "=== Step 2: Extracting FastDeploy archive ==="
-          rm -f FastDeploy.tar.gz 2>/dev/null || true
 
           wget -q --no-proxy ${fd_archive_url} || {
             echo "ERROR: Failed to download archive from ${fd_archive_url}"
             exit 1
           }
 
-          if [ -d "FastDeploy" ]; then
-            echo "ERROR: FastDeploy directory still exists after cleanup!"
-            ls -ld FastDeploy
-            exit 1
-          fi
-
           tar --no-same-owner -xf FastDeploy.tar.gz || {
             echo "ERROR: Failed to extract archive"
             exit 1
           }
 
-          rm -f FastDeploy.tar.gz
-
+          rm -rf FastDeploy.tar.gz
           cd FastDeploy
           git config --global user.name "FastDeployCI"
           git config --global user.email "fastdeploy_ci@example.com"

--- a/.github/workflows/_gpu_4cards_case_test.yml
+++ b/.github/workflows/_gpu_4cards_case_test.yml
@@ -56,68 +56,37 @@ jobs:
           FULL_REPO="${{ github.repository }}"
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
-
           docker pull ${docker_image}
 
-          echo "=== Step 1: Cleanup on host (runner user) ==="
-          CLEAN_RETRIES=3
-          CLEAN_COUNT=0
-          while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-            echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* on host..."
-            rm -rf "${REPO_NAME}"* 2>/dev/null || true
-            sleep 1
+          echo "=== Step 1: Cleanup using Docker (root user) ==="
+          docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+          -e "REPO_NAME=${REPO_NAME}" \
+          ${docker_image} /bin/bash -c '
+            CLEAN_RETRIES=3
+            CLEAN_COUNT=0
 
-            if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-              echo "All ${REPO_NAME}* removed successfully on host"
-              break
-            fi
+            while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
+              rm -rf "${REPO_NAME}"* 2>/dev/null || true
+              sleep 2
 
-            ls -ld "${REPO_NAME}"* 2>/dev/null || true
-
-            CLEAN_COUNT=$((CLEAN_COUNT + 1))
-          done
-
-          if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-            echo "=== Step 2: Cleanup using Docker (root user) ==="
-
-            docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
-            -e "REPO_NAME=${REPO_NAME}" \
-            ${docker_image} /bin/bash -c '
-              CLEAN_RETRIES=3
-              CLEAN_COUNT=0
-
-              while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-                echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
-                rm -rf "${REPO_NAME}"* 2>/dev/null || true
-                sleep 2
-
-                if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                  echo "All ${REPO_NAME}* removed successfully in container"
-                  break
-                fi
-
-                CLEAN_COUNT=$((CLEAN_COUNT + 1))
-              done
-
-              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
-                echo "Directory info:"
-                ls -ld "${REPO_NAME}"* || true
-                echo "Attempting force cleanup with find..."
-                find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
-                exit 1
+              if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "All ${REPO_NAME}* removed successfully in container"
+                break
               fi
-            '
 
-            FINAL_EXIT_CODE=$?
-            if [ $FINAL_EXIT_CODE -ne 0 ]; then
-              echo "ERROR: Container cleanup failed with exit code $FINAL_EXIT_CODE"
+              CLEAN_COUNT=$((CLEAN_COUNT + 1))
+            done
+
+            if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+              echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+              echo "Attempting force cleanup with find..."
+              find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
               exit 1
             fi
-          fi
+          '
 
-          echo "=== Step 3: Extracting FastDeploy archive ==="
-
+          echo "=== Step 2: Extracting FastDeploy archive ==="
           rm -f FastDeploy.tar.gz 2>/dev/null || true
 
           wget -q --no-proxy ${fd_archive_url} || {

--- a/.github/workflows/_gpu_4cards_case_test.yml
+++ b/.github/workflows/_gpu_4cards_case_test.yml
@@ -56,38 +56,88 @@ jobs:
           FULL_REPO="${{ github.repository }}"
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
+
           docker pull ${docker_image}
-          # Clean the repository directory before starting
-          docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
-          -e "REPO_NAME=${REPO_NAME}" \
-          ${docker_image} /bin/bash -c '
-            CLEAN_RETRIES=3
-            CLEAN_COUNT=0
 
-            while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* ..."
-              rm -rf "${REPO_NAME}"* || true
-              sleep 2
+          echo "=== Step 1: Cleanup on host (runner user) ==="
+          CLEAN_RETRIES=3
+          CLEAN_COUNT=0
+          while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+            echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* on host..."
+            rm -rf "${REPO_NAME}"* 2>/dev/null || true
+            sleep 1
 
-              # Check if anything matching ${REPO_NAME}* still exists
-              if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "All ${REPO_NAME}* removed successfully"
-                break
+            if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+              echo "All ${REPO_NAME}* removed successfully on host"
+              break
+            fi
+
+            ls -ld "${REPO_NAME}"* 2>/dev/null || true
+
+            CLEAN_COUNT=$((CLEAN_COUNT + 1))
+          done
+
+          if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+            echo "=== Step 2: Cleanup using Docker (root user) ==="
+
+            docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+            -e "REPO_NAME=${REPO_NAME}" \
+            ${docker_image} /bin/bash -c '
+              CLEAN_RETRIES=3
+              CLEAN_COUNT=0
+
+              while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+                echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
+                rm -rf "${REPO_NAME}"* 2>/dev/null || true
+                sleep 2
+
+                if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                  echo "All ${REPO_NAME}* removed successfully in container"
+                  break
+                fi
+
+                CLEAN_COUNT=$((CLEAN_COUNT + 1))
+              done
+
+              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+                echo "Directory info:"
+                ls -ld "${REPO_NAME}"* || true
+                echo "Attempting force cleanup with find..."
+                find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
+                exit 1
               fi
+            '
 
-              CLEAN_COUNT=$((CLEAN_COUNT + 1))
-            done
-
-            if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-              echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
-              ls -ld "${REPO_NAME}"*
+            FINAL_EXIT_CODE=$?
+            if [ $FINAL_EXIT_CODE -ne 0 ]; then
+              echo "ERROR: Container cleanup failed with exit code $FINAL_EXIT_CODE"
               exit 1
             fi
-          '
+          fi
 
-          wget -q --no-proxy ${fd_archive_url}
-          tar -xf FastDeploy.tar.gz
-          rm -rf FastDeploy.tar.gz
+          echo "=== Step 3: Extracting FastDeploy archive ==="
+
+          rm -f FastDeploy.tar.gz 2>/dev/null || true
+
+          wget -q --no-proxy ${fd_archive_url} || {
+            echo "ERROR: Failed to download archive from ${fd_archive_url}"
+            exit 1
+          }
+
+          if [ -d "FastDeploy" ]; then
+            echo "ERROR: FastDeploy directory still exists after cleanup!"
+            ls -ld FastDeploy
+            exit 1
+          fi
+
+          tar --no-same-owner -xf FastDeploy.tar.gz || {
+            echo "ERROR: Failed to extract archive"
+            exit 1
+          }
+
+          rm -f FastDeploy.tar.gz
+
           cd FastDeploy
           git config --global user.name "FastDeployCI"
           git config --global user.email "fastdeploy_ci@example.com"

--- a/.github/workflows/_gpu_4cards_case_test.yml
+++ b/.github/workflows/_gpu_4cards_case_test.yml
@@ -57,8 +57,7 @@ jobs:
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
           docker pull ${docker_image}
-
-          echo "=== Step 1: Cleanup using Docker (root user) ==="
+          # Clean the repository directory before starting
           docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
           -e "REPO_NAME=${REPO_NAME}" \
           ${docker_image} /bin/bash -c '
@@ -66,12 +65,13 @@ jobs:
             CLEAN_COUNT=0
 
             while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
-              rm -rf "${REPO_NAME}"* 2>/dev/null || true
+              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* ..."
+              rm -rf "${REPO_NAME}"* || true
               sleep 2
 
+              # Check if anything matching ${REPO_NAME}* still exists
               if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "All ${REPO_NAME}* removed successfully in container"
+                echo "All ${REPO_NAME}* removed successfully"
                 break
               fi
 
@@ -80,33 +80,29 @@ jobs:
 
             if ls "${REPO_NAME}"* >/dev/null 2>&1; then
               echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+              ls -ld "${REPO_NAME}"*
               echo "Attempting force cleanup with find..."
-              find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
-              exit 1
+              find /workspace -mindepth 1 -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
+              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "ERROR: Force cleanup still failed"
+                exit 1
+              else
+                echo "Force cleanup succeeded"
+              fi
             fi
           '
-
-          echo "=== Step 2: Extracting FastDeploy archive ==="
-          rm -f FastDeploy.tar.gz 2>/dev/null || true
 
           wget -q --no-proxy ${fd_archive_url} || {
             echo "ERROR: Failed to download archive from ${fd_archive_url}"
             exit 1
           }
 
-          if [ -d "FastDeploy" ]; then
-            echo "ERROR: FastDeploy directory still exists after cleanup!"
-            ls -ld FastDeploy
-            exit 1
-          fi
-
           tar --no-same-owner -xf FastDeploy.tar.gz || {
             echo "ERROR: Failed to extract archive"
             exit 1
           }
 
-          rm -f FastDeploy.tar.gz
-
+          rm -rf FastDeploy.tar.gz
           cd FastDeploy
           git config --global user.name "FastDeployCI"
           git config --global user.email "fastdeploy_ci@example.com"

--- a/.github/workflows/_logprob_test_linux.yml
+++ b/.github/workflows/_logprob_test_linux.yml
@@ -52,66 +52,36 @@ jobs:
           docker_image: ${{ inputs.DOCKER_IMAGE }}
           paddletest_archive_url: ${{ inputs.PADDLETEST_ARCHIVE_URL }}
         run: |
+          set -x
           docker pull ${docker_image}
+          echo "=== Step 1: Cleanup using Docker (root user) ==="
+          docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+          ${docker_image} /bin/bash -c '
+            CLEAN_RETRIES=3
+            CLEAN_COUNT=0
 
-          echo "=== Step 1: Cleanup on host (runner user) ==="
-          CLEAN_RETRIES=3
-          CLEAN_COUNT=0
-          while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-            echo "Attempt $((CLEAN_COUNT+1)) to remove /workspace/* on host..."
-            rm -rf ./* 2>/dev/null || true
-            sleep 1
+            while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+              echo "Attempt $((CLEAN_COUNT+1)) to remove /workspace/* in container..."
+              rm -rf /workspace/* 2>/dev/null || true
+              sleep 2
 
-            if ! ls ./* >/dev/null 2>&1; then
-              echo "All workspace contents removed successfully on host"
-              break
-            fi
-
-            ls -ld ./* 2>/dev/null || true
-
-            CLEAN_COUNT=$((CLEAN_COUNT + 1))
-          done
-
-          if ls ./* >/dev/null 2>&1; then
-            echo "=== Step 2: Cleanup using Docker (root user) ==="
-
-            docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
-            ${docker_image} /bin/bash -c '
-              CLEAN_RETRIES=3
-              CLEAN_COUNT=0
-
-              while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-                echo "Attempt $((CLEAN_COUNT+1)) to remove /workspace/* in container..."
-                rm -rf /workspace/* 2>/dev/null || true
-                sleep 2
-
-                if ! ls /workspace/* >/dev/null 2>&1; then
-                  echo "All workspace contents removed successfully in container"
-                  break
-                fi
-
-                CLEAN_COUNT=$((CLEAN_COUNT + 1))
-              done
-
-              if ls /workspace/* >/dev/null 2>&1; then
-                echo "ERROR: Failed to clean /workspace/* after multiple attempts"
-                echo "Directory info:"
-                ls -ld /workspace/* || true
-                echo "Attempting force cleanup with find..."
-                find /workspace -maxdepth 1 -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
-                exit 1
+              if ! ls /workspace/* >/dev/null 2>&1; then
+                echo "All workspace contents removed successfully in container"
+                break
               fi
-            '
 
-            FINAL_EXIT_CODE=$?
-            if [ $FINAL_EXIT_CODE -ne 0 ]; then
-              echo "ERROR: Container cleanup failed with exit code $FINAL_EXIT_CODE"
+              CLEAN_COUNT=$((CLEAN_COUNT + 1))
+            done
+
+            if ls /workspace/* >/dev/null 2>&1; then
+              echo "ERROR: Failed to clean /workspace/* after multiple attempts"
+              echo "Attempting force cleanup with find..."
+              find /workspace -maxdepth 1 -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
               exit 1
             fi
-          fi
+          '
 
-          echo "=== Step 3: Downloading and extracting PaddleTest archive ==="
-
+          echo "=== Step 2: Downloading and extracting PaddleTest archive ==="
           rm -f PaddleTest.tar.gz 2>/dev/null || true
 
           wget -q --no-proxy ${paddletest_archive_url} || {

--- a/.github/workflows/_logprob_test_linux.yml
+++ b/.github/workflows/_logprob_test_linux.yml
@@ -53,37 +53,85 @@ jobs:
           paddletest_archive_url: ${{ inputs.PADDLETEST_ARCHIVE_URL }}
         run: |
           docker pull ${docker_image}
-          # Clean the repository directory before starting
-          docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
-          -e "REPO_NAME=${REPO_NAME}" \
-          -e "BASE_BRANCH=${BASE_BRANCH}" \
-          ${docker_image} /bin/bash -c '
-            CLEAN_RETRIES=3
-            CLEAN_COUNT=0
 
-            while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-              echo "Attempt $((CLEAN_COUNT+1)) to remove /workspace/* ..."
-              rm -rf /workspace/* || true
-              sleep 2
+          echo "=== Step 1: Cleanup on host (runner user) ==="
+          CLEAN_RETRIES=5
+          CLEAN_COUNT=0
+          while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+            echo "Attempt $((CLEAN_COUNT+1)) to remove /workspace/* on host..."
+            rm -rf ./* 2>/dev/null || true
+            sleep 1
 
-              # Check if anything matching /workspace/* still exists
-              if ! ls /workspace/* >/dev/null 2>&1; then
-                echo "All /workspace/* removed successfully"
-                break
+            if ! ls ./* >/dev/null 2>&1; then
+              echo "All workspace contents removed successfully on host"
+              break
+            fi
+
+            ls -ld ./* 2>/dev/null || true
+
+            CLEAN_COUNT=$((CLEAN_COUNT + 1))
+          done
+
+          if ls ./* >/dev/null 2>&1; then
+            echo "=== Step 2: Cleanup using Docker (root user) ==="
+
+            docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+            ${docker_image} /bin/bash -c '
+              CLEAN_RETRIES=3
+              CLEAN_COUNT=0
+
+              while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+                echo "Attempt $((CLEAN_COUNT+1)) to remove /workspace/* in container..."
+                rm -rf /workspace/* 2>/dev/null || true
+                sleep 2
+
+                if ! ls /workspace/* >/dev/null 2>&1; then
+                  echo "All workspace contents removed successfully in container"
+                  break
+                fi
+
+                CLEAN_COUNT=$((CLEAN_COUNT + 1))
+              done
+
+              if ls /workspace/* >/dev/null 2>&1; then
+                echo "ERROR: Failed to clean /workspace/* after multiple attempts"
+                echo "Directory info:"
+                ls -ld /workspace/* || true
+                echo "Attempting force cleanup with find..."
+                find /workspace -maxdepth 1 -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
+                exit 1
               fi
+            '
 
-              CLEAN_COUNT=$((CLEAN_COUNT + 1))
-            done
-
-            if ls /workspace/* >/dev/null 2>&1; then
-              echo "ERROR: Failed to clean /workspace/* after multiple attempts"
-              ls -ld /workspace/*
+            FINAL_EXIT_CODE=$?
+            if [ $FINAL_EXIT_CODE -ne 0 ]; then
+              echo "ERROR: Container cleanup failed with exit code $FINAL_EXIT_CODE"
               exit 1
             fi
-          '
-          wget -q --no-proxy ${paddletest_archive_url}
-          tar -xf PaddleTest.tar.gz
-          rm -rf PaddleTest.tar.gz
+          fi
+
+          echo "=== Step 3: Downloading and extracting PaddleTest archive ==="
+
+          rm -f PaddleTest.tar.gz 2>/dev/null || true
+
+          wget -q --no-proxy ${paddletest_archive_url} || {
+            echo "ERROR: Failed to download archive from ${paddletest_archive_url}"
+            exit 1
+          }
+
+          if [ -d "PaddleTest" ]; then
+            echo "ERROR: PaddleTest directory still exists after cleanup!"
+            ls -ld PaddleTest
+            exit 1
+          fi
+
+          tar --no-same-owner -xf PaddleTest.tar.gz || {
+            echo "ERROR: Failed to extract archive"
+            exit 1
+          }
+
+          rm -f PaddleTest.tar.gz
+
           cd PaddleTest
           git config --global user.name "FastDeployCI"
           git config --global user.email "fastdeploy_ci@example.com"

--- a/.github/workflows/_logprob_test_linux.yml
+++ b/.github/workflows/_logprob_test_linux.yml
@@ -55,7 +55,7 @@ jobs:
           docker pull ${docker_image}
 
           echo "=== Step 1: Cleanup on host (runner user) ==="
-          CLEAN_RETRIES=5
+          CLEAN_RETRIES=3
           CLEAN_COUNT=0
           while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
             echo "Attempt $((CLEAN_COUNT+1)) to remove /workspace/* on host..."

--- a/.github/workflows/_logprob_test_linux.yml
+++ b/.github/workflows/_logprob_test_linux.yml
@@ -52,21 +52,23 @@ jobs:
           docker_image: ${{ inputs.DOCKER_IMAGE }}
           paddletest_archive_url: ${{ inputs.PADDLETEST_ARCHIVE_URL }}
         run: |
-          set -x
           docker pull ${docker_image}
-          echo "=== Step 1: Cleanup using Docker (root user) ==="
+          # Clean the repository directory before starting
           docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+          -e "REPO_NAME=${REPO_NAME}" \
+          -e "BASE_BRANCH=${BASE_BRANCH}" \
           ${docker_image} /bin/bash -c '
             CLEAN_RETRIES=3
             CLEAN_COUNT=0
 
             while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-              echo "Attempt $((CLEAN_COUNT+1)) to remove /workspace/* in container..."
-              rm -rf /workspace/* 2>/dev/null || true
+              echo "Attempt $((CLEAN_COUNT+1)) to remove /workspace/* ..."
+              rm -rf /workspace/* || true
               sleep 2
 
+              # Check if anything matching /workspace/* still exists
               if ! ls /workspace/* >/dev/null 2>&1; then
-                echo "All workspace contents removed successfully in container"
+                echo "All /workspace/* removed successfully"
                 break
               fi
 
@@ -75,33 +77,28 @@ jobs:
 
             if ls /workspace/* >/dev/null 2>&1; then
               echo "ERROR: Failed to clean /workspace/* after multiple attempts"
+              ls -ld /workspace/*
               echo "Attempting force cleanup with find..."
-              find /workspace -maxdepth 1 -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
-              exit 1
+              find /workspace -mindepth 1 -maxdepth 1 -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
+              if ls /workspace/* >/dev/null 2>&1; then
+                echo "ERROR: Force cleanup failed. Exiting..."
+                exit 1
+              else
+                echo "Force cleanup succeeded."
             fi
           '
-
-          echo "=== Step 2: Downloading and extracting PaddleTest archive ==="
-          rm -f PaddleTest.tar.gz 2>/dev/null || true
 
           wget -q --no-proxy ${paddletest_archive_url} || {
             echo "ERROR: Failed to download archive from ${paddletest_archive_url}"
             exit 1
           }
 
-          if [ -d "PaddleTest" ]; then
-            echo "ERROR: PaddleTest directory still exists after cleanup!"
-            ls -ld PaddleTest
-            exit 1
-          fi
-
           tar --no-same-owner -xf PaddleTest.tar.gz || {
             echo "ERROR: Failed to extract archive"
             exit 1
           }
 
-          rm -f PaddleTest.tar.gz
-
+          rm -rf PaddleTest.tar.gz
           cd PaddleTest
           git config --global user.name "FastDeployCI"
           git config --global user.email "fastdeploy_ci@example.com"

--- a/.github/workflows/_logprob_test_linux.yml
+++ b/.github/workflows/_logprob_test_linux.yml
@@ -85,6 +85,7 @@ jobs:
                 exit 1
               else
                 echo "Force cleanup succeeded."
+              fi
             fi
           '
 

--- a/.github/workflows/_pre_ce_test.yml
+++ b/.github/workflows/_pre_ce_test.yml
@@ -58,68 +58,37 @@ jobs:
           FULL_REPO="${{ github.repository }}"
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
-
           docker pull ${docker_image}
 
-          echo "=== Step 1: Cleanup on host (runner user) ==="
-          CLEAN_RETRIES=3
-          CLEAN_COUNT=0
-          while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-            echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* on host..."
-            rm -rf "${REPO_NAME}"* 2>/dev/null || true
-            sleep 1
+          echo "=== Step 1: Cleanup using Docker (root user) ==="
+          docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+          -e "REPO_NAME=${REPO_NAME}" \
+          ${docker_image} /bin/bash -c '
+            CLEAN_RETRIES=3
+            CLEAN_COUNT=0
 
-            if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-              echo "All ${REPO_NAME}* removed successfully on host"
-              break
-            fi
+            while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
+              rm -rf "${REPO_NAME}"* 2>/dev/null || true
+              sleep 2
 
-            ls -ld "${REPO_NAME}"* 2>/dev/null || true
-
-            CLEAN_COUNT=$((CLEAN_COUNT + 1))
-          done
-
-          if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-            echo "=== Step 2: Cleanup using Docker (root user) ==="
-
-            docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
-            -e "REPO_NAME=${REPO_NAME}" \
-            ${docker_image} /bin/bash -c '
-              CLEAN_RETRIES=3
-              CLEAN_COUNT=0
-
-              while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-                echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
-                rm -rf "${REPO_NAME}"* 2>/dev/null || true
-                sleep 2
-
-                if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                  echo "All ${REPO_NAME}* removed successfully in container"
-                  break
-                fi
-
-                CLEAN_COUNT=$((CLEAN_COUNT + 1))
-              done
-
-              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
-                echo "Directory info:"
-                ls -ld "${REPO_NAME}"* || true
-                echo "Attempting force cleanup with find..."
-                find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
-                exit 1
+              if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "All ${REPO_NAME}* removed successfully in container"
+                break
               fi
-            '
 
-            FINAL_EXIT_CODE=$?
-            if [ $FINAL_EXIT_CODE -ne 0 ]; then
-              echo "ERROR: Container cleanup failed with exit code $FINAL_EXIT_CODE"
+              CLEAN_COUNT=$((CLEAN_COUNT + 1))
+            done
+
+            if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+              echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+              echo "Attempting force cleanup with find..."
+              find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
               exit 1
             fi
-          fi
+          '
 
-          echo "=== Step 3: Extracting FastDeploy archive ==="
-
+          echo "=== Step 2: Extracting FastDeploy archive ==="
           rm -f FastDeploy.tar.gz 2>/dev/null || true
 
           wget -q --no-proxy ${fd_archive_url} || {

--- a/.github/workflows/_pre_ce_test.yml
+++ b/.github/workflows/_pre_ce_test.yml
@@ -59,8 +59,7 @@ jobs:
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
           docker pull ${docker_image}
-
-          echo "=== Step 1: Cleanup using Docker (root user) ==="
+          # Clean the repository directory before starting
           docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
           -e "REPO_NAME=${REPO_NAME}" \
           ${docker_image} /bin/bash -c '
@@ -68,12 +67,13 @@ jobs:
             CLEAN_COUNT=0
 
             while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
-              rm -rf "${REPO_NAME}"* 2>/dev/null || true
+              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* ..."
+              rm -rf "${REPO_NAME}"* || true
               sleep 2
 
+              # Check if anything matching ${REPO_NAME}* still exists
               if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "All ${REPO_NAME}* removed successfully in container"
+                echo "All ${REPO_NAME}* removed successfully"
                 break
               fi
 
@@ -82,33 +82,29 @@ jobs:
 
             if ls "${REPO_NAME}"* >/dev/null 2>&1; then
               echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+              ls -ld "${REPO_NAME}"*
               echo "Attempting force cleanup with find..."
-              find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
-              exit 1
+              find /workspace -mindepth 1 -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
+              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "ERROR: Force cleanup still failed"
+                exit 1
+              else
+                echo "Force cleanup succeeded"
+              fi
             fi
           '
-
-          echo "=== Step 2: Extracting FastDeploy archive ==="
-          rm -f FastDeploy.tar.gz 2>/dev/null || true
 
           wget -q --no-proxy ${fd_archive_url} || {
             echo "ERROR: Failed to download archive from ${fd_archive_url}"
             exit 1
           }
 
-          if [ -d "FastDeploy" ]; then
-            echo "ERROR: FastDeploy directory still exists after cleanup!"
-            ls -ld FastDeploy
-            exit 1
-          fi
-
           tar --no-same-owner -xf FastDeploy.tar.gz || {
             echo "ERROR: Failed to extract archive"
             exit 1
           }
 
-          rm -f FastDeploy.tar.gz
-
+          rm -rf FastDeploy.tar.gz
           cd FastDeploy
           git config --global user.name "FastDeployCI"
           git config --global user.email "fastdeploy_ci@example.com"

--- a/.github/workflows/_pre_ce_test.yml
+++ b/.github/workflows/_pre_ce_test.yml
@@ -58,38 +58,88 @@ jobs:
           FULL_REPO="${{ github.repository }}"
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
+
           docker pull ${docker_image}
-          # Clean the repository directory before starting
-          docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
-          -e "REPO_NAME=${REPO_NAME}" \
-          ${docker_image} /bin/bash -c '
-            CLEAN_RETRIES=3
-            CLEAN_COUNT=0
 
-            while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* ..."
-              rm -rf "${REPO_NAME}"* || true
-              sleep 2
+          echo "=== Step 1: Cleanup on host (runner user) ==="
+          CLEAN_RETRIES=3
+          CLEAN_COUNT=0
+          while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+            echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* on host..."
+            rm -rf "${REPO_NAME}"* 2>/dev/null || true
+            sleep 1
 
-              # Check if anything matching ${REPO_NAME}* still exists
-              if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "All ${REPO_NAME}* removed successfully"
-                break
+            if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+              echo "All ${REPO_NAME}* removed successfully on host"
+              break
+            fi
+
+            ls -ld "${REPO_NAME}"* 2>/dev/null || true
+
+            CLEAN_COUNT=$((CLEAN_COUNT + 1))
+          done
+
+          if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+            echo "=== Step 2: Cleanup using Docker (root user) ==="
+
+            docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+            -e "REPO_NAME=${REPO_NAME}" \
+            ${docker_image} /bin/bash -c '
+              CLEAN_RETRIES=3
+              CLEAN_COUNT=0
+
+              while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+                echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
+                rm -rf "${REPO_NAME}"* 2>/dev/null || true
+                sleep 2
+
+                if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                  echo "All ${REPO_NAME}* removed successfully in container"
+                  break
+                fi
+
+                CLEAN_COUNT=$((CLEAN_COUNT + 1))
+              done
+
+              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+                echo "Directory info:"
+                ls -ld "${REPO_NAME}"* || true
+                echo "Attempting force cleanup with find..."
+                find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
+                exit 1
               fi
+            '
 
-              CLEAN_COUNT=$((CLEAN_COUNT + 1))
-            done
-
-            if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-              echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
-              ls -ld "${REPO_NAME}"*
+            FINAL_EXIT_CODE=$?
+            if [ $FINAL_EXIT_CODE -ne 0 ]; then
+              echo "ERROR: Container cleanup failed with exit code $FINAL_EXIT_CODE"
               exit 1
             fi
-          '
+          fi
 
-          wget -q --no-proxy ${fd_archive_url}
-          tar -xf FastDeploy.tar.gz
-          rm -rf FastDeploy.tar.gz
+          echo "=== Step 3: Extracting FastDeploy archive ==="
+
+          rm -f FastDeploy.tar.gz 2>/dev/null || true
+
+          wget -q --no-proxy ${fd_archive_url} || {
+            echo "ERROR: Failed to download archive from ${fd_archive_url}"
+            exit 1
+          }
+
+          if [ -d "FastDeploy" ]; then
+            echo "ERROR: FastDeploy directory still exists after cleanup!"
+            ls -ld FastDeploy
+            exit 1
+          fi
+
+          tar --no-same-owner -xf FastDeploy.tar.gz || {
+            echo "ERROR: Failed to extract archive"
+            exit 1
+          }
+
+          rm -f FastDeploy.tar.gz
+
           cd FastDeploy
           git config --global user.name "FastDeployCI"
           git config --global user.email "fastdeploy_ci@example.com"

--- a/.github/workflows/_stable_test.yml
+++ b/.github/workflows/_stable_test.yml
@@ -56,68 +56,37 @@ jobs:
           FULL_REPO="${{ github.repository }}"
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
-
           docker pull ${docker_image}
 
-          echo "=== Step 1: Cleanup on host (runner user) ==="
-          CLEAN_RETRIES=3
-          CLEAN_COUNT=0
-          while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-            echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* on host..."
-            rm -rf "${REPO_NAME}"* 2>/dev/null || true
-            sleep 1
+          echo "=== Step 1: Cleanup using Docker (root user) ==="
+          docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+          -e "REPO_NAME=${REPO_NAME}" \
+          ${docker_image} /bin/bash -c '
+            CLEAN_RETRIES=3
+            CLEAN_COUNT=0
 
-            if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-              echo "All ${REPO_NAME}* removed successfully on host"
-              break
-            fi
+            while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
+              rm -rf "${REPO_NAME}"* 2>/dev/null || true
+              sleep 2
 
-            ls -ld "${REPO_NAME}"* 2>/dev/null || true
-
-            CLEAN_COUNT=$((CLEAN_COUNT + 1))
-          done
-
-          if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-            echo "=== Step 2: Cleanup using Docker (root user) ==="
-
-            docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
-            -e "REPO_NAME=${REPO_NAME}" \
-            ${docker_image} /bin/bash -c '
-              CLEAN_RETRIES=3
-              CLEAN_COUNT=0
-
-              while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-                echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
-                rm -rf "${REPO_NAME}"* 2>/dev/null || true
-                sleep 2
-
-                if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                  echo "All ${REPO_NAME}* removed successfully in container"
-                  break
-                fi
-
-                CLEAN_COUNT=$((CLEAN_COUNT + 1))
-              done
-
-              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
-                echo "Directory info:"
-                ls -ld "${REPO_NAME}"* || true
-                echo "Attempting force cleanup with find..."
-                find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
-                exit 1
+              if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "All ${REPO_NAME}* removed successfully in container"
+                break
               fi
-            '
 
-            FINAL_EXIT_CODE=$?
-            if [ $FINAL_EXIT_CODE -ne 0 ]; then
-              echo "ERROR: Container cleanup failed with exit code $FINAL_EXIT_CODE"
+              CLEAN_COUNT=$((CLEAN_COUNT + 1))
+            done
+
+            if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+              echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+              echo "Attempting force cleanup with find..."
+              find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
               exit 1
             fi
-          fi
+          '
 
-          echo "=== Step 3: Extracting FastDeploy archive ==="
-
+          echo "=== Step 2: Extracting FastDeploy archive ==="
           rm -f FastDeploy.tar.gz 2>/dev/null || true
 
           wget -q --no-proxy ${fd_archive_url} || {

--- a/.github/workflows/_stable_test.yml
+++ b/.github/workflows/_stable_test.yml
@@ -56,38 +56,88 @@ jobs:
           FULL_REPO="${{ github.repository }}"
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
+
           docker pull ${docker_image}
-          # Clean the repository directory before starting
-          docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
-          -e "REPO_NAME=${REPO_NAME}" \
-          ${docker_image} /bin/bash -c '
-            CLEAN_RETRIES=3
-            CLEAN_COUNT=0
 
-            while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* ..."
-              rm -rf "${REPO_NAME}"* || true
-              sleep 2
+          echo "=== Step 1: Cleanup on host (runner user) ==="
+          CLEAN_RETRIES=3
+          CLEAN_COUNT=0
+          while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+            echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* on host..."
+            rm -rf "${REPO_NAME}"* 2>/dev/null || true
+            sleep 1
 
-              # Check if anything matching ${REPO_NAME}* still exists
-              if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "All ${REPO_NAME}* removed successfully"
-                break
+            if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+              echo "All ${REPO_NAME}* removed successfully on host"
+              break
+            fi
+
+            ls -ld "${REPO_NAME}"* 2>/dev/null || true
+
+            CLEAN_COUNT=$((CLEAN_COUNT + 1))
+          done
+
+          if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+            echo "=== Step 2: Cleanup using Docker (root user) ==="
+
+            docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+            -e "REPO_NAME=${REPO_NAME}" \
+            ${docker_image} /bin/bash -c '
+              CLEAN_RETRIES=3
+              CLEAN_COUNT=0
+
+              while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+                echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
+                rm -rf "${REPO_NAME}"* 2>/dev/null || true
+                sleep 2
+
+                if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                  echo "All ${REPO_NAME}* removed successfully in container"
+                  break
+                fi
+
+                CLEAN_COUNT=$((CLEAN_COUNT + 1))
+              done
+
+              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+                echo "Directory info:"
+                ls -ld "${REPO_NAME}"* || true
+                echo "Attempting force cleanup with find..."
+                find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
+                exit 1
               fi
+            '
 
-              CLEAN_COUNT=$((CLEAN_COUNT + 1))
-            done
-
-            if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-              echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
-              ls -ld "${REPO_NAME}"*
+            FINAL_EXIT_CODE=$?
+            if [ $FINAL_EXIT_CODE -ne 0 ]; then
+              echo "ERROR: Container cleanup failed with exit code $FINAL_EXIT_CODE"
               exit 1
             fi
-          '
+          fi
 
-          wget -q --no-proxy ${fd_archive_url}
-          tar -xf FastDeploy.tar.gz
-          rm -rf FastDeploy.tar.gz
+          echo "=== Step 3: Extracting FastDeploy archive ==="
+
+          rm -f FastDeploy.tar.gz 2>/dev/null || true
+
+          wget -q --no-proxy ${fd_archive_url} || {
+            echo "ERROR: Failed to download archive from ${fd_archive_url}"
+            exit 1
+          }
+
+          if [ -d "FastDeploy" ]; then
+            echo "ERROR: FastDeploy directory still exists after cleanup!"
+            ls -ld FastDeploy
+            exit 1
+          fi
+
+          tar --no-same-owner -xf FastDeploy.tar.gz || {
+            echo "ERROR: Failed to extract archive"
+            exit 1
+          }
+
+          rm -f FastDeploy.tar.gz
+
           cd FastDeploy
           git config --global user.name "FastDeployCI"
           git config --global user.email "fastdeploy_ci@example.com"

--- a/.github/workflows/_stable_test.yml
+++ b/.github/workflows/_stable_test.yml
@@ -57,8 +57,7 @@ jobs:
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
           docker pull ${docker_image}
-
-          echo "=== Step 1: Cleanup using Docker (root user) ==="
+          # Clean the repository directory before starting
           docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
           -e "REPO_NAME=${REPO_NAME}" \
           ${docker_image} /bin/bash -c '
@@ -66,12 +65,13 @@ jobs:
             CLEAN_COUNT=0
 
             while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
-              rm -rf "${REPO_NAME}"* 2>/dev/null || true
+              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* ..."
+              rm -rf "${REPO_NAME}"* || true
               sleep 2
 
+              # Check if anything matching ${REPO_NAME}* still exists
               if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "All ${REPO_NAME}* removed successfully in container"
+                echo "All ${REPO_NAME}* removed successfully"
                 break
               fi
 
@@ -80,33 +80,29 @@ jobs:
 
             if ls "${REPO_NAME}"* >/dev/null 2>&1; then
               echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+              ls -ld "${REPO_NAME}"*
               echo "Attempting force cleanup with find..."
-              find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
-              exit 1
+              find /workspace -mindepth 1 -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
+              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "ERROR: Force cleanup still failed"
+                exit 1
+              else
+                echo "Force cleanup succeeded"
+              fi
             fi
           '
-
-          echo "=== Step 2: Extracting FastDeploy archive ==="
-          rm -f FastDeploy.tar.gz 2>/dev/null || true
 
           wget -q --no-proxy ${fd_archive_url} || {
             echo "ERROR: Failed to download archive from ${fd_archive_url}"
             exit 1
           }
 
-          if [ -d "FastDeploy" ]; then
-            echo "ERROR: FastDeploy directory still exists after cleanup!"
-            ls -ld FastDeploy
-            exit 1
-          fi
-
           tar --no-same-owner -xf FastDeploy.tar.gz || {
             echo "ERROR: Failed to extract archive"
             exit 1
           }
 
-          rm -f FastDeploy.tar.gz
-
+          rm -rf FastDeploy.tar.gz
           cd FastDeploy
           git config --global user.name "FastDeployCI"
           git config --global user.email "fastdeploy_ci@example.com"

--- a/.github/workflows/_unit_test_coverage.yml
+++ b/.github/workflows/_unit_test_coverage.yml
@@ -61,68 +61,37 @@ jobs:
           FULL_REPO="${{ github.repository }}"
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
-
           docker pull ${docker_image}
 
-          echo "=== Step 1: Cleanup on host (runner user) ==="
-          CLEAN_RETRIES=3
-          CLEAN_COUNT=0
-          while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-            echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* on host..."
-            rm -rf "${REPO_NAME}"* 2>/dev/null || true
-            sleep 1
+          echo "=== Step 1: Cleanup using Docker (root user) ==="
+          docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+          -e "REPO_NAME=${REPO_NAME}" \
+          ${docker_image} /bin/bash -c '
+            CLEAN_RETRIES=3
+            CLEAN_COUNT=0
 
-            if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-              echo "All ${REPO_NAME}* removed successfully on host"
-              break
-            fi
+            while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
+              rm -rf "${REPO_NAME}"* 2>/dev/null || true
+              sleep 2
 
-            ls -ld "${REPO_NAME}"* 2>/dev/null || true
-
-            CLEAN_COUNT=$((CLEAN_COUNT + 1))
-          done
-
-          if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-            echo "=== Step 2: Cleanup using Docker (root user) ==="
-
-            docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
-            -e "REPO_NAME=${REPO_NAME}" \
-            ${docker_image} /bin/bash -c '
-              CLEAN_RETRIES=3
-              CLEAN_COUNT=0
-
-              while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-                echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
-                rm -rf "${REPO_NAME}"* 2>/dev/null || true
-                sleep 2
-
-                if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                  echo "All ${REPO_NAME}* removed successfully in container"
-                  break
-                fi
-
-                CLEAN_COUNT=$((CLEAN_COUNT + 1))
-              done
-
-              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
-                echo "Directory info:"
-                ls -ld "${REPO_NAME}"* || true
-                echo "Attempting force cleanup with find..."
-                find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
-                exit 1
+              if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "All ${REPO_NAME}* removed successfully in container"
+                break
               fi
-            '
 
-            FINAL_EXIT_CODE=$?
-            if [ $FINAL_EXIT_CODE -ne 0 ]; then
-              echo "ERROR: Container cleanup failed with exit code $FINAL_EXIT_CODE"
+              CLEAN_COUNT=$((CLEAN_COUNT + 1))
+            done
+
+            if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+              echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+              echo "Attempting force cleanup with find..."
+              find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
               exit 1
             fi
-          fi
+          '
 
-          echo "=== Step 3: Extracting FastDeploy archive ==="
-
+          echo "=== Step 2: Extracting FastDeploy archive ==="
           rm -f FastDeploy.tar.gz 2>/dev/null || true
 
           wget -q --no-proxy ${fd_archive_url} || {

--- a/.github/workflows/_unit_test_coverage.yml
+++ b/.github/workflows/_unit_test_coverage.yml
@@ -61,38 +61,88 @@ jobs:
           FULL_REPO="${{ github.repository }}"
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
+
           docker pull ${docker_image}
-          # Clean the repository directory before starting
-          docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
-          -e "REPO_NAME=${REPO_NAME}" \
-          ${docker_image} /bin/bash -c '
-            CLEAN_RETRIES=3
-            CLEAN_COUNT=0
 
-            while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* ..."
-              rm -rf "${REPO_NAME}"* || true
-              sleep 2
+          echo "=== Step 1: Cleanup on host (runner user) ==="
+          CLEAN_RETRIES=3
+          CLEAN_COUNT=0
+          while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+            echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* on host..."
+            rm -rf "${REPO_NAME}"* 2>/dev/null || true
+            sleep 1
 
-              # Check if anything matching ${REPO_NAME}* still exists
-              if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "All ${REPO_NAME}* removed successfully"
-                break
+            if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+              echo "All ${REPO_NAME}* removed successfully on host"
+              break
+            fi
+
+            ls -ld "${REPO_NAME}"* 2>/dev/null || true
+
+            CLEAN_COUNT=$((CLEAN_COUNT + 1))
+          done
+
+          if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+            echo "=== Step 2: Cleanup using Docker (root user) ==="
+
+            docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
+            -e "REPO_NAME=${REPO_NAME}" \
+            ${docker_image} /bin/bash -c '
+              CLEAN_RETRIES=3
+              CLEAN_COUNT=0
+
+              while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
+                echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
+                rm -rf "${REPO_NAME}"* 2>/dev/null || true
+                sleep 2
+
+                if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                  echo "All ${REPO_NAME}* removed successfully in container"
+                  break
+                fi
+
+                CLEAN_COUNT=$((CLEAN_COUNT + 1))
+              done
+
+              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+                echo "Directory info:"
+                ls -ld "${REPO_NAME}"* || true
+                echo "Attempting force cleanup with find..."
+                find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
+                exit 1
               fi
+            '
 
-              CLEAN_COUNT=$((CLEAN_COUNT + 1))
-            done
-
-            if ls "${REPO_NAME}"* >/dev/null 2>&1; then
-              echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
-              ls -ld "${REPO_NAME}"*
+            FINAL_EXIT_CODE=$?
+            if [ $FINAL_EXIT_CODE -ne 0 ]; then
+              echo "ERROR: Container cleanup failed with exit code $FINAL_EXIT_CODE"
               exit 1
             fi
-          '
+          fi
 
-          wget -q --no-proxy ${fd_archive_url}
-          tar -xf FastDeploy.tar.gz
-          rm -rf FastDeploy.tar.gz
+          echo "=== Step 3: Extracting FastDeploy archive ==="
+
+          rm -f FastDeploy.tar.gz 2>/dev/null || true
+
+          wget -q --no-proxy ${fd_archive_url} || {
+            echo "ERROR: Failed to download archive from ${fd_archive_url}"
+            exit 1
+          }
+
+          if [ -d "FastDeploy" ]; then
+            echo "ERROR: FastDeploy directory still exists after cleanup!"
+            ls -ld FastDeploy
+            exit 1
+          fi
+
+          tar --no-same-owner -xf FastDeploy.tar.gz || {
+            echo "ERROR: Failed to extract archive"
+            exit 1
+          }
+
+          rm -f FastDeploy.tar.gz
+
           cd FastDeploy
           git config --global user.name "FastDeployCI"
           git config --global user.email "fastdeploy_ci@example.com"

--- a/.github/workflows/_unit_test_coverage.yml
+++ b/.github/workflows/_unit_test_coverage.yml
@@ -62,8 +62,7 @@ jobs:
           REPO_NAME="${FULL_REPO##*/}"
           BASE_BRANCH="${{ github.base_ref }}"
           docker pull ${docker_image}
-
-          echo "=== Step 1: Cleanup using Docker (root user) ==="
+          # Clean the repository directory before starting
           docker run --rm --net=host -v $(pwd):/workspace -w /workspace \
           -e "REPO_NAME=${REPO_NAME}" \
           ${docker_image} /bin/bash -c '
@@ -71,12 +70,13 @@ jobs:
             CLEAN_COUNT=0
 
             while [ $CLEAN_COUNT -lt $CLEAN_RETRIES ]; do
-              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* in container..."
-              rm -rf "${REPO_NAME}"* 2>/dev/null || true
+              echo "Attempt $((CLEAN_COUNT+1)) to remove ${REPO_NAME}* ..."
+              rm -rf "${REPO_NAME}"* || true
               sleep 2
 
+              # Check if anything matching ${REPO_NAME}* still exists
               if ! ls "${REPO_NAME}"* >/dev/null 2>&1; then
-                echo "All ${REPO_NAME}* removed successfully in container"
+                echo "All ${REPO_NAME}* removed successfully"
                 break
               fi
 
@@ -85,33 +85,29 @@ jobs:
 
             if ls "${REPO_NAME}"* >/dev/null 2>&1; then
               echo "ERROR: Failed to clean ${REPO_NAME}* after multiple attempts"
+              ls -ld "${REPO_NAME}"*
               echo "Attempting force cleanup with find..."
-              find /workspace -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
-              exit 1
+              find /workspace -mindepth 1 -maxdepth 1 -name "${REPO_NAME}*" -type d -exec chmod -R u+rwx {} \; -exec rm -rf {} + 2>/dev/null || true
+              if ls "${REPO_NAME}"* >/dev/null 2>&1; then
+                echo "ERROR: Force cleanup still failed"
+                exit 1
+              else
+                echo "Force cleanup succeeded"
+              fi
             fi
           '
-
-          echo "=== Step 2: Extracting FastDeploy archive ==="
-          rm -f FastDeploy.tar.gz 2>/dev/null || true
 
           wget -q --no-proxy ${fd_archive_url} || {
             echo "ERROR: Failed to download archive from ${fd_archive_url}"
             exit 1
           }
 
-          if [ -d "FastDeploy" ]; then
-            echo "ERROR: FastDeploy directory still exists after cleanup!"
-            ls -ld FastDeploy
-            exit 1
-          fi
-
           tar --no-same-owner -xf FastDeploy.tar.gz || {
             echo "ERROR: Failed to extract archive"
             exit 1
           }
 
-          rm -f FastDeploy.tar.gz
-
+          rm -rf FastDeploy.tar.gz
           cd FastDeploy
           git config --global user.name "FastDeployCI"
           git config --global user.email "fastdeploy_ci@example.com"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

The Code Prepare stage has stability issues on `self-hosted runners`, especially when jobs are `cancelled`. In such cases, residual directories or `root-owned` files may remain in the `workspace`, causing subsequent runs to fail during cleanup or extraction.

The previous cleanup logic relied only on container-based deletion, which is not reliable under `abnormal termination` or `permission inconsistency`, leading to CI flakiness.

## Modifications
- Introduce retry mechanism to improve cleanup reliability
- Add `container-based root` cleanup as a fallback
- Handle permission issues with force cleanup (`chmod + find`)
- Improve logging for better observability and debugging
- Use `--no-same-owner` during extraction to prevent permission issues

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.