### PR TITLE
[KSM] add topp_in_topk_mask when use topk

### DIFF
--- a/fastdeploy/engine/request.py
+++ b/fastdeploy/engine/request.py
@@ -412,6 +412,10 @@ class CompletionOutput:
     #   - Non-MTP: list[int]
     #   - MTP: list[list[int]]
     sampling_mask: Optional[Any] = None
+    # Top-p in top-k sampling
+    #   - Non-MTP: list[bool]
+    #   - MTP: list[list[bool]]
+    topp_in_topk_mask: Optional[Any] = None
 
     def to_dict(self):
         """
@@ -430,6 +434,7 @@ class CompletionOutput:
             "text": self.text,
             "reasoning_content": self.reasoning_content,
             "sampling_mask": self.sampling_mask,
+            "topp_in_topk_mask": self.topp_in_topk_mask,
         }
 
     @classmethod

--- a/fastdeploy/entrypoints/openai/protocol.py
+++ b/fastdeploy/entrypoints/openai/protocol.py
@@ -231,6 +231,7 @@ class ChatCompletionResponseChoice(BaseModel):
     prompt_logprobs: Optional[PromptLogprobs] = None
     # Per-token retained vocab indices from top_p/top_k sampling: List[List[int]], one list of vocab indices per token
     sampling_mask: Optional[List[List[int]]] = None
+    topp_in_topk_mask: Optional[List[List[bool]]] = None
     finish_reason: Optional[Literal["stop", "length", "tool_calls", "recover_stop"]]
     speculate_metrics: Optional[SpeculateMetrics] = None
 
@@ -299,6 +300,7 @@ class ChatCompletionResponseStreamChoice(BaseModel):
     # Per-token index list of retained positions after top_p sampling.
     # Non-MTP: [[idx, ...]] (1 token/step). MTP: [[idx, ...], ...] (N accepted tokens/step).
     sampling_mask: Optional[List[List[int]]] = None
+    topp_in_topk_mask: Optional[List[List[bool]]] = None
     finish_reason: Optional[Literal["stop", "length", "tool_calls"]] = None
     arrival_time: Optional[float] = None
     speculate_metrics: Optional[SpeculateMetrics] = None

--- a/fastdeploy/entrypoints/openai/serving_chat.py
+++ b/fastdeploy/entrypoints/openai/serving_chat.py
@@ -422,8 +422,13 @@ class OpenAIServingChat:
                         logprobs=logprobs_res,
                         draft_logprobs=draft_logprobs_res,
                         sampling_mask=(
-                            self._make_sampling_mask_list(output["sampling_mask"])
+                            self._make_mask_list(output["sampling_mask"])
                             if output.get("sampling_mask") is not None
+                            else None
+                        ),
+                        topp_in_topk_mask=(
+                            self._make_mask_list(output["topp_in_topk_mask"])
+                            if output.get("topp_in_topk_mask") is not None
                             else None
                         ),
                         arrival_time=arrival_time,
@@ -547,6 +552,7 @@ class OpenAIServingChat:
             )
             prompt_logprobs_res_list = [[] for _ in range(num_choices)]
             sampling_mask_list = [[] for _ in range(num_choices)]
+            topp_in_topk_mask_list = [[] for _ in range(num_choices)]
             speculate_metrics = [None for _ in range(num_choices)]
             choices = []
             while num_choices > 0:
@@ -629,7 +635,10 @@ class OpenAIServingChat:
                             prompt_logprobs_res_list[idx].extend(clamp_prompt_logprobs(prompt_logprobs_res))
                     output_sampling_mask = output.get("sampling_mask", None)
                     if output_sampling_mask is not None:
-                        sampling_mask_list[idx].append(self._make_sampling_mask_list(output_sampling_mask))
+                        sampling_mask_list[idx].append(self._make_mask_list(output_sampling_mask))
+                    topp_in_topk_mask = output.get("topp_in_topk_mask", None)
+                    if topp_in_topk_mask is not None:
+                        topp_in_topk_mask_list[idx].append(self._make_mask_list(topp_in_topk_mask))
                     speculate_metrics[idx] = data["metrics"].get("speculate_metrics", None)
                     if data["finished"]:
                         num_choices -= 1
@@ -653,6 +662,7 @@ class OpenAIServingChat:
                             response_processor=response_processor,
                             prompt_logprobs_res_list=prompt_logprobs_res_list,
                             sampling_mask_list=sampling_mask_list,
+                            topp_in_topk_mask_list=topp_in_topk_mask_list,
                             max_tokens=max_tokens,
                             speculate_metrics=speculate_metrics[idx],
                         )
@@ -707,6 +717,7 @@ class OpenAIServingChat:
         draft_logprob_contents: list,
         prompt_logprobs_res_list: list,
         sampling_mask_list: list,
+        topp_in_topk_mask_list: list,
         response_processor: ChatResponseProcessor,
         max_tokens: int,
         speculate_metrics: SpeculateMetrics | None,
@@ -749,6 +760,10 @@ class OpenAIServingChat:
         if sampling_mask_list and sampling_mask_list[idx]:
             sampling_mask_full_res = [mask for step in sampling_mask_list[idx] for mask in step]
 
+        topp_in_topk_mask_full_res = None
+        if topp_in_topk_mask_list and topp_in_topk_mask_list[idx]:
+            topp_in_topk_mask_full_res = [mask for step in topp_in_topk_mask_list[idx] for mask in step]
+
         num_cached_tokens[idx] = data.get("num_cached_tokens", 0)
         num_input_image_tokens[idx] = data.get("num_input_image_tokens", 0)
         num_input_video_tokens[idx] = data.get("num_input_video_tokens", 0)
@@ -771,6 +786,7 @@ class OpenAIServingChat:
             draft_logprobs=draft_logprobs_full_res,
             prompt_logprobs=prompt_logprobs_full_res,
             sampling_mask=sampling_mask_full_res,
+            topp_in_topk_mask=topp_in_topk_mask_full_res,
             finish_reason=finish_reason,
             speculate_metrics=speculate_metrics,
         )
@@ -973,16 +989,16 @@ class OpenAIServingChat:
         }
 
     @staticmethod
-    def _make_sampling_mask_list(sampling_mask) -> List[List[int]]:
-        """Wrap sampling_mask into a uniform List[List[int]] format.
+    def _make_mask_list(mask) -> List[List[int]]:
+        """Wrap mask into a uniform List[List[int]] format.
 
-        sampling_mask is already in sparse-index form (no bool-to-index conversion needed):
+        mask is already in sparse-index form (no bool-to-index conversion needed):
           Non-MTP: List[int]        (indices for 1 token/step)  → [[idx, ...]]
           MTP:     List[List[int]]  (indices for N tokens/step) → [[idx, ...], ...]
         """
