### PR TITLE
[Interrupt reasoning] Add interrupt_requests control command support

### DIFF
--- a/fastdeploy/splitwise/internal_adapter_utils.py
+++ b/fastdeploy/splitwise/internal_adapter_utils.py
@@ -105,6 +105,15 @@ class InternalAdapter:
                     with self.response_lock:
                         self.recv_control_cmd_server.response_for_control_cmd(task_id_str, result)
 
+                elif task["cmd"] == "interrupt_requests":
+                    self.engine.resource_manager.add_abort_req_ids(task["req_ids"])
+                    result = {
+                        "task_id": task_id_str,
+                        "result": {"success": True, "interrupted_req_ids": task["req_ids"]},
+                    }
+                    with self.response_lock:
+                        self.recv_control_cmd_server.response_for_control_cmd(task_id_str, result)
+
             except Exception as e:
                 logger.error(f"handle_control_cmd got error: {e}, {traceback.format_exc()!s}")
 


### PR DESCRIPTION
## Motivation

支持接受中断推理的命令。

## Modifications

在 internal_adapter_utils.py的 handle_control_cmd 方法中，新增 interrupt_requests 控制命令的处理分支：

接收 interrupt_requests 命令后，从 task["req_ids"] 中提取需要中断的请求 ID 列表
调用 self.engine.resource_manager.add_abort_req_ids() 将这些请求标记为待中止
构造包含 success 状态和已中断请求 ID 列表的响应，通过控制命令通道回传结果

## Usage or Command

{
    "cmd": "interrupt_requests",
    "task_id": "<task_id>",
    "req_ids": ["req_1", "req_2"]
}

## Accuracy Tests

本次改动不涉及模型前向计算或 kernel 修改，无需精度测试。

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.不涉及精度变化
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
