### PR TITLE
[Cherry-Pick][BugFix] Fix skip_x_record_stream incompatibility across deep_ep versions(#7542)

### DIFF
--- a/fastdeploy/model_executor/layers/moe/ep.py
+++ b/fastdeploy/model_executor/layers/moe/ep.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """
 
+import inspect
 import traceback
 from abc import abstractmethod
 from types import ModuleType
@@ -602,6 +603,8 @@ class EPPrefillRunner(EPRunner):
             use_internode_ll_two_stage=use_internode_ll_two_stage,
         )
         self.num_worst_tokens = prefill_num_worst_tokens
+        self._dispatch_parameters: Optional[set] = None
+        self._combine_parameters: Optional[set] = None
         logger.info(f"prefill_num_worst_tokens {prefill_num_worst_tokens}")
 
     def set_allocate_on_comm_stream(allocate_on_comm_stream: bool = False):
@@ -656,8 +659,12 @@ class EPPrefillRunner(EPRunner):
         }
 
         if envs.FD_USE_PFCC_DEEP_EP:
-            dispatch_args["num_worst_tokens"] = self.num_worst_tokens
-            dispatch_args["skip_x_record_stream"] = self.num_worst_tokens > 0
+            if self._dispatch_parameters is None:
+                self._dispatch_parameters = set(inspect.signature(buffer.dispatch).parameters)
+            if "num_worst_tokens" in self._dispatch_parameters:
+                dispatch_args["num_worst_tokens"] = self.num_worst_tokens
+            if "skip_x_record_stream" in self._dispatch_parameters:
+                dispatch_args["skip_x_record_stream"] = self.num_worst_tokens > 0
 
         return buffer.dispatch(**dispatch_args)
 
@@ -683,7 +690,10 @@ class EPPrefillRunner(EPRunner):
         }
 
         if envs.FD_USE_PFCC_DEEP_EP:
-            combine_args["skip_x_record_stream"] = self.num_worst_tokens > 0
+            if self._combine_parameters is None:
+                self._combine_parameters = set(inspect.signature(buffer.combine).parameters)
+            if "skip_x_record_stream" in self._combine_parameters:
+                combine_args["skip_x_record_stream"] = self.num_worst_tokens > 0
 
         fused_moe_out, _, event = buffer.combine(**combine_args)
         return fused_moe_out, event


### PR DESCRIPTION
Cherry-pick of #7542 (authored by @yuanlehome) to `release/2.6`.

devPR:https://github.com/PaddlePaddle/FastDeploy/pull/7542 <!-- For pass CI -->

---

<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
不同版本的 `deep_ep` 库对 `buffer.dispatch` / `buffer.combine` 接口的参数支持不一致：
旧版本不包含 `num_worst_tokens` 或 `skip_x_record_stream` 参数，直接传入会导致 TypeError。

## Modifications
- 在 `dispatch` 中使用 `inspect.signature` 动态检查 `num_worst_tokens` / `skip_x_record_stream`
参数是否存在，仅在存在时才传入对应参数，实现跨版本兼容。
- 在 `combine` 中同理对 `skip_x_record_stream` 做条件传参。

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
- Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
- You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.