### PR TITLE
[Loader] Add values natural order check to layers grouped validation

### DIFF
--- a/fastdeploy/model_executor/load_weight_utils.py
+++ b/fastdeploy/model_executor/load_weight_utils.py
@@ -40,7 +40,7 @@ from safetensors import safe_open
 from tqdm import tqdm
 
 from fastdeploy import envs
-from fastdeploy.config import FDConfig, LoadConfig
+from fastdeploy.config import FDConfig
 from fastdeploy.model_executor.layers.linear import KVBatchLinear
 from fastdeploy.model_executor.utils import multi_switch_config_context
 
@@ -70,6 +70,11 @@ def layers_are_grouped(keys):
             current_layer = layer
 
     return True
+
+
+def values_are_naturally_ordered(values):
+    """Check if values are sorted in natural order."""
+    return list(values) == sorted(values, key=natural_key)
 
 
 def pdparams_weight_iterator(paddle_file_list: list[str]):
@@ -117,10 +122,12 @@ def get_model_path(fd_config: FDConfig):
     return model_path
 
 
-def get_weight_iterator(model_path: str, load_config: Optional[LoadConfig] = None):
+def get_weight_iterator(model_path: str, fd_config: Optional[FDConfig] = None):
     files_list, ordered_weight_map, use_safetensors, is_layers_are_grouped = get_all_weights_file(model_path)
     if use_safetensors:
+        load_config = fd_config.load_config if fd_config else None
         extra_config = load_config.model_loader_extra_config if load_config else None
+        parallel_config = fd_config.parallel_config if fd_config else None
         if extra_config is not None and extra_config.get("enable_multithread_load", False):
             weights_iterator = multi_thread_safetensors_weights_iterator(
                 files_list,
@@ -128,7 +135,7 @@ def get_weight_iterator(model_path: str, load_config: Optional[LoadConfig] = Non
                 disable_mmap=extra_config.get("disable_mmap", False),
             )
         else:
-            if is_layers_are_grouped:
+            if is_layers_are_grouped or parallel_config.tensor_parallel_size == 1:
                 weights_iterator = safetensors_weights_iterator(files_list)
             else:
                 weights_iterator = safetensors_weights_iterator_ordered(ordered_weight_map)
@@ -532,7 +539,10 @@ def get_all_weights_file(model_path: str):
             with index_file.open("r") as f:
                 weight_map = json.load(f)["weight_map"]
             keys = list(weight_map.keys())
-            is_layers_are_grouped = layers_are_grouped(keys)
+            values = list(weight_map.values())
+            is_keys_orders = layers_are_grouped(keys)
+            is_values_naturally_ordered = values_are_naturally_ordered(values)
+            is_layers_are_grouped = is_keys_orders and is_values_naturally_ordered
             ordered_weight_map = {
                 key: str(model_path / weight_map[key]) for key in sorted(weight_map.keys(), key=natural_key)
             }

--- a/fastdeploy/model_executor/load_weight_utils.py
+++ b/fastdeploy/model_executor/load_weight_utils.py
@@ -135,7 +135,7 @@ def get_weight_iterator(model_path: str, fd_config: Optional[FDConfig] = None):
                 disable_mmap=extra_config.get("disable_mmap", False),
             )
         else:
-            if is_layers_are_grouped or parallel_config.tensor_parallel_size == 1:
+            if is_layers_are_grouped or (parallel_config is not None and parallel_config.tensor_parallel_size == 1):
                 weights_iterator = safetensors_weights_iterator(files_list)
             else:
                 weights_iterator = safetensors_weights_iterator_ordered(ordered_weight_map)

--- a/fastdeploy/model_executor/model_loader/default_loader_v1.py
+++ b/fastdeploy/model_executor/model_loader/default_loader_v1.py
@@ -57,7 +57,7 @@ class DefaultModelLoaderV1(BaseModelLoader):
     @measure_time()
     def load_weights(self, model, fd_config: FDConfig, enable_cache: bool = False) -> None:
         model_path = get_model_path(fd_config)
-        weights_iterator = get_weight_iterator(model_path, fd_config.load_config)
+        weights_iterator = get_weight_iterator(model_path, fd_config)
         if enable_cache:
             load_weights_from_cache(model, weights_iterator)
         else:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
修复 `weight_map` 中 value（权重文件名）无序时可能引发加载 OOM 的问题。原有逻辑仅校验 keys 是否按 layer 分组，未检查 values（各权重文件名）是否按自然顺序排列，导致在某些模型下按非顺序读取多个 shard 文件，需同时持有多个 shard 数据从而 OOM。

## Modifications
- `load_weight_utils.py`：新增 `values_are_naturally_ordered(values)` 辅助函数，利用 `natural_key` 校验 values 是否按自然顺序排列
- `get_all_weights_file`：将 `is_layers_are_grouped` 的计算逻辑从仅检查 keys 分组扩展为同时要求 values 自然有序，两者均满足时才启用分组加载策略

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
