### PR TITLE
[BugFix][KVCache] Fix inference slowdown when enabling CPU cache

### DIFF
--- a/fastdeploy/cache_manager/prefix_cache_manager.py
+++ b/fastdeploy/cache_manager/prefix_cache_manager.py
@@ -289,7 +289,9 @@ class PrefixCacheManager:
                 val_shape_str = str(val_cache_shape)
             val_cache_arg_str = f" --value_cache_shape {val_shape_str}"
         if cache_config.kvcache_storage_backend:
-            storage_arg_str = f" --kvcache_storage_backend {cache_config.kvcache_storage_backend}"
+            storage_arg_str = (
+                f" --create_cache_tensor --kvcache_storage_backend {cache_config.kvcache_storage_backend}"
+            )
         else:
             storage_arg_str = " "
 
@@ -319,7 +321,6 @@ class PrefixCacheManager:
                     + f" --rdma_port {cache_config.local_rdma_comm_ports[i] if cache_config.local_rdma_comm_ports is not None else '0'}"
                     + f" --speculative_config '{self.speculative_config.to_json_string()}'"
                     + f" --default_dtype '{self.config.model_config.dtype}'"
-                    + (" --create_cache_tensor" if not self.enable_splitwise else "")
                     + storage_arg_str
                     + f" --write_policy {cache_config.write_policy}"
                     + f" --max_model_len {self.config.model_config.max_model_len}"

--- a/fastdeploy/cache_manager/prefix_cache_manager.py
+++ b/fastdeploy/cache_manager/prefix_cache_manager.py
@@ -289,9 +289,9 @@ class PrefixCacheManager:
                 val_shape_str = str(val_cache_shape)
             val_cache_arg_str = f" --value_cache_shape {val_shape_str}"
         if cache_config.kvcache_storage_backend:
-            storage_arg_str = (
-                f" --create_cache_tensor --kvcache_storage_backend {cache_config.kvcache_storage_backend}"
-            )
+            storage_arg_str = f" --kvcache_storage_backend {cache_config.kvcache_storage_backend}"
+            if not self.enable_splitwise:
+                storage_arg_str += " --create_cache_tensor"
         else:
             storage_arg_str = " "
 

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -2198,11 +2198,14 @@ class FDConfig:
             auto_dispatch_tokens = self.scheduler_config.max_num_seqs * (num_spec_tokens + 1)
 
             # For speculative, enlarge the threshold to trigger block preallocation earlier,
-            # since each step consumes num_spec_tokens slots at once
+            # since each step consumes num_spec_tokens + 1 slots at once
             old_prealloc_threshold = self.cache_config.prealloc_dec_block_slot_num_threshold
             prealloc_dec_block_slot = self.cache_config.prealloc_dec_block_slot_num_threshold * (num_spec_tokens + 1)
