### PR TITLE
[Scheduler][BugFix] Fix token_budget calculation to use actual decode request count

### DIFF
--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -2253,9 +2253,13 @@ class FDConfig:
         assert (
             self.scheduler_config.max_num_seqs >= 1
         ), f"max_num_seqs: {self.scheduler_config.max_num_seqs} should be larger than 1"
-        assert self.scheduler_config.max_num_batched_tokens >= self.scheduler_config.max_num_seqs, (
+        tokens_per_seq = (
+            (self.speculative_config.num_speculative_tokens + 1) if self.speculative_config is not None else 1
+        )
+        assert self.scheduler_config.max_num_batched_tokens >= self.scheduler_config.max_num_seqs * tokens_per_seq, (
             f"max_num_batched_tokens: {self.scheduler_config.max_num_batched_tokens} "
-            f"should be larger than or equal to max_num_seqs: {self.scheduler_config.max_num_seqs}"
+            f"should be larger than or equal to max_num_seqs: {self.scheduler_config.max_num_seqs} "
+            f"* tokens_per_seq: {tokens_per_seq}"
         )
         assert (
             self.scheduler_config.max_num_batched_tokens

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -2292,7 +2292,9 @@ class FDConfig:
             self.scheduler_config.max_num_seqs >= 1
         ), f"max_num_seqs: {self.scheduler_config.max_num_seqs} should be larger than 1"
         tokens_per_seq = (
-            (self.speculative_config.num_speculative_tokens + 1) if self.speculative_config is not None else 1
+            (getattr(self.speculative_config, "num_speculative_tokens", 0) + 1)
+            if self.speculative_config is not None
+            else 1
         )
         assert self.scheduler_config.max_num_batched_tokens >= self.scheduler_config.max_num_seqs * tokens_per_seq, (
             f"max_num_batched_tokens: {self.scheduler_config.max_num_batched_tokens} "

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -245,6 +245,10 @@ class ResourceManagerV1(ResourceManager):
             block_num = min(block_num, self.config.cache_config.max_block_num_per_seq)
         return block_num
 
+    def _is_decoding(self, request) -> bool:
+        """Return True if the request has finished prefill and is in the decoding phase."""
+        return request.num_computed_tokens >= request.need_prefill_tokens
+
     def _prepare_prefill_task(self, request, new_token_num):
         request.prefill_start_index = request.num_computed_tokens
         request.prefill_end_index = request.num_computed_tokens + new_token_num
@@ -749,7 +753,7 @@ class ResourceManagerV1(ResourceManager):
             and self.config.scheduler_config.splitwise_role != "decode"
         ):
             with self.lock:
-                if request.num_computed_tokens >= request.need_prefill_tokens:  # request is decoding
+                if self._is_decoding(request):  # request is decoding
                     self.cache_manager.cache_output_blocks(request, self.config.cache_config.block_size)
 
     def schedule(self):
@@ -773,12 +777,10 @@ class ResourceManagerV1(ResourceManager):
                 if self.config.speculative_config is not None
                 else 1
             )
+            num_running_decode_reqs = sum(1 for req in self.running if self._is_decoding(req))
             token_budget = (
-                self.config.scheduler_config.max_num_batched_tokens
-                - self.config.scheduler_config.max_num_seqs * tokens_per_seq
+                self.config.scheduler_config.max_num_batched_tokens - num_running_decode_reqs * tokens_per_seq
             )
-            # temperatory solution to avoid negative token_budget
-            token_budget = max(token_budget, min(self.config.scheduler_config.max_num_batched_tokens, 512))
             need_abort_requests = []  # users trigger abortion
 
             # First, schedule the RUNNING requests.
@@ -791,7 +793,7 @@ class ResourceManagerV1(ResourceManager):
                     self.need_block_num_map[request.request_id] = SignalConsumer(need_block_num, 1)
                     self.need_block_num_signal.value[request.idx] = 0
 
-                if request.num_computed_tokens >= request.need_prefill_tokens:  # to be decoding
+                if self._is_decoding(request):  # to be decoding
                     if (
                         self.config.scheduler_config.splitwise_role == "prefill"
                     ):  # do not need to schedule for decoding
@@ -838,7 +840,7 @@ class ResourceManagerV1(ResourceManager):
                             # Prepare decoding task
                             scheduled_reqs.append(self._prepare_decode_task(request))
                         num_decoding_req_nums += 1
