### PR TITLE
[BugFix] Fix profile token num in ep

### DIFF
--- a/fastdeploy/spec_decode/mtp.py
+++ b/fastdeploy/spec_decode/mtp.py
@@ -174,7 +174,9 @@ class MTPProposer(Proposer):
         model_loader = get_model_loader(load_config=self.fd_config.load_config)
         self.model = model_loader.load_model(fd_config=self.fd_config)
 
-    def dummy_prefill_inputs(self, num_tokens: int, batch_size: int, expected_decode_len: int, in_capturing: bool):
+    def dummy_prefill_inputs(
+        self, num_tokens: int, batch_size: int, expected_decode_len: int, in_capturing: bool = False
+    ):
         """Set dummy prefill inputs to model_inputs"""
         max_dec_len = expected_decode_len + 1
 

--- a/fastdeploy/spec_decode/mtp.py
+++ b/fastdeploy/spec_decode/mtp.py
@@ -193,7 +193,7 @@ class MTPProposer(Proposer):
         for i in range(batch_size):
             idx = i
 
-            # When EP is enabled, input tokens may be routed to the same expert if the input idss consist entirely of 5s.
+            # When EP is enabled, input tokens may be routed to the same expert if the input ids consist entirely of 5s.
             # This can lead to OOM, so random input ids should be used instead.
             if self.fd_config.parallel_config.enable_expert_parallel:
                 input_ids = np.random.randint(5, 10000, size=input_length)

--- a/fastdeploy/spec_decode/mtp.py
+++ b/fastdeploy/spec_decode/mtp.py
@@ -180,13 +180,21 @@ class MTPProposer(Proposer):
         """Set dummy prefill inputs to model_inputs"""
         max_dec_len = expected_decode_len + 1
 
-        if in_capturing and current_platform.is_cuda():
-            input_length = self.fd_config.speculative_config.num_speculative_tokens + 1
+        if current_platform.is_cuda():
+            if in_capturing:
+                input_length = self.fd_config.speculative_config.num_speculative_tokens + 1
+            else:
+                input_length = min(
+                    num_tokens // batch_size,
+                    self.model_config.max_model_len - max_dec_len,
+                )
         else:
             input_length = min(
                 num_tokens // batch_size,
                 self.model_config.max_model_len - max_dec_len,
             )
