### PR TITLE
[CI] increase shm-size to 128G in _unit_test_coverage.yml

### DIFF
--- a/.github/workflows/_unit_test_coverage.yml
+++ b/.github/workflows/_unit_test_coverage.yml
@@ -197,6 +197,8 @@ jobs:
           ${RDMA_DEVICES} \
           --device=/dev/infiniband/rdma_cm \
           --ulimit memlock=-1:-1 \
+          --ulimit nofile=65536:65536 \
+          --ulimit nproc=8192:8192 \
           -v $(pwd):/workspace -w /workspace \
           -v "${CACHE_DIR}/gitconfig:/etc/gitconfig:ro" \
           -v "${CACHE_DIR}/.cache:/root/.cache" \

--- a/.github/workflows/_unit_test_coverage.yml
+++ b/.github/workflows/_unit_test_coverage.yml
@@ -193,7 +193,7 @@ jobs:
           --sysctl kernel.msgmnb=268435456 \
           --name ${runner_name} \
           --cap-add=SYS_PTRACE --cap-add=IPC_LOCK \
-          --shm-size=64G \
+          --shm-size=128G \
           ${RDMA_DEVICES} \
           --device=/dev/infiniband/rdma_cm \
           --ulimit memlock=-1:-1 \


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
In parallel test execution, multiple processes may concurrently utilize shared memory (`/dev/shm`), which can lead to instability under the current `64GB` limit. Specifically:

- DataLoader relies on shared memory for multiprocessing data transfer
- CUDA may use shared memory for IPC mechanisms
- Multiple test processes can access `/dev/shm` simultaneously

This may result in intermittent failures (e.g., `Killed`) due to insufficient shared memory.

## Modifications

- Increase Docker shared memory size from `64GB` to `128GB` in `_unit_test_coverage.yml` to improve stability under parallel workloads
- Add `--ulimit nofile=65536:65536` to increase maximum open file descriptors
- Add `--ulimit nproc=8192:8192` to increase maximum user processes

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.