### PR TITLE
[BugFix][Cherry-Pick] Fix race condition in async RL control request(#7430) 

### DIFF
--- a/fastdeploy/entrypoints/engine_client.py
+++ b/fastdeploy/entrypoints/engine_client.py
@@ -552,14 +552,14 @@ class EngineClient:
 
     async def run_control_method(self, request: ControlRequest):
         api_server_logger.info(f"Received control request: {request}")
+        request_id = request.request_id
+        dealer, response_queue = await self.connection_manager.get_connection(request_id)
+        dealer.write([b"", request_id.encode("utf-8")])
         req_dict = request.to_dict()
         if not self.enable_mm and not envs.ENABLE_V1_DATA_PROCESSOR:
             self.zmq_client.send_json(req_dict)
         else:
             self.zmq_client.send_pyobj(req_dict)
-        request_id = request.request_id
-        dealer, response_queue = await self.connection_manager.get_connection(request_id)
-        dealer.write([b"", request_id.encode("utf-8")])
         try:
             # todo: support user specified timeout. default 600s is enough for most control cases
             response = await asyncio.wait_for(response_queue.get(), timeout=600)


### PR DESCRIPTION
This PR cherry-picks https://github.com/PaddlePaddle/FastDeploy/pull/7430 to release/2.5.

💡 If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(https://github.com/PaddlePaddle/FastDeploy/pull/5191)

💡 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(https://github.com/PaddlePaddle/FastDeploy/pull/5191)

## Motivation

In the async RL weight update flow (`/v1/pause` -> `/v1/update_weights` -> `/v1/resume`), `/v1/resume` could occasionally time out after 600s.

Example log:
```text
ERROR engine_client.py[line:571] Control request timed out: ControlResponse(..., error_message=Timeout waiting for control method response)
```

At the same time, engine-side logs showed:
```text
WARNING zmq_server.py[line:270] req_id 'control-...' not in req_dict, caching response
```

This indicates a race in the control path: the engine may finish a fast control request before the response channel registration is ready. In that case, the response first goes into the engine-side cache path, which can lead to the API server waiting on `response_queue.get()` until timeout.

## Modifications

Updated `fastdeploy/entrypoints/engine_client.py` in `run_control_method` to register the control response channel before sending the control request.

Before this change, the control request could be sent before the corresponding response path was ready. After this change, response registration happens first, and the control request is sent afterwards, reducing the race window for fast control methods such as `resume`.

This change only affects the control request path and does not change the normal inference request flow.

## Usage or Command

Repro flow:
1. `/v1/pause`
2. `/v1/update_weights`
3. `/v1/resume`

Before the fix, `/v1/resume` could occasionally hit the timeout race.
After the fix, the control response can be matched and returned normally.

## Accuracy Tests

No model output change. Accuracy testing is not required.

## Unit Tests

No dedicated unit test was added in this PR.
This is a timing-sensitive control-path race fix and was verified through the async RL weight update flow.

## Checklist

- [x] Add at least a tag in the PR title.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
```