### PR TITLE
[BugFix][KVCache] Fix v0 cache manager incorrectly started when ENABLE_V1_KVCACHE_MANAGER is enabled

### DIFF
--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -2231,6 +2231,8 @@ class EngineService:
         threading.Thread(target=decode_loop, daemon=True).start()
 
     def start_cache_service(self, device_ids, ipc_signal_suffix):
+        if envs.ENABLE_V1_KVCACHE_MANAGER:
+            return []
         console_logger.debug("Start cache manager...")
         return self.resource_manager.cache_manager.launch_cache_manager(
             cache_config=self.cfg.cache_config,

--- a/fastdeploy/engine/expert_service.py
+++ b/fastdeploy/engine/expert_service.py
@@ -173,7 +173,9 @@ class ExpertService:
                     time.sleep(1)
             self.reset_kvcache_blocks()
 
-        if self.cfg.scheduler_config.splitwise_role != "mixed" or self.cfg.cache_config.enable_prefix_caching:
+        if not envs.ENABLE_V1_KVCACHE_MANAGER and (
+            self.cfg.scheduler_config.splitwise_role != "mixed" or self.cfg.cache_config.enable_prefix_caching
+        ):
             self.cache_manager_processes = self.engine.start_cache_service(
                 self.cfg.local_device_ids,
                 self.cfg.parallel_config.local_engine_worker_queue_port,

--- a/tests/engine/test_common_engine.py
+++ b/tests/engine/test_common_engine.py
@@ -1089,6 +1089,32 @@ class TestCommonEngineAdditionalCoverage(unittest.TestCase):
         self.assertEqual(result, ["proc"])
         self._detach_finalizer(eng)
 
+    def test_start_cache_service_returns_empty_when_v1_enabled(self):
+        """When ENABLE_V1_KVCACHE_MANAGER=1, start_cache_service should return [] without launching v0."""
+        eng = self._make_mixed_engine()
+        eng.resource_manager.cache_manager = Mock()
+        eng.resource_manager.cache_manager.launch_cache_manager = Mock(return_value=["proc"])
+
+        with patch("fastdeploy.engine.common_engine.envs.ENABLE_V1_KVCACHE_MANAGER", True):
+            result = eng.start_cache_service(["0"], 9999)
+
+        self.assertEqual(result, [])
+        eng.resource_manager.cache_manager.launch_cache_manager.assert_not_called()
+        self._detach_finalizer(eng)
+
+    def test_start_cache_service_launches_v0_when_v1_disabled(self):
+        """When ENABLE_V1_KVCACHE_MANAGER=0, start_cache_service should invoke launch_cache_manager normally."""
+        eng = self._make_mixed_engine()
+        eng.resource_manager.cache_manager = Mock()
+        eng.resource_manager.cache_manager.launch_cache_manager = Mock(return_value=["proc"])
+
+        with patch("fastdeploy.engine.common_engine.envs.ENABLE_V1_KVCACHE_MANAGER", False):
+            result = eng.start_cache_service(["0"], 9999)
+
+        self.assertEqual(result, ["proc"])
+        eng.resource_manager.cache_manager.launch_cache_manager.assert_called_once()
+        self._detach_finalizer(eng)
+
     def test_control_update_weights_success(self):
         eng = self._make_mixed_engine()
         eng.is_paused = True

--- a/tests/engine/test_expert_service.py
+++ b/tests/engine/test_expert_service.py
@@ -99,6 +99,7 @@ class TestExpertService(unittest.TestCase):
     def test_start_method(self, mock_envs, mock_threading, mock_time, mock_engine_service):
         mock_envs.FD_ENABLE_RETURN_TEXT = False
         mock_envs.FD_ENABLE_MULTI_API_SERVER = False
+        mock_envs.ENABLE_V1_KVCACHE_MANAGER = False
 
         local_data_parallel_id = 0
 

--- a/tests/engine/test_expert_service.py
+++ b/tests/engine/test_expert_service.py
@@ -285,6 +285,72 @@ class TestExpertService(unittest.TestCase):
         self.assertEqual(call_count[0], 3)  # Failed twice, succeeded on third try
         self.assertTrue(result)
 
+    @patch("fastdeploy.engine.expert_service.EngineService")
+    @patch("fastdeploy.engine.expert_service.time")
+    @patch("fastdeploy.engine.expert_service.threading")
+    @patch("fastdeploy.engine.expert_service.envs")
+    @patch("fastdeploy.engine.expert_service.IPCSignal")
+    def test_start_does_not_call_cache_service_when_v1_enabled(
+        self, mock_ipc_signal, mock_envs, mock_threading, mock_time, mock_engine_service
+    ):
+        """When ENABLE_V1_KVCACHE_MANAGER=1, start() must NOT call start_cache_service."""
+        mock_envs.FD_ENABLE_RETURN_TEXT = False
+        mock_envs.FD_ENABLE_MULTI_API_SERVER = False
+        mock_envs.ENABLE_V1_KVCACHE_MANAGER = True
+
+        mock_ipc_signal.return_value = Mock(value=[100])
+        mock_engine_instance = mock_engine_service.return_value
+
+        expert_service = ExpertService(self.mock_cfg, 0)
+        expert_service.start(None, 0)
+
+        mock_engine_instance.start_cache_service.assert_not_called()
+
+    @patch("fastdeploy.engine.expert_service.EngineService")
+    @patch("fastdeploy.engine.expert_service.time")
+    @patch("fastdeploy.engine.expert_service.threading")
+    @patch("fastdeploy.engine.expert_service.envs")
+    @patch("fastdeploy.engine.expert_service.IPCSignal")
+    def test_start_calls_cache_service_when_v1_disabled_prefix_caching(
+        self, mock_ipc_signal, mock_envs, mock_threading, mock_time, mock_engine_service
+    ):
+        """When ENABLE_V1_KVCACHE_MANAGER=0 and enable_prefix_caching=True, start_cache_service is called."""
+        mock_envs.FD_ENABLE_RETURN_TEXT = False
+        mock_envs.FD_ENABLE_MULTI_API_SERVER = False
+        mock_envs.ENABLE_V1_KVCACHE_MANAGER = False
+
+        self.mock_cfg.cache_config.enable_prefix_caching = True
+        mock_ipc_signal.return_value = Mock(value=[100])
+        mock_engine_instance = mock_engine_service.return_value
+        mock_engine_instance.start_cache_service.return_value = [Mock(pid=1234)]
+
+        expert_service = ExpertService(self.mock_cfg, 0)
+        expert_service.start(None, 0)
+
+        mock_engine_instance.start_cache_service.assert_called_once()
+
+    @patch("fastdeploy.engine.expert_service.EngineService")
+    @patch("fastdeploy.engine.expert_service.time")
+    @patch("fastdeploy.engine.expert_service.threading")
+    @patch("fastdeploy.engine.expert_service.envs")
+    @patch("fastdeploy.engine.expert_service.IPCSignal")
+    def test_start_skips_cache_service_when_v1_enabled_regardless_of_prefix_caching(
+        self, mock_ipc_signal, mock_envs, mock_threading, mock_time, mock_engine_service
+    ):
+        """ENABLE_V1_KVCACHE_MANAGER=1 takes precedence: even with enable_prefix_caching=True, no v0 launch."""
+        mock_envs.FD_ENABLE_RETURN_TEXT = False
+        mock_envs.FD_ENABLE_MULTI_API_SERVER = False
+        mock_envs.ENABLE_V1_KVCACHE_MANAGER = True
+
+        self.mock_cfg.cache_config.enable_prefix_caching = True
+        mock_ipc_signal.return_value = Mock(value=[100])
+        mock_engine_instance = mock_engine_service.return_value
+
+        expert_service = ExpertService(self.mock_cfg, 0)
+        expert_service.start(None, 0)
+
+        mock_engine_instance.start_cache_service.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

When `ENABLE_V1_KVCACHE_MANAGER=1`, the v0 cache manager should not be started. However, there were two code paths where v0 cache manager processes could still be launched:

1. `EngineService.start_cache_service()` — missing early return guard for V1 mode
2. `ExpertService` — `start_cache_service` was called without checking `ENABLE_V1_KVCACHE_MANAGER` flag

This caused v0 cache manager processes to be incorrectly spawned alongside v1, leading to conflicts and unexpected behavior.

## Modifications

- `fastdeploy/engine/common_engine.py`: Add early return `return []` in `start_cache_service()` when `ENABLE_V1_KVCACHE_MANAGER` is enabled
- `fastdeploy/engine/expert_service.py`: Wrap `start_cache_service` call with `not envs.ENABLE_V1_KVCACHE_MANAGER` condition guard to prevent v0 cache manager from starting when v1 is active

## Usage or Command

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. The fix is a guard condition to prevent incorrect code path execution; existing tests cover the affected functions.
- [ ] Provide accuracy results. N/A — this is a bug fix that prevents incorrect process spawning, not a model computation change.