### PR TITLE
[CI] Modify 4-card container startup config and move test case

### DIFF
--- a/.github/workflows/_gpu_4cards_case_test.yml
+++ b/.github/workflows/_gpu_4cards_case_test.yml
@@ -181,11 +181,17 @@ jobs:
             docker rm -f ${runner_name} || true
           fi
 
+          export RDMA_DEVICES=$(find /dev/infiniband/uverbs* -maxdepth 1 -not -type d | xargs -I{} echo '--device {}:{}')
+
           docker run --rm --net=host \
-          --shm-size=64g \
           --sysctl kernel.msgmax=1048576 \
           --sysctl kernel.msgmnb=268435456 \
           --name ${runner_name} \
+          --cap-add=SYS_PTRACE --cap-add=IPC_LOCK \
+          --shm-size=64G \
+          ${RDMA_DEVICES} \
+          --device=/dev/infiniband/rdma_cm \
+          --ulimit memlock=-1:-1 \
           -v $(pwd):/workspace -w /workspace \
           -v "${CACHE_DIR}/gitconfig:/etc/gitconfig:ro" \
           -v "${CACHE_DIR}/.cache:/root/.cache" \
@@ -197,6 +203,10 @@ jobs:
           -e "FD_METRICS_PORT=${FD_METRICS_PORT}" \
           -e "FLASK_PORT=${FLASK_PORT}" \
           -e "FD_CACHE_QUEUE_PORT=${FD_CACHE_QUEUE_PORT}" \
+          -e "FD_ROUTER_PORT=${FD_ROUTER_PORT}" \
+          -e "FD_CONNECTOR_PORT=${FD_CONNECTOR_PORT}" \
+          -e "FD_RDMA_PORT=${FD_RDMA_PORT}" \
+          -e "CLEAN_CUDA=1" \
           -e TZ="Asia/Shanghai" \
           -e "fd_wheel_url=${fd_wheel_url}" \
           -e "BASE_REF=${BASE_REF}" \

--- a/tests/e2e/4cards_cases/test_ernie_03b_pd_router_v1_rdma_tp2.py
+++ b/tests/e2e/4cards_cases/test_ernie_03b_pd_router_v1_rdma_tp2.py
@@ -26,7 +26,7 @@ import time
 
 import pytest
 import requests
-from utils.serving_utils import (
+from e2e.utils.serving_utils import (
     FD_API_PORT,
     FD_CACHE_QUEUE_PORT,
     FD_ENGINE_QUEUE_PORT,
@@ -90,7 +90,7 @@ def setup_and_run_server():
 
     # get rdma nics
     current_dir = os.path.dirname(os.path.abspath(__file__))
-    shell_path = os.path.join(current_dir, "utils/get_rdma_nics.sh")
+    shell_path = os.path.join(current_dir, "../utils/get_rdma_nics.sh")
     output = subprocess.check_output(["bash", shell_path, "gpu"], text=True)
     _, rdma_nics = output.split("=")
     print(f"shell_path: {shell_path}, rdma_nics: {rdma_nics}")
@@ -171,7 +171,7 @@ def setup_and_run_server():
     # decode实例
     print("start decode...")
     env_decode = os.environ.copy()
-    env_decode["CUDA_VISIBLE_DEVICES"] = "1"
+    env_decode["CUDA_VISIBLE_DEVICES"] = "2"
     env_decode["FD_LOG_DIR"] = os.path.join(base_log_dir, "log_decode")
     # env_decode["KVCACHE_RDMA_NICS"] = rdma_nics
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
- Improve stability and compatibility of 4-card CI jobs with RDMA-enabled environments  
- Ensure proper device mounting and resource limits for multi-card inference tests  

## Modifications
- Update 4-card container startup configuration:
  - Add RDMA device auto-detection and injection (`RDMA_DEVICES`)
  - Mount `/dev/infiniband/rdma_cm` for RDMA communication
  - Add `--ulimit memlock=-1:-1` to support RDMA memory locking
  - Add required capabilities (`SYS_PTRACE`, `IPC_LOCK`)
  - Adjust shared memory configuration (`--shm-size=64g`)
- Add new environment variables for router, connector, and RDMA ports
- Enable CUDA cleanup flag (`CLEAN_CUDA=1`)
- Reorganize e2e test case:
  - Move `test_ernie_03b_pd_router_v1_rdma_tp2.py` into `4cards_cases` directory for clearer test grouping

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.