### PR TITLE
[PD] Fix PD interaction and error response

### DIFF
--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -985,14 +985,18 @@ class EngineService:
                             status, msg = self.split_connector.check_decode_allocated(task)
                             task.metrics.ask_decode_resource_finish_time = time.time()
                             if not status:
-                                self.llm_logger.error(f"{task.request_id} prefill failed with msg:{msg}.")
+                                error_msg = (
+                                    f"PD Error: prefill failed to apply for resource from decode, "
+                                    f"req: {task.request_id}, msg:{msg}."
+                                )
+                                self.llm_logger.error(error_msg)
                                 self.scheduler.put_results(
                                     [
                                         RequestOutput(
                                             request_id=task.request_id,
                                             finished=True,
                                             error_code=500,
-                                            error_msg=msg,
+                                            error_msg=error_msg,
                                         )
                                     ]
                                 )
@@ -1101,14 +1105,17 @@ class EngineService:
                     if self.cfg.scheduler_config.splitwise_role == "decode":
                         for task in batch_request:
                             if task.task_type == RequestType.PREEMPTED:
-                                msg = f"{task.request_id} decode not enough blocks, need to be rescheduled."
+                                msg = (
+                                    f"PD Error: decode does not have enough blocks for "
+                                    f"preallocated request. req:{task.request_id} "
+                                )
                                 self.llm_logger.error(msg)
                                 self.scheduler.put_results(
                                     [
                                         RequestOutput(
                                             request_id=task.request_id,
                                             finished=True,
-                                            error_code=500,
+                                            error_code=502,
                                             error_msg=msg,
                                         )
                                     ]

--- a/fastdeploy/engine/request.py
+++ b/fastdeploy/engine/request.py
@@ -222,6 +222,7 @@ class Request:
             self.metrics = RequestMetrics()
         else:
             self.metrics = metrics
+        self.metrics.prompt_token_ids_len = self.prompt_token_ids_len
         # from ChatCompletionRequest or CompletionRequest
         self.user = user
         self.metadata = metadata
@@ -1056,6 +1057,7 @@ class RequestMetrics:
     speculate_metrics: Optional[SpeculateMetrics] = None
 
     # cache related
+    prompt_token_ids_len: Optional[int] = None
     gpu_cache_token_num: Optional[int] = 0
     cpu_cache_token_num: Optional[int] = 0
     storage_cache_token_num: Optional[int] = 0

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -1380,6 +1380,7 @@ class ResourceManagerV1(ResourceManager):
                 request.metrics.storage_cache_token_num = metrics["storage_match_token_num"]
                 request.metrics.cpu_cache_prepare_time = metrics["cpu_cache_prepare_time"]
                 request.metrics.storage_cache_prepare_time = metrics["storage_cache_prepare_time"]
+                request.metrics.prompt_token_ids_len = request.prompt_token_ids_len
 
                 main_process_metrics.prefix_cache_token_num.inc(request.num_computed_tokens)
                 main_process_metrics.prefix_gpu_cache_token_num.inc(request.metrics.gpu_cache_token_num)
@@ -1506,7 +1507,6 @@ class ResourceManagerV1(ResourceManager):
             request.disaggregate_info["block_tables"] = request.block_tables
             allocated_position = self.get_available_position()
             request.idx = allocated_position
-            self.tasks_list[request.idx] = request
             self.stop_flags[request.idx] = False
             self.requests[request.request_id] = request
             self.req_dict[request.request_id] = allocated_position
@@ -1550,6 +1550,8 @@ class ResourceManagerV1(ResourceManager):
             request.metrics = copy.deepcopy(request_output.metrics)
             request.metrics.decode_inference_start_time = time.time()
             request.metrics.update_decoder_start_time()
+
+            self.tasks_list[request.idx] = request
             self.running.append(request)
 
     def _free_blocks(self, request: Request):

--- a/fastdeploy/entrypoints/openai/protocol.py
+++ b/fastdeploy/entrypoints/openai/protocol.py
@@ -270,7 +270,7 @@ class ChatCompletionResponseChoice(BaseModel):
     logprobs: Optional[LogProbs] = None
     draft_logprobs: Optional[LogProbs] = None
     prompt_logprobs: Optional[PromptLogprobs] = None
-    finish_reason: Optional[Literal["stop", "length", "tool_calls", "recover_stop", "abort"]]
+    finish_reason: Optional[Literal["stop", "length", "tool_calls", "recover_stop", "abort", "pd_reschedule"]]
     speculate_metrics: Optional[SpeculateMetrics] = None
 
 
@@ -335,7 +335,7 @@ class ChatCompletionResponseStreamChoice(BaseModel):
     logprobs: Optional[LogProbs] = None
     draft_logprobs: Optional[LogProbs] = None
     prompt_logprobs: Optional[PromptLogprobs] = None
-    finish_reason: Optional[Literal["stop", "length", "tool_calls", "recover_stop", "abort"]] = None
+    finish_reason: Optional[Literal["stop", "length", "tool_calls", "recover_stop", "abort", "pd_reschedule"]] = None
     arrival_time: Optional[float] = None
     speculate_metrics: Optional[SpeculateMetrics] = None
 
@@ -371,7 +371,7 @@ class CompletionResponseChoice(BaseModel):
     draft_logprobs: Optional[CompletionLogprobs] = None
     prompt_logprobs: Optional[PromptLogprobs] = None
     reasoning_content: Optional[str] = None
-    finish_reason: Optional[Literal["stop", "length", "tool_calls", "recover_stop", "abort"]] = None
+    finish_reason: Optional[Literal["stop", "length", "tool_calls", "recover_stop", "abort", "pd_reschedule"]] = None
     tool_calls: Optional[List[DeltaToolCall | ToolCall]] = None
     speculate_metrics: Optional[SpeculateMetrics] = None
 
@@ -417,7 +417,7 @@ class CompletionResponseStreamChoice(BaseModel):
     prompt_tokens: Optional[str] = None
     completion_tokens: Optional[str] = None
     reasoning_content: Optional[str] = None
-    finish_reason: Optional[Literal["stop", "length", "tool_calls", "recover_stop", "abort"]] = None
+    finish_reason: Optional[Literal["stop", "length", "tool_calls", "recover_stop", "abort", "pd_reschedule"]] = None
     tool_calls: Optional[List[DeltaToolCall | ToolCall]] = None
     speculate_metrics: Optional[SpeculateMetrics] = None
 

--- a/fastdeploy/entrypoints/openai/serving_chat.py
+++ b/fastdeploy/entrypoints/openai/serving_chat.py
@@ -653,10 +653,22 @@ class OpenAIServingChat:
                     request=request,
                 )
                 async for data in generator:
-                    if data.get("error_code", 200) != 200:
-                        raise ValueError("{}".format(data["error_msg"]))
                     idx = int(data["request_id"].split("_")[-1])
-                    # api_server_logger.debug(f"Client {request_id} received: {data}")
+                    if data.get("error_code", 200) != 200:
+                        # Error response - include already-generated tokens in the response
+                        data["outputs"] = {
+                            "text": "",
+                            "completion_tokens": "",
+                            "reasoning_content": "",
+                            "tool_calls": None,
+                            "reasoning_token_num": 0,
+                            "num_image_tokens": 0,
+                            "token_ids": [],
+                            "top_logprobs": None,
+                            "draft_top_logprobs": None,
+                        }
+                        data["metrics"] = data.get("metrics") or {}
+                        data["finished"] = True
                     previous_num_tokens[idx] += len(data["outputs"]["token_ids"])
                     completion_token_ids[idx].extend(data["outputs"]["token_ids"])
                     # The logprob for handling the response
@@ -797,6 +809,26 @@ class OpenAIServingChat:
         idx = int(data["request_id"].split("_")[-1])
         output = data["outputs"]
 
+        finish_reason = "stop"
+        if previous_num_tokens != max_tokens:
+            finish_reason = "stop"
+            if output.get("tool_calls"):
+                finish_reason = "tool_calls"
+        else:
+            finish_reason = "length"
+        if data.get("error_msg", None) is not None and "Recover" in data["error_msg"]:
+            finish_reason = "recover_stop"
+
+        if data.get("error_msg", None) is not None and "Aborted" in data["error_msg"]:
+            finish_reason = "abort"
+
+        if data.get("error_msg", None) is not None and "PD Error" in data["error_msg"]:
+            finish_reason = "pd_reschedule"
+
+        return_completion_token_ids = False
+        if request.return_token_ids or finish_reason == "pd_reschedule":
+            return_completion_token_ids = True
+
         if output is not None and output.get("metrics") and output["metrics"].get("request_start_time"):
             main_process_metrics.e2e_request_latency.observe(
                 time.time() - data.get("metrics").get("request_start_time")
@@ -806,7 +838,7 @@ class OpenAIServingChat:
             reasoning_content=output.get("reasoning_content"),
             tool_calls=output.get("tool_calls"),
             prompt_token_ids=prompt_token_ids if request.return_token_ids else None,
-            completion_token_ids=completion_token_ids if request.return_token_ids else None,
+            completion_token_ids=completion_token_ids if return_completion_token_ids else None,
             prompt_tokens=prompt_tokens if request.return_token_ids else None,
             completion_tokens=output.get("completion_tokens") if request.return_token_ids else None,
         )
