### PR TITLE
[BugFix] Fix multimodal 3D RoPE dtype and position_ids indexing error

### DIFF
--- a/fastdeploy/model_executor/layers/rotary_embedding.py
+++ b/fastdeploy/model_executor/layers/rotary_embedding.py
@@ -447,12 +447,12 @@ class ErnieVlRotaryEmbedding3D:
 
         # Build position_ids_3d: [bsz, max_position, 3]
         position_ids_3d = paddle.tile(
-            paddle.arange(self.max_position, dtype="int64").unsqueeze(0).unsqueeze(-1),
+            paddle.arange(self.max_position, dtype="float32").unsqueeze(0).unsqueeze(-1),
             [bsz, 1, 3],
         )
         for i in range(bsz):
             position_ids_cur = position_ids[cumsum_seqlens[i] : cumsum_seqlens[i + 1]]
-            prefix_max_position_ids = paddle.max(position_ids_cur) + 1
+            prefix_max_position_ids = paddle.max(position_ids_cur[..., 0]) + 1
             dec_pos_ids = paddle.tile(
                 paddle.arange(max_len_lst[i], dtype="int64").unsqueeze(-1),
                 [1, 3],
@@ -519,12 +519,12 @@ class QwenVlRotaryEmbedding3D:
         bsz = len(cumsum_seqlens) - 1
         # position_ids_3d: [bsz, seq_len, 3]
         position_ids_3d = paddle.tile(
-            paddle.arange(self.max_position, dtype="int64").unsqueeze(0).unsqueeze(-1),
+            paddle.arange(self.max_position, dtype="float32").unsqueeze(0).unsqueeze(-1),
             [bsz, 1, 3],
         )
         for i in range(bsz):
             position_ids_cur = position_ids[cumsum_seqlens[i] : cumsum_seqlens[i + 1]]
-            prefix_max_position_ids = paddle.max(position_ids_cur) + 1
+            prefix_max_position_ids = paddle.max(position_ids_cur[..., 0]) + 1
             dec_pos_ids = paddle.tile(
                 paddle.arange(max_len_lst[i], dtype="int64").unsqueeze(-1),
                 [1, 3],

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -983,7 +983,7 @@ class GPUModelRunner(ModelRunnerBase):
         self._process_mm_features(req_dicts)
         if len(rope_3d_position_ids["position_ids_idx"]) > 0:
             packed_position_ids = paddle.to_tensor(
-                np.concatenate(rope_3d_position_ids["position_ids_lst"]), dtype="int64"
+                np.concatenate(rope_3d_position_ids["position_ids_lst"]), dtype="float32"
             )
             rope_3d_lst = self.prepare_rope3d(
                 packed_position_ids,


### PR DESCRIPTION
## Motivation

- Fix `paddle.arange` dtype from `int64` to `float32` for 3D position_ids in `ErnieVlRotaryEmbedding3D` and `QwenVlRotaryEmbedding3D`, ensuring dtype consistency with downstream computation and avoiding implicit cast errors.
- Fix `prefix_max_position_ids` calculation by indexing `position_ids_cur[..., 0]` instead of the full 3D tensor, preventing incorrect max value when the 3D position_ids contain heterogeneous spatial/temporal dimensions.
- Align `gpu_model_runner.py` where `rope_3d_position_ids` is packed to use `float32` dtype, matching the rotary embedding layer expectation.

## Files Changed

- `fastdeploy/model_executor/layers/rotary_embedding.py` — Fix dtype and indexing in `ErnieVlRotaryEmbedding3D` and `QwenVlRotaryEmbedding3D`
- `fastdeploy/worker/gpu_model_runner.py` — Fix packed position_ids dtype to `float32`

## Test Plan

- [ ] Verify multimodal (VL) model inference with 3D RoPE produces correct results
- [ ] Confirm no dtype mismatch errors during prefill and decode phases


## Modifications

<!-- Detail the changes made in this pull request. -->

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
