### PR TITLE
[BugFix][PD Disaggregation][KVCache] Fix low cache hit rate in PD split (disaggregation) scenario

### DIFF
--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -927,6 +927,7 @@ class ResourceManagerV1(ResourceManager):
                     if (
                         self.config.cache_config.enable_prefix_caching
                         and self.config.scheduler_config.splitwise_role != "decode"
+                        and self.config.scheduler_config.splitwise_role != "prefill"
                     ):
                         self.cache_manager.update_cache_blocks(
                             request, self.config.cache_config.block_size, request.num_computed_tokens
@@ -1374,6 +1375,11 @@ class ResourceManagerV1(ResourceManager):
                     self.stop_flags[request.idx] = False
                     self.requests[request.request_id] = request
                     self.req_dict[request.request_id] = allocated_position
+
+                    self.cache_manager.update_cache_blocks(
+                        request, self.config.cache_config.block_size, request.need_prefill_tokens
+                    )
+
                     return True
                 else:
                     self._free_blocks(request)


### PR DESCRIPTION
## Motivation

在 PD 分离（disaggregation）场景下，prefill 节点收到请求后，未能及时更新 prefix cache block 的命中信息，导致 prefix cache 命中率异常偏低，影响推理性能。

具体问题：
- prefill 节点在通过 `_allocate_gpu_blocks` 成功分配block后，没有调用 `update_cache_blocks` 更新 cache block 状态，导致已命中的 prefix cache 无法被正确记录

## Modifications

1. **统一 prefill 节点的 cache block 更新**：在 `_free_blocks_when_stop` 方法中，新增对 `splitwise_role != "prefill"` 的排除判断，避免 prefill 节点重复更新 cache block 状态。

2. **prefill 节点主动更新 cache block**：在 `preallocate_resource_in_p` 方法中，prefill 节点成功分配block后，主动调用 `update_cache_blocks`（使用 `need_prefill_tokens`）。

## Usage or Command

启动 PD 分离服务进行验证：

```bash
# 启动 router
bash run_router.sh

# 启动 P 节点（prefill）
bash run_p.sh

# 启动 D 节点（decode）
bash run_d.sh

# 发送请求并观察 cache hit rate 日志
curl -X POST http://${SERVER_IP}:${SERVER_PORT}/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model": "your-model", "messages": [{"role": "user", "content": "..."}]}'
```

修复后，prefill 节点日志中 prefix cache 命中率应显著提升。

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests. （该 bug fix 涉及运行时状态更新，需要端到端 PD 分离环境验证，单元测试覆盖困难）
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.