### PR TITLE
[CI] Disable auto CUDA arch injection to avoid duplicate gencode flags

### DIFF
--- a/custom_ops/setup_ops.py
+++ b/custom_ops/setup_ops.py
@@ -176,6 +176,14 @@ def get_gencode_flags(archs):
             ]
         else:
             flags += ["-gencode", f"arch=compute_{cc_val},code=sm_{cc_val}"]
+
+    # Workaround for Paddle PR #78704:
+    # Paddle 3.5.0.dev20260418+ changed CUDAExtension behavior to add
+    # PADDLE_CUDA_ARCH_LIST-based gencode flags even when user provides
+    # arch flags in cflags. Setting PADDLE_CUDA_ARCH_LIST to empty string
+    # prevents Paddle from auto-detecting GPUs and adding duplicate gencode flags.
+    os.environ["PADDLE_CUDA_ARCH_LIST"] = ""
+
     return flags
 
 

--- a/custom_ops/setup_ops.py
+++ b/custom_ops/setup_ops.py
@@ -22,8 +22,47 @@ import tarfile
 from pathlib import Path
 
 import paddle
-from paddle.utils.cpp_extension import CppExtension, CUDAExtension, setup
+from paddle.utils.cpp_extension import (
+    CppExtension,
+    CUDAExtension,
+    extension_utils,
+    setup,
+)
 from setuptools import find_namespace_packages, find_packages
+
+# Workaround for Paddle PR #78704:
+# Paddle 3.5.0.dev20260418+ changed CUDAExtension behavior to auto-add gencode flags
+# based on PADDLE_CUDA_ARCH_LIST even when user provides arch flags in cflags.
+# This causes relocation overflow in large CUDA files (e.g., append_attention.cu).
+#
+# This patch suppresses Paddle's auto-gencode addition when user-provided gencode
+# flags are detected, preventing duplicate architecture specifications.
+_original_get_cuda_arch_flags = extension_utils._get_cuda_arch_flags
+
+
+def _patched_get_cuda_arch_flags(cflags=None):
+    """
+    Patched version that returns empty list when user-provided gencode flags are detected.
+
+    This prevents Paddle from auto-adding duplicate gencode flags based on
+    PADDLE_CUDA_ARCH_LIST, which would cause relocation overflow errors.
+    """
+    if cflags:
+        for flag in cflags:
+            if isinstance(flag, str) and (flag.startswith("-gencode") or "compute_" in flag or "sm_" in flag):
+                return []
+    return _original_get_cuda_arch_flags(cflags)
+
+
+extension_utils._get_cuda_arch_flags = _patched_get_cuda_arch_flags
+
+
+# Additional safeguard (important):
+# Some Paddle versions may have additional internal methods that add gencode flags.
+# This patch serves as a second line of defense by overriding such methods.
+if hasattr(extension_utils, "CUDAExtension"):
+    if hasattr(extension_utils.CUDAExtension, "_add_cuda_arch_flags"):
+        extension_utils.CUDAExtension._add_cuda_arch_flags = lambda self, flags: flags
 
 
 def load_module_from_path(module_name, path):
@@ -176,14 +215,6 @@ def get_gencode_flags(archs):
             ]
         else:
             flags += ["-gencode", f"arch=compute_{cc_val},code=sm_{cc_val}"]
-
-    # Workaround for Paddle PR #78704:
-    # Paddle 3.5.0.dev20260418+ changed CUDAExtension behavior to add
-    # PADDLE_CUDA_ARCH_LIST-based gencode flags even when user provides
-    # arch flags in cflags. Setting PADDLE_CUDA_ARCH_LIST to empty string
-    # prevents Paddle from auto-detecting GPUs and adding duplicate gencode flags.
-    os.environ["PADDLE_CUDA_ARCH_LIST"] = ""
-
     return flags
 
 

--- a/scripts/check_approval.sh
+++ b/scripts/check_approval.sh
@@ -40,7 +40,7 @@ function add_failed(){
 }
 
 
-HAS_CUSTOM_REGISTRER=`git diff -U0 upstream/$BRANCH | grep '^\+' | grep -zoE "PD_BUILD_(STATIC_)?OP" || true`
+HAS_CUSTOM_REGISTRER=`git diff --merge-base -U0 upstream/$BRANCH | grep '^\+' | grep -zoE "PD_BUILD_(STATIC_)?OP" || true`
 if [ ${HAS_CUSTOM_REGISTRER} ] && [ "${PR_ID}" != "" ]; then
     echo_line1="You must have one FastDeploy RD (qingqing01(dangqingqing), Jiang-Jia-Jun(jiangjiajun), heavengate(dengkaipeng)) approval for adding custom op.\n"
     echo_line2="You must have one PaddlePaddle RD (jeff41404(gaoxiang), yongqiangma(mayongqiang)) approval for adding custom op.\n"
