### PR TITLE
[Cherry-Pick] Use triton qk_norm both in Prefill and Decode

### DIFF
--- a/fastdeploy/model_executor/layers/normalization.py
+++ b/fastdeploy/model_executor/layers/normalization.py
@@ -331,7 +331,7 @@ class QKRMSNorm(nn.Layer):
         forward_meta,
         proxy_rmsnorm=None,
     ) -> paddle.Tensor:
-        if proxy_rmsnorm is None and self.qk_norm_fused and forward_meta.step_use_cudagraph:
+        if proxy_rmsnorm is None and self.qk_norm_fused:
             qkv_out = qk_rmsnorm_fused(
                 qkv_out,
                 self.q_norm.weight,

--- a/tests/e2e/test_Qwen3VL_serving.py
+++ b/tests/e2e/test_Qwen3VL_serving.py
@@ -173,7 +173,7 @@ def test_consistency_between_runs(api_url, headers, consistent_payload):
     content1 = result1["choices"][0]["message"]["content"]
 
     # base result
-    content2 = "视频中手机支架的颜色是黑色的。"
+    content2 = "视频中手机支架的颜色是黑色。"
 
     # Verify that result is same as the base result
     assert content1.startswith(content2), content1


### PR DESCRIPTION
## Motivation
Prefill 阶段使用QKRMSNorm融合算子. 部分模型 单Kernel部分加速2～7倍. Prefill 空泡较大的模型单次Forward可加速2倍左右.  

## Modifications

使用QKRMSNorm 替代paddle 散Op

## Usage or Command

## Accuracy Tests


## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
