### PR TITLE
use self.hidden_size not use self.fd_config.model_config.hidden_size

### DIFF
--- a/fastdeploy/model_executor/layers/moe/moe.py
+++ b/fastdeploy/model_executor/layers/moe/moe.py
@@ -788,7 +788,7 @@ class FusedMoE(nn.Layer):
         chunk_size = self.fd_config.parallel_config.chunked_moe_size
         token_num = x.shape[0]
         fake_x = paddle.empty(
-            shape=[0, self.fd_config.model_config.hidden_size],
+            shape=[0, self.hidden_size],
             dtype=paddle.get_default_dtype(),
         )
         # input size that are less than a chunk, less than the max size data or empty input

--- a/tests/distributed/chunked_moe.py
+++ b/tests/distributed/chunked_moe.py
@@ -170,7 +170,7 @@ class TestChunkedMoE(unittest.TestCase):
         fused_moe.quant_method = MockQuantMethod()
         fused_moe.enable_routing_replay = None
 
-        fused_moe.hidden_size = mock_fd_config.hidden_size
+        fused_moe.hidden_size = mock_fd_config.model_config.hidden_size
         return fused_moe
 
     def run_model_runner(self):

--- a/tests/distributed/chunked_moe.py
+++ b/tests/distributed/chunked_moe.py
@@ -169,6 +169,8 @@ class TestChunkedMoE(unittest.TestCase):
         fused_moe.fd_config = mock_fd_config
         fused_moe.quant_method = MockQuantMethod()
         fused_moe.enable_routing_replay = None
+
+        fused_moe.hidden_size = mock_fd_config.hidden_size
         return fused_moe
 
     def run_model_runner(self):


### PR DESCRIPTION
## 📋 Review 摘要

**PR 概述**：优化 MoE 层代码，使用缓存的 `self.hidden_size` 属性替代直接访问嵌套配置

**变更范围**：`fastdeploy/model_executor/layers/moe/moe.py`、`tests/distributed/chunked_moe.py`

**影响面 Tag**：`[Optimization]`

### 📝 PR 规范检查

PR 标题和描述未完全遵循项目规范：

1. **标题缺少 Tag**：根据 checklist，PR 标题必须包含有效的 `[Tag]`
2. **描述未填写 Motivation/Modifications**：这两个章节需要说明变更的目的和具体改动

**标题建议**（可直接复制）：
- `[Optimization] use self.hidden_size not use self.fd_config.model_config.hidden_size`

**描述模板**（可直接复制）：
```markdown
## Motivation

优化 `forward_chunked_moe` 方法中的属性访问，避免每次调用时遍历嵌套对象 `self.fd_config.model_config.hidden_size`，改用已在 `__init__` 中缓存的 `self.hidden_size` 属性，提高代码可读性和性能。

## Modifications

1. 将 `forward_chunked_moe` 中的 `self.fd_config.model_config.hidden_size` 替换为 `self.hidden_size`
2. 测试文件 `chunked_moe.py` 中补充 `hidden_size` 属性初始化（因为使用 `__new__` 创建对象时不会调用 `__init__`）
```

### 问题

| 级别 | 文件 | 概述 |
|------|------|------|
| 🟡 建议 | PR 标题/描述 | 缺少 `[Tag]` 和 Motivation/Modifications 填写 |

### 总体评价

代码变更本身是正确的优化性重构。`self.hidden_size` 在 `FusedMoE.__init__` 第 207 行已正确初始化，替换后避免了重复访问嵌套配置，有利于提高代码可读性和性能。测试文件中同步添加了属性初始化，确保单元测试正常运行。建议完善 PR 标题和描述后合并。