+            max_prealloc_dec_block_slot = max(
+                0, self.cache_config.block_size * self.cache_config.enc_dec_block_num - 1
+            )
             self.cache_config.prealloc_dec_block_slot_num_threshold = min(
-                prealloc_dec_block_slot, self.cache_config.block_size * self.cache_config.enc_dec_block_num - 1
+                prealloc_dec_block_slot, max_prealloc_dec_block_slot
             )
             logger.info(
                 f"prealloc_dec_block_slot_num_threshold updated: {old_prealloc_threshold} -> "

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -2196,6 +2196,13 @@ class FDConfig:
         if self.speculative_config is not None and self.speculative_config.method is not None:
             num_spec_tokens = self.speculative_config.num_speculative_tokens
             auto_dispatch_tokens = self.scheduler_config.max_num_seqs * (num_spec_tokens + 1)
+
+            # For speculative, enlarge the threshold to trigger block preallocation earlier,
+            # since each step consumes num_spec_tokens slots at once
+            prealloc_dec_block_slot = self.cache_config.prealloc_dec_block_slot_num_threshold * num_spec_tokens
+            self.cache_config.prealloc_dec_block_slot_num_threshold = min(
+                prealloc_dec_block_slot, self.cache_config.block_size * self.cache_config.enc_dec_block_num - 1
+            )
         else:
             auto_dispatch_tokens = self.scheduler_config.max_num_seqs
         if (

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -2199,10 +2199,18 @@ class FDConfig:
 
             # For speculative, enlarge the threshold to trigger block preallocation earlier,
             # since each step consumes num_spec_tokens slots at once
-            prealloc_dec_block_slot = self.cache_config.prealloc_dec_block_slot_num_threshold * num_spec_tokens
+            old_prealloc_threshold = self.cache_config.prealloc_dec_block_slot_num_threshold
+            prealloc_dec_block_slot = self.cache_config.prealloc_dec_block_slot_num_threshold * (num_spec_tokens + 1)
             self.cache_config.prealloc_dec_block_slot_num_threshold = min(
                 prealloc_dec_block_slot, self.cache_config.block_size * self.cache_config.enc_dec_block_num - 1
             )
+            logger.info(
+                f"prealloc_dec_block_slot_num_threshold updated: {old_prealloc_threshold} -> "
+                f"{self.cache_config.prealloc_dec_block_slot_num_threshold} "
+                f"(num_spec_tokens={num_spec_tokens}, block_size={self.cache_config.block_size}, "
+                f"enc_dec_block_num={self.cache_config.enc_dec_block_num})"
+            )
+
         else:
             auto_dispatch_tokens = self.scheduler_config.max_num_seqs
         if (

--- a/fastdeploy/spec_decode/mtp.py
+++ b/fastdeploy/spec_decode/mtp.py
@@ -247,8 +247,7 @@ class MTPProposer(Proposer):
         # 1. During profiling, it creates its own kv cache.
         # 2. If no need to profile, create kv cache if cache managers do not exist.
         create_cache_tensor = profile or not (
-            self.fd_config.cache_config.num_cpu_blocks > 0
-            or self.fd_config.cache_config.kvcache_storage_backend
+            self.fd_config.cache_config.kvcache_storage_backend
             or self.fd_config.scheduler_config.splitwise_role != "mixed"
         )
 

--- a/fastdeploy/spec_decode/mtp.py
+++ b/fastdeploy/spec_decode/mtp.py
@@ -245,7 +245,10 @@ class MTPProposer(Proposer):
 
         # Check if gpu runner needs to create kv cache
         # 1. During profiling, it creates its own kv cache.
-        # 2. If no need to profile, create kv cache if cache managers do not exist.
+        # 2. If no need to profile, create kv cache unless kvcache_storage_backend or
+        #    p/d disaggregation is enabled. Note: CPU cache (num_cpu_blocks > 0) does NOT
+        #    prevent GPU runner from creating GPU cache tensors; cache transfer manager
+        #    handles CPU<->GPU swap on top of the GPU tensors created here.
         create_cache_tensor = profile or not (
             self.fd_config.cache_config.kvcache_storage_backend
             or self.fd_config.scheduler_config.splitwise_role != "mixed"

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1510,8 +1510,7 @@ class GPUModelRunner(ModelRunnerBase):
         # 1. During profiling, it creates its own kv cache.
         # 2. If no need to profile, create kv cache if cache managers do not exist.
         create_cache_tensor = profile or not (
-            self.fd_config.cache_config.num_cpu_blocks > 0
-            or self.fd_config.cache_config.kvcache_storage_backend
+            self.fd_config.cache_config.kvcache_storage_backend
             or self.fd_config.scheduler_config.splitwise_role != "mixed"
         )
 
@@ -2794,8 +2793,7 @@ class GPUModelRunner(ModelRunnerBase):
             self.cache_controller.free_gpu_cache()
         else:
             create_cache_tensor = profile or not (
-                self.fd_config.cache_config.num_cpu_blocks > 0
-                or self.fd_config.cache_config.kvcache_storage_backend
+                self.fd_config.cache_config.kvcache_storage_backend
                 or self.fd_config.scheduler_config.splitwise_role != "mixed"
             )
             local_rank = self.local_rank % self.parallel_config.tensor_parallel_size

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1508,7 +1508,10 @@ class GPUModelRunner(ModelRunnerBase):
 
         # Check if gpu runner needs to create kv cache
         # 1. During profiling, it creates its own kv cache.
-        # 2. If no need to profile, create kv cache if cache managers do not exist.
+        # 2. If no need to profile, create kv cache unless kvcache_storage_backend or
+        #    p/d disaggregation is enabled. Note: CPU cache (num_cpu_blocks > 0) does NOT
+        #    prevent GPU runner from creating GPU cache tensors; cache transfer manager
+        #    handles CPU<->GPU swap on top of the GPU tensors created here.
         create_cache_tensor = profile or not (
             self.fd_config.cache_config.kvcache_storage_backend
             or self.fd_config.scheduler_config.splitwise_role != "mixed"

--- a/fastdeploy/worker/metax_model_runner.py
+++ b/fastdeploy/worker/metax_model_runner.py
@@ -1345,9 +1345,10 @@ class MetaxModelRunner(ModelRunnerBase):
         # Check if gpu runner needs to create kv cache
         # 1. During profiling, it creates its own kv cache.
         # 2. If no need to profile, create kv cache if cache managers do not exist.
+        #    Note: even when CPU cache (num_cpu_blocks > 0) is enabled, GPU runner still
+        #    creates GPU cache tensors; cache transfer manager handles CPU<->GPU swap.
         create_cache_tensor = profile or not (
-            self.fd_config.cache_config.num_cpu_blocks > 0
-            or self.fd_config.cache_config.kvcache_storage_backend
+            self.fd_config.cache_config.kvcache_storage_backend
             or self.fd_config.scheduler_config.splitwise_role != "mixed"
         )
 
@@ -2491,8 +2492,7 @@ class MetaxModelRunner(ModelRunnerBase):
     def clear_cache(self, profile=False):
         """Clear cached data from shared inputs and forward metadata"""
         create_cache_tensor = profile or not (
-            self.fd_config.cache_config.num_cpu_blocks > 0
-            or self.fd_config.cache_config.kvcache_storage_backend
+            self.fd_config.cache_config.kvcache_storage_backend
             or self.fd_config.scheduler_config.splitwise_role != "mixed"
         )
         local_rank = self.local_rank % self.parallel_config.tensor_parallel_size

--- a/fastdeploy/worker/xpu_model_runner.py
+++ b/fastdeploy/worker/xpu_model_runner.py
@@ -1259,9 +1259,10 @@ class XPUModelRunner(ModelRunnerBase):
         # Check if gpu runner needs to create kv cache
         # 1. During profiling, it creates its own kv cache.
         # 2. GPU runner creates kv cache tensor unless p/d disaggregation is enabled.
+        #    Note: even when CPU cache (num_cpu_blocks > 0) is enabled, GPU runner still
+        #    creates GPU cache tensors; cache transfer manager handles CPU<->GPU swap.
         create_cache_tensor = profile or not (
-            self.fd_config.cache_config.num_cpu_blocks > 0
-            or self.fd_config.cache_config.kvcache_storage_backend
+            self.fd_config.cache_config.kvcache_storage_backend
             or self.fd_config.scheduler_config.splitwise_role != "mixed"
         )
         if not create_cache_tensor:


### PR DESCRIPTION
## Motivation

在开启 CPU cache（`num_cpu_blocks > 0`）时，推理性能出现明显降速。

根因分析：
- 原逻辑中，开启 CPU cache 时（`num_cpu_blocks > 0`），`model_runner` 中 `create_cache_tensor` 被置为 `False`，GPU cache tensor 的创建被推迟到 cache transfer manager 中进行
- cache transfer manager 创建 GPU cache 时，model runner 通过 IPC 方式访问 cache，引发性能降速

此外，部分场景（如投机解码）下，每个调度步骤一次性消耗 `num_spec_tokens` 个 slot，原有的 `prealloc_dec_block_slot_num_threshold` 阈值偏小，导致块预分配触发不够及时，影响推理性能。

## Modifications

**Fix 1：将开启 CPU cache 场景下 GPU cache tensor 的创建位置，从 cache transfer manager 转移回 model runner。**

- `fastdeploy/worker/gpu_model_runner.py`：`create_cache_tensor` 判断中移除 `num_cpu_blocks > 0` 条件（`init_cache` 和 `clear_cache` 两处），使 GPU cache tensor 始终在 model runner 中创建，不再依赖 cache transfer manager
- `fastdeploy/cache_manager/prefix_cache_manager.py`：将 `--create_cache_tensor` 参数从非 splitwise 场景的条件判断中移出，统一归到 `kvcache_storage_backend` 配置路径下，与上述逻辑保持一致

**Fix 2：部分场景下自动扩大块预分配阈值。**

- `fastdeploy/config.py`：在 `FDConfig` 初始化阶段，当启用 speculative decoding 时，将 `prealloc_dec_block_slot_num_threshold` 扩大为原值乘以 `num_spec_tokens`，同时确保不超过 enc_dec_block 容量上限

## Usage or Command

**Fix 2：启用投机解码时，`prealloc_dec_block_slot_num_threshold` 阈值自动调整，无需额外配置。**

```bash
python -m fastdeploy.entrypoints.openai.api_server \
  --speculative-config '{"method": "draft_model", "num_speculative_tokens": 4}' \
  --prealloc-dec-block-slot-num-threshold 36 \
  ...
```

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. (Bug fix with straightforward logic change, existing tests cover the affected code paths)
- [ ] Provide accuracy results.