### PR TITLE
[Others] Fix parameter name typo in slice_fn

### DIFF
--- a/fastdeploy/model_executor/utils.py
+++ b/fastdeploy/model_executor/utils.py
@@ -117,18 +117,18 @@ def set_weight_attrs(param, param_attr_map: Optional[dict[str, Any]]):
         setattr(param, key, value)
 
 
-def slice_fn(weight_or_paramter, output_dim, start, end, step=1):
-    if hasattr(weight_or_paramter, "get_shape"):
-        shape = weight_or_paramter.get_shape()
+def slice_fn(weight_or_parameter, output_dim, start, end, step=1):
+    if hasattr(weight_or_parameter, "get_shape"):
+        shape = weight_or_parameter.get_shape()
     else:
-        shape = weight_or_paramter.shape
+        shape = weight_or_parameter.shape
     if len(shape) == 1:
-        weight_or_paramter = weight_or_paramter[start:end]
+        weight_or_parameter = weight_or_parameter[start:end]
     elif output_dim:
-        weight_or_paramter = weight_or_paramter[..., start:end]
+        weight_or_parameter = weight_or_parameter[..., start:end]
     else:
-        weight_or_paramter = weight_or_paramter[start:end, ...]
-    return weight_or_paramter
+        weight_or_parameter = weight_or_parameter[start:end, ...]
+    return weight_or_parameter
 
 
 def process_weight_transpose(layer, weight_name):


### PR DESCRIPTION
## Motivation

Fix a typo in `fastdeploy/model_executor/utils.py`: the internal parameter name of `slice_fn()` is `weight_or_paramter` (missing 'e' in "parameter"). This is a simple code quality fix.

## Modifications

- **`fastdeploy/model_executor/utils.py`**: Renamed internal parameter `weight_or_paramter` → `weight_or_parameter` in `slice_fn()`. This is a local parameter name change with no impact on the function signature or callers.

## Usage or Command

N/A — pure rename of an internal parameter, no behavior change.

## Accuracy Tests

N/A — no logic changes.

## Checklist

- [x] Add at least a tag in the PR title: `[Typo]`
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests (N/A — rename only, existing tests cover this).
- [x] Provide accuracy results. (N/A — no model inference changes.)
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag. (N/A — submitting to `develop`.)