### PR TITLE
[OP] Add flashmla baseline implementation and precision test

### DIFF
--- a/fastdeploy/model_executor/layers/attention/mla_attention_backend.py
+++ b/fastdeploy/model_executor/layers/attention/mla_attention_backend.py
@@ -713,3 +713,33 @@ class MLAAttentionBackend(AttentionBackend):
                 )
 
                 return final_res
+
+    @staticmethod
+    def flashmla_baseline(decoder_q, latent_cache, block_table, cache_seqlens, attn_softmax_scale):
+        page_size = 64
+        q_num_heads = decoder_q.shape[2]
+        assert decoder_q.shape[1:] == [1, q_num_heads, 576]
+        assert latent_cache.shape[1:] == [1, page_size, 576]
+
+        res_baseline = paddle.zeros([decoder_q.shape[0], 1, q_num_heads, 512])
+        for batch_id in range(decoder_q.shape[0]):
+            kv_len = cache_seqlens[batch_id].item()
+            extract_k = paddle.zeros([kv_len, 576], dtype=decoder_q.dtype)
+            extract_v = paddle.zeros([kv_len, 512], dtype=decoder_q.dtype)
+
+            for local_seq_id in range(0, kv_len, page_size):
+                start = local_seq_id
+                end = min(local_seq_id + page_size, kv_len)
+                physical_id = block_table[batch_id, local_seq_id // page_size].item()
+
+                page_end = page_size if end % page_size == 0 else end % page_size
+                extract_k[start:end, :] = latent_cache[physical_id, 0, :page_end, :]
+                extract_v[start:end, :] = latent_cache[physical_id, 0, :page_end, :512]
+
+            this_batch_q = decoder_q[batch_id, 0, :, :]
+            p = paddle.matmul(this_batch_q, extract_k.transpose([1, 0]).contiguous())
+            p = p * attn_softmax_scale
+            p = paddle.nn.functional.softmax(p, -1)
+            res_baseline[batch_id, 0, :, :] = paddle.matmul(p, extract_v).contiguous()
+
+        return res_baseline

--- a/tests/operators/test_flashmla_precision.py
+++ b/tests/operators/test_flashmla_precision.py
@@ -1,0 +1,76 @@
+"""
+# Copyright (c) 2025  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
+import unittest
+
+import paddle
+
+from fastdeploy.model_executor.layers.attention.mla_attention_backend import (
+    MLAAttentionBackend,
+)
+
+
+class TestFlashMLA(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_flashmla(self):
+        bsz = 128
+        kv_len = 1000
+        decoder_q = paddle.randn([bsz, 1, 128, 576], dtype="bfloat16")
+        cache_seqlens = paddle.zeros([bsz], dtype="int32") + kv_len
+        block_tables = paddle.arange((kv_len // 64 + 1) * bsz, dtype="int32").reshape([bsz, -1])
+        latent_cache = paddle.randn([10000, 1, 64, 576], dtype="bfloat16")
+        # copy from dsv3
+        attn_softmax_scale = 0.1352337788608801
+
+        baseline_out = MLAAttentionBackend.flashmla_baseline(
+            decoder_q, latent_cache, block_tables, cache_seqlens, attn_softmax_scale
+        )
+
+        paddle.enable_compat(scope={"flash_mla"})  # Enable paddle.enable_compat before importing flash_mla
+        try:
+            import flash_mla
+        except ImportError:
+            print(100 * "Please install flash_mla first")
+            return
+
+        tile_scheduler_metadata, num_splits = flash_mla.get_mla_metadata()
+
+        new_cache_shape = latent_cache.shape
+        assert new_cache_shape[1] == 1
+        new_cache_shape[1], new_cache_shape[2] = new_cache_shape[2], new_cache_shape[1]
+
+        decoder_res, _ = flash_mla.flash_mla_with_kvcache(
+            decoder_q,
+            # 外面的开源仓库的kv cache存储格式和FD的不同
+            # 幸好这里缓存的头是1，直接view即可，否则上上下下要改很多！
+            latent_cache.view(new_cache_shape),
+            block_tables,
+            cache_seqlens,
+            512,  # t.dv,
+            tile_scheduler_metadata,
+            num_splits,
+            softmax_scale=attn_softmax_scale,
+            causal=True,
+        )
+
+        max_diff = (decoder_res - baseline_out).abs().max().item()
+        self.assertLessEqual(max_diff, 0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/operators/test_flashmla_precision.py
+++ b/tests/operators/test_flashmla_precision.py
@@ -18,6 +18,8 @@ import unittest
 
 import paddle
 
+paddle.set_default_dtype("bfloat16")
+
 from fastdeploy.model_executor.layers.attention.mla_attention_backend import (
     MLAAttentionBackend,
 )


### PR DESCRIPTION
> 🤖 AI Code Review | `2026-04-19 18:33 CST`

## 📋 Review 摘要

**PR 概述**：为 MLA Attention 新增 baseline 参考实现及其与 flash_mla 的精度对比测试
**变更范围**：`model_executor/layers/attention/`、`tests/operators/`
**影响面 Tag**：`OP` `KVCache`

### 📝 PR 规范检查

PR 标题为 `commit`，缺少有效 Tag 且无语义；描述中 Motivation / Modifications 均为空。

**标题建议**（可直接复制）：
- `[OP] Add flashmla baseline implementation and precision test`

**描述模板**（可直接复制）：
> **Motivation**: 为 flash_mla 算子提供纯 Python baseline 参考实现，用于精度对比验证。
>
> **Modifications**:
> - 在 `MLAAttentionBackend` 中新增 `flashmla_baseline` 静态方法，实现朴素 MLA decode attention 计算。
> - 新增 `tests/operators/test_flashmla_precision.py`，对比 baseline 与 flash_mla 算子输出误差。

### 问题

| 级别 | 文件 | 概述 |
|------|------|------|
| 🔴 Bug | `mla_attention_backend.py:724` | `res_baseline` 未指定 `dtype`，在非测试场景下可能导致 dtype 不一致 |
| 🟡 建议 | `test_flashmla_precision.py:50` | `flash_mla` 不可用时应使用 `skipTest` 而非 `return`，避免测试静默通过 |

### 总体评价
baseline 实现逻辑正确，测试思路清晰。需要修复 `res_baseline` 的 dtype 问题以确保函数在任意调用环境下的正确性，并改进测试的跳过机制。