### PR TITLE
[KSM] support keep sampling mask

### DIFF
--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -211,6 +211,7 @@ class ModelConfig:
         self.enable_logprob = False
         self.max_logprobs = 20
         self.logprobs_mode = "raw_logprobs"
+        self.enable_keep_sampling_mask = False
         self.redundant_experts_num = 0
         self.seed = 0
         self.quantization = None

--- a/fastdeploy/engine/args_utils.py
+++ b/fastdeploy/engine/args_utils.py
@@ -460,6 +460,14 @@ class EngineArgs:
     Must be explicitly enabled via the `--enable-logprob` startup parameter to output logprob values.
     """
 
+    enable_keep_sampling_mask: bool = False
+    """
+    When enabled, the server returns a sparse index list for each generated token, indicating
+    which vocabulary positions were retained after top_p/top_k sampling, and streams it to
+    the client. In MTP (multi-token prediction) scenarios this field is a List[List[int]],
+    where each inner list contains the retained vocabulary indices for a predicted token.
+    """
+
     max_logprobs: int = 20
     """
     Maximum number of log probabilities to return when `enable_logprob` is True. The default value comes the default for the
@@ -900,6 +908,18 @@ class EngineArgs:
             action="store_true",
             default=EngineArgs.enable_logprob,
             help="Enable output of token-level log probabilities.",
+        )
+        model_group.add_argument(
+            "--enable-keep-sampling-mask",
+            action="store_true",
+            default=EngineArgs.enable_keep_sampling_mask,
+            help=(
+                "Enable output of sampling mask as a sparse index list over the vocabulary. "
+                "For non-MTP decoding, this is a list[int] per token step indicating which "
+                "vocabulary indices were kept after top_p/top_k sampling. "
+                "For MTP decoding, this is a list[list[int]] per token step, where each inner "
+                "list corresponds to one MTP group."
+            ),
         )
         model_group.add_argument(
             "--max-logprobs",

--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -2491,6 +2491,7 @@ class EngineService:
             "moe_gate_fp32": self.cfg.model_config.moe_gate_fp32,
             "enable_entropy": self.cfg.model_config.enable_entropy,
             "enable_overlap_schedule": self.cfg.scheduler_config.enable_overlap_schedule,
+            "enable_keep_sampling_mask": self.cfg.model_config.enable_keep_sampling_mask,
         }
         for worker_flag, value in worker_store_true_flag.items():
             if value:

--- a/fastdeploy/engine/engine.py
+++ b/fastdeploy/engine/engine.py
@@ -655,6 +655,7 @@ class LLMEngine:
             "enable_entropy": self.cfg.model_config.enable_entropy,
             "ep_prefill_use_worst_num_tokens": self.cfg.parallel_config.ep_prefill_use_worst_num_tokens,
             "enable_overlap_schedule": self.cfg.scheduler_config.enable_overlap_schedule,
+            "enable_keep_sampling_mask": self.cfg.model_config.enable_keep_sampling_mask,
         }
         for worker_flag, value in worker_store_true_flag.items():
             if value:

--- a/fastdeploy/engine/request.py
+++ b/fastdeploy/engine/request.py
@@ -727,6 +727,10 @@ class CompletionOutput:
     delta_message: Optional[DeltaMessage] = None
     multipart: Optional[list[Any]] = None
     num_image_tokens: Optional[int] = None
+    # Sparse indices of retained vocab ids:
+    #   - Non-MTP: list[int]
+    #   - MTP: list[list[int]]
+    sampling_mask: Optional[Any] = None
 
     def to_dict(self):
         """
@@ -745,6 +749,7 @@ class CompletionOutput:
             "text": self.text,
             "reasoning_content": self.reasoning_content,
             "reasoning_token_num": self.reasoning_token_num,
+            "sampling_mask": self.sampling_mask,
         }
 
     @classmethod

--- a/fastdeploy/entrypoints/openai/protocol.py
+++ b/fastdeploy/entrypoints/openai/protocol.py
@@ -270,6 +270,8 @@ class ChatCompletionResponseChoice(BaseModel):
     prompt_logprobs: Optional[PromptLogprobs] = None
     finish_reason: Optional[Literal["stop", "length", "tool_calls", "recover_stop"]]
     speculate_metrics: Optional[SpeculateMetrics] = None
+    # Per-token retained vocab indices from top_p/top_k sampling: List[List[int]], one list of vocab indices per token
+    sampling_mask: Optional[List[List[int]]] = None
 
 
 class ChatCompletionResponse(BaseModel):
@@ -333,6 +335,9 @@ class ChatCompletionResponseStreamChoice(BaseModel):
     logprobs: Optional[LogProbs] = None
     draft_logprobs: Optional[LogProbs] = None
     prompt_logprobs: Optional[PromptLogprobs] = None
+    # Per-token index list of retained positions after top_p sampling.
+    # Non-MTP: [[idx, ...]] (1 token/step). MTP: [[idx, ...], ...] (N accepted tokens/step).
+    sampling_mask: Optional[List[List[int]]] = None
     finish_reason: Optional[Literal["stop", "length", "tool_calls", "recover_stop"]] = None
     arrival_time: Optional[float] = None
     speculate_metrics: Optional[SpeculateMetrics] = None

--- a/fastdeploy/entrypoints/openai/serving_chat.py
+++ b/fastdeploy/entrypoints/openai/serving_chat.py
@@ -435,6 +435,11 @@ class OpenAIServingChat:
                         delta=delta_message,
                         logprobs=logprobs_res,
                         draft_logprobs=draft_logprobs_res,
+                        sampling_mask=(
+                            self._make_sampling_mask_list(output["sampling_mask"])
+                            if output.get("sampling_mask") is not None
+                            else None
+                        ),
                         arrival_time=arrival_time,
                         speculate_metrics=output_speculate_metrics,
                     )
@@ -580,6 +585,7 @@ class OpenAIServingChat:
                 decoder_base_url=self.tokenizer_base_url,
             )
             prompt_logprobs_res_list = [[] for _ in range(num_choices)]
+            sampling_mask_list = [[] for _ in range(num_choices)]
             speculate_metrics = [None for _ in range(num_choices)]
             choices = []
             while num_choices > 0:
@@ -660,6 +666,9 @@ class OpenAIServingChat:
                         )
                         if prompt_logprobs_res:
                             prompt_logprobs_res_list[idx].extend(clamp_prompt_logprobs(prompt_logprobs_res))
+                    output_sampling_mask = output.get("sampling_mask", None)
+                    if output_sampling_mask is not None:
+                        sampling_mask_list[idx].append(self._make_sampling_mask_list(output_sampling_mask))
                     speculate_metrics[idx] = data["metrics"].get("speculate_metrics", None)
                     if data["finished"]:
                         trace_carrier = data.get("trace_carrier")
@@ -695,6 +704,7 @@ class OpenAIServingChat:
                             draft_logprob_contents=draft_logprob_contents,
                             response_processor=response_processor,
                             prompt_logprobs_res_list=prompt_logprobs_res_list,
+                            sampling_mask_list=sampling_mask_list,
                             max_tokens=max_tokens,
                             speculate_metrics=speculate_metrics[idx],
                         )
@@ -749,6 +759,7 @@ class OpenAIServingChat:
         logprob_contents: list,
         draft_logprob_contents: list,
         prompt_logprobs_res_list: list,
+        sampling_mask_list: list,
         response_processor: ChatResponseProcessor,
         max_tokens: int,
         speculate_metrics: SpeculateMetrics | None,
@@ -787,6 +798,11 @@ class OpenAIServingChat:
         if prompt_logprobs_res_list[idx]:
             prompt_logprobs_full_res = prompt_logprobs_res_list[idx]
 
+        # Flatten per-step List[List[int]] into a single List[List[int]] over all tokens.
+        sampling_mask_full_res = None
+        if sampling_mask_list and sampling_mask_list[idx]:
+            sampling_mask_full_res = [mask for step in sampling_mask_list[idx] for mask in step]
+
         num_cached_tokens[idx] = data.get("num_cached_tokens", 0)
         num_input_image_tokens[idx] = data.get("num_input_image_tokens", 0)
         num_input_video_tokens[idx] = data.get("num_input_video_tokens", 0)
@@ -810,6 +826,7 @@ class OpenAIServingChat:
             logprobs=logprobs_full_res,
             draft_logprobs=draft_logprobs_full_res,
             prompt_logprobs=prompt_logprobs_full_res,
+            sampling_mask=sampling_mask_full_res,
             finish_reason=finish_reason,
             speculate_metrics=speculate_metrics,
         )
@@ -1000,3 +1017,18 @@ class OpenAIServingChat:
             )
             for token_id, logprob, rank, token in zip(logprob_token_ids, logprobs, ranks, decoded_tokens)
         }
+
+    @staticmethod
+    def _make_sampling_mask_list(sampling_mask) -> List[List[int]]:
+        """Wrap sampling_mask into a uniform List[List[int]] format.
+
+        sampling_mask is already in sparse-index form (no bool-to-index conversion needed):
+          Non-MTP: List[int]        (indices for 1 token/step)  → [[idx, ...]]
+          MTP:     List[List[int]]  (indices for N tokens/step) → [[idx, ...], ...]
+        """
+        assert sampling_mask is not None
+        if sampling_mask and isinstance(sampling_mask[0], list):
+            # MTP: already List[List[int]], return as-is
+            return sampling_mask
+        # Non-MTP: already List[int], wrap in outer list for uniform format
+        return [sampling_mask]

--- a/fastdeploy/model_executor/layers/sample/logprobs.py
+++ b/fastdeploy/model_executor/layers/sample/logprobs.py
@@ -16,6 +16,7 @@
 
 from typing import Callable, List, Optional, Tuple
 
+import numpy as np
 import paddle
 import paddle.nn.functional as F
 import triton
@@ -133,7 +134,7 @@ def build_output_logprobs(
     is_naive: bool = False,
     logprobs_mode: str = "default",
     compute_logprobs_fn: Optional[Callable] = None,
-) -> Tuple[Optional[LogprobsTensors], Optional[paddle.Tensor]]:
+) -> Tuple[Optional[LogprobsTensors], Optional[paddle.Tensor], Optional[paddle.Tensor]]:
     """
     Build logprobs output for both NAIVE and speculative (MTP/Ngram) modes.
 
