### PR TITLE
[Cherry-Pick][Docs] Update Release Note(#7302)

### DIFF
--- a/dockerfiles/Dockerfile.gpu
+++ b/dockerfiles/Dockerfile.gpu
@@ -1,6 +1,6 @@
 FROM ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/fastdeploy-cuda-12.6:tag-base
-ARG PADDLE_VERSION=3.3.0
-ARG FD_VERSION=2.4.0
+ARG PADDLE_VERSION=3.3.1
+ARG FD_VERSION=2.5.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -16,7 +16,7 @@ RUN python -m pip uninstall paddlepaddle-gpu fastdeploy-gpu -y
 RUN python -m pip install --no-cache-dir paddlepaddle-gpu==${PADDLE_VERSION} -i https://www.paddlepaddle.org.cn/packages/stable/cu126/
 
 # build and install FastDeploy
-RUN python -m pip install --no-cache-dir  fastdeploy-gpu==${FD_VERSION} -i https://www.paddlepaddle.org.cn/packages/stable/fastdeploy-gpu-80_90/ --extra-index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
+RUN python -m pip install --no-cache-dir fastdeploy-gpu==${FD_VERSION} -i https://www.paddlepaddle.org.cn/packages/stable/cu126/ --extra-index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
 
 ENV http_proxy=""
 ENV https_proxy=""

--- a/dockerfiles/Dockerfile.xpu
+++ b/dockerfiles/Dockerfile.xpu
@@ -15,7 +15,7 @@ RUN python -m pip uninstall paddlepaddle-gpu paddlepaddle-xpu fastdeploy-xpu -y
 RUN python -m pip uninstall -y Pillow && rm -rf /usr/local/lib/python3.10/dist-packages/Pillow* && rm -rf /usr/local/lib/python3.10/dist-packages/pillow* && python -m pip install Pillow==11.3.0
 
 # install paddlepaddle-xpu
-ARG PADDLE_VERSION=nightly
+ARG PADDLE_VERSION=3.3.1
 
 RUN if [ "$PADDLE_VERSION" = "nightly" ]; then \
         python -m pip install --no-cache-dir --progress-bar off paddlepaddle-xpu -i https://www.paddlepaddle.org.cn/packages/nightly/xpu-p800/; \
@@ -26,7 +26,7 @@ RUN if [ "$PADDLE_VERSION" = "nightly" ]; then \
 # install fastdeploy-xpu
 ARG INSTALL_REQUIREMENTS=true
 ARG INSTALL_FASTDEPLOY=true
-ARG FASTDEPLOY_VERSION=2.4.0
+ARG FASTDEPLOY_VERSION=2.5.0
 
 RUN if [ "$INSTALL_FASTDEPLOY" = "true" ]; then \
         python -m pip install --no-cache-dir fastdeploy-xpu==${FASTDEPLOY_VERSION} -i https://www.paddlepaddle.org.cn/packages/stable/fastdeploy-xpu-p800/ --extra-index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple; \

--- a/docs/get_started/installation/nvidia_gpu.md
+++ b/docs/get_started/installation/nvidia_gpu.md
@@ -12,10 +12,13 @@ The following installation methods are available when your environment meets the
 
 ## 1. Pre-built Docker Installation (Recommended)
 
-**Notice**: The pre-built image supports SM 80/86/89/90 architecture GPUs (e.g. A800/H800/L20/L40/4090).
+**Notice**: The pre-built image supports SM 80/86/89/90 architecture GPUs (e.g. A800/H800/L20/L40/4090), and requires Python 3.10.
 
 ```shell
+# CUDA 12.6
 docker pull ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/fastdeploy-cuda-12.6:2.5.0
+# CUDA 12.9
+docker pull ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/fastdeploy-cuda-12.9:2.5.0
 ```
 
 ## 2. Pre-built Pip Installation
@@ -38,7 +41,7 @@ python -m pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/
 Then install fastdeploy. **Do not install from PyPI**. Use the following methods instead (supports SM80/86/89/90 GPU architectures).
 
 **Note**: Stable FastDeploy release pairs with stable PaddlePaddle; Nightly Build FastDeploy pairs with Nightly Build PaddlePaddle. The `--extra-index-url` is only used for downloading fastdeploy-gpu's dependencies; fastdeploy-gpu itself must be installed from the Paddle source specified by `-i`.
-```
+```shell
 # Install stable release FastDeploy
 # CUDA 12.6
 python -m pip install fastdeploy-gpu==2.5.0 -i https://www.paddlepaddle.org.cn/packages/stable/cu126/ --extra-index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
@@ -54,7 +57,7 @@ python -m pip install fastdeploy-gpu -i https://www.paddlepaddle.org.cn/packages
 
 ## 3. Build from Source Using Docker
 
-- Note: ```dockerfiles/Dockerfile.gpu``` by default supports SM 80/90 architectures. To support other architectures, modify ```bash build.sh 1 python false [80,90]``` in the Dockerfile. It's recommended to specify no more than 2 architectures.
+> Note: `dockerfiles/Dockerfile.gpu` currently supports CUDA 12.6 only, targeting SM 80/86/89/90 architectures, and requires Python 3.10. To support other architectures, modify ```bash build.sh 1 python false [80,90]``` in the Dockerfile. It's recommended to specify no more than 2 architectures.
 
 ```shell
 git clone https://github.com/PaddlePaddle/FastDeploy
@@ -83,8 +86,7 @@ The built packages will be in the ```FastDeploy/dist``` directory.
 
 ## 5. Precompiled Operator Wheel Packages
 
-FastDeploy provides precompiled GPU operator wheel packages for quick setup without building the entire source code.
-This method currently supports **SM80/90 architecture (e.g., A100/H100)** and **CUDA 12.6** environments only.
+FastDeploy provides precompiled GPU operator wheel packages for quick setup without building the entire source code. This method currently supports **SM80/90 architecture (e.g., A100/H100)** **CUDA 12.6** and **Python 3.10** environments only.
 
 > By default, `build.sh` compiles all custom operators from source.To use the precompiled package, enable it with the `FD_USE_PRECOMPILED` parameter.
 > If the precompiled package cannot be downloaded or does not match the current environment, the system will automatically fall back to `4. Build Wheel from Source`.
@@ -113,7 +115,7 @@ cd FastDeploy
 bash build.sh 1 python false [90] 1
 
 # Use precompiled wheel from a specific commit
-bash build.sh 1 python false [90] 1 8a9e7b53af4a98583cab65e4b44e3265a93e56d2
+bash build.sh 1 python false [90] 1 d693d4be1448d414097882386fdc24c8bec2a63a
 ```
 
 The downloaded wheel packages will be stored in the `FastDeploy/pre_wheel` directory.
@@ -122,9 +124,9 @@ After the build completes, the operator binaries can be found in `FastDeploy/fas
 > **Notes:**
 >
 > - This mode prioritizes downloading precompiled GPU operator wheels to reduce build time.
-> - Currently supports **GPU, SM80/90, CUDA 12.6** only.
+> - Currently supports **GPU, SM80/90, CUDA 12.6, Python3.10** only.
 > - For custom architectures or modified operator logic, please use **source compilation (Section 4)**.
-> - You can check whether the precompiled wheel for a specific commit has been successfully built on the [FastDeploy CI Build Status Page](https://github.com/PaddlePaddle/FastDeploy/actions/workflows/ci_image_update.yml).
+> - You can check whether the precompiled wheel for a specific commit has been successfully built on the [FastDeploy CI Build Status Page](https://github.com/PaddlePaddle/FastDeploy/actions/workflows/ce_job.yml).
 
 ## Environment Verification
 

--- a/docs/zh/get_started/installation/nvidia_gpu.md
+++ b/docs/zh/get_started/installation/nvidia_gpu.md
@@ -14,10 +14,13 @@
 
 ## 1. 预编译Docker安装(推荐)
 
-**注意**： 预编译镜像支持 80/86/89/90 架构的GPU硬件 (如 A800/H800/L20/L40/4090)。
+**注意**： 预编译镜像支持 80/86/89/90 架构的GPU硬件 (如 A800/H800/L20/L40/4090) 且仅支持 Python 3.10。
 
 ``` shell
+# CUDA 12.6
 docker pull ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/fastdeploy-cuda-12.6:2.5.0
+# CUDA 12.9
+docker pull ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/fastdeploy-cuda-12.9:2.5.0
 ```
 
 ## 2. 预编译Pip安装
@@ -41,7 +44,7 @@ python -m pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/
 再安装 fastdeploy，**注意不要通过pypi源安装**，需要通过如下方式安装(目前支持80/86/89/90四个架构GPU）
 
 **注意**: 稳定版本的FastDeploy搭配稳定版本的PaddlePaddle; 而Nightly Build的FastDeploy则对应Nightly Build的PaddlePaddle。其中 `--extra-index-url` 仅用于安装 fastdeploy-gpu 所需的依赖包，fastdeploy-gpu 本身必须从 `-i` 指定的 Paddle 源安装。
-```
+```shell
 # 安装稳定版本FastDeploy
 # CUDA 12.6
 python -m pip install fastdeploy-gpu==2.5.0 -i https://www.paddlepaddle.org.cn/packages/stable/cu126/ --extra-index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
@@ -57,7 +60,7 @@ python -m pip install fastdeploy-gpu -i https://www.paddlepaddle.org.cn/packages
 
 ## 3. 镜像自行构建
 
-> 注意 ```dockerfiles/Dockerfile.gpu``` 默认编译的架构支持SM 80/90，如若需要支持其它架构，需自行修改Dockerfile中的 ```bash build.sh 1 python false [80,90]```，建议不超过2个架构。
+> 注意 ```dockerfiles/Dockerfile.gpu``` 默认编译产物仅支持 SM 80/86/89/90 架构，基于 CUDA 12.6 环境构建，且仅支持 Python 3.10，如若需要支持其它架构，需自行修改Dockerfile中的 ```bash build.sh 1 python false [80,90]```，建议不超过2个架构。
 
 ```
 git clone https://github.com/PaddlePaddle/FastDeploy
@@ -91,7 +94,7 @@ bash build.sh 1 python false [80,90]
 
 ## 5. 算子预编译 Wheel 包
 
-FastDeploy 提供了 GPU 算子预编译版 Wheel 包，可在无需完整源码编译的情况下快速构建。该方式当前仅支持 **SM80/90 架构（A100/H100等）** 和 **CUDA 12.6** 环境。
+FastDeploy 提供了 GPU 算子预编译版 Wheel 包，可在无需完整源码编译的情况下快速构建。该方式当前仅支持 **SM80/90 架构（A100/H100等）** **CUDA 12.6** 和 **Python 3.10** 环境。
 
 >默认情况下，`build.sh` 会从源码编译；若希望使用预编译包，可使用`FD_USE_PRECOMPILED` 参数；
 >若预编译包下载失败或与环境不匹配，系统会自动回退至 `4. wheel 包源码编译` 模式。
@@ -119,7 +122,7 @@ cd FastDeploy
 bash build.sh 1 python false [90] 1
 
 # 从指定 commitID 获取对应预编译算子
-bash build.sh 1 python false [90] 1 8a9e7b53af4a98583cab65e4b44e3265a93e56d2
+bash build.sh 1 python false [90] 1 d693d4be1448d414097882386fdc24c8bec2a63a
 ```
 
 下载的 whl 包在 `FastDeploy/pre_wheel`目录下。
@@ -128,7 +131,7 @@ bash build.sh 1 python false [90] 1 8a9e7b53af4a98583cab65e4b44e3265a93e56d2
 
 > **说明：**
 > - 该模式会优先下载预编译的 GPU 算子 whl 包，减少编译时间；
-> - 目前仅支持 **GPU， SM80/90 架构， CUDA 12.6**；
+> - 目前仅支持 **GPU， SM80/90 架构， CUDA 12.6， Python3.10**；
 > - 若希望自定义架构或修改算子逻辑，请使用 **源码编译方式（第4节）**。
 > - 您可以在 FastDeploy CI 构建状态页面查看对应 commit 的预编译 whl 是否已构建成功。
 


### PR DESCRIPTION
Cherry-pick of #7302 #7289  (authored by @EmmonsCurse) to `release/2.6`.

devPR:https://github.com/PaddlePaddle/FastDeploy/pull/7302 https://github.com/PaddlePaddle/FastDeploy/pull/7289 <!-- For pass CI -->

---

<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
- The previous CI and documentation did not reflect this constraint, leading to potential incompatibility and confusion.
- Additionally, environment consistency (CUDA / Paddle / FastDeploy versions) and artifact references required updates.

## Modifications
1. **Align with updated wheel constraints**
   - Updated documentation and usage to reflect that prebuilt `fastdeploy-gpu` wheels now support **GPU, SM80/90, CUDA 12.6, Python3.10** only
2. **Update Docker build configuration**
   - Modified `dockerfiles/Dockerfile.xpu`:
     - Set: `FASTDEPLOY_VERSION=2.5.0` and `PADDLE_VERSION=3.3.1`
3. **Update pre-built image**
    - Updated documentation and usage to clearly state that the pre-built `image` is restricted to **Python 3.10 only**.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.