-        assert sampling_mask is not None
-        if sampling_mask and isinstance(sampling_mask[0], list):
+        assert mask is not None
+        if mask and isinstance(mask[0], list):
             # MTP: already List[List[int]], return as-is
-            return sampling_mask
+            return mask
         # Non-MTP: already List[int], wrap in outer list for uniform format
-        return [sampling_mask]
+        return [mask]

--- a/fastdeploy/entrypoints/openai/serving_chat.py
+++ b/fastdeploy/entrypoints/openai/serving_chat.py
@@ -20,7 +20,7 @@ import time
 import traceback
 import uuid
 from collections.abc import Iterable
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import numpy as np
 
@@ -989,10 +989,10 @@ class OpenAIServingChat:
         }
 
     @staticmethod
-    def _make_mask_list(mask) -> List[List[int]]:
-        """Wrap mask into a uniform List[List[int]] format.
-
-        mask is already in sparse-index form (no bool-to-index conversion needed):
+    def _make_mask_list(mask) -> List[List[Any]]:
+        """Wrap mask into a uniform List[List[Any]] format.
+        for example:
+        sampling_mask is already in sparse-index form (no bool-to-index conversion needed):
           Non-MTP: List[int]        (indices for 1 token/step)  → [[idx, ...]]
           MTP:     List[List[int]]  (indices for N tokens/step) → [[idx, ...], ...]
         """

--- a/fastdeploy/model_executor/layers/sample/sampler.py
+++ b/fastdeploy/model_executor/layers/sample/sampler.py
@@ -133,8 +133,7 @@ def _compute_sampling_mask(
         - topp_in_topk_mask: List of length num_reqs; element i is a 1-D
           bool numpy array of length effective_k[i] (sorted-prob order),
           where True means the top-k candidate was also selected by top-p.
-          When top-k is disabled the array covers the full vocab (all tokens
-          are trivially "in top-k") and equals the top-p mask directly.
+          When top-k is disabled, returns None (no top-k candidates to filter).
     """
     real_bsz = probs.shape[0]
     vocab_size = probs.shape[1]

