### PR TITLE
[Cherry-Pick][Speculative Decoding] Add MTP logprob support for PD disaggregation (#7442)

### DIFF
--- a/custom_ops/gpu_ops/speculate_decoding/draft_model/mtp_save_first_token_with_topk.cc
+++ b/custom_ops/gpu_ops/speculate_decoding/draft_model/mtp_save_first_token_with_topk.cc
@@ -38,8 +38,6 @@ void MTPSaveFirstTokenWithTopK(const paddle::Tensor& sampled_token_ids,
                                int message_flag,  // Target: 3, Draft: 4
                                int64_t rank_id,
                                bool save_each_rank) {
-  // NOTE(yaohuicong): Skip non-zero TP ranks — they share identical sampling
-  // outputs, so only rank 0 needs to send results to the message queue.
   if (rank_id > 0) {
     return;
   }

--- a/custom_ops/gpu_ops/speculate_decoding/draft_model/mtp_save_first_token_with_topk.cc
+++ b/custom_ops/gpu_ops/speculate_decoding/draft_model/mtp_save_first_token_with_topk.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,26 +18,26 @@
 #include <sys/msg.h>
 #include <sys/types.h>
 #include "paddle/extension.h"
-#include "../custom_ftok.h"
-#include "speculate_logprob_msg.h"
+#include "../../custom_ftok.h"
+#include "../speculate_logprob_msg.h"
 
 #ifndef PD_BUILD_STATIC_OP
 #define PD_BUILD_STATIC_OP(name) PD_BUILD_OP(static_op_##name)
 #endif
 
-void SpeculateSaveOutMmsgTopK(const paddle::Tensor& sampled_token_ids,
-                              const paddle::Tensor& logprob_token_ids,
-                              const paddle::Tensor& logprob_scores,
-                              const paddle::Tensor& logprob_ranks,
-                              const paddle::Tensor& token_num_per_batch,
-                              const paddle::Tensor& cu_batch_token_offset,
-                              const paddle::Tensor& not_need_stop,
-                              const paddle::Tensor& seq_lens_decoder,
-                              const paddle::Tensor& prompt_lens,
-                              const paddle::Tensor& preempted_idx,
-                              int message_flag,  // Target: 3, Draft: 4
-                              int64_t rank_id,
-                              bool save_each_rank) {
+void MTPSaveFirstTokenWithTopK(const paddle::Tensor& sampled_token_ids,
+                               const paddle::Tensor& logprob_token_ids,
+                               const paddle::Tensor& logprob_scores,
+                               const paddle::Tensor& logprob_ranks,
+                               const paddle::Tensor& token_num_per_batch,
+                               const paddle::Tensor& cu_batch_token_offset,
+                               const paddle::Tensor& not_need_stop,
+                               const paddle::Tensor& seq_lens_decoder,
+                               const paddle::Tensor& prompt_lens,
+                               const paddle::Tensor& preempted_idx,
+                               int message_flag,  // Target: 3, Draft: 4
+                               int64_t rank_id,
+                               bool save_each_rank) {
   // NOTE(yaohuicong): Skip non-zero TP ranks — they share identical sampling
   // outputs, so only rank 0 needs to send results to the message queue.
   if (rank_id > 0) {
@@ -126,10 +126,12 @@ void SpeculateSaveOutMmsgTopK(const paddle::Tensor& sampled_token_ids,
   int max_num_logprobs = logprob_token_ids.shape()[1];
   for (int i = 0; i < bsz; i++) {
     int cur_token_num;
-    if (seq_lens_decoder_data[i] < prompt_lens_data[i]) {
+    if (seq_lens_decoder_data[i] < prompt_lens_data[i] ||
+        token_num_per_batch_data[i] == 0) {
+      // chunk prefill or stop slots
       cur_token_num = 0;
     } else {
-      cur_token_num = token_num_per_batch_data[i];
+      cur_token_num = token_num_per_batch_data[i] + 1;
     }
     msg_sed.meta[3 + i] = cur_token_num;
     if (preempted_idx_data[i] == 1) {
@@ -141,20 +143,30 @@ void SpeculateSaveOutMmsgTopK(const paddle::Tensor& sampled_token_ids,
     for (int j = 0; j < cur_token_num; j++) {
       auto* cur_tokens = &cur_batch_msg_sed->tokens[j * (K + 1)];
       auto* cur_scores = &cur_batch_msg_sed->scores[j * (K + 1)];
-      for (int k = 0; k < K + 1; k++) {
-        if (k == 0) {
-          cur_tokens[k] = (int)sampled_token_ids_data[i * max_draft_tokens + j];
-          cur_scores[k] = logprob_scores_data[(token_offset + j) * (K + 1) + k];
-        } else if (k < max_num_logprobs) {
-          cur_tokens[k] =
-              (int)logprob_token_ids_data[(token_offset + j) * (K + 1) + k];
-          cur_scores[k] = logprob_scores_data[(token_offset + j) * (K + 1) + k];
-        } else {
-          cur_tokens[k] = -1;
-          cur_scores[k] = 0.0;
+      if (j == 0) {
+        // first token has full logprobs
+        for (int k = 0; k < K + 1; k++) {
+          if (k == 0) {
+            cur_tokens[k] =
+                (int)sampled_token_ids_data[i * max_draft_tokens + j];
+            cur_scores[k] =
+                logprob_scores_data[(token_offset + j) * (K + 1) + k];
+          } else if (k < max_num_logprobs) {
+            // only for first token
+            cur_tokens[k] =
+                (int)logprob_token_ids_data[(token_offset + j) * (K + 1) + k];
+            cur_scores[k] =
+                logprob_scores_data[(token_offset + j) * (K + 1) + k];
+          } else {
+            cur_tokens[k] = -1;
+            cur_scores[k] = 0.0;
+          }
         }
+        cur_batch_msg_sed->ranks[j] = (int)logprob_ranks_data[token_offset + j];
+      } else {
+        // draft token only has token_id
+        cur_tokens[0] = (int)sampled_token_ids_data[i * max_draft_tokens + j];
       }
-      cur_batch_msg_sed->ranks[j] = (int)logprob_ranks_data[token_offset + j];
     }
   }
 #ifdef SPECULATE_SAVE_WITH_OUTPUT_DEBUG
@@ -189,7 +201,7 @@ void SpeculateSaveOutMmsgTopK(const paddle::Tensor& sampled_token_ids,
   }
 }
 
-PD_BUILD_STATIC_OP(speculate_save_output_topk)
+PD_BUILD_STATIC_OP(mtp_save_first_token_with_topk)
     .Inputs({"sampled_token_ids",
              "logprob_token_ids",
              "logprob_scores",
@@ -201,4 +213,4 @@ PD_BUILD_STATIC_OP(speculate_save_output_topk)
              "prompt_lens",
              "preempted_idx"})
     .Attrs({"message_flag: int", "rank_id: int64_t", "save_each_rank: bool"})
-    .SetKernelFn(PD_KERNEL(SpeculateSaveOutMmsgTopK));
+    .SetKernelFn(PD_KERNEL(MTPSaveFirstTokenWithTopK));

--- a/custom_ops/gpu_ops/speculate_decoding/draft_model/mtp_save_first_token_with_topk.cc
+++ b/custom_ops/gpu_ops/speculate_decoding/draft_model/mtp_save_first_token_with_topk.cc
@@ -38,7 +38,7 @@ void MTPSaveFirstTokenWithTopK(const paddle::Tensor& sampled_token_ids,
                                int message_flag,  // Target: 3, Draft: 4
                                int64_t rank_id,
                                bool save_each_rank) {
-  if (rank_id > 0) {
+  if (!save_each_rank && rank_id > 0) {
     return;
   }
 
@@ -139,22 +139,26 @@ void MTPSaveFirstTokenWithTopK(const paddle::Tensor& sampled_token_ids,
     auto* cur_batch_msg_sed = &msg_sed.mtext[i];
     int token_offset = cu_batch_token_offset_data[i];
     for (int j = 0; j < cur_token_num; j++) {
-      auto* cur_tokens = &cur_batch_msg_sed->tokens[j * (K + 1)];
-      auto* cur_scores = &cur_batch_msg_sed->scores[j * (K + 1)];
+      auto* cur_tokens = &cur_batch_msg_sed->tokens[j * (SPEC_LOGPROB_K + 1)];
+      auto* cur_scores = &cur_batch_msg_sed->scores[j * (SPEC_LOGPROB_K + 1)];
       if (j == 0) {
         // first token has full logprobs
-        for (int k = 0; k < K + 1; k++) {
+        for (int k = 0; k < SPEC_LOGPROB_K + 1; k++) {
           if (k == 0) {
             cur_tokens[k] =
                 (int)sampled_token_ids_data[i * max_draft_tokens + j];
             cur_scores[k] =
-                logprob_scores_data[(token_offset + j) * (K + 1) + k];
+                logprob_scores_data[(token_offset + j) * (SPEC_LOGPROB_K + 1) +
+                                    k];
           } else if (k < max_num_logprobs) {
             // only for first token
             cur_tokens[k] =
-                (int)logprob_token_ids_data[(token_offset + j) * (K + 1) + k];
+                (int)logprob_token_ids_data[(token_offset + j) *
+                                                (SPEC_LOGPROB_K + 1) +
+                                            k];
             cur_scores[k] =
-                logprob_scores_data[(token_offset + j) * (K + 1) + k];
+                logprob_scores_data[(token_offset + j) * (SPEC_LOGPROB_K + 1) +
+                                    k];
           } else {
             cur_tokens[k] = -1;
             cur_scores[k] = 0.0;
@@ -177,15 +181,15 @@ void MTPSaveFirstTokenWithTopK(const paddle::Tensor& sampled_token_ids,
     auto* cur_batch_msg_sed = &msg_sed.mtext[i];
     std::cout << "batch " << i << " token_num: " << cur_token_num << std::endl;
     for (int j = 0; j < cur_token_num; j++) {
-      auto* cur_tokens = &cur_batch_msg_sed->tokens[j * (K + 1)];
-      auto* cur_scores = &cur_batch_msg_sed->scores[j * (K + 1)];
+      auto* cur_tokens = &cur_batch_msg_sed->tokens[j * (SPEC_LOGPROB_K + 1)];
+      auto* cur_scores = &cur_batch_msg_sed->scores[j * (SPEC_LOGPROB_K + 1)];
       std::cout << "tokens: ";
-      for (int k = 0; k < K + 1; k++) {
+      for (int k = 0; k < SPEC_LOGPROB_K + 1; k++) {
         std::cout << cur_tokens[k] << " ";
       }
       std::cout << std::endl;
       std::cout << "scores: ";
-      for (int k = 0; k < K + 1; k++) {
+      for (int k = 0; k < SPEC_LOGPROB_K + 1; k++) {
         std::cout << cur_scores[k] << " ";
       }
       std::cout << std::endl;

--- a/custom_ops/gpu_ops/speculate_decoding/speculate_get_output_with_topk.cc
+++ b/custom_ops/gpu_ops/speculate_decoding/speculate_get_output_with_topk.cc
@@ -19,26 +19,11 @@
 #include <sys/types.h>
 #include "paddle/extension.h"
 #include "../custom_ftok.h"
+#include "speculate_logprob_msg.h"
 
 #ifndef PD_BUILD_STATIC_OP
 #define PD_BUILD_STATIC_OP(name) PD_BUILD_OP(static_op_##name)
 #endif
-
-#define MAX_BSZ 512
-#define K 20
-#define MAX_DRAFT_TOKEN_NUM 6
-
-struct batch_msgdata {
-  int tokens[MAX_DRAFT_TOKEN_NUM * (K + 1)];
-  float scores[MAX_DRAFT_TOKEN_NUM * (K + 1)];
-  int ranks[MAX_DRAFT_TOKEN_NUM];
-};
-
-struct msgdata {
-  long mtype;
-  int meta[3 + MAX_BSZ];  // stop_flag, message_flag, bsz, batch_token_nums
-  batch_msgdata mtext[MAX_BSZ];
-};
 
 void SpeculateGetOutMmsgTopK(const paddle::Tensor& output_tokens,
                              const paddle::Tensor& output_scores,

--- a/custom_ops/gpu_ops/speculate_decoding/speculate_get_output_with_topk.cc
+++ b/custom_ops/gpu_ops/speculate_decoding/speculate_get_output_with_topk.cc
@@ -78,22 +78,22 @@ void SpeculateGetOutMmsgTopK(const paddle::Tensor& output_tokens,
   output_tokens_data[1] = (int64_t)msg_rcv.meta[1];
   output_tokens_data[2] = (int64_t)msg_rcv.meta[2];
 
-  int output_tokens_offset = 3 + MAX_BSZ;
+  int output_tokens_offset = 3 + SPEC_LOGPROB_MAX_BSZ;
   for (int i = 0; i < bsz; i++) {
     int cur_token_num = msg_rcv.meta[3 + i];
     output_tokens_data[3 + i] = (int64_t)cur_token_num;  // batch_token_nums
 
     auto* cur_output_token = output_tokens_data + output_tokens_offset +
-                             i * (MAX_DRAFT_TOKEN_NUM * (K + 1));
+                             i * (MAX_DRAFT_TOKEN_NUM * (SPEC_LOGPROB_K + 1));
     auto* cur_output_score =
-        output_scores_data + i * (MAX_DRAFT_TOKEN_NUM * (K + 1));
+        output_scores_data + i * (MAX_DRAFT_TOKEN_NUM * (SPEC_LOGPROB_K + 1));
     auto* cur_batch_msg_rcv = &msg_rcv.mtext[i];
     for (int j = 0; j < cur_token_num; j++) {
       for (int k = 0; k < real_k + 1; k++) {
-        cur_output_token[j * (K + 1) + k] =
-            (int64_t)cur_batch_msg_rcv->tokens[j * (K + 1) + k];
-        cur_output_score[j * (K + 1) + k] =
-            cur_batch_msg_rcv->scores[j * (K + 1) + k];
+        cur_output_token[j * (SPEC_LOGPROB_K + 1) + k] =
+            (int64_t)cur_batch_msg_rcv->tokens[j * (SPEC_LOGPROB_K + 1) + k];
+        cur_output_score[j * (SPEC_LOGPROB_K + 1) + k] =
+            cur_batch_msg_rcv->scores[j * (SPEC_LOGPROB_K + 1) + k];
       }
       output_ranks_data[i * MAX_DRAFT_TOKEN_NUM + j] =
           (int64_t)cur_batch_msg_rcv->ranks[j];
@@ -109,17 +109,19 @@ void SpeculateGetOutMmsgTopK(const paddle::Tensor& output_tokens,
     std::cout << "batch " << i << " token_num: " << cur_token_num << std::endl;
     for (int j = 0; j < cur_token_num; j++) {
       std::cout << "tokens: ";
-      for (int k = 0; k < K + 1; k++) {
+      for (int k = 0; k < SPEC_LOGPROB_K + 1; k++) {
         std::cout << output_tokens_data[output_tokens_offset +
-                                        i * MAX_DRAFT_TOKEN_NUM * (K + 1) +
-                                        j * (K + 1) + k]
+                                        i * MAX_DRAFT_TOKEN_NUM *
+                                            (SPEC_LOGPROB_K + 1) +
+                                        j * (SPEC_LOGPROB_K + 1) + k]
                   << " ";
       }
       std::cout << std::endl;
       std::cout << "scores: ";
-      for (int k = 0; k < K + 1; k++) {
-        std::cout << output_scores_data[i * MAX_DRAFT_TOKEN_NUM * (K + 1) +
-                                        j * (K + 1) + k]
+      for (int k = 0; k < SPEC_LOGPROB_K + 1; k++) {
+        std::cout << output_scores_data[i * MAX_DRAFT_TOKEN_NUM *
+                                            (SPEC_LOGPROB_K + 1) +
+                                        j * (SPEC_LOGPROB_K + 1) + k]
                   << " ";
       }
       std::cout << std::endl;

--- a/custom_ops/gpu_ops/speculate_decoding/speculate_logprob_msg.h
+++ b/custom_ops/gpu_ops/speculate_decoding/speculate_logprob_msg.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/ipc.h>
+#include <sys/msg.h>
+#include <sys/types.h>
+#include "paddle/extension.h"
+
+#define MAX_BSZ 512
+#define K 20
+#define MAX_DRAFT_TOKEN_NUM 6
+
+struct batch_msgdata {
+  int tokens[MAX_DRAFT_TOKEN_NUM * (K + 1)];
+  float scores[MAX_DRAFT_TOKEN_NUM * (K + 1)];
+  int ranks[MAX_DRAFT_TOKEN_NUM];
+};
+
+struct msgdata {
+  long mtype;
+  int meta[3 + MAX_BSZ];  // stop_flag, message_flag, bsz, batch_token_nums
+  batch_msgdata mtext[MAX_BSZ];
+};

--- a/custom_ops/gpu_ops/speculate_decoding/speculate_logprob_msg.h
+++ b/custom_ops/gpu_ops/speculate_decoding/speculate_logprob_msg.h
@@ -21,18 +21,19 @@
 #include <sys/types.h>
 #include "paddle/extension.h"
 
-#define MAX_BSZ 512
-#define K 20
+#define SPEC_LOGPROB_MAX_BSZ 512
+#define SPEC_LOGPROB_K 20
 #define MAX_DRAFT_TOKEN_NUM 6
 
 struct batch_msgdata {
-  int tokens[MAX_DRAFT_TOKEN_NUM * (K + 1)];
-  float scores[MAX_DRAFT_TOKEN_NUM * (K + 1)];
+  int tokens[MAX_DRAFT_TOKEN_NUM * (SPEC_LOGPROB_K + 1)];
+  float scores[MAX_DRAFT_TOKEN_NUM * (SPEC_LOGPROB_K + 1)];
   int ranks[MAX_DRAFT_TOKEN_NUM];
 };
 
 struct msgdata {
   long mtype;
-  int meta[3 + MAX_BSZ];  // stop_flag, message_flag, bsz, batch_token_nums
-  batch_msgdata mtext[MAX_BSZ];
+  // stop_flag, message_flag, bsz, batch_token_nums
+  int meta[3 + SPEC_LOGPROB_MAX_BSZ];
+  batch_msgdata mtext[SPEC_LOGPROB_MAX_BSZ];
 };

--- a/custom_ops/gpu_ops/speculate_decoding/speculate_save_output_with_topk.cc
+++ b/custom_ops/gpu_ops/speculate_decoding/speculate_save_output_with_topk.cc
@@ -139,16 +139,21 @@ void SpeculateSaveOutMmsgTopK(const paddle::Tensor& sampled_token_ids,
     auto* cur_batch_msg_sed = &msg_sed.mtext[i];
     int token_offset = cu_batch_token_offset_data[i];
     for (int j = 0; j < cur_token_num; j++) {
-      auto* cur_tokens = &cur_batch_msg_sed->tokens[j * (K + 1)];
-      auto* cur_scores = &cur_batch_msg_sed->scores[j * (K + 1)];
-      for (int k = 0; k < K + 1; k++) {
+      auto* cur_tokens = &cur_batch_msg_sed->tokens[j * (SPEC_LOGPROB_K + 1)];
+      auto* cur_scores = &cur_batch_msg_sed->scores[j * (SPEC_LOGPROB_K + 1)];
+      for (int k = 0; k < SPEC_LOGPROB_K + 1; k++) {
         if (k == 0) {
           cur_tokens[k] = (int)sampled_token_ids_data[i * max_draft_tokens + j];
-          cur_scores[k] = logprob_scores_data[(token_offset + j) * (K + 1) + k];
+          cur_scores[k] =
+              logprob_scores_data[(token_offset + j) * (SPEC_LOGPROB_K + 1) +
+                                  k];
         } else if (k < max_num_logprobs) {
-          cur_tokens[k] =
-              (int)logprob_token_ids_data[(token_offset + j) * (K + 1) + k];
-          cur_scores[k] = logprob_scores_data[(token_offset + j) * (K + 1) + k];
+          cur_tokens[k] = (int)
+              logprob_token_ids_data[(token_offset + j) * (SPEC_LOGPROB_K + 1) +
+                                     k];
+          cur_scores[k] =
+              logprob_scores_data[(token_offset + j) * (SPEC_LOGPROB_K + 1) +
+                                  k];
         } else {
           cur_tokens[k] = -1;
           cur_scores[k] = 0.0;
@@ -167,15 +172,15 @@ void SpeculateSaveOutMmsgTopK(const paddle::Tensor& sampled_token_ids,
     auto* cur_batch_msg_sed = &msg_sed.mtext[i];
     std::cout << "batch " << i << " token_num: " << cur_token_num << std::endl;
     for (int j = 0; j < cur_token_num; j++) {
-      auto* cur_tokens = &cur_batch_msg_sed->tokens[j * (K + 1)];
-      auto* cur_scores = &cur_batch_msg_sed->scores[j * (K + 1)];
+      auto* cur_tokens = &cur_batch_msg_sed->tokens[j * (SPEC_LOGPROB_K + 1)];
+      auto* cur_scores = &cur_batch_msg_sed->scores[j * (SPEC_LOGPROB_K + 1)];
       std::cout << "tokens: ";
-      for (int k = 0; k < K + 1; k++) {
+      for (int k = 0; k < SPEC_LOGPROB_K + 1; k++) {
         std::cout << cur_tokens[k] << " ";
       }
       std::cout << std::endl;
       std::cout << "scores: ";
-      for (int k = 0; k < K + 1; k++) {
+      for (int k = 0; k < SPEC_LOGPROB_K + 1; k++) {
         std::cout << cur_scores[k] << " ";
       }
       std::cout << std::endl;

--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -533,10 +533,10 @@ def save_output_specualate(
     proposer_share_inputs: ProposerInputBatch,
     local_rank: int,
     tensor_parallel_rank: int,
-    splitwise_role: str = "mixed",
     save_each_rank: bool = False,
+    is_mtp_prefill: bool = False,
 ):
-    if splitwise_role == "prefill":
+    if is_mtp_prefill:
         if tensor_parallel_rank == 0:
             skip_chunk_prefill = bool(int(envs.ENABLE_V1_KVCACHE_SCHEDULER))
             if sampler_output.logprobs_tensors is None:
@@ -607,7 +607,7 @@ def save_output_specualate(
     else:
         if sampler_output.logprobs_tensors is None:
             recover_share_inputs = recover_batch_index_for_output(
-                proposer_share_inputs,
+                share_inputs,
                 model_output.index_to_batch_id,
                 model_output.enable_pd_reorder,
                 [

--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -22,9 +22,14 @@ import paddle
 
 from fastdeploy import envs
 from fastdeploy.config import SpeculativeConfig
+from fastdeploy.model_executor.ops.gpu import (
+    mtp_save_first_token,
+    mtp_save_first_token_with_topk,
+)
 from fastdeploy.platforms import current_platform
 from fastdeploy.worker.input_batch import (
     InputBatch,
+    ProposerInputBatch,
     recover_batch_index_for_output,
     recover_batch_index_for_sampler_output,
 )
@@ -525,13 +530,84 @@ def save_output_specualate(
     sampler_output: SamplerOutput,
     model_output: ModelOutputData,
     share_inputs: InputBatch,
+    proposer_share_inputs: ProposerInputBatch,
+    local_rank: int,
+    tensor_parallel_rank: int,
+    splitwise_role: str = "mixed",
     save_each_rank: bool = False,
-    skip_save_output: bool = False,
 ):
-    if not skip_save_output:
+    if splitwise_role == "prefill":
+        if tensor_parallel_rank == 0:
+            skip_chunk_prefill = bool(int(envs.ENABLE_V1_KVCACHE_SCHEDULER))
+            if sampler_output.logprobs_tensors is None:
+                recover_proposer_share_inputs_map = recover_batch_index_for_output(
+                    proposer_share_inputs,
+                    proposer_share_inputs.index_to_batch_id,
+                    proposer_share_inputs.enable_pd_reorder,
+                    [
+                        "base_model_draft_tokens",
+                        "seq_lens_decoder",
+                        "prompt_lens",
+                        "step_idx",
+                    ],
+                )
+                mtp_save_first_token(
+                    recover_proposer_share_inputs_map["base_model_draft_tokens"],
+                    proposer_share_inputs["not_need_stop"],
+                    recover_proposer_share_inputs_map["seq_lens_decoder"],
+                    recover_proposer_share_inputs_map["prompt_lens"],
+                    recover_proposer_share_inputs_map["step_idx"],
+                    local_rank,
+                    save_each_rank,
+                    skip_chunk_prefill,
+                )
+            else:
+                recover_share_inputs_map = recover_batch_index_for_output(
+                    share_inputs,
+                    model_output.index_to_batch_id,
+                    model_output.enable_pd_reorder,
+                    [
+                        "sampled_token_ids",
+                        "accept_tokens_cpu",
+                        "accept_num_cpu",
+                        "seq_lens_decoder_cpu",
+                        "prompt_lens_cpu",
+                        "last_preempted_idx",
+                    ],
+                )
+                recover_batch_index_for_sampler_output(
+                    sampler_output, model_output.index_to_batch_id, model_output.enable_pd_reorder
+                )
+                recover_proposer_share_inputs_map = recover_batch_index_for_output(
+                    proposer_share_inputs,
+                    proposer_share_inputs.index_to_batch_id,
+                    proposer_share_inputs.enable_pd_reorder,
+                    [
+                        "base_model_draft_tokens",
+                        "seq_lens_decoder",
+                        "prompt_lens",
+                        "step_idx",
+                    ],
+                )
+                mtp_save_first_token_with_topk(
+                    recover_proposer_share_inputs_map["base_model_draft_tokens"],
+                    sampler_output.logprobs_tensors.logprob_token_ids,
+                    sampler_output.logprobs_tensors.logprobs,
+                    sampler_output.logprobs_tensors.selected_token_ranks,
+                    recover_share_inputs_map["accept_num_cpu"],
+                    sampler_output.cu_batch_token_offset,
+                    model_output.not_need_stop,
+                    recover_share_inputs_map["seq_lens_decoder_cpu"],
+                    recover_share_inputs_map["prompt_lens_cpu"],
+                    recover_share_inputs_map["last_preempted_idx"],
+                    3,  # mtype
+                    model_output.mp_rank,
+                    save_each_rank,
+                )
+    else:
         if sampler_output.logprobs_tensors is None:
             recover_share_inputs = recover_batch_index_for_output(
-                share_inputs,
+                proposer_share_inputs,
                 model_output.index_to_batch_id,
                 model_output.enable_pd_reorder,
                 [

--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -582,12 +582,7 @@ def save_output_specualate(
                     proposer_share_inputs,
                     proposer_share_inputs.index_to_batch_id,
                     proposer_share_inputs.enable_pd_reorder,
-                    [
-                        "base_model_draft_tokens",
-                        "seq_lens_decoder",
-                        "prompt_lens",
-                        "step_idx",
-                    ],
+                    ["base_model_draft_tokens"],
                 )
                 mtp_save_first_token_with_topk(
                     recover_proposer_share_inputs_map["base_model_draft_tokens"],

--- a/fastdeploy/spec_decode/mtp.py
+++ b/fastdeploy/spec_decode/mtp.py
@@ -43,6 +43,7 @@ if current_platform.is_xpu():
         draft_model_update,
         eagle_get_hidden_states,
         eagle_get_self_hidden_states,
+        mtp_save_first_token,
         mtp_step_paddle,
         set_data_ipc,
         share_external_data,
@@ -833,6 +834,26 @@ class MTPProposer(Proposer):
         )
 
         if self.role == "prefill" and self.parallel_config.tensor_parallel_rank == 0:
+            if current_platform.is_xpu():
+                # Note(wangyanpeng): mtp_save_first_token for GPU platforms has been moved to model_runner.
+                # Only XPU platform is retained here.
+                skip_save = bool(int(envs.ENABLE_V1_KVCACHE_SCHEDULER))
+                recover_model_output_map = recover_batch_index_for_output(
+                    self.model_inputs,
+                    self.model_inputs.index_to_batch_id,
+                    self.model_inputs.enable_pd_reorder,
+                    ["base_model_draft_tokens", "seq_lens_decoder", "prompt_lens", "step_idx"],
+                )
+                mtp_save_first_token(
+                    recover_model_output_map["base_model_draft_tokens"],
+                    self.model_inputs["not_need_stop"],
+                    recover_model_output_map["seq_lens_decoder"],
+                    recover_model_output_map["prompt_lens"],
+                    recover_model_output_map["step_idx"],
+                    self.local_rank,
+                    self.parallel_config.use_ep,
+                    skip_save,
+                )
             # Ensure only save first token once.
             paddle.assign(
                 paddle.where(

--- a/fastdeploy/spec_decode/mtp.py
+++ b/fastdeploy/spec_decode/mtp.py
@@ -43,7 +43,6 @@ if current_platform.is_xpu():
         draft_model_update,
         eagle_get_hidden_states,
         eagle_get_self_hidden_states,
-        mtp_save_first_token,
         mtp_step_paddle,
         set_data_ipc,
         share_external_data,
@@ -62,7 +61,6 @@ else:
         eagle_get_self_hidden_states,
         eagle_gather_hidden_states,
         hybrid_mtp_ngram,
-        mtp_save_first_token,
         mtp_step_paddle,
         share_external_data,
         speculate_get_logits,
@@ -835,23 +833,6 @@ class MTPProposer(Proposer):
         )
 
         if self.role == "prefill" and self.parallel_config.tensor_parallel_rank == 0:
-            skip_save = bool(int(envs.ENABLE_V1_KVCACHE_SCHEDULER))
-            recover_model_output_map = recover_batch_index_for_output(
-                self.model_inputs,
-                self.model_inputs.index_to_batch_id,
-                self.model_inputs.enable_pd_reorder,
-                ["base_model_draft_tokens", "seq_lens_decoder", "prompt_lens", "step_idx"],
-            )
-            mtp_save_first_token(
-                recover_model_output_map["base_model_draft_tokens"],
-                self.model_inputs["not_need_stop"],
-                recover_model_output_map["seq_lens_decoder"],
-                recover_model_output_map["prompt_lens"],
-                recover_model_output_map["step_idx"],
-                self.local_rank,
-                self.parallel_config.use_ep,
-                skip_save,
-            )
             # Ensure only save first token once.
             paddle.assign(
                 paddle.where(

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -2477,7 +2477,7 @@ class GPUModelRunner(ModelRunnerBase):
         model_output_data,
         sampler_output,
     ):
-        if self.speculative_decoding and self.spec_method == SpecMethod.MTP:
+        if self.speculative_decoding:
             save_output_specualate(
                 sampler_output=sampler_output,
                 model_output=model_output_data,
@@ -2485,8 +2485,10 @@ class GPUModelRunner(ModelRunnerBase):
                 proposer_share_inputs=self.proposer.model_inputs,
                 local_rank=self.local_rank,
                 tensor_parallel_rank=self.parallel_config.tensor_parallel_rank,
-                splitwise_role=self.scheduler_config.splitwise_role,
                 save_each_rank=self.parallel_config.use_ep,
+                is_mtp_prefill=(
+                    self.spec_method == SpecMethod.MTP and self.scheduler_config.splitwise_role == "prefill"
+                ),
             )
         else:
             save_output_normal(

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -2477,14 +2477,16 @@ class GPUModelRunner(ModelRunnerBase):
         model_output_data,
         sampler_output,
     ):
-        if self.speculative_decoding:
-            skip_save_output = self.spec_method == SpecMethod.MTP and self.scheduler_config.splitwise_role == "prefill"
+        if self.speculative_decoding and self.spec_method == SpecMethod.MTP:
             save_output_specualate(
                 sampler_output=sampler_output,
                 model_output=model_output_data,
                 share_inputs=self.share_inputs,
+                proposer_share_inputs=self.proposer.model_inputs,
+                local_rank=self.local_rank,
+                tensor_parallel_rank=self.parallel_config.tensor_parallel_rank,
+                splitwise_role=self.scheduler_config.splitwise_role,
                 save_each_rank=self.parallel_config.use_ep,
-                skip_save_output=skip_save_output,
             )
         else:
             save_output_normal(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Enable logprob return for MTP speculative decoding under PD disaggregation architecture, particularly for handling the first token at prefill nodes.

## Modifications

<!-- Detail the changes made in this pull request. -->

1. Add `mtp_save_first_token_with_topk.cc` 
- support logprob saving for the first token at prefill nodes
2. Add `speculate_logprob_msg.h` 
- extract common message structure definitions
3. Refactor `save_output_specualate` function to differentiate prefill and decode node processing logic
4. Move `mtp_save_first_token` call from `mtp.py` to `pre_and_post_process.py`

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
