### PR TITLE
[Cherry-Pick][BugFix] Fix flash mask attn 2.5 

### DIFF
--- a/custom_ops/gpu_ops/flash_mask_attn/flash_mask_attn.cu
+++ b/custom_ops/gpu_ops/flash_mask_attn/flash_mask_attn.cu
@@ -54,7 +54,6 @@ void DispatchFlashAttentionMask(const paddle::Tensor& q_input,
   PADDLE_ENFORCE(k_token_num == v_input.dims()[0], "Unmatched shape");
   PADDLE_ENFORCE(head_dim == 128, "Unmatched shape");
   PADDLE_ENFORCE(batch_size > 0, "Unmatched shape");
-  PADDLE_ENFORCE(batch_size == seq_len_encoder.dims()[0], "Unmatched shape");
   PADDLE_ENFORCE(batch_size == cu_seq_k.dims()[0] - 1, "Unmatched shape");
 
   constexpr int kBlockM = 128;

--- a/fastdeploy/model_executor/layers/attention/flash_mask_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/flash_mask_attn_backend.py
@@ -281,7 +281,7 @@ class FlashMaskAttentionBackend(AttentionBackend):
                 q,
                 k,
                 v,
-                forward_meta.cu_seqlens_q,
+                forward_meta.cu_seqlens_q[: forward_meta.attn_cu_seqlens_k.shape[0]],
                 forward_meta.attn_cu_seqlens_k,
                 forward_meta.seq_lens_encoder,
                 res_encoder,

--- a/fastdeploy/model_executor/layers/attention/ops/flash_mask_attention.py
+++ b/fastdeploy/model_executor/layers/attention/ops/flash_mask_attention.py
@@ -33,9 +33,6 @@ def flash_mask_attention(
     num_heads: int = 0,
     kv_num_heads: int = 0,
     head_dim: int = 128,
-    max_seq_len: int = 0,
-    q_token_num: int = 0,
-    kv_token_num: int = 0,
 ):
     if current_platform.is_cuda():
         from fastdeploy.model_executor.ops.gpu import flash_mask_attention
@@ -52,9 +49,6 @@ def flash_mask_attention(
             num_heads,
             kv_num_heads,
             head_dim,
-            max_seq_len,
-            q_token_num,
-            kv_token_num,
         )
     else:
         raise NotImplementedError


### PR DESCRIPTION
## Motivation
- 修复 DispatchFlashAttentionMask 中 batch_size 的推导来源：由 cu_seq_q 改为 cu_seq_k
- 注释掉运行时的 PADDLE_ENFORCE shape 校验
- cherry-pick from https://github.com/PaddlePaddle/FastDeploy/pull/7210 and https://github.com/PaddlePaddle/FastDeploy/pull/6535

## Background
在 SM90 flash mask attention 算子中，cu_seqlens_q 和 seq_lens_encoder 的输入 shape 可能按 max_batch 维度预分配，其实际有效长度可能小于 tensor 的第一维大小。此时若以 cu_seq_q.dims()[0] - 1 推导 batch_size，会得到一个偏大的值（等于 max_batch 而非真实 batch size），导致后续 kernel launch 的 batch 维度不正确。

cu_seq_k 始终按真实 batch size 填充，因此改为从 cu_seq_k 推导 batch_size 可获得正确值。

同时，由于 cu_seqlens_q / seq_lens_encoder 的 shape 可能为 max_batch（大于实际 batch size），原有的 PADDLE_ENFORCE(batch_size == seq_len_encoder.dims()[0]) 等断言将误报失败，因此暂时注释掉相关校验。

<img width="1205" height="225" alt="infoflow 2026-04-07 15-45-41" src="https://github.com/user-attachments/assets/dadb5072-03bb-43d6-a69f-d55e6d96c57c" />




## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