-                    token_budget -= 1
+                    # Decode token cost has been pre-deducted upfront (num_running_decode_reqs * tokens_per_seq).
                     if (
                         request.use_extend_tables
                         and request.request_id not in self.using_extend_tables_req_id

--- a/tests/eplb/test_eplb_utils.py
+++ b/tests/eplb/test_eplb_utils.py
@@ -168,7 +168,6 @@ class TestInitEplbSignals(unittest.TestCase):
 
         cache_cfg = CacheConfig(args)
         model_cfg = SimpleNamespace(enable_mm=True)  # Enable multimodal for feature testing
-        speculative_cfg = SimpleNamespace(method=None)
         model_cfg.print = print
         model_cfg.max_model_len = 5120
         model_cfg.num_hidden_layers = 3
@@ -200,7 +199,7 @@ class TestInitEplbSignals(unittest.TestCase):
             cache_config=cache_cfg,
             parallel_config=parallel_cfg,
             graph_opt_config=graph_opt_cfg,
-            speculative_config=speculative_cfg,
+            speculative_config=None,
             scheduler_config=scheduler_cfg,
             eplb_config=eplb_config,
         )

--- a/tests/eplb/test_experts_manager.py
+++ b/tests/eplb/test_experts_manager.py
@@ -48,7 +48,6 @@ class TestRedundantExpertManager(unittest.TestCase):
 
         cache_cfg = CacheConfig(args)
         model_cfg = SimpleNamespace(enable_mm=True)  # Enable multimodal for feature testing
-        speculative_cfg = SimpleNamespace(method=None)
         model_cfg.print = print
         model_cfg.max_model_len = 5120
         model_cfg.num_hidden_layers = 3
@@ -80,7 +79,7 @@ class TestRedundantExpertManager(unittest.TestCase):
             cache_config=cache_cfg,
             parallel_config=parallel_cfg,
             graph_opt_config=graph_opt_cfg,
-            speculative_config=speculative_cfg,
+            speculative_config=None,
             scheduler_config=scheduler_cfg,
             eplb_config=eplb_config,
         )

--- a/tests/v1/cache_manager/test_prefix_cache.py
+++ b/tests/v1/cache_manager/test_prefix_cache.py
@@ -31,7 +31,6 @@ def make_prefix_cache_manager(max_num_seqs, enable_mm=False, num_gpu_blocks_over
     args = asdict(engine_args)
     cache_cfg = CacheConfig(args)
     model_cfg = SimpleNamespace(enable_mm=enable_mm, max_model_len=4196)
-    speculative_cfg = SimpleNamespace(method=None)
     model_cfg.print = print
     model_cfg.architectures = ["test_model"]
     model_cfg.mm_max_tokens_per_item = None
@@ -46,7 +45,7 @@ def make_prefix_cache_manager(max_num_seqs, enable_mm=False, num_gpu_blocks_over
         cache_config=cache_cfg,
         parallel_config=parallel_cfg,
         graph_opt_config=graph_opt_cfg,
-        speculative_config=speculative_cfg,
+        speculative_config=None,
         scheduler_config=scheduler_cfg,
     )
     return PrefixCacheManager(config=fd_config, tensor_parallel_size=8, splitwise_role="mixed")

--- a/tests/v1/test_resource_manager_v1.py
+++ b/tests/v1/test_resource_manager_v1.py
@@ -139,7 +139,6 @@ class TestResourceManagerV1(unittest.TestCase):
 
         cache_cfg = CacheConfig(args)
         model_cfg = SimpleNamespace(enable_mm=True)  # Enable multimodal for feature testing
-        speculative_cfg = SimpleNamespace(method=None)
         model_cfg.print = print
         model_cfg.max_model_len = 3200
         model_cfg.architectures = ["test_model"]
@@ -156,7 +155,7 @@ class TestResourceManagerV1(unittest.TestCase):
             cache_config=cache_cfg,
             parallel_config=parallel_cfg,
             graph_opt_config=graph_opt_cfg,
-            speculative_config=speculative_cfg,
+            speculative_config=None,
             scheduler_config=scheduler_cfg,
         )
         self.manager = ResourceManagerV1(

--- a/tests/v1/test_schedule_output.py
+++ b/tests/v1/test_schedule_output.py
@@ -29,7 +29,6 @@ def test_normal_schedule():
     args = asdict(engine_args)
     cache_cfg = CacheConfig(args)
     model_cfg = SimpleNamespace(enable_mm=False)
-    speculative_cfg = SimpleNamespace(method=None)
     model_cfg.print = print
     model_cfg.max_model_len = 5120
     model_cfg.mm_max_tokens_per_item = None
@@ -41,7 +40,7 @@ def test_normal_schedule():
         model_config=model_cfg,
         cache_config=cache_cfg,
         parallel_config=parallel_cfg,
-        speculative_config=speculative_cfg,
+        speculative_config=None,
         graph_opt_config=graph_opt_cfg,
         scheduler_config=scheduler_cfg,
     )
