### PR TITLE
[Cherry-Pick][BugFix] Fix Async D2H copy bug & flash mash atten cache V out of bound bug

### DIFF
--- a/custom_ops/gpu_ops/append_attn/get_block_shape_and_split_kv_block.cu
+++ b/custom_ops/gpu_ops/append_attn/get_block_shape_and_split_kv_block.cu
@@ -290,10 +290,16 @@ void GetBlockShapeAndSplitKVBlock(
   // Note (sunxin): Skip capturing the DtoH copy (it's time-consuming); CPU data
   // is only for branching in attention.
 #ifndef PADDLE_WITH_CUSTOM_DEVICE_METAX_GPU
-  if (!phi::backends::gpu::IsCUDAGraphCapturing())
-#endif
+  if (!phi::backends::gpu::IsCUDAGraphCapturing()) {
     max_len_tensor_cpu.copy_(
         max_len_tensor_gpu, max_len_tensor_cpu.place(), false);
+    cudaStreamSynchronize(stream);
+  }
+#else
+  max_len_tensor_cpu.copy_(
+      max_len_tensor_gpu, max_len_tensor_cpu.place(), false);
+  cudaStreamSynchronize(stream);
+#endif
 
   auto max_len_cpu_ptr = max_len_tensor_cpu.data<int>();
   int max_len_this_time = max_len_cpu_ptr[0];
@@ -442,6 +448,12 @@ void GetBlockShapeAndSplitKVBlock(
     encoder_num_blocks_x_cpu.copy_(
         encoder_num_blocks_x, encoder_num_blocks_x_cpu.place(), false);
   }
+#ifndef PADDLE_WITH_CUSTOM_DEVICE_METAX_GPU
+  if (!phi::backends::gpu::IsCUDAGraphCapturing())
+    cudaStreamSynchronize(stream);
+#else
+  cudaStreamSynchronize(stream);
+#endif
 }
 
 std::vector<std::vector<int64_t>> GetBlockShapeAndSplitKVBlockInferShape(

--- a/custom_ops/gpu_ops/append_attn/get_block_shape_and_split_kv_block.cu
+++ b/custom_ops/gpu_ops/append_attn/get_block_shape_and_split_kv_block.cu
@@ -293,7 +293,7 @@ void GetBlockShapeAndSplitKVBlock(
   if (!phi::backends::gpu::IsCUDAGraphCapturing())
 #endif
     max_len_tensor_cpu.copy_(
-        max_len_tensor_gpu, max_len_tensor_cpu.place(), blocking = true);
+        max_len_tensor_gpu, max_len_tensor_cpu.place(), true);
 
   auto max_len_cpu_ptr = max_len_tensor_cpu.data<int>();
   int max_len_this_time = max_len_cpu_ptr[0];
@@ -336,11 +336,10 @@ void GetBlockShapeAndSplitKVBlock(
                                  block_size,
                                  sm_cout);
 
-      decoder_num_blocks_cpu.copy_(decoder_num_blocks_device,
-                                   decoder_num_blocks_cpu.place(),
-                                   blocking = true);
-      auto decoder_chunk_size_cpu = decoder_chunk_size_device.copy_to(
-          paddle::CPUPlace(), blocking = true);
+      decoder_num_blocks_cpu.copy_(
+          decoder_num_blocks_device, decoder_num_blocks_cpu.place(), true);
+      auto decoder_chunk_size_cpu =
+          decoder_chunk_size_device.copy_to(paddle::CPUPlace(), true);
       const int chunk_size = decoder_chunk_size_cpu.data<int>()[0];
 
       CUDA_CHECK(cudaMemsetAsync(decoder_batch_ids.data<int>(),
@@ -387,9 +386,8 @@ void GetBlockShapeAndSplitKVBlock(
 #ifndef PADDLE_WITH_CUSTOM_DEVICE_METAX_GPU
       if (!phi::backends::gpu::IsCUDAGraphCapturing())
 #endif
-        decoder_num_blocks_cpu.copy_(decoder_num_blocks_device,
-                                     decoder_num_blocks_cpu.place(),
-                                     blocking = true);
+        decoder_num_blocks_cpu.copy_(
+            decoder_num_blocks_device, decoder_num_blocks_cpu.place(), true);
     }
   }
 
@@ -418,7 +416,7 @@ void GetBlockShapeAndSplitKVBlock(
         block_size);
 
     kv_num_blocks_x_cpu.copy_(
-        kv_num_blocks_x, kv_num_blocks_x_cpu.place(), blocking = true);
+        kv_num_blocks_x, kv_num_blocks_x_cpu.place(), true);
     // Clear buffer
     const uint32_t encoder_max_tile_size_per_bs_q =
         div_up((max_enc_dec_len_this_time * group_size), encoder_block_shape_q);
@@ -441,9 +439,8 @@ void GetBlockShapeAndSplitKVBlock(
                                         bsz,
                                         encoder_block_shape_q,
                                         group_size);
-    encoder_num_blocks_x_cpu.copy_(encoder_num_blocks_x,
-                                   encoder_num_blocks_x_cpu.place(),
-                                   blocking = true);
+    encoder_num_blocks_x_cpu.copy_(
+        encoder_num_blocks_x, encoder_num_blocks_x_cpu.place(), true);
   }
 }
 