+            if self.fd_config.parallel_config.enable_expert_parallel:
+                input_length = min(input_length, 32)
 
         block_num = (
             input_length + self.cache_config.block_size - 1

--- a/fastdeploy/spec_decode/mtp.py
+++ b/fastdeploy/spec_decode/mtp.py
@@ -174,20 +174,15 @@ class MTPProposer(Proposer):
         model_loader = get_model_loader(load_config=self.fd_config.load_config)
         self.model = model_loader.load_model(fd_config=self.fd_config)
 
-    def dummy_prefill_inputs(
-        self, num_tokens: int, batch_size: int, expected_decode_len: int, in_capturing: bool = False
-    ):
+    def dummy_prefill_inputs(self, num_tokens: int, batch_size: int, expected_decode_len: int):
         """Set dummy prefill inputs to model_inputs"""
         max_dec_len = expected_decode_len + 1
 
         if current_platform.is_cuda():
-            if in_capturing:
-                input_length = self.fd_config.speculative_config.num_speculative_tokens + 1
-            else:
-                input_length = min(
-                    num_tokens // batch_size,
-                    self.model_config.max_model_len - max_dec_len,
-                )
+            input_length = min(
+                num_tokens // batch_size,
+                self.model_config.max_model_len - max_dec_len,
+            )
         else:
             input_length = min(
                 num_tokens // batch_size,

--- a/fastdeploy/spec_decode/mtp.py
+++ b/fastdeploy/spec_decode/mtp.py
@@ -180,7 +180,7 @@ class MTPProposer(Proposer):
         """Set dummy prefill inputs to model_inputs"""
         max_dec_len = expected_decode_len + 1
 
-        if in_capturing:
+        if in_capturing and current_platform.is_cuda():
             input_length = self.fd_config.speculative_config.num_speculative_tokens + 1
         else:
             input_length = min(

--- a/fastdeploy/spec_decode/mtp.py
+++ b/fastdeploy/spec_decode/mtp.py
@@ -197,7 +197,7 @@ class MTPProposer(Proposer):
 
             # When EP is enabled, input tokens may be routed to the same expert if the input ids consist entirely of 5s.
             # This can lead to OOM, so random input ids should be used instead.
-            if self.fd_config.parallel_config.enable_expert_parallel:
+            if self.fd_config.parallel_config.enable_expert_parallel and current_platform.is_cuda():
                 input_ids = np.random.randint(5, 10000, size=input_length)
             else:
                 input_ids = np.array([5] * input_length)

--- a/fastdeploy/spec_decode/mtp.py
+++ b/fastdeploy/spec_decode/mtp.py
@@ -174,18 +174,17 @@ class MTPProposer(Proposer):
         model_loader = get_model_loader(load_config=self.fd_config.load_config)
         self.model = model_loader.load_model(fd_config=self.fd_config)
 
-    def dummy_prefill_inputs(self, num_tokens: int, batch_size: int, expected_decode_len: int):
+    def dummy_prefill_inputs(self, num_tokens: int, batch_size: int, expected_decode_len: int, in_capturing: bool):
         """Set dummy prefill inputs to model_inputs"""
         max_dec_len = expected_decode_len + 1
 
-        input_length = min(
-            num_tokens // batch_size,
-            self.model_config.max_model_len - max_dec_len,
-        )
-
-        # TODO(wanglongzhi): Figure out the accurate buffer size of DeepEP.
-        if self.fd_config.parallel_config.enable_expert_parallel:
-            input_length = min(input_length, 32)
+        if in_capturing:
+            input_length = self.fd_config.speculative_config.num_speculative_tokens + 1
+        else:
+            input_length = min(
+                num_tokens // batch_size,
+                self.model_config.max_model_len - max_dec_len,
+            )
 
         block_num = (
             input_length + self.cache_config.block_size - 1
@@ -193,7 +192,15 @@ class MTPProposer(Proposer):
 
         for i in range(batch_size):
             idx = i
-            self.model_inputs["input_ids"][idx : idx + 1, :input_length] = np.array([5] * input_length)
+
+            # When EP is enabled, input tokens may be routed to the same expert if the input idss consist entirely of 5s.
+            # This can lead to OOM, so random input ids should be used instead.
+            if self.fd_config.parallel_config.enable_expert_parallel:
+                input_ids = np.random.randint(5, 10000, size=input_length)
+            else:
+                input_ids = np.array([5] * input_length)
+
+            self.model_inputs["input_ids"][idx : idx + 1, :input_length] = input_ids
             self.model_inputs["eos_token_id"][:] = np.array([2], dtype="int64").reshape(-1, 1)
             self.model_inputs["seq_lens_this_time_buffer"][idx : idx + 1] = input_length
             self.model_inputs["seq_lens_encoder"][idx : idx + 1] = input_length

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1059,7 +1059,12 @@ class GPUModelRunner(ModelRunnerBase):
         raise NotImplementedError("GPUs only support KVCACHE SCHEDULER V1 in versions 2.6 and above.")
 
     def get_input_length_list(
-        self, num_tokens: int, batch_size: int, expected_decode_len: int, capture_prefill: bool = False
+        self,
+        num_tokens: int,
+        batch_size: int,
+        expected_decode_len: int,
+        in_capturing: bool,
+        capture_prefill: bool = False,
     ):
         """
         Generates some list for _dummy_prefill_inputs, when capture pure prefill or mtp,
@@ -1098,15 +1103,14 @@ class GPUModelRunner(ModelRunnerBase):
         """
         # NOTE(gongshaotian): The maximum decoding length is equal to the expected decoded tokens plus the eos token
         max_dec_len = expected_decode_len + 1
-        input_length = min(
-            num_tokens // (1 if capture_prefill else batch_size),
-            self.model_config.max_model_len - max_dec_len,
-        )
 
-        # NOTE(wanglongzhi): When the full length is too large, DeepEP's buffer size will not be enough to cause the result to appear nan.
-        # TODO(wanglongzhi): Figure out the accurate buffer size of DeepEP.
-        if self.fd_config.parallel_config.enable_expert_parallel:
-            input_length = min(input_length, 32)
+        if in_capturing:
+            input_length = self.fd_config.speculative_config.num_speculative_tokens + 1
+        else:
+            input_length = min(
+                num_tokens // batch_size,
+                self.model_config.max_model_len - max_dec_len,
+            )
 
         block_num = (
             input_length + self.cache_config.block_size - 1
@@ -1152,8 +1156,15 @@ class GPUModelRunner(ModelRunnerBase):
             idx = i
             input_length = input_length_list[i]
             max_dec_len = max_dec_len_list[i]
-            self.share_inputs["input_ids"][idx : idx + 1, :input_length] = np.array([5] * input_length)
-            self.share_inputs["token_ids_all"][idx : idx + 1, :input_length] = np.array([5] * input_length)
+            # When EP is enabled, input tokens may be routed to the same expert if the input idss consist entirely of 5s.
+            # This can lead to OOM, so random input ids should be used instead.
+            if self.fd_config.parallel_config.enable_expert_parallel:
+                input_ids = np.random.randint(5, 10000, size=input_length)
+            else:
+                input_ids = np.array([5] * input_length)
+
+            self.share_inputs["input_ids"][idx : idx + 1, :input_length] = input_ids
+            self.share_inputs["token_ids_all"][idx : idx + 1, :input_length] = input_ids
             self.share_inputs["eos_token_id"][:] = np.array(
                 [2] * self.model_config.eos_tokens_lens, dtype="int64"
             ).reshape(-1, 1)
@@ -1913,18 +1924,21 @@ class GPUModelRunner(ModelRunnerBase):
             num_tokens=num_tokens,
             batch_size=batch_size,
             expected_decode_len=expected_decode_len,
+            in_capturing=in_capturing,
             capture_prefill=capture_prefill,
         )
         self._dummy_prefill_inputs(
             input_length_list=input_length_list,
             max_dec_len_list=max_dec_len_list,
             block_num=block_num,
+            in_capturing=in_capturing,
         )
         if self.spec_method == SpecMethod.MTP:
             self.proposer.dummy_prefill_inputs(
                 num_tokens=num_tokens,
                 batch_size=batch_size,
                 expected_decode_len=expected_decode_len,
+                in_capturing=in_capturing,
             )
 
         while True:

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1156,7 +1156,7 @@ class GPUModelRunner(ModelRunnerBase):
             idx = i
             input_length = input_length_list[i]
             max_dec_len = max_dec_len_list[i]
-            # When EP is enabled, input tokens may be routed to the same expert if the input idss consist entirely of 5s.
+            # When EP is enabled, input tokens may be routed to the same expert if the input ids consist entirely of 5s.
             # This can lead to OOM, so random input ids should be used instead.
             if self.fd_config.parallel_config.enable_expert_parallel:
                 input_ids = np.random.randint(5, 10000, size=input_length)

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1931,7 +1931,6 @@ class GPUModelRunner(ModelRunnerBase):
             input_length_list=input_length_list,
             max_dec_len_list=max_dec_len_list,
             block_num=block_num,
-            in_capturing=in_capturing,
         )
         if self.spec_method == SpecMethod.MTP:
             self.proposer.dummy_prefill_inputs(

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1108,7 +1108,7 @@ class GPUModelRunner(ModelRunnerBase):
             input_length = self.fd_config.speculative_config.num_speculative_tokens + 1
         else:
             input_length = min(
-                num_tokens // batch_size,
+                num_tokens // (1 if capture_prefill else batch_size),
                 self.model_config.max_model_len - max_dec_len,
             )
 

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1063,7 +1063,6 @@ class GPUModelRunner(ModelRunnerBase):
         num_tokens: int,
         batch_size: int,
         expected_decode_len: int,
-        in_capturing: bool,
         capture_prefill: bool = False,
     ):
         """
@@ -1103,14 +1102,10 @@ class GPUModelRunner(ModelRunnerBase):
         """
         # NOTE(gongshaotian): The maximum decoding length is equal to the expected decoded tokens plus the eos token
         max_dec_len = expected_decode_len + 1
-
-        if in_capturing:
-            input_length = self.fd_config.speculative_config.num_speculative_tokens + 1
-        else:
-            input_length = min(
-                num_tokens // (1 if capture_prefill else batch_size),
-                self.model_config.max_model_len - max_dec_len,
-            )
+        input_length = min(
+            num_tokens // (1 if capture_prefill else batch_size),
+            self.model_config.max_model_len - max_dec_len,
+        )
 
         block_num = (
             input_length + self.cache_config.block_size - 1
@@ -1924,7 +1919,6 @@ class GPUModelRunner(ModelRunnerBase):
             num_tokens=num_tokens,
             batch_size=batch_size,
             expected_decode_len=expected_decode_len,
-            in_capturing=in_capturing,
             capture_prefill=capture_prefill,
         )
         self._dummy_prefill_inputs(
@@ -1937,7 +1931,6 @@ class GPUModelRunner(ModelRunnerBase):
                 num_tokens=num_tokens,
                 batch_size=batch_size,
                 expected_decode_len=expected_decode_len,
-                in_capturing=in_capturing,
             )
 
         while True:

--- a/fastdeploy/worker/metax_model_runner.py
+++ b/fastdeploy/worker/metax_model_runner.py
@@ -1068,7 +1068,6 @@ class MetaxModelRunner(ModelRunnerBase):
             idx = i
             input_length = input_length_list[i]
             max_dec_len = max_dec_len_list[i]
-
             self.share_inputs["input_ids"][idx : idx + 1, :input_length] = np.array([5] * input_length)
             self.share_inputs["token_ids_all"][idx : idx + 1, :input_length] = np.array([5] * input_length)
             self.share_inputs["eos_token_id"][:] = np.array(

--- a/fastdeploy/worker/metax_model_runner.py
+++ b/fastdeploy/worker/metax_model_runner.py
@@ -975,12 +975,7 @@ class MetaxModelRunner(ModelRunnerBase):
             self.proposer.insert_prefill_inputs(req_dicts, num_running_requests)
 
     def get_input_length_list(
-        self,
-        num_tokens: int,
-        batch_size: int,
-        expected_decode_len: int,
-        in_capturing: bool,
-        capture_prefill: bool = False,
+        self, num_tokens: int, batch_size: int, expected_decode_len: int, capture_prefill: bool = False
     ):
         """
         Generates some list for _dummy_prefill_inputs, when capture pure prefill or mtp,
@@ -1019,13 +1014,16 @@ class MetaxModelRunner(ModelRunnerBase):
         """
         # NOTE(gongshaotian): The maximum decoding length is equal to the expected decoded tokens plus the eos token
         max_dec_len = expected_decode_len + 1
-        if in_capturing:
-            input_length = self.fd_config.speculative_config.num_speculative_tokens + 1
-        else:
-            input_length = min(
-                num_tokens // batch_size,
-                self.model_config.max_model_len - max_dec_len,
-            )
+        input_length = min(
+            num_tokens // (1 if capture_prefill else batch_size),
+            self.model_config.max_model_len - max_dec_len,
+        )
+
+        # NOTE(wanglongzhi): When the full length is too large, DeepEP's buffer size will not be enough to cause the result to appear nan.
+        # TODO(wanglongzhi): Figure out the accurate buffer size of DeepEP.
+        if self.fd_config.parallel_config.enable_expert_parallel:
+            input_length = min(input_length, 32)
+
         block_num = (
             input_length + self.cache_config.block_size - 1
         ) // self.cache_config.block_size + self.cache_config.enc_dec_block_num
@@ -1070,15 +1068,9 @@ class MetaxModelRunner(ModelRunnerBase):
             idx = i
             input_length = input_length_list[i]
             max_dec_len = max_dec_len_list[i]
-            # When EP is enabled, input tokens may be routed to the same expert if the input idss consist entirely of 5s.
-            # This can lead to OOM, so random input ids should be used instead.
-            if self.fd_config.parallel_config.enable_expert_parallel:
-                input_ids = np.random.randint(5, 10000, size=input_length)
-            else:
-                input_ids = np.array([5] * input_length)
 
-            self.share_inputs["input_ids"][idx : idx + 1, :input_length] = input_ids
-            self.share_inputs["token_ids_all"][idx : idx + 1, :input_length] = input_ids
+            self.share_inputs["input_ids"][idx : idx + 1, :input_length] = np.array([5] * input_length)
+            self.share_inputs["token_ids_all"][idx : idx + 1, :input_length] = np.array([5] * input_length)
             self.share_inputs["eos_token_id"][:] = np.array(
                 [2] * self.model_config.eos_tokens_lens, dtype="int64"
             ).reshape(-1, 1)
@@ -1734,7 +1726,6 @@ class MetaxModelRunner(ModelRunnerBase):
             num_tokens=num_tokens,
             batch_size=batch_size,
             expected_decode_len=expected_decode_len,
-            in_capturing=in_capturing,
             capture_prefill=capture_prefill,
         )
         self._dummy_prefill_inputs(
@@ -1747,7 +1738,6 @@ class MetaxModelRunner(ModelRunnerBase):
                 num_tokens=num_tokens,
                 batch_size=batch_size,
                 expected_decode_len=expected_decode_len,
-                in_capturing=in_capturing,
             )
 
         while True:

--- a/fastdeploy/worker/metax_model_runner.py
+++ b/fastdeploy/worker/metax_model_runner.py
@@ -975,7 +975,12 @@ class MetaxModelRunner(ModelRunnerBase):
             self.proposer.insert_prefill_inputs(req_dicts, num_running_requests)
 
     def get_input_length_list(
-        self, num_tokens: int, batch_size: int, expected_decode_len: int, capture_prefill: bool = False
+        self,
+        num_tokens: int,
+        batch_size: int,
+        expected_decode_len: int,
+        in_capturing: bool,
+        capture_prefill: bool = False,
     ):
         """
         Generates some list for _dummy_prefill_inputs, when capture pure prefill or mtp,
@@ -1014,16 +1019,13 @@ class MetaxModelRunner(ModelRunnerBase):
         """
         # NOTE(gongshaotian): The maximum decoding length is equal to the expected decoded tokens plus the eos token
         max_dec_len = expected_decode_len + 1
-        input_length = min(
-            num_tokens // (1 if capture_prefill else batch_size),
-            self.model_config.max_model_len - max_dec_len,
-        )
-
-        # NOTE(wanglongzhi): When the full length is too large, DeepEP's buffer size will not be enough to cause the result to appear nan.
-        # TODO(wanglongzhi): Figure out the accurate buffer size of DeepEP.
-        if self.fd_config.parallel_config.enable_expert_parallel:
-            input_length = min(input_length, 32)
-
+        if in_capturing:
+            input_length = self.fd_config.speculative_config.num_speculative_tokens + 1
+        else:
+            input_length = min(
+                num_tokens // batch_size,
+                self.model_config.max_model_len - max_dec_len,
+            )
         block_num = (
             input_length + self.cache_config.block_size - 1
         ) // self.cache_config.block_size + self.cache_config.enc_dec_block_num
@@ -1068,8 +1070,15 @@ class MetaxModelRunner(ModelRunnerBase):
             idx = i
             input_length = input_length_list[i]
             max_dec_len = max_dec_len_list[i]
-            self.share_inputs["input_ids"][idx : idx + 1, :input_length] = np.array([5] * input_length)
-            self.share_inputs["token_ids_all"][idx : idx + 1, :input_length] = np.array([5] * input_length)
+            # When EP is enabled, input tokens may be routed to the same expert if the input idss consist entirely of 5s.
+            # This can lead to OOM, so random input ids should be used instead.
+            if self.fd_config.parallel_config.enable_expert_parallel:
+                input_ids = np.random.randint(5, 10000, size=input_length)
+            else:
+                input_ids = np.array([5] * input_length)
+
+            self.share_inputs["input_ids"][idx : idx + 1, :input_length] = input_ids
+            self.share_inputs["token_ids_all"][idx : idx + 1, :input_length] = input_ids
             self.share_inputs["eos_token_id"][:] = np.array(
                 [2] * self.model_config.eos_tokens_lens, dtype="int64"
             ).reshape(-1, 1)
@@ -1725,6 +1734,7 @@ class MetaxModelRunner(ModelRunnerBase):
             num_tokens=num_tokens,
             batch_size=batch_size,
             expected_decode_len=expected_decode_len,
+            in_capturing=in_capturing,
             capture_prefill=capture_prefill,
         )
         self._dummy_prefill_inputs(
@@ -1737,6 +1747,7 @@ class MetaxModelRunner(ModelRunnerBase):
                 num_tokens=num_tokens,
                 batch_size=batch_size,
                 expected_decode_len=expected_decode_len,
+                in_capturing=in_capturing,
             )
 
         while True:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
之前的代码中，dummy run 时的输入 token 数目太大且全都路由到一个专家，且当时的 deepep buffer size 设置的比较小， cudagraph + ep 会跑出 nan，所以当时限制了 ep 时 dummy run 的输入 token 数目。但是 profile run 也会调用 dummy run，从而导致 ep 下的 profile 出来的 block 数目会过于理想，因此需要调整 ep 下 profile run 的 token 数目。

## Modifications

<!-- Detail the changes made in this pull request. -->
该 PR 修改了 dummy_run 时的 token 数目：
- 在 capture 时的 token 数目为：num_speculative_tokens + 1（当前 cudagraph 只跑 decode，与 sglang 实现一致）
- 在 profile run 时 token 数目不变，但是输入 token 改为 random 初始化而不是之前的全 5，否则 EP 下所有 token 会被路由到一个专家，导致所在的卡 OOM


## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