@@ -95,7 +94,6 @@ def test_preempted_request():
     args = asdict(engine_args)
     cache_cfg = CacheConfig(args)
     model_cfg = SimpleNamespace(enable_mm=False)
-    speculative_cfg = SimpleNamespace(method=None)
     model_cfg.print = print
     model_cfg.max_model_len = 5120
     model_cfg.mm_max_tokens_per_item = None
@@ -108,7 +106,7 @@ def test_preempted_request():
         cache_config=cache_cfg,
         parallel_config=parallel_cfg,
         graph_opt_config=graph_opt_cfg,
-        speculative_config=speculative_cfg,
+        speculative_config=None,
         scheduler_config=scheduler_cfg,
     )
     resource_manager_v1 = ResourceManagerV1(
@@ -162,7 +160,6 @@ def test_caching_output():
     args = asdict(engine_args)
     cache_cfg = CacheConfig(args)
     model_cfg = SimpleNamespace(enable_mm=False)
-    speculative_cfg = SimpleNamespace(method=None)
     model_cfg.print = print
     model_cfg.max_model_len = 5120
     model_cfg.mm_max_tokens_per_item = None
@@ -175,7 +172,7 @@ def test_caching_output():
         cache_config=cache_cfg,
         parallel_config=parallel_cfg,
         graph_opt_config=graph_opt_cfg,
-        speculative_config=speculative_cfg,
+        speculative_config=None,
         scheduler_config=scheduler_cfg,
     )
     resource_manager_v1 = ResourceManagerV1(


### PR DESCRIPTION
## Motivation

当前 `token_budget` 的计算方式存在两个问题：

1. **预扣过多**：budget 按 `max_num_seqs * tokens_per_seq` 预扣，而不是 running 队列中实际处于 decode 阶段的请求数，导致 prefill 可用的 token 数被低估。
2. **循环内重复扣减**：decode 分支固定执行 `token_budget -= 1`，在 spec decode 场景下（`tokens_per_seq > 1`）每个 decode 请求只扣 1，少扣了 `num_speculative_tokens` 个。

## Modifications

- `resource_manager_v1.py`
  - 新增 `_is_decoding(request)` 内部方法，封装 `num_computed_tokens >= need_prefill_tokens` 判断，全文统一使用
  - 调度前统计 running 队列中真实的 decode 请求数 `num_running_decode_reqs`，以 `num_running_decode_reqs * tokens_per_seq` 一次性预扣 budget，替代原来的 `max_num_seqs * tokens_per_seq`
  - 去掉 decode 分支内的 `token_budget -= 1`（已在循环前整体预扣）

- `config.py`
  - 修复 `max_num_batched_tokens` 的合法性校验，考虑 spec decode 场景下 `tokens_per_seq = num_speculative_tokens + 1`，改为检查 `max_num_batched_tokens >= max_num_seqs * tokens_per_seq`

## Usage or Command

```bash
# 普通启动（非spec decode，行为不变）
python -m fastdeploy.entrypoints.openai.api_server \
  --max-num-batched-tokens 8192 \
  --max-num-seqs 256 \
  ...

# spec decode 场景（tokens_per_seq = num_speculative_tokens + 1）
# 确保 max_num_batched_tokens >= max_num_seqs * tokens_per_seq，否则启动报错
python -m fastdeploy.entrypoints.openai.api_server \
  --max-num-batched-tokens 8192 \
  --max-num-seqs 256 \
  --num-speculative-tokens 4 \
  ...
```

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. 当前修改为调度逻辑优化，已有 running 队列的集成测试覆盖，无需额外单元测试。
- [ ] Provide accuracy results.