--- a/custom_ops/gpu_ops/append_attn/get_block_shape_and_split_kv_block.cu
+++ b/custom_ops/gpu_ops/append_attn/get_block_shape_and_split_kv_block.cu
@@ -290,16 +290,10 @@ void GetBlockShapeAndSplitKVBlock(
   // Note (sunxin): Skip capturing the DtoH copy (it's time-consuming); CPU data
   // is only for branching in attention.
 #ifndef PADDLE_WITH_CUSTOM_DEVICE_METAX_GPU
-  if (!phi::backends::gpu::IsCUDAGraphCapturing()) {
-    max_len_tensor_cpu.copy_(
-        max_len_tensor_gpu, max_len_tensor_cpu.place(), false);
-    cudaStreamSynchronize(stream);
-  }
-#else
-  max_len_tensor_cpu.copy_(
-      max_len_tensor_gpu, max_len_tensor_cpu.place(), false);
-  cudaStreamSynchronize(stream);
+  if (!phi::backends::gpu::IsCUDAGraphCapturing())
 #endif
+    max_len_tensor_cpu.copy_(
+        max_len_tensor_gpu, max_len_tensor_cpu.place(), blocking = true);
 
   auto max_len_cpu_ptr = max_len_tensor_cpu.data<int>();
   int max_len_this_time = max_len_cpu_ptr[0];
@@ -342,10 +336,11 @@ void GetBlockShapeAndSplitKVBlock(
                                  block_size,
                                  sm_cout);
 
-      decoder_num_blocks_cpu.copy_(
-          decoder_num_blocks_device, decoder_num_blocks_cpu.place(), false);
-      auto decoder_chunk_size_cpu =
-          decoder_chunk_size_device.copy_to(paddle::CPUPlace(), false);
+      decoder_num_blocks_cpu.copy_(decoder_num_blocks_device,
+                                   decoder_num_blocks_cpu.place(),
+                                   blocking = true);
+      auto decoder_chunk_size_cpu = decoder_chunk_size_device.copy_to(
+          paddle::CPUPlace(), blocking = true);
       const int chunk_size = decoder_chunk_size_cpu.data<int>()[0];
 
       CUDA_CHECK(cudaMemsetAsync(decoder_batch_ids.data<int>(),
@@ -392,8 +387,9 @@ void GetBlockShapeAndSplitKVBlock(
 #ifndef PADDLE_WITH_CUSTOM_DEVICE_METAX_GPU
       if (!phi::backends::gpu::IsCUDAGraphCapturing())
 #endif
-        decoder_num_blocks_cpu.copy_(
-            decoder_num_blocks_device, decoder_num_blocks_cpu.place(), false);
+        decoder_num_blocks_cpu.copy_(decoder_num_blocks_device,
+                                     decoder_num_blocks_cpu.place(),
+                                     blocking = true);
     }
   }
 
@@ -422,7 +418,7 @@ void GetBlockShapeAndSplitKVBlock(
         block_size);
 
     kv_num_blocks_x_cpu.copy_(
-        kv_num_blocks_x, kv_num_blocks_x_cpu.place(), false);
+        kv_num_blocks_x, kv_num_blocks_x_cpu.place(), blocking = true);
     // Clear buffer
     const uint32_t encoder_max_tile_size_per_bs_q =
         div_up((max_enc_dec_len_this_time * group_size), encoder_block_shape_q);
@@ -445,15 +441,10 @@ void GetBlockShapeAndSplitKVBlock(
                                         bsz,
                                         encoder_block_shape_q,
                                         group_size);
-    encoder_num_blocks_x_cpu.copy_(
-        encoder_num_blocks_x, encoder_num_blocks_x_cpu.place(), false);
+    encoder_num_blocks_x_cpu.copy_(encoder_num_blocks_x,
+                                   encoder_num_blocks_x_cpu.place(),
+                                   blocking = true);
   }