--- a/fastdeploy/model_executor/layers/sample/sampler.py
+++ b/fastdeploy/model_executor/layers/sample/sampler.py
@@ -245,8 +245,11 @@ def _compute_sampling_mask(
         topk_sorted_cpu = sorted_indices[:, :max_k_topk].cpu().numpy()  # [B, max_k_topk]
         topp_window_cpu = topp_mask[:, :max_k_topk].cpu().numpy()  # [B, max_k_topk]
         # top-k indices: contiguous block in sorted order (0 .. effective_k-1).
-        sparse_indices = [topk_sorted_cpu[i, : effective_k_cpu[i]] for i in range(real_bsz)]
-        topp_in_topk_mask = [topp_window_cpu[i, : effective_k_cpu[i]] for i in range(real_bsz)]
+        sparse_indices = [None] * real_bsz
+        topp_in_topk_mask = [None] * real_bsz
+        for i in range(real_bsz):
+            sparse_indices[i] = topk_sorted_cpu[i, : effective_k_cpu[i]]
+            topp_in_topk_mask[i] = topp_window_cpu[i, : effective_k_cpu[i]]
     else:
         k_per_row = topp_mask.astype("int32").sum(axis=-1)  # [B]
         max_k = int(k_per_row.max().item())

--- a/fastdeploy/model_executor/layers/sample/sampler.py
+++ b/fastdeploy/model_executor/layers/sample/sampler.py
@@ -157,7 +157,15 @@ def _compute_sampling_mask(
         col_idx = paddle.arange(vocab_size, dtype=top_k.dtype).unsqueeze(0)  # [1, V]
         # top_k == 0 means "disabled" → keep all columns for that row.
         effective_k = paddle.where(top_k > 0, top_k, paddle.full_like(top_k, vocab_size))
-        topk_mask = col_idx < effective_k  # [B, V], True = inside top-k
+        strict_topk_mask = col_idx < effective_k  # [B, V], True = inside top-k
+
+        # Relax: also keep positions whose prob ties with the k-th element.
+        # boundary index (0-based) = effective_k - 1, clamped to [0, V-1].
+        k_idx = (effective_k - 1).clip(min=0).squeeze(-1).astype("int64")  # [B] k-th index
+        batch_idx = paddle.arange(k_idx.shape[0], dtype="int64")  # [B] bs index
+        boundary_prob = sorted_probs[batch_idx, k_idx].unsqueeze(-1)  # [B, 1] k-th prob
+        tie_mask = sorted_probs == boundary_prob  # [B, V]
+        topk_mask = strict_topk_mask | tie_mask  # [B, V]
 
         # Zero out tail, then renorm row-wise.
         masked_sorted_probs = paddle.where(topk_mask, sorted_probs, paddle.zeros_like(sorted_probs))
@@ -196,36 +204,13 @@ def _compute_sampling_mask(
     # ------------------------------------------------------------------
     # Stage 4: compute logZ for renormalization
     #
-    # Goal: log π_mask(k) = log π_full(k) - logZ, where π_mask is the
-    # distribution actually sampled from (top-k truncated + top-p nucleus).
-    #
-    # When top_k is active the sampling pipeline first renormalises to
-    # π_topk, then applies top-p on π_topk.  The total log-normaliser
-    # that maps π_full → π_mask absorbs both steps:
-    #
-    #   logZ = log Z_topk  +  log Z_topp_on_renorm
-    #
-    # where Z_topk = Σ_{j∈topk} π_full(j)   (= row_sums, already computed)
-    #       Z_topp = Σ_{k∈K}    π_topk(k)   (sum of renorm probs in K)
-    #
-    # Substituting:
-    #   log π_mask(k) = log π_full(k) - log Z_topk - log Z_topp
-    #                 = log π_topk(k) - log Z_topp    ✓
-    #
-    # When top_k is absent Z_topk = 1 → logZ = log Z_topp as before.
+    # Z_K = sum(probs[i] * final_mask[i]) for each request i
+    # logZ_K = log(Z_K), with small constant to avoid log(0)
     # ------------------------------------------------------------------
-    if has_top_k:
-        # Z_topp: sum of renormed probs that survive the intersection mask
-        final_mask = topk_mask & topp_mask
-        candidate_probs = paddle.where(final_mask, renorm_sorted_probs, paddle.zeros_like(renorm_sorted_probs))
-        z_topp = candidate_probs.sum(axis=-1)  # [B]
-        # row_sums: [B, 1] already clipped ≥ 1e-9, squeeze to [B]
-        log_z_topk = paddle.log(row_sums.squeeze(-1))
-        logz_per_batch = (log_z_topk + paddle.log(z_topp + 1e-10)).cpu().numpy()  # [B]
-    else:
-        candidate_probs = paddle.where(topp_mask, sorted_probs, paddle.zeros_like(sorted_probs))
-        z_k = candidate_probs.sum(axis=-1)  # [B]
-        logz_per_batch = paddle.log(z_k + 1e-10).cpu().numpy()  # [B]
+
+    candidate_probs = paddle.where(topp_mask, sorted_probs, paddle.zeros_like(sorted_probs))
+    z_k = candidate_probs.sum(axis=-1)  # [B]
+    logz_per_batch = paddle.log(z_k + 1e-10).cpu().numpy()  # [B]
 
     # ------------------------------------------------------------------
     # Stage 5: build sparse_indices (top-k) and topp_in_topk_mask
@@ -238,17 +223,20 @@ def _compute_sampling_mask(
     # up to max_k_topk columns), so only two GPU→CPU transfers are needed.
     # ------------------------------------------------------------------
     if has_top_k:
-        effective_k_cpu = effective_k.cpu().numpy().flatten().astype(int)  # [B]
-        max_k_topk = int(effective_k.max().item())
+        # actual_k[i] = number of retained tokens after tie-relaxed top-k.
+        # May exceed effective_k[i] when the k-th and (k+1)-th probs are equal.
+        actual_k = topk_mask.astype("int32").sum(axis=-1)  # [B]
+        actual_k_cpu = actual_k.cpu().numpy().flatten().astype(int)  # [B]
+        max_k_topk = int(actual_k.max().item())
         # Single D2H transfer for both outputs.
         topk_sorted_cpu = sorted_indices[:, :max_k_topk].cpu().numpy()  # [B, max_k_topk]
         topp_window_cpu = topp_mask[:, :max_k_topk].cpu().numpy()  # [B, max_k_topk]
-        # top-k indices: contiguous block in sorted order (0 .. effective_k-1).
+        # top-k indices: actual retained count per row (>= effective_k when ties exist).
         sparse_indices = [None] * real_bsz
         topp_in_topk_mask = [None] * real_bsz
         for i in range(real_bsz):
-            sparse_indices[i] = topk_sorted_cpu[i, : effective_k_cpu[i]]
-            topp_in_topk_mask[i] = topp_window_cpu[i, : effective_k_cpu[i]]
+            sparse_indices[i] = topk_sorted_cpu[i, : actual_k_cpu[i]]
+            topp_in_topk_mask[i] = topp_window_cpu[i, : actual_k_cpu[i]]
     else:
         k_per_row = topp_mask.astype("int32").sum(axis=-1)  # [B]
         max_k = int(k_per_row.max().item())

--- a/fastdeploy/model_executor/layers/sample/sampler.py
+++ b/fastdeploy/model_executor/layers/sample/sampler.py
@@ -99,7 +99,7 @@ def _compute_sampling_mask(
     top_p: paddle.Tensor,
     top_k: Optional[paddle.Tensor] = None,
     top_k_list: Optional[list] = None,
-) -> tuple[List[np.ndarray], np.ndarray]:
+) -> tuple[List[np.ndarray], np.ndarray, List[np.ndarray]]:
     """
     Compute a combined top-k + top-p (nucleus) sampling mask as sparse
     retained-token indices.
@@ -128,7 +128,13 @@ def _compute_sampling_mask(
         - sparse_indices: List of length num_reqs; element i is a 1-D int64
           numpy array of the retained vocab indices for request i.
         - logz_per_batch: 1-D numpy array of shape [num_reqs] containing
-          log(Z_K) where Z_K is the sum of probabilities in the candidate set.
+          log(Z_K) where Z_K is the sum of probabilities in the candidate set
+          (intersection of top-k and top-p).
+        - topp_in_topk_mask: List of length num_reqs; element i is a 1-D
+          bool numpy array of length effective_k[i] (sorted-prob order),
+          where True means the top-k candidate was also selected by top-p.
+          When top-k is disabled the array covers the full vocab (all tokens
+          are trivially "in top-k") and equals the top-p mask directly.
     """
     real_bsz = probs.shape[0]
     vocab_size = probs.shape[1]
@@ -189,15 +195,7 @@ def _compute_sampling_mask(
     topp_mask = topp_mask | (renorm_sorted_probs >= boundary_prob)
 
     # ------------------------------------------------------------------
-    # Stage 4: intersect on GPU, then minimal D2H.
-    # ------------------------------------------------------------------
-    final_mask = topk_mask & topp_mask if has_top_k else topp_mask  # [B, V]
-
-    k_per_row = final_mask.astype("int32").sum(axis=-1)  # [B]
-    max_k = int(k_per_row.max().item())
-
-    # ------------------------------------------------------------------
-    # Stage 5: compute logZ for renormalization
+    # Stage 4: compute logZ for renormalization
     #
     # Goal: log π_mask(k) = log π_full(k) - logZ, where π_mask is the
     # distribution actually sampled from (top-k truncated + top-p nucleus).
@@ -218,23 +216,47 @@ def _compute_sampling_mask(
     # When top_k is absent Z_topk = 1 → logZ = log Z_topp as before.
     # ------------------------------------------------------------------
     if has_top_k:
-        # Z_topp: sum of renormed probs that survive the final mask
+        # Z_topp: sum of renormed probs that survive the intersection mask
+        final_mask = topk_mask & topp_mask
         candidate_probs = paddle.where(final_mask, renorm_sorted_probs, paddle.zeros_like(renorm_sorted_probs))
         z_topp = candidate_probs.sum(axis=-1)  # [B]
         # row_sums: [B, 1] already clipped ≥ 1e-9, squeeze to [B]
         log_z_topk = paddle.log(row_sums.squeeze(-1))
         logz_per_batch = (log_z_topk + paddle.log(z_topp + 1e-10)).cpu().numpy()  # [B]
     else:
-        candidate_probs = paddle.where(final_mask, sorted_probs, paddle.zeros_like(sorted_probs))
+        candidate_probs = paddle.where(topp_mask, sorted_probs, paddle.zeros_like(sorted_probs))
         z_k = candidate_probs.sum(axis=-1)  # [B]
         logz_per_batch = paddle.log(z_k + 1e-10).cpu().numpy()  # [B]
 
-    # Transfer only the leading max_k columns — typically max_k << vocab_size.
-    indices_window_cpu = sorted_indices[:, :max_k].cpu().numpy()  # [B, max_k]
-    mask_window_cpu = final_mask[:, :max_k].cpu().numpy()  # [B, max_k]
+    # ------------------------------------------------------------------
+    # Stage 5: build sparse_indices (top-k) and topp_in_topk_mask
+    #
+    # sparse_indices: retained vocab indices from top-k only.
+    # topp_in_topk_mask: boolean mask over top-k candidates indicating
+    # which ones were further selected by top-p.
+    #
+    # Both outputs share the same D2H window (sorted_indices + topp_mask
+    # up to max_k_topk columns), so only two GPU→CPU transfers are needed.
+    # ------------------------------------------------------------------
+    if has_top_k:
+        effective_k_cpu = effective_k.cpu().numpy().flatten().astype(int)  # [B]
+        max_k_topk = int(effective_k.max().item())
+        # Single D2H transfer for both outputs.
+        topk_sorted_cpu = sorted_indices[:, :max_k_topk].cpu().numpy()  # [B, max_k_topk]
+        topp_window_cpu = topp_mask[:, :max_k_topk].cpu().numpy()  # [B, max_k_topk]
+        # top-k indices: contiguous block in sorted order (0 .. effective_k-1).
+        sparse_indices = [topk_sorted_cpu[i, : effective_k_cpu[i]] for i in range(real_bsz)]
+        topp_in_topk_mask = [topp_window_cpu[i, : effective_k_cpu[i]] for i in range(real_bsz)]
+    else:
+        k_per_row = topp_mask.astype("int32").sum(axis=-1)  # [B]
+        max_k = int(k_per_row.max().item())
+        # Transfer only the leading max_k columns — typically max_k << vocab_size.
+        indices_window_cpu = sorted_indices[:, :max_k].cpu().numpy()  # [B, max_k]
+        mask_window_cpu = topp_mask[:, :max_k].cpu().numpy()  # [B, max_k]
+        sparse_indices = [indices_window_cpu[i, mask_window_cpu[i]] for i in range(real_bsz)]
+        topp_in_topk_mask = None
 
-    sparse_indices = [indices_window_cpu[i, mask_window_cpu[i]] for i in range(real_bsz)]
-    return sparse_indices, logz_per_batch
+    return sparse_indices, logz_per_batch, topp_in_topk_mask
 
 
 class GuidedDecoding:
@@ -674,8 +696,9 @@ class Sampler(nn.Layer):
         # Binary mask [num_reqs, vocab_size]: 1 = retained by top_k/top_p, 0 = truncated.
         sampling_mask = None
         logz_per_batch = None
+        topp_in_topk_mask = None
         if sampling_metadata.keep_sampling_mask:
-            sampling_mask, logz_per_batch = _compute_sampling_mask(
+            sampling_mask, logz_per_batch, topp_in_topk_mask = _compute_sampling_mask(
                 probs,
                 sampling_metadata.top_p,
                 top_k=sampling_metadata.top_k,
@@ -707,6 +730,7 @@ class Sampler(nn.Layer):
             logits=logits,
             sampling_mask=sampling_mask,
             logz_per_batch=logz_per_batch,
+            topp_in_topk_mask=topp_in_topk_mask,
         )
 
         return sampler_output
@@ -1024,6 +1048,7 @@ class SpeculativeSampler(nn.Layer):
         # Shape: [total_accepted_tokens, vocab_size], bool (CPU).
         sampling_mask = None
         logz_per_batch = None
+        topp_in_topk_mask = None
         if keep_sampling_mask:
             # Expand top_p from [batch, 1] to [total_accepted, 1].
             accept_top_p = sampling_metadata.top_p[:real_bsz].squeeze(1).repeat_interleave(accept_nums).unsqueeze(1)
@@ -1036,7 +1061,7 @@ class SpeculativeSampler(nn.Layer):
                 accept_top_k = (
                     sampling_metadata.top_k[:real_bsz].squeeze(1).repeat_interleave(accept_nums).unsqueeze(1)
                 )
-            sampling_mask, logz_per_batch = _compute_sampling_mask(
+            sampling_mask, logz_per_batch, topp_in_topk_mask = _compute_sampling_mask(
                 target_probs,
                 accept_top_p,
                 top_k=accept_top_k,
@@ -1051,6 +1076,7 @@ class SpeculativeSampler(nn.Layer):
             logits=logits,
             sampling_mask=sampling_mask,
             logz_per_batch=logz_per_batch,
+            topp_in_topk_mask=topp_in_topk_mask,
         )
 
         return sampler_output

--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -201,6 +201,7 @@ def _build_stream_transfer_data(
     logprobs: Optional[LogprobsTensors] = None,
     prompt_logprobs_list: Optional[LogprobsTensors] = None,
     sampling_mask: Optional[List[np.ndarray]] = None,
+    topp_in_topk_mask: Optional[List[np.ndarray]] = None,
 ):
     """Split output_tokens and output"""
 
@@ -211,6 +212,7 @@ def _build_stream_transfer_data(
         output_tokens_lists = np.split(output_tokens, output_tokens.shape[0])
 
         sampling_mask_list = sampling_mask
+        topp_in_topk_mask_list = topp_in_topk_mask
 
         for bid, output_token_per_sample in enumerate(output_tokens_lists):
             stream_transfer_data = StreamTransferData(
@@ -222,6 +224,8 @@ def _build_stream_transfer_data(
                 stream_transfer_data.prompt_logprobs = prompt_logprobs_list[bid]
             if sampling_mask_list is not None:
                 stream_transfer_data.sampling_mask = sampling_mask_list[bid]
+            if topp_in_topk_mask_list is not None:
+                stream_transfer_data.topp_in_topk_mask = topp_in_topk_mask_list[bid]
             stream_transfer_datas.append(stream_transfer_data)
     elif pooler_outputs is not None:
         for bid, pooler_output in enumerate(pooler_outputs):

--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -399,6 +399,7 @@ def post_process_normal(
                     logprobs=sampler_output.logprobs_tensors,
                     prompt_logprobs_list=model_output.prompt_logprobs_list,
                     sampling_mask=sampler_output.sampling_mask,
+                    topp_in_topk_mask=sampler_output.topp_in_topk_mask,
                 )
                 async_output_queue.put(output)
         else:
@@ -421,7 +422,14 @@ def post_process_normal(
             # Send sampling_mask via ZMQ side-channel when enabled.
             if sampler_output.sampling_mask is not None and model_output.mp_rank == 0:
                 # sampling_mask is List[np.ndarray] of sparse int indices, one array per request.
-                mask_dict = {i: arr.tolist() for i, arr in enumerate(sampler_output.sampling_mask)}
+                mask_dict = {}
+                for i in range(len(sampler_output.sampling_mask)):
+                    mask_dict[i] = {
+                        "sampling_mask": sampler_output.sampling_mask[i].tolist(),
+                        "topp_in_topk_mask": (
+                            sampler_output.topp_in_topk_mask[i].tolist() if sampler_output.topp_in_topk_mask else None
+                        ),
+                    }
                 sampling_mask_zmq_client.send_pyobj(mask_dict)
 
 
@@ -557,7 +565,16 @@ def post_process_specualate(
                 n = int(n)
                 if n > 0:
                     # List of n sparse index arrays, one per accepted token
-                    mask_dict[i] = [arr.tolist() for arr in sampler_output.sampling_mask[offset : offset + n]]
+                    sampling_mask_tmp = [arr.tolist() for arr in sampler_output.sampling_mask[offset : offset + n]]
+                    topp_in_topk_mask_tmp = (
+                        [arr.tolist() for arr in sampler_output.topp_in_topk_mask[offset : offset + n]]
+                        if sampler_output.topp_in_topk_mask
+                        else None
+                    )
+                    mask_dict[i] = {
+                        "sampling_mask": sampling_mask_tmp,
+                        "topp_in_topk_mask": topp_in_topk_mask_tmp,
+                    }
                 offset += n
             sampling_mask_zmq_client.send_pyobj(mask_dict)
 

--- a/fastdeploy/output/stream_transfer_data.py
+++ b/fastdeploy/output/stream_transfer_data.py
@@ -50,3 +50,6 @@ class StreamTransferData:
     # this request.  Sparse format: only retained positions, not a dense
     # vocab-sized bool mask.
     sampling_mask: Optional[np.array] = None
+    # List of length num_reqs; element i is a 1-D bool array of length
+    # effective_k[i] (in descending-probability order within the top-k window).s
+    topp_in_topk_mask: Optional[list] = None

--- a/fastdeploy/output/stream_transfer_data.py
+++ b/fastdeploy/output/stream_transfer_data.py
@@ -51,5 +51,5 @@ class StreamTransferData:
     # vocab-sized bool mask.
     sampling_mask: Optional[np.array] = None
     # List of length num_reqs; element i is a 1-D bool array of length
-    # effective_k[i] (in descending-probability order within the top-k window).s
+    # effective_k[i] (in descending-probability order within the top-k window).
     topp_in_topk_mask: Optional[list] = None

--- a/fastdeploy/output/token_processor.py
+++ b/fastdeploy/output/token_processor.py
@@ -308,6 +308,8 @@ class TokenProcessor:
                             llm_logger.warning(f"Failed to parse prompt_logprobs from StreamTransferData: {e}")
                 if getattr(stream_data, "sampling_mask", None) is not None:
                     result.outputs.sampling_mask = stream_data.sampling_mask.tolist()
+                if getattr(stream_data, "topp_in_topk_mask", None) is not None:
+                    result.outputs.topp_in_topk_mask = stream_data.topp_in_topk_mask.tolist()
                 if self.tokens_counter[task_id] == 0:
                     if task.messages is not None:
                         result.prompt = task.messages
@@ -791,7 +793,8 @@ class TokenProcessor:
                 result.num_input_video_tokens = task.multimodal_inputs.get("num_input_video_tokens", 0)
 
             if self.use_sampling_mask and i in sampling_masks_per_request:
-                result.outputs.sampling_mask = sampling_masks_per_request[i]
+                result.outputs.sampling_mask = sampling_masks_per_request[i]["sampling_mask"]
+                result.outputs.topp_in_topk_mask = sampling_masks_per_request[i]["topp_in_topk_mask"]
 
             is_prefill = task.disaggregate_info is not None and task.disaggregate_info["role"] == "prefill"
 

--- a/fastdeploy/worker/output.py
+++ b/fastdeploy/worker/output.py
@@ -197,6 +197,12 @@ class SamplerOutput:
     # Used for renormalizing logprobs to match the truncated sampling distribution.
     # Shape: [num_reqs]
     logz_per_batch: Optional[np.ndarray] = None
+    # topp_in_topk_mask: Boolean mask over top-k candidates indicating which
+    # ones are further selected by top-p (True = in top-p nucleus, False = not).
+    # List of length num_reqs; element i is a 1-D bool array of length
+    # effective_k[i] (in descending-probability order within the top-k window).
+    # When top-k is disabled, length equals vocab_size (all tokens are candidates).
+    topp_in_topk_mask: Optional[List[np.ndarray]] = None
 
 
 @dataclass

--- a/fastdeploy/worker/output.py
+++ b/fastdeploy/worker/output.py
@@ -201,7 +201,7 @@ class SamplerOutput:
     # ones are further selected by top-p (True = in top-p nucleus, False = not).
     # List of length num_reqs; element i is a 1-D bool array of length
     # effective_k[i] (in descending-probability order within the top-k window).
-    # When top-k is disabled, length equals vocab_size (all tokens are candidates).
+    # When top-k is disabled, return None.
     topp_in_topk_mask: Optional[List[np.ndarray]] = None
 
 

--- a/tests/e2e/test_ernie_21b_mtp.py
+++ b/tests/e2e/test_ernie_21b_mtp.py
@@ -320,6 +320,36 @@ def _assert_sampling_mask_format(sampling_mask, max_tokens):
             assert idx >= 0, f"mask 索引不应为负数，实际: {idx}"
 
 
+def _assert_topp_in_topk_mask_format(topp_in_topk_mask, sampling_mask=None):
+    """验证 topp_in_topk_mask 字段格式的公共辅助函数。
+
+    topp_in_topk_mask 是 List[List[bool]]：
+    - 外层列表长度 == 生成的 token 数
+    - 内层列表为 bool 值，True 表示该 top-k 候选也被 top-p 选中
+    - 当传入 sampling_mask 时，验证两者内外列表长度一致
+    """
+    assert topp_in_topk_mask is not None, "topp_in_topk_mask 不应为 None"
+    assert isinstance(topp_in_topk_mask, list), "topp_in_topk_mask 应为 list"
+    assert len(topp_in_topk_mask) > 0, "topp_in_topk_mask 不应为空"
+
+    for i, token_mask in enumerate(topp_in_topk_mask):
+        assert isinstance(token_mask, list), f"每个 token 的 topp_in_topk_mask 应为 list，实际: {type(token_mask)}"
+        assert len(token_mask) > 0, "每个 token 的 topp_in_topk_mask 不应为空"
+        for val in token_mask:
+            assert isinstance(val, bool), f"topp_in_topk_mask 元素应为 bool，实际: {type(val)}"
+
+    if sampling_mask is not None:
+        assert len(topp_in_topk_mask) == len(sampling_mask), (
+            f"topp_in_topk_mask 外层长度 {len(topp_in_topk_mask)} "
+            f"应与 sampling_mask 外层长度 {len(sampling_mask)} 一致"
+        )
+        for i, (topp_mask, s_mask) in enumerate(zip(topp_in_topk_mask, sampling_mask)):
+            assert len(topp_mask) == len(s_mask), (
+                f"token {i}: topp_in_topk_mask 内层长度 {len(topp_mask)} "
+                f"应与 sampling_mask 内层长度 {len(s_mask)} 一致"
+            )
+
+
 def test_keep_sampling_mask_stream(api_url):
     """测试流式响应中 keep_sampling_mask 功能（MTP 模式）。
 
@@ -364,6 +394,8 @@ def test_keep_sampling_mask_stream(api_url):
                 for idx in token_mask:
                     assert isinstance(idx, int) and idx >= 0, f"mask 索引应为非负 int，实际: {idx}"
             all_sampling_masks.extend(mask)
+        # 无 top_k 时 topp_in_topk_mask 应不存在
+        assert choice.get("topp_in_topk_mask") is None, "无 top_k 时 topp_in_topk_mask 应为 None"
 
     # 最后一个 chunk 携带 usage 信息
     usage = chunks[-1].get("usage")
@@ -407,6 +439,8 @@ def test_keep_sampling_mask_non_stream(api_url):
     assert (
         len(sampling_mask) == completion_tokens
     ), f"sampling_mask 长度 {len(sampling_mask)} 应等于 completion_tokens {completion_tokens}"
+    # 无 top_k 时 topp_in_topk_mask 应不存在
+    assert choice.get("topp_in_topk_mask") is None, "无 top_k 时 topp_in_topk_mask 应为 None"
 
 
 def test_keep_sampling_mask_top_p_1_stream(api_url):
@@ -471,3 +505,97 @@ def test_keep_sampling_mask_consistent_with_top_p(api_url):
     avg_small = get_avg_mask_len(0.1)
     avg_large = get_avg_mask_len(0.9)
     assert avg_small <= avg_large, f"top_p=0.1 的平均 mask 长度 ({avg_small:.1f}) 应 <= top_p=0.9 ({avg_large:.1f})"
+
+
+def test_topp_in_topk_mask_with_topk_non_stream(api_url):
+    """测试非流式响应中使用 top_k 时 topp_in_topk_mask 功能（MTP 模式）。
+
+    验证：
+    1. sampling_mask 和 topp_in_topk_mask 均存在
+    2. 两者外层列表长度相同（== completion_tokens）
+    3. 每个位置内层列表长度相同（sampling_mask 为 top-k 下标，topp_in_topk_mask 为等长布尔掩码）
+    4. topp_in_topk_mask 中至少有一个 True（采样到的 token 一定在 top-p 候选集中）
+    """
+    max_tokens = 20
+    payload = {
+        "model": "default",
+        "temperature": 1.0,
+        "top_k": 50,
+        "top_p": 0.9,
+        "seed": 42,
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "请用一句话介绍Python语言。"},
+        ],
+        "max_tokens": max_tokens,
+        "stream": False,
+    }
+
+    response = send_request(url=api_url, payload=payload).json()
+    assert "choices" in response, f"响应缺少 choices 字段: {response}"
+    choice = response["choices"][0]
+    assert "sampling_mask" in choice, f"choice 缺少 sampling_mask 字段: {choice}"
+    assert "topp_in_topk_mask" in choice, f"choice 缺少 topp_in_topk_mask 字段: {choice}"
+
+    sampling_mask = choice["sampling_mask"]
+    topp_in_topk_mask = choice["topp_in_topk_mask"]
+    completion_tokens = response["usage"]["completion_tokens"]
+
+    _assert_sampling_mask_format(sampling_mask, max_tokens)
+    _assert_topp_in_topk_mask_format(topp_in_topk_mask, sampling_mask)
+    assert (
+        len(sampling_mask) == completion_tokens
+    ), f"sampling_mask 长度 {len(sampling_mask)} 应等于 completion_tokens {completion_tokens}"
+
+    # 每个 token 的 topp_in_topk_mask 中至少有一个 True（采样到的 token 一定在 top-p 内）
+    for i, token_mask in enumerate(topp_in_topk_mask):
+        assert any(token_mask), f"token {i} 的 topp_in_topk_mask 中应至少有一个 True"
+
+
+def test_topp_in_topk_mask_with_topk_stream(api_url):
+    """测试流式响应中使用 top_k 时 topp_in_topk_mask 功能（MTP 模式）。
+
+    验证每个有内容的 chunk 携带 sampling_mask 和 topp_in_topk_mask，
+    两者内外列表长度一致。
+    """
+    max_tokens = 15
+    payload = {
+        "model": "default",
+        "temperature": 1.0,
+        "top_k": 50,
+        "top_p": 0.9,
+        "seed": 42,
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "1+1="},
+        ],
+        "max_tokens": max_tokens,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+
+    response = send_request(url=api_url, payload=payload)
+    chunks = get_stream_chunks(response)
+    assert len(chunks) > 1, "流式响应应包含至少两个 chunk"
+
+    for chunk in chunks[:-1]:
+        choice = chunk["choices"][0]
+        has_content = bool(choice.get("delta", {}).get("content"))
+        mask = choice.get("sampling_mask")
+        topp_mask = choice.get("topp_in_topk_mask")
+        if has_content:
+            assert mask is not None, f"有内容的 chunk 缺少 sampling_mask: {choice}"
+            assert topp_mask is not None, f"有内容的 chunk 缺少 topp_in_topk_mask: {choice}"
+        if mask is not None and topp_mask is not None:
+            # 外层长度一致
+            assert len(mask) == len(
+                topp_mask
+            ), f"sampling_mask 外层长度 {len(mask)} != topp_in_topk_mask 外层长度 {len(topp_mask)}"
+            for j, (s_m, t_m) in enumerate(zip(mask, topp_mask)):
+                # 内层长度一致
+                assert len(s_m) == len(
+                    t_m
+                ), f"token {j}: sampling_mask 内层长度 {len(s_m)} != topp_in_topk_mask 内层长度 {len(t_m)}"
+                # 元素为 bool
+                for val in t_m:
+                    assert isinstance(val, bool), f"topp_in_topk_mask 元素应为 bool，实际: {type(val)}"

--- a/tests/entrypoints/openai/test_max_streaming_tokens.py
+++ b/tests/entrypoints/openai/test_max_streaming_tokens.py
@@ -567,6 +567,7 @@ class TestMaxStreamingResponseTokens(IsolatedAsyncioTestCase):
                 max_tokens=max_tokens_list[idx],
                 speculate_metrics=None,
                 sampling_mask_list=None,
+                topp_in_topk_mask_list=None,
             )
 
             expected = case["expected"]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

本PR为FastDeploy的KSM（Keep Sampling Mask）功能添加 `topp_in_topk_mask` 字段支持，用于在启用top-k采样时，标记top-k候选中哪些token被top-p进一步选中。

在当前的采样逻辑中，当同时启用top-k和top-p采样时：
- sampling_mask 仅返回同时满足top-k和top-p候选的索引列表（稀疏格式）
- 无法区分这些top-k候选中哪些最终被top-p接受

这导致下游消费者（如OpenAI API客户端、日志分析工具）无法准确还原采样决策的完整语义：
- 无法分析"top-k剪枝了哪些token"与"top-p进一步过滤了哪些token"的各自贡献
- 无法重建完整的采样概率分布（需要同时知道top-k范围和top-p选择）
 
本PR通过新增 topp_in_topk_mask 布尔掩码字段，提供top-k候选上的精细化标注，使采样决策完全可解释和可复现。

变量含义
- sampling_mask: 不使用topk时表示同时满足top-k和top-p候选的索引列表（稀疏格式，List[int]），使用topk时表示满足top-k候选的索引列表
- topp_in_topk_mask: 布尔掩码，标记 sampling_mask 中每个top-k候选是否被top-p选中（List[bool]，长度与 sampling_mask 相同）
- 当top-k未启用时，topp_in_topk_mask 为 None（此时 sampling_mask 即为完整的top-p候选集合）

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications

<!-- Detail the changes made in this pull request. -->

1. fastdeploy/engine/request.py，fastdeploy/entrypoints/openai/protocol.py，fastdeploy/output/stream_transfer_data.py，fastdeploy/worker/output.py
    - 在各种输出类中补充了topp_in_topk_mask成员
2. sampler.py
    - _compute_sampling_mask函数中补充topp_in_topk_mask计算逻辑
    - 同步修改_compute_sampling_mask函数调用时的输出，并传递给SamplerOutput
4. serving_chat.py
    - 新增 topp_in_topk_mask 参数传递，将Worker计算结果传递给用户
    - 函数重命名：_make_sampling_mask_list → _make_mask_list（通用化处理），使其能够同时格式化sampling_mask和topp_in_topk_mask
6. pre_and_post_process.py
    - 修改sampling_mask的ZMQ传输逻辑，同时传输sampling_mask与topp_in_topk_mask

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->
服务启动脚本
```shell
MODEL_PATH="/root/paddlejob/tmpspace/GLM-4.5-Air-New/"
export FD_USE_GET_SAVE_OUTPUT_V1=0
python -m fastdeploy.entrypoints.openai.api_server \
    --port 9293 \
    --host $(hostname -i) \
    --model "$MODEL_PATH" \
    --disable-custom-all-reduce \
    --tensor-parallel-size 4 \
    --max-model-len 131072 \
    --max-num-seqs 32 \
    --gpu-memory-utilization 0.9 \
    --graph-optimization-config '{"use_cudagraph":true}' \
    --enable-logprob \
    --speculative-config '{"method":"mtp","num_speculative_tokens":1,"num_model_steps":1,"model":"'$MODEL_PATH'"}' \
    --enable-keep-sampling-mask \
```

请求指令
```shell
# 不带topk
curl -X POST "http:/localhost:9293/v1/chat/completions" -H "Content-Type: application/json" -d '{
    "messages": [
        {"role": "system", "content": "你是谁"}
    ] ,
    "temperature":1.0,
    "top_p": 0.8,
    "seed": 2333
  }'

# 带topk
curl -X POST "http:/localhost:9293/v1/chat/completions" -H "Content-Type: application/json" -d '{
    "messages": [
        {"role": "system", "content": "你是谁"}
    ] ,
    "temperature":1.0,
    "top_p": 0.8,
    "seed": 2333,
    "top_k": 5
  }'
```

## Accuracy Tests

结果正确
<img width="1028" height="214" alt="3579bc7ee1ec32fcfb5781a553b86e16" src="https://github.com/user-attachments/assets/98da4782-af38-41e6-a498-4454cf75c1a5" />


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