@@ -833,18 +865,6 @@ class OpenAIServingChat:
         num_input_video_tokens[idx] = data.get("num_input_video_tokens", 0)
         num_image_tokens[idx] = output.get("num_image_tokens", 0) or 0
 
-        finish_reason = "stop"
-        if previous_num_tokens != max_tokens:
-            finish_reason = "stop"
-            if output.get("tool_calls"):
-                finish_reason = "tool_calls"
-        else:
-            finish_reason = "length"
-        if data.get("error_msg", None) is not None and "Recover" in data["error_msg"]:
-            finish_reason = "recover_stop"
-
-        if data.get("error_msg", None) is not None and "Aborted" in data["error_msg"]:
-            finish_reason = "abort"
         return ChatCompletionResponseChoice(
             index=idx,
             message=message,

--- a/fastdeploy/entrypoints/openai/serving_completion.py
+++ b/fastdeploy/entrypoints/openai/serving_completion.py
@@ -326,7 +326,15 @@ class OpenAIServingCompletion:
                 for data in response:
                     rid = int(data["request_id"].split("_")[-1])
                     if data.get("error_code", 200) != 200:
-                        raise ValueError("{}".format(data["error_msg"]))
+                        data["outputs"] = {
+                            "text": "",
+                            "completion_tokens": "",
+                            "token_ids": [],
+                            "top_logprobs": None,
+                            "draft_top_logprobs": None,
+                        }
+                        data["metrics"] = data.get("metrics") or {}
+                        data["finished"] = True
 
                     output = data["outputs"]
                     output_top_logprobs = output.get("top_logprobs") or None
@@ -772,13 +780,19 @@ class OpenAIServingCompletion:
             )
             if final_res.get("error_msg", None) is not None and "Aborted" in final_res["error_msg"]:
                 finish_reason = "abort"