-#ifndef PADDLE_WITH_CUSTOM_DEVICE_METAX_GPU
-  if (!phi::backends::gpu::IsCUDAGraphCapturing())
-    cudaStreamSynchronize(stream);
-#else
-  cudaStreamSynchronize(stream);
-#endif
 }
 
 std::vector<std::vector<int64_t>> GetBlockShapeAndSplitKVBlockInferShape(

--- a/custom_ops/gpu_ops/append_attn/pre_cache_len_concat.cu
+++ b/custom_ops/gpu_ops/append_attn/pre_cache_len_concat.cu
@@ -87,9 +87,9 @@ std::vector<paddle::Tensor> PreCacheLenConcat(
       bsz,
       block_size);
   paddle::Tensor pre_cache_num_blocks_cpu =
-      pre_cache_num_blocks.copy_to(paddle::CPUPlace(), blocking = true);
+      pre_cache_num_blocks.copy_to(paddle::CPUPlace(), true);
   paddle::Tensor kv_token_num_cpu =
-      kv_token_num.copy_to(paddle::CPUPlace(), blocking = true);
+      kv_token_num.copy_to(paddle::CPUPlace(), true);
 
   return {
       cu_seqlens_k,

--- a/custom_ops/gpu_ops/append_attn/pre_cache_len_concat.cu
+++ b/custom_ops/gpu_ops/append_attn/pre_cache_len_concat.cu
@@ -87,9 +87,9 @@ std::vector<paddle::Tensor> PreCacheLenConcat(
       bsz,
       block_size);
   paddle::Tensor pre_cache_num_blocks_cpu =
-      pre_cache_num_blocks.copy_to(paddle::CPUPlace(), false);
+      pre_cache_num_blocks.copy_to(paddle::CPUPlace(), blocking = true);
   paddle::Tensor kv_token_num_cpu =
-      kv_token_num.copy_to(paddle::CPUPlace(), false);
+      kv_token_num.copy_to(paddle::CPUPlace(), blocking = true);
 
   return {
       cu_seqlens_k,

--- a/custom_ops/gpu_ops/flash_mask_attn/mainloop_attn.hpp
+++ b/custom_ops/gpu_ops/flash_mask_attn/mainloop_attn.hpp
@@ -489,6 +489,23 @@ struct CollectiveMainloopAttn {
           tiled_mma0, tSrQ, tSrK(_, _, _, smem_pipe_read_k.index()), tSrS);
       softmax.rescale_o(tOrO, scores_scale);
       consumer_wait(pipeline_v, smem_pipe_read_v);
+      if (seq_len_k - n_block * kBlockN < kBlockN) {
+        int valid_k = seq_len_k - n_block * kBlockN;
+        auto sVt_this = sVt(_, _, smem_pipe_read_v.index());
+        constexpr int kHdLo = decltype(get<0, 0>(shape(sVt_this)))::value;
+        constexpr int kHdHi = decltype(get<0, 1>(shape(sVt_this)))::value;
+        if (thread_idx >= valid_k && thread_idx < kBlockN) {
+#pragma unroll
+          for (int hd_hi = 0; hd_hi < kHdHi; ++hd_hi) {
+#pragma unroll
+            for (int hd_lo = 0; hd_lo < kHdLo; ++hd_lo) {
+              sVt_this(make_coord(make_coord(hd_lo, hd_hi), thread_idx)) =
+                  Element(0);
+            }
+          }
+        }
+        cutlass::arch::fence_view_async_shared();
+      }
       gemm</*zero_init=*/false, /*wg_wait=*/-1>(
           tiled_mma1, tOrP, tOrV(_, _, _, smem_pipe_read_v.index()), tOrO);
       warp_scheduler_barrier_arrive();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
1. Async D2H copy bug: 使用异步拷贝后立即读取 CPU 数据，导致可能读取到未完成的拷贝结果，引发数据竞态问题
2. Flash Mask Attention out of bound: 当 seq_len 不是 kBlockN 整数倍时，最后一个 block 的共享内存访问越界
<!-- Describe the purpose and goals of this pull request. -->
## Modifications
1. 将 `copy_` 和 `copy_to` 的最后一个参数从 `false` 改为 `true`，将异步拷贝改为同步拷贝，确保数据在读取前已完成
   - get_block_shape_and_split_kv_block.cu: 4 处
   - pre_cache_len_concat.cu: 2 处

2. 在 mainloop_attn.hpp 中添加边界条件处理：当处理最后一个 block 时，将超出 valid_k 部分的共享内存清零
<!-- Detail the changes made in this pull request. -->

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
