### PR TITLE
[CI] Remove flashinfer cache cleanup to reduce unit test runtime

### DIFF
--- a/tests/layers/test_trtllm_allreduce_rms_fusion.py
+++ b/tests/layers/test_trtllm_allreduce_rms_fusion.py
@@ -21,12 +21,6 @@ import sys
 
 def test_run_distributed():
     """Launch multi-GPU distributed test via paddle.distributed.launch as subprocess"""
-    # clearn flashinfer cache directory
-    flashinfer_cache_dir = os.path.join(os.sep, "root", ".cache", "flashinfer")
-    if os.path.exists(flashinfer_cache_dir):
-        print(f"=== Clearing flashinfer cache directory: {flashinfer_cache_dir} ===")
-        subprocess.run(["rm", "-rf", flashinfer_cache_dir], check=True)
-
     current_dir = os.path.dirname(os.path.abspath(__file__))
     run_script = os.path.join(current_dir, "trtllm_allreduce_rms_fusion.py")
     os.environ["CUDA_VISIBLE_DEVICES"] = "0,1"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

The `flashinfer cache` cleanup step was introducing unnecessary overhead during unit test execution. 
Since the cache removal is not required for test correctness, it leads to increased test runtime without providing additional value.

## Modifications
- Removed the explicit cleanup of the flashinfer cache directory (`/root/.cache/flashinfer`) in the distributed test.
- Eliminated subprocess-based cache deletion to streamline test startup and improve overall CI efficiency.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.