+            if final_res.get("error_msg", None) is not None and "PD Error" in final_res["error_msg"]:
+                finish_reason = "pd_reschedule"
+
+            return_completion_token_ids = False
+            if request.return_token_ids or finish_reason == "pd_reschedule":
+                return_completion_token_ids = True
 
             choice_data = CompletionResponseChoice(
                 token_ids=token_ids,
                 index=len(choices),
                 text=output_text,
                 prompt_token_ids=prompt_token_ids if request.return_token_ids else None,
-                completion_token_ids=completion_token_ids if request.return_token_ids else None,
+                completion_token_ids=completion_token_ids if return_completion_token_ids else None,
                 completion_tokens=output.get("completion_tokens") if request.return_token_ids else None,
                 prompt_tokens=(
                     prompt_tokens_list[idx // (1 if request.n is None else request.n)]

--- a/fastdeploy/input/base_processor.py
+++ b/fastdeploy/input/base_processor.py
@@ -242,6 +242,17 @@ class BaseTextProcessor(ABC):
 
         ``stream`` is read from ``kwargs`` (default: True).
         """
+        # Error responses (e.g., preemption) have outputs=None or error_code!=200.
+        # Skip token decoding and return as-is to let upstream error handling take over.
+        if isinstance(response_dict, dict):
+            outputs = response_dict.get("outputs")
+            error_code = response_dict.get("error_code", 200)
+        else:
+            outputs = getattr(response_dict, "outputs", None)
+            error_code = getattr(response_dict, "error_code", 200)
+        if outputs is None or error_code != 200:
+            return response_dict
+
         stream = kwargs.get("stream", True)
         if stream:
             return self.process_response_dict_streaming(response_dict, **kwargs)

--- a/fastdeploy/output/token_processor.py
+++ b/fastdeploy/output/token_processor.py
@@ -577,8 +577,11 @@ class TokenProcessor:
                         self.prefill_result_status[finished_task_id[0]] = finished_task_id[1]
                 if task_id in self.prefill_result_status:
                     if self.prefill_result_status[task_id] != "finished":
-                        result.error_code = 400
-                        result.error_message = f"{task_id} failed to {self.prefill_result_status[task_id]}"
+                        result.error_code = 501
+                        result.error_msg = (
+                            f"PD Error: prefill failed to send cache to decode, "
+                            f"{task_id}, {self.prefill_result_status[task_id]}"
+                        )
                     log_request(
                         RequestLogLevel.STAGES,
                         message="wait for sending cache, request_id: {request_id}, cost seconds: {cost_seconds}",
@@ -789,7 +792,7 @@ class TokenProcessor:
         batch_result = list()
         # reschedule
         for i in range(batch):
-            if self.resource_manager.stop_flags[i]:
+            if self.resource_manager.stop_flags[i] or self.resource_manager.tasks_list[i] is None:
                 continue
 
             recovery_stop = False

--- a/fastdeploy/router/router.py
+++ b/fastdeploy/router/router.py
@@ -49,6 +49,14 @@ class RouterArgs:
     """
     Request timeout in seconds
     """
+    preempt_retry_count: int = 3
+    """
+    Max retry count when decode instance preempts a request in splitwise mode.
+    """
+    preempt_retry_exclude_decode: bool = False
+    """
+    Whether to exclude the previously used decode instance when retrying after preemption.
+    """
 
     @staticmethod
     def add_cli_args(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
@@ -76,6 +84,18 @@ class RouterArgs:
             default=RouterArgs.request_timeout_secs,
             help="Request timeout in seconds",
         )
+        parser.add_argument(
+            "--preempt-retry-count",
+            type=int,
+            default=RouterArgs.preempt_retry_count,
+            help="Max retry count when decode instance preempts a request in splitwise mode.",
+        )
+        parser.add_argument(
+            "--preempt-retry-exclude-decode",
+            action="store_true",
+            default=RouterArgs.preempt_retry_exclude_decode,
+            help="Whether to exclude the previously used decode instance when retrying after preemption.",
+        )
         return parser
 
 
@@ -91,6 +111,8 @@ class Router:
         self.port = args.port
         self.splitwise = args.splitwise
         self.timeout = args.request_timeout_secs
+        self.preempt_retry_count = args.preempt_retry_count
+        self.preempt_retry_exclude_decode = args.preempt_retry_exclude_decode
 
         self.mixed_servers = []
         self.prefill_servers = []
@@ -152,16 +174,21 @@ class Router:
                 instances = [inst for inst in instances if inst.version == version]
             return [inst.to_dict() for inst in instances]
 
-    async def select_pd(self):
-        """Select one prefill and one decode server"""
+    async def select_pd(self, exclude_decode=None):
+        """Select one prefill and one decode server, optionally excluding a decode instance."""
         async with self.lock:
             if not self.prefill_servers:
                 raise RuntimeError(f"No prefill servers available (decode={len(self.decode_servers)})")
             if not self.decode_servers:
                 raise RuntimeError(f"No decode servers available (prefill={len(self.prefill_servers)})")
             pidx = random.randint(0, len(self.prefill_servers) - 1)
-            didx = random.randint(0, len(self.decode_servers) - 1)
-            return self.prefill_servers[pidx], self.decode_servers[didx]
+            available_decode = (
+                [d for d in self.decode_servers if d is not exclude_decode] if exclude_decode else self.decode_servers
+            )
+            if not available_decode:
+                available_decode = self.decode_servers
+            didx = random.randint(0, len(available_decode) - 1)
+            return self.prefill_servers[pidx], available_decode[didx]
 
     async def select_mixed(self):
         """Select one mixed server"""
@@ -191,57 +218,108 @@ class Router:
 
     async def handle_splitwise_request(self, request_data: dict, endpoint_name: str):
         logger.debug(f"Received request: {request_data}")
-        prefill_server, decode_server = await self.select_pd()
-        logger.debug(f"Selected prefill server: {prefill_server}")
-        logger.debug(f"Selected decode server: {decode_server}")
+        last_decode_server = None
+        # Preserve client request_id on first attempt; append retry suffix on subsequent attempts
+        base_request_id = request_data.get("request_id") or str(uuid4())
+        max_attempts = self.preempt_retry_count + 1
+        completion_token_ids = []
 
-        if prefill_server.tp_size != decode_server.tp_size and decode_server.tp_size != 1:
-            raise HTTPException(
-                status_code=400,
-                detail="The tp_size of prefill and decode should be equal or the tp_size of decode is 1",
+        for attempt in range(max_attempts):
+            prefill_server, decode_server = await self.select_pd(
+                exclude_decode=last_decode_server if self.preempt_retry_exclude_decode else None
             )
+            logger.debug(f"Selected prefill server: {prefill_server}, decode server: {decode_server}")
 
-        # TODO: unify the disaggregate_info in server and remove redundancy params
-        is_same_node = prefill_server.host_ip == decode_server.host_ip
-        is_support_ipc = "ipc" in prefill_server.transfer_protocol and "ipc" in decode_server.transfer_protocol
-        is_same_tp_size = prefill_server.tp_size == decode_server.tp_size
-        use_ipc = is_same_node and is_support_ipc and is_same_tp_size
+            if prefill_server.tp_size != decode_server.tp_size and decode_server.tp_size != 1:
+                raise HTTPException(
+                    status_code=400,
+                    detail="The tp_size of prefill and decode should be equal or the tp_size of decode is 1",
+                )
 
-        disaggregate_info = {
-            "prefill_ip": prefill_server.host_ip,
-            "decode_ip": decode_server.host_ip,
-            "prefill_connector_port": prefill_server.connector_port,
-            "decode_connector_port": decode_server.connector_port,
-            "decode_device_ids": decode_server.device_ids,
-            "decode_rdma_ports": decode_server.rdma_ports,
-            "transfer_protocol": "ipc" if use_ipc else "rdma",
-            "decode_tp_size": decode_server.tp_size,
-        }
+            # TODO: unify the disaggregate_info in server and remove redundancy params
+            is_same_node = prefill_server.host_ip == decode_server.host_ip
+            is_support_ipc = "ipc" in prefill_server.transfer_protocol and "ipc" in decode_server.transfer_protocol
+            is_same_tp_size = prefill_server.tp_size == decode_server.tp_size
+            use_ipc = is_same_node and is_support_ipc and is_same_tp_size
 
-        modified_request = request_data.copy()
-        modified_request["disaggregate_info"] = disaggregate_info
-        if "request_id" not in modified_request:
-            modified_request["request_id"] = str(uuid4())
+            disaggregate_info = {
+                "prefill_ip": prefill_server.host_ip,
+                "decode_ip": decode_server.host_ip,
+                "prefill_connector_port": prefill_server.connector_port,
+                "decode_connector_port": decode_server.connector_port,
+                "decode_device_ids": decode_server.device_ids,
+                "decode_rdma_ports": decode_server.rdma_ports,
+                "transfer_protocol": "ipc" if use_ipc else "rdma",
+                "decode_tp_size": decode_server.tp_size,
+            }
 
-        logger.debug(f"Modified request: {modified_request}")
+            modified_request = request_data.copy()
+            modified_request["disaggregate_info"] = disaggregate_info
+            if completion_token_ids:
+                modified_request["completion_token_ids"] = completion_token_ids
+            if attempt == 0:
+                modified_request["request_id"] = base_request_id
+            else:
+                modified_request["request_id"] = f"{base_request_id}-retry{attempt}"
 
-        if request_data.get("stream", False):
-            return await self._generate_stream(
-                modified_request, [prefill_server.url(), decode_server.url()], endpoint=endpoint_name
-            )
-        else:
-            return await self._generate(
-                modified_request, [prefill_server.url(), decode_server.url()], endpoint=endpoint_name
-            )
+            logger.debug(f"Modified request: {modified_request}")
 
-    async def _generate(
+            if request_data.get("stream", False):
+                return await self._generate_stream(
+                    modified_request, [prefill_server.url(), decode_server.url()], endpoint=endpoint_name
+                )
+            else:
+                ret_json, status_code = await self._do_generate(
+                    modified_request, [prefill_server.url(), decode_server.url()], endpoint=endpoint_name
+                )
+                logger.debug(f"Get response of req {modified_request['request_id']}: {ret_json}")
+
+                if self._is_need_reschedule(ret_json):
+                    last_decode_server = decode_server
+                    choices = ret_json.get("choices", [])
+                    if choices:
+                        completion_token_ids.extend(choices[0].get("message", {}).get("completion_token_ids", []))
+
+                    logger.warning(
+                        f"Preemption detected on attempt {attempt+1}/{max_attempts}, "
+                        f"decode={decode_server.url()}, req_id {modified_request['request_id']},"
+                        f"retrying with new PD instances..."
+                    )
+                else:
+                    break
+
+        logger.debug(f"Return response of req_id {base_request_id}: {ret_json}")
+        return ORJSONResponse(content=ret_json, status_code=status_code)
+
+    def _is_need_reschedule(self, ret_json: dict) -> bool:
+        # ChatCompletionResponse format: choices[0].finish_reason == "pd_reschedule"
+        choices = ret_json.get("choices", [])
+        if choices:
+            finish_reason = choices[0].get("finish_reason", "")
+            if finish_reason == "pd_reschedule":
+                logger.debug(f"PD reschedule request, ret_json: {ret_json}")
+                return True
+        # ErrorResponse format compatibility
+        error = ret_json.get("error", {})
+        if isinstance(error, dict) and "PD Error" in str(error.get("message", "")):
+            return True
+        return False
+
+    async def _do_generate(
         self, modified_request, urls, return_result_url_index=-1, endpoint="v1/chat/completions"
-    ) -> ORJSONResponse:
+    ) -> tuple:
+        """Send requests and return (ret_json, status_code)."""
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=self.timeout)) as session:
             tasks = [session.post(f"{url}/{endpoint}", json=modified_request) for url in urls]
             results = await asyncio.gather(*tasks)
             ret_json = await results[return_result_url_index].json()
-            return ORJSONResponse(content=ret_json, status_code=results[return_result_url_index].status)
+            return ret_json, results[return_result_url_index].status
+
+    async def _generate(
+        self, modified_request, urls, return_result_url_index=-1, endpoint="v1/chat/completions"
+    ) -> ORJSONResponse:
+        ret_json, status_code = await self._do_generate(modified_request, urls, return_result_url_index, endpoint)
+        return ORJSONResponse(content=ret_json, status_code=status_code)
 
     async def _generate_stream(
         self, modified_request, urls, return_result_url_index=-1, endpoint="v1/chat/completions"

--- a/fastdeploy/splitwise/splitwise_connector.py
+++ b/fastdeploy/splitwise/splitwise_connector.py
@@ -277,23 +277,15 @@ class SplitwiseConnector:
                     "request_id": tasks[i].request_id,
                     "error_msg": tasks[i].get("error_msg"),
                 }
-                if (
-                    envs.ENABLE_V1_KVCACHE_SCHEDULER
-                    and tasks[i].request_id in self.resource_manager.waiting_abort_req_id_set
-                ):
-                    addr = f"{dsg_info['prefill_ip']}:" + f"{dsg_info['prefill_connector_port']}"
-                    if addr not in cache_info:
-                        cache_info[addr] = []
-                    cache_info[addr].append(info)
             else:
-                addr = f"{dsg_info['prefill_ip']}:" + f"{dsg_info['prefill_connector_port']}"
                 info = {
                     "request_id": tasks[i].request_id,
                     "dest_block_ids": dsg_info["block_tables"],
                 }
-                if addr not in cache_info:
-                    cache_info[addr] = []
-                cache_info[addr].append(info)
+            addr = f"{dsg_info['prefill_ip']}:" + f"{dsg_info['prefill_connector_port']}"
+            if addr not in cache_info:
+                cache_info[addr] = []
+            cache_info[addr].append(info)
 
         self.logger.debug(f"send cache info to prefill, {cache_info}")
         if len(cache_info):

--- a/tests/engine/test_request.py
+++ b/tests/engine/test_request.py
@@ -412,6 +412,7 @@ class TestRequestInstanceMethods(unittest.TestCase):
         request.prompt_token_ids_len = 3
         request.sampling_params = SamplingParams()
         request.metrics = RequestMetrics()
+        request.metrics.prompt_token_ids_len = 3
 
         data = request.to_dict()
 

--- a/tests/entrypoints/test_serving_completion.py
+++ b/tests/entrypoints/test_serving_completion.py
@@ -21,6 +21,7 @@ import numpy as np
 import paddle
 
 import fastdeploy.metrics.trace as tracing
+from fastdeploy.entrypoints.openai.protocol import CompletionResponse
 from fastdeploy.entrypoints.openai.serving_completion import OpenAIServingCompletion
 from fastdeploy.utils import ErrorCode, ParameterError
 from fastdeploy.worker.output import LogprobsLists, LogprobsTensors, SpeculateMetrics
@@ -171,7 +172,8 @@ class TestServingCompletion(unittest.IsolatedAsyncioTestCase):
         ec.connection_manager.get_connection = AsyncMock(return_value=(Mock(), rq))
         serving = OpenAIServingCompletion(ec, None, "pid", None, -1)
         res = await serving.completion_full_generator(_make_request(), 1, "req", 1, "m", [[1, 2]], [["p1", "p2"]], [2])
-        self.assertIsNone(res)
+        self.assertIsNotNone(res)
+        self.assertIsInstance(res, CompletionResponse)
         ec.connection_manager.cleanup_request.assert_called_once_with("req")
 
     def test_logprobs_helpers(self):

--- a/tests/input/test_ernie_vl_processor.py
+++ b/tests/input/test_ernie_vl_processor.py
@@ -361,14 +361,14 @@ class TestErnie4_5VLProcessorProcessResponseDictStreaming(unittest.TestCase):
 
             # Test with stream=True
             processor.process_response_dict_streaming = MagicMock(return_value={"text": "response"})
-            response_dict = {"ids": [1, 2, 3]}
+            response_dict = {"ids": [1, 2, 3], "outputs": [[1, 2, 3]]}
             result = processor.process_response_dict(response_dict, stream=True)
             processor.process_response_dict_streaming.assert_called_once()
             self.assertEqual(result, {"text": "response"})
 
             # Test with stream=False
             processor.process_response_dict_normal = MagicMock(return_value={"text": "response"})
-            response_dict = {"ids": [1, 2, 3]}
+            response_dict = {"ids": [1, 2, 3], "outputs": [[1, 2, 3]]}
             result = processor.process_response_dict(response_dict, stream=False)
             processor.process_response_dict_normal.assert_called_once()
             self.assertEqual(result, {"text": "response"})

--- a/tests/output/test_token_processor.py
+++ b/tests/output/test_token_processor.py
@@ -601,8 +601,8 @@ def test_recycle_resources_prefill_failure_sets_error():
     with mock.patch.object(envs, "ENABLE_V1_KVCACHE_SCHEDULER", False):
         processor._recycle_resources(task_id, 0, task, result, is_prefill=True)
 
-    assert result.error_code == 400
-    assert "failed" in result.error_message
+    assert result.error_code == 501
+    assert "failed" in result.error_msg
     assert connector.calls and connector.calls[0][1][0] is result
 
 

--- a/tests/router/test_router.py
+++ b/tests/router/test_router.py
@@ -28,7 +28,14 @@ from fastdeploy.router.router import Router, RouterArgs
 
 
 def _make_args(**kwargs):
-    defaults = {"host": "0.0.0.0", "port": 9000, "splitwise": False, "request_timeout_secs": 30}
+    defaults = {
+        "host": "0.0.0.0",
+        "port": 9000,
+        "splitwise": False,
+        "request_timeout_secs": 30,
+        "preempt_retry_count": 3,
+        "preempt_retry_exclude_decode": False,
+    }
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
 

--- a/tests/splitwise/test_splitwise_connector.py
+++ b/tests/splitwise/test_splitwise_connector.py
@@ -203,15 +203,6 @@ def test_send_cache_info_to_prefill_groups_by_addr_and_skips_error():
                 "block_tables": [1, 2, 3],
             },
         ),
-        DummyTask(
-            request_id="req-err",
-            disaggregate_info={
-                "prefill_ip": "10.0.0.2",
-                "prefill_connector_port": 9002,
-                "block_tables": [9],
-            },
-            error_msg="failed",
-        ),
     ]
 
     connector.send_cache_info_to_prefill(tasks)

--- a/tests/v1/test_resource_manager_v1.py
+++ b/tests/v1/test_resource_manager_v1.py
@@ -580,6 +580,7 @@ class TestResourceManagerV1Additional(unittest.TestCase):
         self.assertTrue(manager.has_resource_for_prefilled_req("prefilled"))
 
         request = _make_request(request_id="req-prefilled")
+        request.idx = 0
         request.metrics.decode_recv_req_time = 1.0
         request.metrics.decode_preallocate_req_time = 2.0
         manager.requests[request.request_id] = request


### PR DESCRIPTION
## Motivation
修复 PD 分离式推理场景下的多项问题：
1. decode 端 tasks_list 注册时机过早，导致请求在 prefill 完成前被 batch output 处理引发空指针；
2. 错误消息不统一，不便于 Router 层识别可重试错误；
3. 非流式请求在 decode 抢占时缺少自动重试机制。

## Modifications
1. 将 `tasks_list` 注册从 `preallocate_resource_in_d` 延迟到 `add_prefilled_request`，配合 `_process_batch_output` 增加 None 检查，避免worker生成无用的输出导致错误；
2. 统一错误消息前缀为 `PD Error`，Router 和 Serving 层据此识别 PD 错误并设置 `finish_reason=pd_reschedule`，便于roter支持重调度；
3. Router 新增 `preempt_retry_count` / `preempt_retry_exclude_decode` 参数，非流式请求 decode 抢占时自动重试；
4. `serving_chat` 错误路径保留已生成 token，返回部分结果而非直接抛异常；
5. `splitwise_connector` 修复`send_cache_info_to_prefill` 逻辑错误，避免资源不足后不会及时通知P实例。