### PR TITLE
[Cherry-Pick][CI] Align logprobs test baselines with Paddle Update(#7481)

### DIFF
--- a/.github/workflows/_logprob_test_linux.yml
+++ b/.github/workflows/_logprob_test_linux.yml
@@ -220,7 +220,7 @@ jobs:
             -d "{\"messages\": [{\"role\": \"user\", \"content\": \"1+1=?\"}], \"logprobs\": true}"
           set +e
           rm -rf ./baseline_output
-          cp -r baseline_dev_0311/ERNIE-4.5-0.3B-Paddle ./baseline_output
+          cp -r baseline_0419/ERNIE-4.5-0.3B-Paddle ./baseline_output
           LOGPROB_EXIT_CODE=0
           python3.10 lanucher.py --request_template TOKEN_LOGPROB --url http://localhost:${FD_API_PORT}/v1/chat/completions  --case ./cases/demo.yaml  --concurrency 1 --name demo --exe logprob || LOGPROB_EXIT_CODE=$?
           echo "LOGPROB_EXIT_CODE=${LOGPROB_EXIT_CODE}" > /workspace/exit_code.env

--- a/tests/e2e/4cards_cases/test_ernie_21b_tp1_dp4.py
+++ b/tests/e2e/4cards_cases/test_ernie_21b_tp1_dp4.py
@@ -609,9 +609,9 @@ def test_non_stream_with_logprobs(api_url):
 
     base_path = os.getenv("MODEL_PATH")
     if base_path:
-        base_file = os.path.join(base_path, "21b_tp1_dp4_logprobs_non_stream_static_baseline.txt")
+        base_file = os.path.join(base_path, "21b_tp1_dp4_logprobs_non_stream_static_baseline_0419.txt")
     else:
-        base_file = "21b_tp1_dp4_logprobs_non_stream_static_baseline.txt"
+        base_file = "21b_tp1_dp4_logprobs_non_stream_static_baseline_0419.txt"
 
     with open(base_file, "r", encoding="utf-8") as f:
         baseline = json.load(f)
@@ -647,9 +647,9 @@ def test_stream_with_logprobs(api_url):
 
     base_path = os.getenv("MODEL_PATH")
     if base_path:
-        base_file = os.path.join(base_path, "21b_tp1_dp4_logprobs_stream_static_baseline.txt")
+        base_file = os.path.join(base_path, "21b_tp1_dp4_logprobs_stream_static_baseline_0419.txt")
     else:
-        base_file = "21b_tp1_dp4_logprobs_stream_static_baseline.txt"
+        base_file = "21b_tp1_dp4_logprobs_stream_static_baseline_0419.txt"
 
     with open(base_file, "r", encoding="utf-8") as f:
         baseline = json.load(f)

--- a/tests/e2e/4cards_cases/test_ernie_21b_tp1_dp4_mtp.py
+++ b/tests/e2e/4cards_cases/test_ernie_21b_tp1_dp4_mtp.py
@@ -516,9 +516,9 @@ def test_non_stream_with_logprobs(api_url):
     base_path = os.getenv("MODEL_PATH")
 
     if base_path:
-        base_file = os.path.join(base_path, "21b_tp1_dp4_mtp_logprobs_non_stream_static_baseline.txt")
+        base_file = os.path.join(base_path, "21b_tp1_dp4_mtp_logprobs_non_stream_static_baseline_0419.txt")
     else:
-        base_file = "21b_tp1_dp4_mtp_logprobs_non_stream_static_baseline.txt"
+        base_file = "21b_tp1_dp4_mtp_logprobs_non_stream_static_baseline_0419.txt"
 
     with open(base_file, "r", encoding="utf-8") as f:
         baseline = json.load(f)
@@ -555,9 +555,9 @@ def test_stream_with_logprobs(api_url):
     base_path = os.getenv("MODEL_PATH")
 
     if base_path:
-        base_file = os.path.join(base_path, "21b_tp1_dp4_mtp_logprobs_stream_static_baseline.txt")
+        base_file = os.path.join(base_path, "21b_tp1_dp4_mtp_logprobs_stream_static_baseline_0419.txt")
     else:
-        base_file = "21b_tp1_dp4_mtp_logprobs_stream_static_baseline.txt"
+        base_file = "21b_tp1_dp4_mtp_logprobs_stream_static_baseline_0419.txt"
 
     with open(base_file, "r", encoding="utf-8") as f:
         baseline = json.load(f)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

Recent changes introduced in Paddle (PR #78409) affect the behavior and output of logprobs. The existing test baselines are no longer consistent with the updated implementation, leading to mismatches during CI validation.

To ensure test correctness and maintain CI stability, the logprobs-related test baselines need to be updated accordingly.

## Modifications

- Updated expected baseline values for logprobs-related tests to match the behavior introduced by Paddle https://github.com/PaddlePaddle/Paddle/pull/78659.
- Adapted the following test cases:
  - `test_ernie_21b_tp1_dp4.py`
  - `test_ernie_21b_tp1_dp4_mtp.py`
  - `run_tests_logprob`
- Ensured consistency between test outputs and the updated Paddle implementation.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.