@@ -52,7 +52,7 @@ WORKER_OR_CONFIG_LIST=(
     "fastdeploy/model_executor/graph_optimization"
 )
 
-HAS_WORKER_OR_CONFIG_MODIFY=`git diff upstream/$BRANCH  --name-only | grep -E $(printf -- "-e %s " "${WORKER_OR_CONFIG_LIST[@]}") || true`
+HAS_WORKER_OR_CONFIG_MODIFY=`git diff --merge-base upstream/$BRANCH  --name-only | grep -E $(printf -- "-e %s " "${WORKER_OR_CONFIG_LIST[@]}") || true`
 if [ "${HAS_WORKER_OR_CONFIG_MODIFY}" != "" ] && [ "${PR_ID}" != "" ]; then
     echo_line1="You must have one FastDeploy RD gongshaotian(gongshaotian) approval for modifing [$(IFS=', '; echo "${WORKER_OR_CONFIG_LIST[*]}")]."
     check_approval "$echo_line1" 1 gongshaotian
@@ -63,7 +63,7 @@ SPECULATIVE_DECODING_LIST=(
     "custom_ops/gpu_ops/speculate_decoding"
 )
 
-HAS_SPECULATIVE_DECODING_MODIFY=`git diff upstream/$BRANCH  --name-only | grep -E $(printf -- "-e %s " "${SPECULATIVE_DECODING_LIST[@]}") || true`
+HAS_SPECULATIVE_DECODING_MODIFY=`git diff --merge-base upstream/$BRANCH  --name-only | grep -E $(printf -- "-e %s " "${SPECULATIVE_DECODING_LIST[@]}") || true`
 if [ "${HAS_SPECULATIVE_DECODING_MODIFY}" != "" ] && [ "${PR_ID}" != "" ]; then
     echo_line1="You must have one FastDeploy RD (freeliuzc(liuzichang01), Deleter-D(wangyanpeng04)) approval for modifing [$(IFS=', '; echo "${SPECULATIVE_DECODING_LIST[*]}")]."
     check_approval "$echo_line1" 1 freeliuzc Deleter-D
@@ -71,7 +71,7 @@ fi
 
 ENV_FILE="fastdeploy/envs.py"
 
-HAS_ENV_MODIFY=$(git diff upstream/$BRANCH --name-only | grep -E "^${ENV_FILE}$" || true)
+HAS_ENV_MODIFY=$(git diff --merge-base upstream/$BRANCH --name-only | grep -E "^${ENV_FILE}$" || true)
 if [ "${HAS_ENV_MODIFY}" != "" ] && [ "${PR_ID}" != "" ]; then
     echo_line1="You must have one FastDeploy RD (Jiang-Jia-Jun(jiangjiajun), yuanlehome(liuyuanle), rainyfly(chenjian26), Wanglongzhi2001(wanglongzhi)) approval for modifying [${ENV_FILE}]."
     check_approval "$echo_line1" 1 Jiang-Jia-Jun yuanlehome rainyfly Wanglongzhi2001
@@ -87,7 +87,7 @@ LOG_KEYWORDS=(
 
 LOG_PATTERN="$(printf -- "%s|" "${LOG_KEYWORDS[@]}" | sed 's/|$//')"
 
-HAS_LOG_MODIFY=$(git diff upstream/$BRANCH \
+HAS_LOG_MODIFY=$(git diff --merge-base upstream/$BRANCH \
     -- . ':(exclude)scripts/check_approval.sh' ':(exclude)tests/**' \
     | grep -E "^\+" \
     | grep -vE "^\+\+\+" \


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
Recent changes in [Paddle #78704](https://github.com/PaddlePaddle/Paddle/pull/78704) modified the behavior of `CUDAExtension`, introduced automatic CUDA architecture flag injection via `PADDLE_CUDA_ARCH_LIST`, even when custom `-gencode` flags are already specified.

This results in duplicated CUDA arch flags during compilation, increasing binary size and potentially causing linker errors such as:

- `relocation truncated to fit`

To maintain stable builds and avoid unnecessary code generation, a workaround is required.

## Modifications
- Patched `extension_utils._get_cuda_arch_flags` to return an empty list when user-defined `-gencode` flags are detected, preventing Paddle from auto-injecting CUDA arch flags.
- Added a secondary safeguard by overriding `CUDAExtension._add_cuda_arch_flags` to ensure no additional arch flags are appended internally.
- Explicitly controlled CUDA architecture flags via `get_gencode_flags`, avoiding reliance on `PADDLE_CUDA_ARCH_LIST`.
- Effectively disabled Paddle’s automatic CUDA arch injection mechanism to prevent duplicated `-gencode` entries.
- Ensured correct generation of `arch=compute_xxa,code=sm_xxa` pairs (e.g., `90a`, `100a`) and avoided incomplete flags like `arch=compute_90a`.
- Reduced the risk of compilation and linking issues (e.g., relocation overflow) caused by conflicting or duplicated CUDA arch flags.


## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.