@@ -153,14 +154,11 @@ def build_output_logprobs(
             scaling and top_p normalization. Used when logprobs_mode == "raw_logprobs".
 
     Returns:
-        tuple: (logprobs_tensors, cu_batch_token_offset)
+        tuple: (logprobs_tensors, cu_batch_token_offset, output_logits)
     """
     num_logprobs = sampling_metadata.max_num_logprobs
     logprobs_tensors = None
     cu_batch_token_offset = None
-
-    if num_logprobs is None:
-        return logprobs_tensors, cu_batch_token_offset
 
     real_bsz = share_inputs["seq_lens_this_time"].shape[0]
 
@@ -208,6 +206,10 @@ def build_output_logprobs(
         mask = idx < share_inputs["accept_num"].unsqueeze(1)
         token_ids = paddle.masked_select(share_inputs["accept_tokens"], mask)
 
+    # Adapate for sampling mask
+    if num_logprobs is None:
+        return None, None, output_logits
+
     # Compute logprobs with temperature scaling and top_p normalization
     if logprobs_mode == "raw_logprobs":
         raw_logprobs = compute_logprobs_fn(output_logits, sampling_metadata)
@@ -217,5 +219,28 @@ def build_output_logprobs(
         raw_logprobs = F.log_softmax(output_logits, axis=-1)
 
     logprobs_tensors = gather_logprobs(raw_logprobs, num_logprobs, token_ids=token_ids)
+    # output_logits use to compute sampling_mask
+    return logprobs_tensors, cu_batch_token_offset, output_logits
 
-    return logprobs_tensors, cu_batch_token_offset
+
+def logprobs_renormalize_with_logz(logprobs: paddle.Tensor, logz: np.ndarray, logprobs_tensors: LogprobsTensors):
+    """
+    Renormalize logprobs to match truncated sampling distribution.
+    Args:
+        logprobs: tensor [B, max_num_logprobs + 1]
+        logz: [B], log(sum(probs in candidate set K)) for each request
+        logprobs_tensors: LogprobsTensors
+    """
+    logz = paddle.to_tensor(logz, dtype=logprobs.dtype)
+    # Renormalize: log π_masked = log π_full - log Z_K
+    # Only normalize valid candidates; padding positions use -inf
+    valid_mask = paddle.isfinite(logprobs)
+    normalized_logprobs = paddle.where(
+        valid_mask, logprobs - logz.unsqueeze(1), paddle.full_like(logprobs, float("-inf"))
+    )
+    # Update logprobs_tensors with normalized values
+    return LogprobsTensors(
+        logprob_token_ids=logprobs_tensors.logprob_token_ids,
+        logprobs=normalized_logprobs,
+        selected_token_ranks=logprobs_tensors.selected_token_ranks,
+    )

--- a/fastdeploy/model_executor/layers/sample/logprobs.py
+++ b/fastdeploy/model_executor/layers/sample/logprobs.py
@@ -206,7 +206,7 @@ def build_output_logprobs(
         mask = idx < share_inputs["accept_num"].unsqueeze(1)
         token_ids = paddle.masked_select(share_inputs["accept_tokens"], mask)
 
-    # Adapate for sampling mask
+    # Adapt for sampling mask
     if num_logprobs is None:
         return None, None, output_logits
 

--- a/fastdeploy/model_executor/layers/sample/logprobs.py
+++ b/fastdeploy/model_executor/layers/sample/logprobs.py
@@ -16,7 +16,6 @@
 
 from typing import Callable, List, Optional, Tuple
 
-import numpy as np
 import paddle
 import paddle.nn.functional as F
 import triton
@@ -223,15 +222,19 @@ def build_output_logprobs(
     return logprobs_tensors, cu_batch_token_offset, output_logits
 
 
-def logprobs_renormalize_with_logz(logprobs: paddle.Tensor, logz: np.ndarray, logprobs_tensors: LogprobsTensors):
+def logprobs_renormalize_with_logz(logprobs: paddle.Tensor, logz, logprobs_tensors: LogprobsTensors):
     """
     Renormalize logprobs to match truncated sampling distribution.
     Args:
         logprobs: tensor [B, max_num_logprobs + 1]
-        logz: [B], log(sum(probs in candidate set K)) for each request
+        logz: [B], log(sum(probs in candidate set K)) for each request.
+              Can be np.ndarray or paddle.Tensor (CPU pinned memory).
         logprobs_tensors: LogprobsTensors
     """
-    logz = paddle.to_tensor(logz, dtype=logprobs.dtype)
+    if isinstance(logz, paddle.Tensor):
+        logz = logz.astype(logprobs.dtype)
+    else:
+        logz = paddle.to_tensor(logz, dtype=logprobs.dtype)
     # Renormalize: log π_masked = log π_full - log Z_K
     # Only normalize valid candidates; padding positions use -inf
     valid_mask = paddle.isfinite(logprobs)

--- a/fastdeploy/model_executor/layers/sample/meta_data.py
+++ b/fastdeploy/model_executor/layers/sample/meta_data.py
@@ -66,3 +66,5 @@ class SamplingMetadata:
     # Add for HPU post-processing
     seq_lens_encoder: Optional[paddle.Tensor] = None
     seq_lens_decoder: Optional[paddle.Tensor] = None
+    # Add for keep sampling mask
+    keep_sampling_mask: Optional[bool] = None

--- a/fastdeploy/model_executor/layers/sample/sampler.py
+++ b/fastdeploy/model_executor/layers/sample/sampler.py
@@ -111,10 +111,10 @@ def _compute_sampling_mask(
     top_p: paddle.Tensor,
     top_k: Optional[paddle.Tensor] = None,
     top_k_list: Optional[list] = None,
-) -> tuple[List[np.ndarray], np.ndarray]:
+) -> tuple[paddle.Tensor, paddle.Tensor, paddle.Tensor, int]:
     """
-    Compute a combined top-k + top-p (nucleus) sampling mask as sparse
-    retained-token indices.
+    Compute a combined top-k + top-p (nucleus) sampling mask — GPU only,
+    no D2H transfer or CPU sync.
 
     Processing order:
       1. Sort probs descending once (shared by top-k and top-p stages).
@@ -136,11 +136,11 @@ def _compute_sampling_mask(
                     top-k filtering is needed at all.
 
     Returns:
-        Tuple of (sparse_indices, logz_per_batch):
-        - sparse_indices: List of length num_reqs; element i is a 1-D int64
-          numpy array of the retained vocab indices for request i.
-        - logz_per_batch: 1-D numpy array of shape [num_reqs] containing
-          log(Z_K) where Z_K is the sum of probabilities in the candidate set.
+        Tuple of (indices_window, mask_window, logz_per_batch, real_bsz):
+        - indices_window: [B, max_k] GPU int64 tensor of sorted vocab indices.
+        - mask_window: [B, max_k] GPU bool tensor, True = retained.
+        - logz_per_batch: [B] GPU float32 tensor, log(Z_K) per request.
+        - real_bsz: int, the batch size.
     """
     real_bsz = probs.shape[0]
     vocab_size = probs.shape[1]
@@ -210,7 +210,7 @@ def _compute_sampling_mask(
     final_mask = topk_mask & topp_mask if has_top_k else topp_mask  # [B, V]
 
     k_per_row = final_mask.astype("int32").sum(axis=-1)  # [B]
-    max_k = int(k_per_row.max().item())
+    max_k = k_per_row.max().reshape([-1])  # [1], stays on GPU
 
     # ------------------------------------------------------------------
     # Stage 5: compute logZ_K for renormalization
@@ -219,14 +219,38 @@ def _compute_sampling_mask(
     # ------------------------------------------------------------------
     candidate_probs = paddle.where(final_mask, sorted_probs, paddle.zeros_like(sorted_probs))
     z_k = candidate_probs.sum(axis=-1)  # [B]
-    logz_per_batch = paddle.log(z_k + 1e-10).cpu().numpy()  # [B]
+    logz_per_batch = paddle.log(z_k + 1e-10)  # [B], GPU
 
-    # Transfer only the leading max_k columns — typically max_k << vocab_size.
-    indices_window_cpu = sorted_indices[:, :max_k].cpu().numpy()  # [B, max_k]
-    mask_window_cpu = final_mask[:, :max_k].cpu().numpy()  # [B, max_k]
+    # Slice only the leading max_k columns on GPU — typically max_k << vocab_size.
+    # All outputs stay on GPU; D2H is deferred to save_output via async copy_.
+    indices_window = sorted_indices.slice([1], [0], max_k)  # [B, max_k]
+    mask_window = final_mask.slice([1], [0], max_k)  # [B, max_k]
 
-    sparse_indices = [indices_window_cpu[i, mask_window_cpu[i]] for i in range(real_bsz)]
-    return sparse_indices, logz_per_batch
+    return indices_window, mask_window, logz_per_batch, real_bsz
+
+
+def _extract_sparse_indices(
+    indices_window_cpu: np.ndarray,
+    mask_window_cpu: np.ndarray,
+    real_bsz: int,
+) -> List[np.ndarray]:
+    """
+    Extract per-request sparse retained-token indices from CPU numpy arrays.
+
+    This is the CPU-side counterpart of _compute_sampling_mask. It should be
+    called after the sampling_mask_event has been synchronized, so that the
+    async D2H copy is guaranteed to be complete.
+
+    Args:
+        indices_window_cpu: [B, max_k] int64 numpy array of sorted vocab indices.
+        mask_window_cpu: [B, max_k] bool numpy array, True = retained.
+        real_bsz: batch size (number of rows to process).
+
+    Returns:
+        List of length real_bsz; element i is a 1-D int64 numpy array of
+        retained vocab indices for request i.
+    """
+    return [indices_window_cpu[i, mask_window_cpu[i]] for i in range(real_bsz)]
 
 
 class GuidedDecoding:
@@ -680,16 +704,31 @@ class Sampler(nn.Layer):
         probs = min_p_sampling(probs, sampling_metadata.min_p, sampling_metadata.min_p_list)
 
         # Compute sampling mask BEFORE top_k_top_p_sampling modifies probs.
-        # Binary mask [num_reqs, vocab_size]: 1 = retained by top_k/top_p, 0 = truncated.
+        # All GPU ops; D2H is done via async copy_ with event sync in save_output.
         sampling_mask = None
         logz_per_batch = None
+        sampling_mask_event = None
         if sampling_metadata.keep_sampling_mask:
-            sampling_mask, logz_per_batch = _compute_sampling_mask(
+            sampling_mask_event = paddle.device.cuda.create_event()
+            indices_window_gpu, mask_window_gpu, logz_per_batch, mask_bsz = _compute_sampling_mask(
                 probs,
                 sampling_metadata.top_p,
                 top_k=sampling_metadata.top_k,
                 top_k_list=sampling_metadata.top_k_list,
             )
+            # Allocate CPU pinned tensors and async copy
+            indices_window_cpu = paddle.empty_like(
+                indices_window_gpu, dtype=indices_window_gpu.dtype, device="cpu"
+            ).pin_memory()
+            mask_window_cpu = paddle.empty_like(
+                mask_window_gpu, dtype=mask_window_gpu.dtype, device="cpu"
+            ).pin_memory()
+            indices_window_cpu.copy_(indices_window_gpu, False)
+            mask_window_cpu.copy_(mask_window_gpu, False)
+            # Record event — sync this event before reading CPU buffers
+            sampling_mask_event.record()
+            # Store deferred GPU→CPU data; sparse extraction happens in save_output
+            sampling_mask = (indices_window_cpu, mask_window_cpu, mask_bsz)
 
         _, next_tokens = top_k_top_p_sampling(
             probs,
@@ -716,6 +755,7 @@ class Sampler(nn.Layer):
             logits=logits,
             sampling_mask=sampling_mask,
             logz_per_batch=logz_per_batch,
+            sampling_mask_event=sampling_mask_event,
         )
 
         return sampler_output
@@ -1188,9 +1228,7 @@ class SpeculativeSampler(nn.Layer):
                 # Derive target probs from already-extracted target_logits; avoids a second kernel call.
                 target_probs = F.softmax(target_logits, axis=-1)
                 # Compute sampling mask at accepted token positions.
-                # Shape: [total_accepted_tokens, vocab_size], bool (CPU).
                 # Expand top_p from [batch, 1] to [total_accepted, 1].
-                # total_accepted = accept_nums.sum()
                 accept_top_p = (
                     sampling_metadata.top_p[:real_bsz].squeeze(1).repeat_interleave(accept_nums).unsqueeze(1)
                 )
@@ -1203,12 +1241,26 @@ class SpeculativeSampler(nn.Layer):
                     accept_top_k = (
                         sampling_metadata.top_k[:real_bsz].squeeze(1).repeat_interleave(accept_nums).unsqueeze(1)
                     )
-                sampler_output.sampling_mask, sampler_output.logz_per_batch = _compute_sampling_mask(
+                indices_window_gpu, mask_window_gpu, logz_per_batch, mask_bsz = _compute_sampling_mask(
                     target_probs,
                     accept_top_p,
                     top_k=accept_top_k,
                     top_k_list=sampling_metadata.top_k_list,
                 )
+                # Async D2H copy with event
+                indices_window_cpu = paddle.empty_like(
+                    indices_window_gpu, dtype=indices_window_gpu.dtype, device="cpu"
+                ).pin_memory()
+                mask_window_cpu = paddle.empty_like(
+                    mask_window_gpu, dtype=mask_window_gpu.dtype, device="cpu"
+                ).pin_memory()
+                indices_window_cpu.copy_(indices_window_gpu, False)
+                mask_window_cpu.copy_(mask_window_gpu, False)
+                sampling_mask_event = paddle.device.cuda.create_event()
+                sampling_mask_event.record()
+                sampler_output.sampling_mask = (indices_window_cpu, mask_window_cpu, mask_bsz)
+                sampler_output.logz_per_batch = logz_per_batch
+                sampler_output.sampling_mask_event = sampling_mask_event
         return sampler_output
 
     def forward_xpu(

--- a/fastdeploy/model_executor/layers/sample/sampler.py
+++ b/fastdeploy/model_executor/layers/sample/sampler.py
@@ -1170,7 +1170,7 @@ class SpeculativeSampler(nn.Layer):
 
         keep_sampling_mask = sampling_metadata.keep_sampling_mask
         # Build logprobs via unified path (outside of sampling logic)
-        if sampling_metadata.max_num_logprobs is not None:
+        if sampling_metadata.max_num_logprobs is not None or keep_sampling_mask:
             logprobs_tensors, cu_batch_token_offset, target_logits = build_output_logprobs(
                 logits,
                 sampling_metadata,

--- a/fastdeploy/model_executor/layers/sample/sampler.py
+++ b/fastdeploy/model_executor/layers/sample/sampler.py
@@ -19,6 +19,7 @@ import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, List, Optional
 
+import numpy as np
 import paddle
 import paddle.nn.functional as F
 from paddle import nn
@@ -103,6 +104,129 @@ def padding_sampling_params(top_p, top_k, infer_seed, seq_lens_this_time, seq_le
     topp_seed[:, 0] = (topp_seed[:, 0] + offsets) % MAX_INFER_SEED
 
     return top_p_padding, top_k_padding, topp_seed
+
+
+def _compute_sampling_mask(
+    probs: paddle.Tensor,
+    top_p: paddle.Tensor,
+    top_k: Optional[paddle.Tensor] = None,
+    top_k_list: Optional[list] = None,
+) -> tuple[List[np.ndarray], np.ndarray]:
+    """
+    Compute a combined top-k + top-p (nucleus) sampling mask as sparse
+    retained-token indices.
+
+    Processing order:
+      1. Sort probs descending once (shared by top-k and top-p stages).
+      2. top-k mask  — zero out positions beyond top_k[i] in sorted order.
+      3. top-k renorm — renormalise in-place after truncation.
+      4. top-p mask  — cumsum on the already-sorted renormed probs; no
+                       second argsort needed.
+      5. intersect   — AND of the two masks, applied on GPU before D2H.
+
+    Either filter can be disabled:
+      - top-k is skipped when top_k_list is None or all values <= 0.
+      - top-p[i] >= 1.0  →  keep all tokens for that request.
+
+    Args:
+        probs:      [num_reqs, vocab_size] softmax probabilities (GPU).
+        top_p:      [num_reqs, 1] top-p threshold per request (GPU).
+        top_k:      [num_reqs, 1] top-k per request (GPU, int); 0 = disabled.
+        top_k_list: Python list of top-k values; used to decide whether any
+                    top-k filtering is needed at all.
+
+    Returns:
+        Tuple of (sparse_indices, logz_per_batch):
+        - sparse_indices: List of length num_reqs; element i is a 1-D int64
+          numpy array of the retained vocab indices for request i.
+        - logz_per_batch: 1-D numpy array of shape [num_reqs] containing
+          log(Z_K) where Z_K is the sum of probabilities in the candidate set.
+    """
+    real_bsz = probs.shape[0]
+    vocab_size = probs.shape[1]
+    top_p = top_p[:real_bsz]  # [B, 1]
+
+    has_top_k = top_k is not None and top_k_list and any(x > 0 for x in top_k_list)
+
+    # ------------------------------------------------------------------
+    # Stage 1: single sort — descending by probability.
+    # sorted_indices / sorted_probs are reused by both top-k and top-p.
+    # ------------------------------------------------------------------
+    sorted_indices = paddle.argsort(probs, axis=-1, descending=True)  # [B, V]
+    sorted_probs = paddle.take_along_axis(probs, sorted_indices, axis=-1)  # [B, V]
+
+    # ------------------------------------------------------------------
+    # Stage 2: top-k mask (GPU, no D2H)
+    # ------------------------------------------------------------------
+    if has_top_k:
+        top_k = top_k[:real_bsz]  # [B, 1]
+        # top_k == 0 means "disabled" → keep all columns for that row.
+        effective_k = paddle.where(top_k > 0, top_k, paddle.full_like(top_k, vocab_size))
+
+        # Relax: also keep positions whose prob ties with the k-th element.
+        # boundary index (0-based) = effective_k - 1, clamped to [0, V-1].
+        k_idx = (effective_k - 1).clip(min=0).squeeze(-1).astype("int64")  # [B] k-th index
+        batch_idx = paddle.arange(k_idx.shape[0], dtype="int64")  # [B] bs index
+        boundary_prob = sorted_probs[batch_idx, k_idx].unsqueeze(-1)  # [B, 1] min_probs in topk candidates
+        topk_mask = sorted_probs >= boundary_prob  # [B, V] True = retained by top-k
+
+        # Zero out tail, then renorm row-wise.
+        masked_sorted_probs = paddle.where(topk_mask, sorted_probs, paddle.zeros_like(sorted_probs))
+        row_sums = masked_sorted_probs.sum(axis=-1, keepdim=True).clip(min=1e-9)
+        renorm_sorted_probs = masked_sorted_probs / row_sums  # [B, V]
+    else:
+        topk_mask = None
+        renorm_sorted_probs = sorted_probs
+
+    # ------------------------------------------------------------------
+    # Stage 3: top-p mask on already-sorted renormed probs (no re-sort).
+    # ------------------------------------------------------------------
+    cum_probs = paddle.cumsum(renorm_sorted_probs, axis=-1)  # [B, V]
+    topp_mask = (cum_probs - renorm_sorted_probs) <= top_p  # [B, V]
+    # When top_p[i] >= 1.0, keep the entire row.
+    topp_mask = paddle.where(
+        (top_p >= 1.0).expand_as(topp_mask),
+        paddle.ones_like(topp_mask),
+        topp_mask,
+    )
+
+    # Extend mask to cover sort tie-breaking: include all tokens whose
+    # probability >= the boundary token's probability (last retained
+    # in sorted order).  In descending-sorted probs this just extends
+    # the contiguous True block by the run of equal-prob tokens.
+    k_per_row = topp_mask.astype("int32").sum(axis=-1, keepdim=True)  # [B,1]
+    # boundary_idx = last True position (k-1), clamp for safety
+    boundary_idx = (k_per_row - 1).clip(min=0)  # [B, 1]
+    boundary_prob = paddle.take_along_axis(
+        renorm_sorted_probs,
+        boundary_idx,
+        axis=-1,
+    )  # [B, 1]
+    topp_mask = topp_mask | (renorm_sorted_probs >= boundary_prob)
+
+    # ------------------------------------------------------------------
+    # Stage 4: intersect on GPU, then minimal D2H.
+    # ------------------------------------------------------------------
+    final_mask = topk_mask & topp_mask if has_top_k else topp_mask  # [B, V]
+
+    k_per_row = final_mask.astype("int32").sum(axis=-1)  # [B]
+    max_k = int(k_per_row.max().item())
+
+    # ------------------------------------------------------------------
+    # Stage 5: compute logZ_K for renormalization
+    # Z_K = sum(probs[i] * final_mask[i]) for each request i
+    # logZ_K = log(Z_K), with small constant to avoid log(0)
+    # ------------------------------------------------------------------
+    candidate_probs = paddle.where(final_mask, sorted_probs, paddle.zeros_like(sorted_probs))
+    z_k = candidate_probs.sum(axis=-1)  # [B]
+    logz_per_batch = paddle.log(z_k + 1e-10).cpu().numpy()  # [B]
+
+    # Transfer only the leading max_k columns — typically max_k << vocab_size.
+    indices_window_cpu = sorted_indices[:, :max_k].cpu().numpy()  # [B, max_k]
+    mask_window_cpu = final_mask[:, :max_k].cpu().numpy()  # [B, max_k]
+
+    sparse_indices = [indices_window_cpu[i, mask_window_cpu[i]] for i in range(real_bsz)]
+    return sparse_indices, logz_per_batch
 
 
 class GuidedDecoding:
@@ -554,6 +678,19 @@ class Sampler(nn.Layer):
             _record_logits_diagnostic(logits, tag="post_penalty_logits", probs=probs)
 
         probs = min_p_sampling(probs, sampling_metadata.min_p, sampling_metadata.min_p_list)
+
+        # Compute sampling mask BEFORE top_k_top_p_sampling modifies probs.
+        # Binary mask [num_reqs, vocab_size]: 1 = retained by top_k/top_p, 0 = truncated.
+        sampling_mask = None
+        logz_per_batch = None
+        if sampling_metadata.keep_sampling_mask:
+            sampling_mask, logz_per_batch = _compute_sampling_mask(
+                probs,
+                sampling_metadata.top_p,
+                top_k=sampling_metadata.top_k,
+                top_k_list=sampling_metadata.top_k_list,
+            )
+
         _, next_tokens = top_k_top_p_sampling(
             probs,
             sampling_metadata.top_p,
@@ -577,6 +714,8 @@ class Sampler(nn.Layer):
             sampled_token_ids=next_tokens,
             logprobs_tensors=logprobs_tensors,
             logits=logits,
+            sampling_mask=sampling_mask,
+            logz_per_batch=logz_per_batch,
         )
 
         return sampler_output
@@ -1029,9 +1168,10 @@ class SpeculativeSampler(nn.Layer):
                 reject_all_drafts,
             )
 
+        keep_sampling_mask = sampling_metadata.keep_sampling_mask
         # Build logprobs via unified path (outside of sampling logic)
         if sampling_metadata.max_num_logprobs is not None:
-            logprobs_tensors, cu_batch_token_offset = build_output_logprobs(
+            logprobs_tensors, cu_batch_token_offset, target_logits = build_output_logprobs(
                 logits,
                 sampling_metadata,
                 share_inputs,
@@ -1042,6 +1182,33 @@ class SpeculativeSampler(nn.Layer):
             sampler_output.logprobs_tensors = logprobs_tensors
             if cu_batch_token_offset is not None:
                 sampler_output.cu_batch_token_offset = cu_batch_token_offset.cpu()
+            if keep_sampling_mask:
+                real_bsz = share_inputs["seq_lens_this_time"].shape[0]
+                accept_nums = share_inputs["accept_num"][:real_bsz].reshape([-1])
+                # Derive target probs from already-extracted target_logits; avoids a second kernel call.
+                target_probs = F.softmax(target_logits, axis=-1)
+                # Compute sampling mask at accepted token positions.
+                # Shape: [total_accepted_tokens, vocab_size], bool (CPU).
+                # Expand top_p from [batch, 1] to [total_accepted, 1].
+                # total_accepted = accept_nums.sum()
+                accept_top_p = (
+                    sampling_metadata.top_p[:real_bsz].squeeze(1).repeat_interleave(accept_nums).unsqueeze(1)
+                )
+                accept_top_k = None
+                if (
+                    sampling_metadata.top_k is not None
+                    and sampling_metadata.top_k_list
+                    and any(x > 0 for x in sampling_metadata.top_k_list)
+                ):
+                    accept_top_k = (
+                        sampling_metadata.top_k[:real_bsz].squeeze(1).repeat_interleave(accept_nums).unsqueeze(1)
+                    )
+                sampler_output.sampling_mask, sampler_output.logz_per_batch = _compute_sampling_mask(
+                    target_probs,
+                    accept_top_p,
+                    top_k=accept_top_k,
+                    top_k_list=sampling_metadata.top_k_list,
+                )
         return sampler_output
 
     def forward_xpu(

--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -627,12 +627,15 @@ def save_output_specualate(
             accept_nums = model_output.accept_num[:real_bsz].flatten().tolist()
             mask_dict = {}
             offset = 0
+            total_masks = len(sampler_output.sampling_mask)
             for i, n in enumerate(accept_nums):
-                n = int(n)
+                n = max(int(n), 0)
                 if n > 0:
                     # List of n sparse index arrays, one per accepted token
                     mask_dict[i] = [arr.tolist() for arr in sampler_output.sampling_mask[offset : offset + n]]
                 offset += n
+            if offset != total_masks:
+                raise ValueError(f"sampling_mask length mismatch: expected {offset}, got {total_masks}")
             sampling_mask_zmq_client.send_pyobj(mask_dict)
     share_inputs["last_preempted_idx"][:] = 0
 

--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -22,6 +22,7 @@ import paddle
 
 from fastdeploy import envs
 from fastdeploy.config import SpeculativeConfig
+from fastdeploy.inter_communicator import ZmqIpcClient
 from fastdeploy.platforms import current_platform
 from fastdeploy.worker.input_batch import (
     InputBatch,
@@ -108,6 +109,9 @@ from fastdeploy.model_executor.entropy_utils import (
 )
 from fastdeploy.model_executor.layers.moe.routing_indices_cache import (
     RoutingReplayManager,
+)
+from fastdeploy.model_executor.layers.sample.logprobs import (
+    logprobs_renormalize_with_logz,
 )
 from fastdeploy.model_executor.layers.sample.meta_data import SamplingMetadata
 from fastdeploy.output.pooler import PoolerOutput, PoolingSequenceGroupOutput
@@ -216,6 +220,7 @@ def _build_stream_transfer_data(
     pooler_outputs: List[PoolingSequenceGroupOutput] = None,
     logprobs: Optional[LogprobsTensors] = None,
     prompt_logprobs_list: Optional[LogprobsTensors] = None,
+    sampling_mask: Optional[List[np.ndarray]] = None,
 ):
     """Split output_tokens and output"""
 
@@ -225,6 +230,8 @@ def _build_stream_transfer_data(
         output_tokens = output_tokens.numpy().reshape([-1])
         output_tokens_lists = np.split(output_tokens, output_tokens.shape[0])
 
+        sampling_mask_list = sampling_mask
+
         for bid, output_token_per_sample in enumerate(output_tokens_lists):
             stream_transfer_data = StreamTransferData(
                 decoder_state=DecoderState.TEXT, tokens=output_token_per_sample, batch_id=bid
@@ -233,6 +240,8 @@ def _build_stream_transfer_data(
                 stream_transfer_data.logprobs = logprobs.slice_rows(bid, bid + 1)
             if prompt_logprobs_list:
                 stream_transfer_data.prompt_logprobs = prompt_logprobs_list[bid]
+            if sampling_mask_list is not None:
+                stream_transfer_data.sampling_mask = sampling_mask_list[bid]
             stream_transfer_datas.append(stream_transfer_data)
     elif pooler_outputs is not None:
         for bid, pooler_output in enumerate(pooler_outputs):
@@ -368,6 +377,14 @@ def post_process_normal(
                 model_output.is_block_step,
             )
 
+    # Renormalize logprobs to match truncated sampling distribution (when enabled).
+    if sampler_output.logprobs_tensors is not None and sampler_output.logz_per_batch is not None:
+        sampler_output.logprobs_tensors = logprobs_renormalize_with_logz(
+            sampler_output.logprobs_tensors.logprobs,
+            sampler_output.logz_per_batch,
+            sampler_output.logprobs_tensors,
+        )
+
 
 def save_output_normal(
     model_output: ModelOutputData,
@@ -375,6 +392,7 @@ def save_output_normal(
     share_inputs: Dict[str, paddle.Tensor],
     async_output_queue: queue.Queue = None,
     save_each_rank: bool = False,
+    sampling_mask_zmq_client: Optional[ZmqIpcClient] = None,
 ):
     # Transmit the model's output and stop generation signal via message queue.
     # In the future, we will abandon this approach.
@@ -393,6 +411,7 @@ def save_output_normal(
                 recover_share_inputs_map["sampled_token_ids"],
                 logprobs=sampler_output.logprobs_tensors,
                 prompt_logprobs_list=model_output.prompt_logprobs_list,
+                sampling_mask=sampler_output.sampling_mask,
             )
             async_output_queue.put(output)
     else:
@@ -429,6 +448,12 @@ def save_output_normal(
                 recover_share_inputs_map["last_preempted_idx"],
                 model_output.mp_rank,
             )
+        # Send sampling_mask via ZMQ side-channel when enabled.
+        if sampler_output.sampling_mask is not None and model_output.mp_rank == 0:
+            # sampling_mask is List[np.ndarray] of sparse int indices, one array per request.
+            mask_dict = {i: arr.tolist() for i, arr in enumerate(sampler_output.sampling_mask)}
+
+            sampling_mask_zmq_client.send_pyobj(mask_dict)
     share_inputs["last_preempted_idx"][:] = 0
 
 
@@ -520,6 +545,14 @@ def post_process_specualate(
         model_output.max_dec_len,  # max_dec_len
     )
 
+    # Renormalize logprobs to match truncated sampling distribution (when enabled).
+    if sampler_output.logprobs_tensors is not None and sampler_output.logz_per_batch is not None:
+        sampler_output.logprobs_tensors = logprobs_renormalize_with_logz(
+            sampler_output.logprobs_tensors.logprobs,
+            sampler_output.logz_per_batch,
+            sampler_output.logprobs_tensors,
+        )
+
 
 def save_output_specualate(
     sampler_output: SamplerOutput,
@@ -527,6 +560,7 @@ def save_output_specualate(
     share_inputs: InputBatch,
     save_each_rank: bool = False,
     skip_save_output: bool = False,
+    sampling_mask_zmq_client: ZmqIpcClient = None,
 ):
     if not skip_save_output:
         if sampler_output.logprobs_tensors is None:
@@ -585,6 +619,21 @@ def save_output_specualate(
                 model_output.mp_rank,
                 save_each_rank,
             )
+        # Send sampling_mask via ZMQ side-channel when enabled.
+        if sampler_output.sampling_mask is not None and model_output.mp_rank == 0:
+            # sampling_mask is List[np.ndarray] of sparse int indices, length = total_accepted_tokens.
+            # Group by request using accept_num so each entry is List[np.ndarray] (n arrays per req).
+            real_bsz = model_output.accept_num.shape[0]
+            accept_nums = model_output.accept_num[:real_bsz].flatten().tolist()
+            mask_dict = {}
+            offset = 0
+            for i, n in enumerate(accept_nums):
+                n = int(n)
+                if n > 0:
+                    # List of n sparse index arrays, one per accepted token
+                    mask_dict[i] = [arr.tolist() for arr in sampler_output.sampling_mask[offset : offset + n]]
+                offset += n
+            sampling_mask_zmq_client.send_pyobj(mask_dict)
     share_inputs["last_preempted_idx"][:] = 0
 
 

--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -22,7 +22,6 @@ import paddle
 
 from fastdeploy import envs
 from fastdeploy.config import SpeculativeConfig
-from fastdeploy.inter_communicator import ZmqIpcClient
 from fastdeploy.model_executor.ops.gpu import (
     mtp_save_first_token,
     mtp_save_first_token_with_topk,
@@ -119,6 +118,7 @@ from fastdeploy.model_executor.layers.sample.logprobs import (
     logprobs_renormalize_with_logz,
 )
 from fastdeploy.model_executor.layers.sample.meta_data import SamplingMetadata
+from fastdeploy.model_executor.layers.sample.sampler import _extract_sparse_indices
 from fastdeploy.output.pooler import PoolerOutput, PoolingSequenceGroupOutput
 from fastdeploy.output.stream_transfer_data import DecoderState, StreamTransferData
 from fastdeploy.worker.output import LogprobsTensors, ModelOutputData, SamplerOutput
@@ -382,13 +382,8 @@ def post_process_normal(
                 model_output.is_block_step,
             )
 
-    # Renormalize logprobs to match truncated sampling distribution (when enabled).
-    if sampler_output.logprobs_tensors is not None and sampler_output.logz_per_batch is not None:
-        sampler_output.logprobs_tensors = logprobs_renormalize_with_logz(
-            sampler_output.logprobs_tensors.logprobs,
-            sampler_output.logz_per_batch,
-            sampler_output.logprobs_tensors,
-        )
+    # logprobs renormalization with logz is deferred to save_output,
+    # so that async D2H of logz_per_batch has more time to complete.
 
 
 def save_output_normal(
@@ -397,8 +392,28 @@ def save_output_normal(
     share_inputs: Dict[str, paddle.Tensor],
     async_output_queue: queue.Queue = None,
     save_each_rank: bool = False,
-    sampling_mask_zmq_client: Optional[ZmqIpcClient] = None,
+    sampling_mask_async_queue: Optional[queue.Queue] = None,
 ):
+    # Resolve deferred async D2H: sync event once at the top so all paths below
+    # can safely read sampling_mask and logz_per_batch.
+    if sampler_output.sampling_mask_event is not None:
+        sampler_output.sampling_mask_event.synchronize()
+        # Extract sparse indices from pinned CPU buffers
+        if sampler_output.sampling_mask is not None:
+            indices_window_cpu, mask_window_cpu, mask_bsz = sampler_output.sampling_mask
+            sampler_output.sampling_mask = _extract_sparse_indices(
+                indices_window_cpu.numpy(), mask_window_cpu.numpy(), mask_bsz
+            )
+        sampler_output.sampling_mask_event = None
+
+    # Renormalize logprobs with logz (deferred from post_process for better overlap).
+    if sampler_output.logprobs_tensors is not None and sampler_output.logz_per_batch is not None:
+        sampler_output.logprobs_tensors = logprobs_renormalize_with_logz(
+            sampler_output.logprobs_tensors.logprobs,
+            sampler_output.logz_per_batch,
+            sampler_output.logprobs_tensors,
+        )
+
     # Transmit the model's output and stop generation signal via message queue.
     # In the future, we will abandon this approach.
     if envs.FD_USE_GET_SAVE_OUTPUT_V1:
@@ -453,12 +468,13 @@ def save_output_normal(
                 recover_share_inputs_map["last_preempted_idx"],
                 model_output.mp_rank,
             )
-        # Send sampling_mask via ZMQ side-channel when enabled.
+        # Send sampling_mask via ZMQ side-channel when enabled (async via background thread).
         if sampler_output.sampling_mask is not None and model_output.mp_rank == 0:
-            # sampling_mask is List[np.ndarray] of sparse int indices, one array per request.
-            mask_dict = {i: arr.tolist() for i, arr in enumerate(sampler_output.sampling_mask)}
-
-            sampling_mask_zmq_client.send_pyobj(mask_dict)
+            # sampling_mask already resolved at function entry.
+            assert (
+                sampling_mask_async_queue is not None
+            ), "sampling_mask_async_queue must not be None when sampling_mask is enabled"
+            sampling_mask_async_queue.put((sampler_output.sampling_mask, None))
     share_inputs["last_preempted_idx"][:] = 0
 
 
@@ -550,13 +566,8 @@ def post_process_specualate(
         model_output.max_dec_len,  # max_dec_len
     )
 
-    # Renormalize logprobs to match truncated sampling distribution (when enabled).
-    if sampler_output.logprobs_tensors is not None and sampler_output.logz_per_batch is not None:
-        sampler_output.logprobs_tensors = logprobs_renormalize_with_logz(
-            sampler_output.logprobs_tensors.logprobs,
-            sampler_output.logz_per_batch,
-            sampler_output.logprobs_tensors,
-        )
+    # logprobs renormalization with logz is deferred to save_output,
+    # so that async D2H of logz_per_batch has more time to complete.
 
 
 def save_output_specualate(
@@ -567,9 +578,28 @@ def save_output_specualate(
     local_rank: int,
     tensor_parallel_rank: int,
     save_each_rank: bool = False,
-    sampling_mask_zmq_client: ZmqIpcClient = None,
+    sampling_mask_async_queue: Optional[queue.Queue] = None,
     is_mtp_prefill: bool = False,
 ):
+    # Resolve deferred async D2H: sync event once at the top so all paths below
+    # can safely read sampling_mask and logz_per_batch.
+    if sampler_output.sampling_mask_event is not None:
+        sampler_output.sampling_mask_event.synchronize()
+        if sampler_output.sampling_mask is not None:
+            indices_window_cpu, mask_window_cpu, mask_bsz = sampler_output.sampling_mask
+            sampler_output.sampling_mask = _extract_sparse_indices(
+                indices_window_cpu.numpy(), mask_window_cpu.numpy(), mask_bsz
+            )
+        sampler_output.sampling_mask_event = None
+
+    # Renormalize logprobs with logz (deferred from post_process for better overlap).
+    if sampler_output.logprobs_tensors is not None and sampler_output.logz_per_batch is not None:
+        sampler_output.logprobs_tensors = logprobs_renormalize_with_logz(
+            sampler_output.logprobs_tensors.logprobs,
+            sampler_output.logz_per_batch,
+            sampler_output.logprobs_tensors,
+        )
+
     if is_mtp_prefill:
         if tensor_parallel_rank == 0:
             skip_chunk_prefill = bool(int(envs.ENABLE_V1_KVCACHE_SCHEDULER))
@@ -690,24 +720,16 @@ def save_output_specualate(
                 model_output.mp_rank,
                 save_each_rank,
             )
-        # Send sampling_mask via ZMQ side-channel when enabled.
+        # Send sampling_mask via ZMQ side-channel when enabled (async via background thread).
         if sampler_output.sampling_mask is not None and model_output.mp_rank == 0:
-            # sampling_mask is List[np.ndarray] of sparse int indices, length = total_accepted_tokens.
+            # sampling_mask already resolved at function entry.
             # Group by request using accept_num so each entry is List[np.ndarray] (n arrays per req).
             real_bsz = model_output.accept_num.shape[0]
             accept_nums = model_output.accept_num[:real_bsz].flatten().tolist()
-            mask_dict = {}
-            offset = 0
-            total_masks = len(sampler_output.sampling_mask)
-            for i, n in enumerate(accept_nums):
-                n = max(int(n), 0)
-                if n > 0:
-                    # List of n sparse index arrays, one per accepted token
-                    mask_dict[i] = [arr.tolist() for arr in sampler_output.sampling_mask[offset : offset + n]]
-                offset += n
-            if offset != total_masks:
-                raise ValueError(f"sampling_mask length mismatch: expected {offset}, got {total_masks}")
-            sampling_mask_zmq_client.send_pyobj(mask_dict)
+            assert (
+                sampling_mask_async_queue is not None
+            ), "sampling_mask_async_queue must not be None when sampling_mask is enabled"
+            sampling_mask_async_queue.put((sampler_output.sampling_mask, accept_nums))
     share_inputs["last_preempted_idx"][:] = 0
 
 

--- a/fastdeploy/output/stream_transfer_data.py
+++ b/fastdeploy/output/stream_transfer_data.py
@@ -46,3 +46,7 @@ class StreamTransferData:
     accept_num: Optional[np.array] = None
     # [num_reqs, hidden_size]
     pooler_output: Optional[np.array] = None
+    # 1-D int32 numpy array of vocab indices retained by top_p/top_k for
+    # this request.  Sparse format: only retained positions, not a dense
+    # vocab-sized bool mask.
+    sampling_mask: Optional[np.array] = None

--- a/fastdeploy/output/token_processor.py
+++ b/fastdeploy/output/token_processor.py
@@ -83,6 +83,14 @@ class TokenProcessor:
 
         self.speculative_decoding = self.cfg.speculative_config.method is not None
         self.use_logprobs = self.cfg.model_config.enable_logprob
+        self.use_sampling_mask = getattr(self.cfg.model_config, "enable_keep_sampling_mask", False)
+        if not envs.FD_USE_GET_SAVE_OUTPUT_V1 and self.use_sampling_mask:
+            rank_id = self.cfg.parallel_config.local_data_parallel_id
+            port = self.cfg.parallel_config.engine_worker_queue_port[rank_id]
+            self.sampling_mask_zmq_server = ZmqIpcServer(
+                name=f"sampling_mask_output_rank_{rank_id}_{port}", mode=zmq.PULL
+            )
+            llm_logger.info(f"create zmq sampling_mask_output_rank_{rank_id}_{port}")
         self.enable_draft_logprob = self.cfg.speculative_config.enable_draft_logprob
 
         if self.speculative_decoding:
@@ -357,6 +365,8 @@ class TokenProcessor:
                             result.prompt_logprobs = stream_data.prompt_logprobs
                         except Exception as e:
                             llm_logger.warning(f"Failed to parse prompt_logprobs from StreamTransferData: {e}")
+                if getattr(stream_data, "sampling_mask", None) is not None:
+                    result.outputs.sampling_mask = stream_data.sampling_mask.tolist()
                 if self.tokens_counter[task_id] == 0:
                     if task.messages is not None:
                         result.prompt = task.messages
@@ -734,6 +744,15 @@ class TokenProcessor:
             batch = self.output_tokens[1, 0]
             tokens = tokens[2 : batch + 2]
 
+        # Receive sampling constraints per request from ZMQ side-channel (if enabled).
+        # The worker sends a dict {batch_id: sparse_vocab_indices} each step,
+        # where the value is a list[int] or list[list[int]] of allowed token ids
+        sampling_masks_per_request = {}
+        if self.use_sampling_mask and not envs.FD_USE_GET_SAVE_OUTPUT_V1 and hasattr(self, "sampling_mask_zmq_server"):
+            _, mask_data = self.sampling_mask_zmq_server.receive_pyobj_once(block=True)
+            if mask_data is not None and isinstance(mask_data, dict):
+                sampling_masks_per_request = mask_data
+
         batch_result = list()
         # reschedule
         for i in range(batch):
@@ -867,6 +886,9 @@ class TokenProcessor:
             if task.get("multimodal_inputs", None):
                 result.num_input_image_tokens = task.multimodal_inputs.get("num_input_image_tokens", 0)
                 result.num_input_video_tokens = task.multimodal_inputs.get("num_input_video_tokens", 0)
+
+            if self.use_sampling_mask and i in sampling_masks_per_request:
+                result.outputs.sampling_mask = sampling_masks_per_request[i]
 
             if is_prefill and len(token_ids) > 1:
                 result.outputs.draft_token_ids = copy.deepcopy(token_ids)

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -126,6 +126,7 @@ class GPUModelRunner(ModelRunnerBase):
         self.spec_method = self.fd_config.speculative_config.method
         self.speculative_decoding = self.spec_method is not None
         self.enable_logprob = fd_config.model_config.enable_logprob
+        self.enable_keep_sampling_mask = fd_config.model_config.enable_keep_sampling_mask
         self.enable_early_stop = self.fd_config.early_stop_config.enable_early_stop
         self.is_pooling_model = self.fd_config.model_config.runner_type == "pooling"
         self.ori_vocab_size = self.fd_config.model_config.ori_vocab_size
@@ -235,6 +236,17 @@ class GPUModelRunner(ModelRunnerBase):
 
         # Rollout routing replay config
         self.routing_replay_manager = None
+
+        # ZMQ side-channel for sampling_mask in non-FD_USE_GET_SAVE_OUTPUT_V1 path
+        self.sampling_mask_zmq_client = None
+        if not envs.FD_USE_GET_SAVE_OUTPUT_V1 and self.enable_keep_sampling_mask:
+            rank_id = self.parallel_config.local_data_parallel_id
+            port = self.parallel_config.engine_worker_queue_port[rank_id]
+            self.sampling_mask_zmq_client = ZmqIpcClient(
+                name=f"sampling_mask_output_rank_{rank_id}_{port}", mode=zmq.PUSH
+            )
+            self.sampling_mask_zmq_client.connect()
+            logger.info(f"create send zmq sampling_mask_output_rank_{rank_id}_{port}")
 
         self.zmq_client = None
         self.async_output_queue = None
@@ -1233,6 +1245,7 @@ class GPUModelRunner(ModelRunnerBase):
             top_p_normalized_logprobs=self.share_inputs["top_p_normalized_logprobs"],
             logits_processors=self.share_inputs["logits_processors"],
             share_inputs=self.share_inputs,
+            keep_sampling_mask=self.enable_keep_sampling_mask,
         )
         return token_num, token_num_event
 
@@ -2485,6 +2498,7 @@ class GPUModelRunner(ModelRunnerBase):
                 share_inputs=self.share_inputs,
                 save_each_rank=self.parallel_config.use_ep,
                 skip_save_output=skip_save_output,
+                sampling_mask_zmq_client=self.sampling_mask_zmq_client,
             )
         else:
             save_output_normal(
@@ -2493,6 +2507,7 @@ class GPUModelRunner(ModelRunnerBase):
                 share_inputs=self.share_inputs,
                 async_output_queue=self.async_output_queue,
                 save_each_rank=self.parallel_config.use_ep,
+                sampling_mask_zmq_client=self.sampling_mask_zmq_client,
             )
 
     def _pool(self, hidden_states: paddle.Tensor, num_running_requests: int) -> Optional[ModelRunnerOutput]:

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -248,6 +248,16 @@ class GPUModelRunner(ModelRunnerBase):
             self.sampling_mask_zmq_client.connect()
             logger.info(f"create send zmq sampling_mask_output_rank_{rank_id}_{port}")
 
+        self.sampling_mask_async_queue = None
+        if self.sampling_mask_zmq_client is not None:
+            self.sampling_mask_async_queue = queue.Queue()
+            self._sampling_mask_send_thread = Thread(
+                target=self._async_sampling_mask_send_loop,
+                daemon=True,
+                name="WorkerAsyncSamplingMaskSend",
+            )
+            self._sampling_mask_send_thread.start()
+
         self.zmq_client = None
         self.async_output_queue = None
         if envs.FD_USE_GET_SAVE_OUTPUT_V1:
@@ -297,6 +307,27 @@ class GPUModelRunner(ModelRunnerBase):
                 self.zmq_client.send_pyobj(output)
             except Exception as e:
                 logger.exception("Exception in async output loop: %s", e)
+
+    def _async_sampling_mask_send_loop(self):
+        """Background thread: serialize and send sampling_mask over ZMQ."""
+        while True:
+            try:
+                mask_list, accept_nums = self.sampling_mask_async_queue.get()
+                if accept_nums is None:
+                    # Normal (non-speculative) path
+                    mask_dict = {i: arr.tolist() for i, arr in enumerate(mask_list)}
+                else:
+                    # Speculative path: group by accept_num
+                    mask_dict = {}
+                    offset = 0
+                    for i, n in enumerate(accept_nums):
+                        n = int(n)
+                        if n > 0:
+                            mask_dict[i] = [arr.tolist() for arr in mask_list[offset : offset + n]]
+                        offset += n
+                self.sampling_mask_zmq_client.send_pyobj(mask_dict)
+            except Exception as e:
+                logger.exception("Exception in async sampling_mask send loop: %s", e)
 
     def exist_prefill(self):
         """
@@ -2499,7 +2530,7 @@ class GPUModelRunner(ModelRunnerBase):
                 local_rank=self.local_rank,
                 tensor_parallel_rank=self.parallel_config.tensor_parallel_rank,
                 save_each_rank=self.parallel_config.use_ep,
-                sampling_mask_zmq_client=self.sampling_mask_zmq_client,
+                sampling_mask_async_queue=self.sampling_mask_async_queue,
                 is_mtp_prefill=(
                     self.spec_method == SpecMethod.MTP and self.scheduler_config.splitwise_role == "prefill"
                 ),
@@ -2511,7 +2542,7 @@ class GPUModelRunner(ModelRunnerBase):
                 share_inputs=self.share_inputs,
                 async_output_queue=self.async_output_queue,
                 save_each_rank=self.parallel_config.use_ep,
-                sampling_mask_zmq_client=self.sampling_mask_zmq_client,
+                sampling_mask_async_queue=self.sampling_mask_async_queue,
             )
 
     def _pool(self, hidden_states: paddle.Tensor, num_running_requests: int) -> Optional[ModelRunnerOutput]:

--- a/fastdeploy/worker/output.py
+++ b/fastdeploy/worker/output.py
@@ -15,8 +15,9 @@
 """
 
 from dataclasses import dataclass, field
-from typing import NamedTuple, Optional
+from typing import List, NamedTuple, Optional
 
+import numpy as np
 import paddle
 
 
@@ -178,6 +179,24 @@ class SamplerOutput:
     token_num_per_batch: Optional[paddle.Tensor] = None
     cu_batch_token_offset: Optional[paddle.Tensor] = None
     logits: Optional[paddle.Tensor] = None
+    # Sparse sampling mask for top_p/top_k:
+    #   - Non-speculative decoding: per-request mask. This is a list of length
+    #     num_reqs, where element i is a 1-D int32 numpy array of vocab indices
+    #     retained by top_p/top_k for request i. Replaces the previous dense
+    #     [num_reqs, vocab_size] bool tensor.
+    #   - Speculative decoding: flattened per-accepted-token mask. This may be
+    #     stored as a list aligned with all accepted tokens
+    #     (e.g. length = total_accepted_tokens) and is regrouped by accept_num
+    #     (number of accepted tokens per request) in post-processing before
+    #     being sent back as per-request data.
+    # Callers MUST NOT assume this is always shaped by num_reqs; they should
+    # check whether the current path is speculative or non-speculative when
+    # interpreting the dimension.
+    sampling_mask: Optional[List[np.ndarray]] = None
+    # logZ_K for each request: log(sum(probs in candidate set K))
+    # Used for renormalizing logprobs to match the truncated sampling distribution.
+    # Shape: [num_reqs]
+    logz_per_batch: Optional[np.ndarray] = None
 
 
 @dataclass

--- a/fastdeploy/worker/output.py
+++ b/fastdeploy/worker/output.py
@@ -180,6 +180,11 @@ class SamplerOutput:
     cu_batch_token_offset: Optional[paddle.Tensor] = None
     logits: Optional[paddle.Tensor] = None
     # Sparse sampling mask for top_p/top_k:
+    #   Before sampling_mask_event sync: stored as a deferred tuple
+    #     (indices_window_cpu, mask_window_cpu, real_bsz) where the CPU tensors
+    #     are pinned-memory targets of async D2H copies.
+    #   After event sync + _extract_sparse_indices: converted to the final
+    #     List[np.ndarray] format below.
     #   - Non-speculative decoding: per-request mask. This is a list of length
     #     num_reqs, where element i is a 1-D int32 numpy array of vocab indices
     #     retained by top_p/top_k for request i. Replaces the previous dense
@@ -197,6 +202,9 @@ class SamplerOutput:
     # Used for renormalizing logprobs to match the truncated sampling distribution.
     # Shape: [num_reqs]
     logz_per_batch: Optional[np.ndarray] = None
+    # CUDA event that guards async D2H copy of sampling_mask / logz_per_batch.
+    # Must be synchronized before reading sampling_mask or logz_per_batch.
+    sampling_mask_event: Optional[object] = None
 
 
 @dataclass

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -1096,6 +1096,16 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--enable_keep_sampling_mask",
+        "--enable-keep-sampling-mask",
+        action="store_true",
+        help=(
+            "Enable output of keep_sampling_mask as sparse vocab index list per token step "
+            "(Non-MTP: List[int]; MTP: List[List[int]])."
+        ),
+    )
+
+    parser.add_argument(
         "--num_cpu_blocks",
         type=int,
         default=0,

--- a/tests/e2e/test_ernie_21b_mtp.py
+++ b/tests/e2e/test_ernie_21b_mtp.py
@@ -83,6 +83,7 @@ def setup_and_run_server():
         json.dumps(speculative_config),
         "--graph-optimization-config",
         '{"use_cudagraph":true,  "use_unique_memory_pool":true, "draft_model_use_cudagraph":true}',
+        "--enable-keep-sampling-mask",
     ]
 
     # Start subprocess in new process group
@@ -366,3 +367,176 @@ def test_mtp_accept_ratio(api_url):
     prompt_tokens = chunks[-1]["usage"]["prompt_tokens"]
     cached_tokens = chunks[-1]["usage"]["prompt_tokens_details"]["cached_tokens"]
     assert cached_tokens == prompt_tokens // 64 * 64, "cached_tokens数量有问题"
+
+
+def _assert_sampling_mask_format(sampling_mask, max_tokens):
+    """验证 sampling_mask 字段格式的公共辅助函数。
+
+    sampling_mask 是 List[List[int]]：
+    - 外层列表长度 == 生成的 token 数（completion_tokens），对应 MTP 每步可接受多个 token
+    - 内层列表为保留位置的词汇表索引（int），非空且单调递增
+    """
+    assert sampling_mask is not None, "sampling_mask 不应为 None"
+    assert isinstance(sampling_mask, list), "sampling_mask 应为 list"
+    assert len(sampling_mask) > 0, "sampling_mask 不应为空"
+    assert len(sampling_mask) <= max_tokens, "sampling_mask 长度不应超过 max_tokens"
+
+    for token_mask in sampling_mask:
+        assert isinstance(token_mask, list), f"每个 token 的 mask 应为 list，实际: {type(token_mask)}"
+        assert len(token_mask) > 0, "每个 token 的 mask 不应为空（至少保留采样到的 token）"
+        for idx in token_mask:
+            assert isinstance(idx, int), f"mask 中的每个元素应为 int，实际: {type(idx)}"
+            assert idx >= 0, f"mask 索引不应为负数，实际: {idx}"
+
+
+def test_keep_sampling_mask_stream(api_url):
+    """测试流式响应中 keep_sampling_mask 功能（MTP 模式）。
+
+    验证：
+    1. 每个非空 chunk 的 choices[0].sampling_mask 格式为 List[List[int]]
+    2. 内层列表包含词汇表保留位置的索引，非空且单调递增
+    3. 最终 sampling_mask 总长度等于 completion_tokens
+    """
+    max_tokens = 20
+    payload = {
+        "model": "default",
+        "temperature": 1.0,
+        "top_p": 0.9,
+        "seed": 42,
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "请用一句话介绍Python语言。"},
+        ],
+        "max_tokens": max_tokens,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+
+    response = send_request(url=api_url, payload=payload)
+    chunks = get_stream_chunks(response)
+
+    assert len(chunks) > 1, "流式响应应包含至少两个 chunk"
+
+    all_sampling_masks = []
+    for chunk in chunks[:-1]:  # 最后一个 chunk 是 usage-only
+        choice = chunk["choices"][0]
+        # 仅当 delta 有实际内容时才应携带 sampling_mask（首个 role chunk 内容为空，不含该字段）
+        has_content = bool(choice.get("delta", {}).get("content"))
+        mask = choice.get("sampling_mask")
+        if has_content:
+            assert mask is not None, f"有内容的 chunk 缺少 sampling_mask 字段: {choice}"
+        if mask is not None:
+            assert isinstance(mask, list), f"sampling_mask 应为 list，实际: {type(mask)}"
+            for token_mask in mask:
+                assert isinstance(token_mask, list), "每个 token mask 应为 list"
+                assert len(token_mask) > 0, "每个 token mask 不应为空"
+                for idx in token_mask:
+                    assert isinstance(idx, int) and idx >= 0, f"mask 索引应为非负 int，实际: {idx}"
+            all_sampling_masks.extend(mask)
+
+    # 最后一个 chunk 携带 usage 信息
+    usage = chunks[-1].get("usage")
+    if usage:
+        completion_tokens = usage["completion_tokens"]
+        assert (
+            len(all_sampling_masks) == completion_tokens
+        ), f"sampling_mask 总长度 {len(all_sampling_masks)} 应等于 completion_tokens {completion_tokens}"
+
+
+def test_keep_sampling_mask_non_stream(api_url):
+    """测试非流式响应中 keep_sampling_mask 功能（MTP 模式）。
+
+    验证：
+    1. choices[0].sampling_mask 格式为 List[List[int]]
+    2. 长度等于 completion_tokens
+    3. 内层列表包含非负递增的词汇表索引
+    """
+    max_tokens = 20
+    payload = {
+        "model": "default",
+        "temperature": 1.0,
+        "top_p": 0.9,
+        "seed": 42,
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "请用一句话介绍Python语言。"},
+        ],
+        "max_tokens": max_tokens,
+        "stream": False,
+    }
+
+    response = send_request(url=api_url, payload=payload).json()
+    assert "choices" in response, f"响应缺少 choices 字段: {response}"
+    choice = response["choices"][0]
+    assert "sampling_mask" in choice, f"choice 缺少 sampling_mask 字段: {choice}"
+
+    sampling_mask = choice["sampling_mask"]
+    completion_tokens = response["usage"]["completion_tokens"]
+    _assert_sampling_mask_format(sampling_mask, max_tokens)
+    assert (
+        len(sampling_mask) == completion_tokens
+    ), f"sampling_mask 长度 {len(sampling_mask)} 应等于 completion_tokens {completion_tokens}"
+
+
+def test_keep_sampling_mask_top_p_1_stream(api_url):
+    """测试 top_p=1.0 时流式响应的 sampling_mask（MTP 模式）。
+
+    top_p=1.0 表示保留全部词汇，每个 token mask 应包含所有词汇表位置。
+    验证 mask 非空且每个内层列表长度 > 1（至少保留多个候选 token）。
+    """
+    max_tokens = 10
+    payload = {
+        "model": "default",
+        "temperature": 1.0,
+        "top_p": 1.0,
+        "seed": 42,
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "1+1="},
+        ],
+        "max_tokens": max_tokens,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+
+    response = send_request(url=api_url, payload=payload)
+    chunks = get_stream_chunks(response)
+    assert len(chunks) > 1, "流式响应应包含至少两个 chunk"
+
+    for chunk in chunks[:-1]:
+        choice = chunk["choices"][0]
+        mask = choice.get("sampling_mask")
+        if mask is not None:
+            for token_mask in mask:
+                assert len(token_mask) > 1, "top_p=1.0 时每个 token 的候选集应大于 1"
+
+
+def test_keep_sampling_mask_consistent_with_top_p(api_url):
+    """对比 top_p=0.1 与 top_p=0.9 时 sampling_mask 的候选集大小（非流式，MTP 模式）。
+
+    top_p 越小，保留的候选 token 越少，平均 mask 长度应更短。
+    """
+    max_tokens = 15
+
+    def get_avg_mask_len(top_p):
+        payload = {
+            "model": "default",
+            "temperature": 1.0,
+            "top_p": top_p,
+            "seed": 42,
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "请列举三种编程语言。"},
+            ],
+            "max_tokens": max_tokens,
+            "stream": False,
+        }
+        resp = send_request(url=api_url, payload=payload).json()
+        mask = resp["choices"][0].get("sampling_mask")
+        if not mask:
+            return 0
+        return sum(len(m) for m in mask) / len(mask)
+
+    avg_small = get_avg_mask_len(0.1)
+    avg_large = get_avg_mask_len(0.9)
+    assert avg_small <= avg_large, f"top_p=0.1 的平均 mask 长度 ({avg_small:.1f}) 应 <= top_p=0.9 ({avg_large:.1f})"

--- a/tests/entrypoints/openai/test_max_streaming_tokens.py
+++ b/tests/entrypoints/openai/test_max_streaming_tokens.py
@@ -577,6 +577,7 @@ class TestMaxStreamingResponseTokens(IsolatedAsyncioTestCase):
                 response_processor=mock_response_processor,
                 max_tokens=max_tokens_list[idx],
                 speculate_metrics=None,
+                sampling_mask_list=None,
             )
 
             expected = case["expected"]

--- a/tests/entrypoints/openai/test_serving_chat.py
+++ b/tests/entrypoints/openai/test_serving_chat.py
@@ -398,6 +398,7 @@ class TestOpenAIServingCompletion(unittest.IsolatedAsyncioTestCase):
             response_processor=response_processor,
             max_tokens=2,
             speculate_metrics=None,
+            sampling_mask_list=None,
         )
 
         self.assertEqual(choice.finish_reason, "recover_stop")
@@ -421,6 +422,7 @@ class TestOpenAIServingCompletion(unittest.IsolatedAsyncioTestCase):
             response_processor=response_processor,
             max_tokens=2,
             speculate_metrics=None,
+            sampling_mask_list=None,
         )
         self.assertEqual(choice_length.finish_reason, "length")
 

--- a/tests/metrics/test_new_metrics.py
+++ b/tests/metrics/test_new_metrics.py
@@ -54,6 +54,8 @@ class TestCoverageFix(unittest.TestCase):
     def setUp(self):
         """为 TokenProcessor 测试设置通用的 mock 对象。"""
         self.mock_cfg = MagicMock()
+        self.mock_cfg.parallel_config.local_data_parallel_id = 0
+        self.mock_cfg.parallel_config.engine_worker_queue_port = ["9700"]
         self.mock_cached_generated_tokens = MagicMock()
         self.mock_engine_worker_queue = MagicMock()
         self.mock_split_connector = MagicMock()

--- a/tests/output/test_process_batch_draft_tokens.py
+++ b/tests/output/test_process_batch_draft_tokens.py
@@ -30,6 +30,8 @@ class TestProcessBatchDraftTokens(unittest.TestCase):
         # 模拟 cfg
         cfg = MagicMock()
         cfg.speculative_config = MagicMock()
+        cfg.parallel_config.local_data_parallel_id = 0
+        cfg.parallel_config.engine_worker_queue_port = ["9700"]
         cfg.speculative_config.method = "mtp"
         cfg.speculative_config.num_speculative_tokens = 3
         cfg.model_config = MagicMock()

--- a/tests/output/test_process_batch_output.py
+++ b/tests/output/test_process_batch_output.py
@@ -166,6 +166,7 @@ class TestTokenProcessorProcessBatchOutput(unittest.TestCase):
         processor.total_step_per_request = {}
         processor.accept_token_num_per_head_per_request = {}
         processor.accept_token_num_per_head = [0] * MAX_DRAFT_TOKENS
+        processor.use_sampling_mask = False
 
         # processor._recycle_resources = Mock()
 

--- a/tests/output/test_process_batch_output_use_zmq.py
+++ b/tests/output/test_process_batch_output_use_zmq.py
@@ -31,6 +31,7 @@ class TestTokenProcessorLogprobs(unittest.TestCase):
         self.cfg.model_config.enable_logprob = True
         self.cfg.speculative_config.method = None
         self.cfg.parallel_config.local_data_parallel_id = 0
+        self.cfg.parallel_config.engine_worker_queue_port = ["9700"]
         self.cached_generated_tokens = MagicMock()
         self.engine_worker_queue = MagicMock()
         self.split_connector = MagicMock()

--- a/tests/output/test_token_processor_trace_print.py
+++ b/tests/output/test_token_processor_trace_print.py
@@ -23,6 +23,8 @@ from fastdeploy.output.token_processor import TokenProcessor
 class TestTokenProcessorMetrics:
     def setup_method(self):
         self.mock_cfg = MagicMock()
+        self.mock_cfg.parallel_config.local_data_parallel_id = 0
+        self.mock_cfg.parallel_config.engine_worker_queue_port = ["9700"]
         self.mock_cached_tokens = MagicMock()
         self.mock_engine_queue = MagicMock()
         self.mock_split_connector = MagicMock()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

本 PR 为 FastDeploy 实现 Keep Sampling Mask (KSM) 功能，用于在 top_p/top_k 采样过程中返回保留的词汇表索引列表（稀疏格式）。

当前推理引擎在执行 top_p/top_k 采样时，仅返回最终采样的 token ID，但不提供采样过程中的候选集合信息。这导致：
1. 可解释性不足：无法了解模型在每个 token 生成时考虑了哪些候选词
2. 调试困难：难以分析采样策略（如 top_p=0.9, top_k=50）的实际效果
3. 下游应用受限：无法基于候选集合实现自定义后处理逻辑logprobs 
4. 归一化不完整：返回的 logprobs 未基于截断后的候选集合重新归一化
 
本 PR 通过新增 sampling_mask 字段，记录每个 token 采样时保留的词汇表索引（稀疏格式），并提供基于候选集合的 logprobs 重归一化功能。
<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications

<!-- Detail the changes made in this pull request. -->

sampler.py 下新增_compute_sampling_mask方法
添加启动参数--enable-keep-sampling-mask
logprobs.py 下新增logz的renormalize函数，`logprobs_renormalize_with_logz`
pre_and_post_process.py的post_processs中调用renormalize函数

## Usage or Command

服务启动指令：
```
export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
MODEL_PATH="/root/paddlejob/tmpspace/GLM-4.5-Air/"
python -m fastdeploy.entrypoints.openai.api_server \
    --port 9293 \
    --host $(hostname -i) \
    --model "$MODEL_PATH" \
    --disable-custom-all-reduce \
    --tensor-parallel-size 8 \
    --max-model-len 131072 \
    --max-num-seqs 32 \
    --gpu-memory-utilization 0.9 \
    --graph-optimization-config '{"use_cudagraph":true}' \
    --enable-logprob \
    --enable-keep-sampling-mask \
    --speculative-config '{"method":"mtp","num_speculative_tokens":1,"num_model_steps":1,"model":"'$MODEL_PATH'"}'
```


<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

yes

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
