### PR TITLE
[Speculate Decoding] Fix reasoning_phase_token_constraint call args in SpeculativeSampler

### DIFF
--- a/fastdeploy/model_executor/layers/sample/sampler.py
+++ b/fastdeploy/model_executor/layers/sample/sampler.py
@@ -996,7 +996,8 @@ class SpeculativeSampler(nn.Layer):
         if self.enf_gen_phase_tag:
             reasoning_phase_token_constraint(
                 logits,
-                sampling_metadata.pre_token_ids,
+                token_ids_all,
+                prompt_lens,
                 share_inputs["stop_flags"],
                 share_inputs["seq_lens_this_time"],
                 share_inputs["seq_lens_encoder"],


### PR DESCRIPTION
## Motivation

在 `SpeculativeSampler` 中调用 `reasoning_phase_token_constraint` 时，传入的参数与函数签名不匹配：
- 第二个参数错误地使用了 `sampling_metadata.pre_token_ids`
- 缺少第三个必传参数 `prompt_lens`

导致推理约束逻辑无法正确执行，提测失败。

## Modifications

修复 `SpeculativeSampler` 中 `reasoning_phase_token_constraint` 的调用参数：
- 将 `sampling_metadata.pre_token_ids` 替换为 `token_ids_all`
- 新增 `prompt_lens` 参数

## Usage or Command

无新功能，为 Bug 修复。

## Accuracy Tests

无模型输出变更，仅修复参数传递错误。

## Checklist

- [ ] Add at least a tag in the PR title.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. 本次为参数传递 Bug 修复，已有相关算子测试覆盖，无需新增单测。
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
