### PR TITLE
Revert "[CI] Temporarily pin paddlepaddle-gpu to 3.5.0.dev20260417"

### DIFF
--- a/.github/workflows/_accuracy_test.yml
+++ b/.github/workflows/_accuracy_test.yml
@@ -180,7 +180,7 @@ jobs:
           -e TZ="Asia/Shanghai" \
           -e "no_proxy=localhost,127.0.0.1,0.0.0.0,bcebos.com,.bcebos.com,bj.bcebos.com,su.bcebos.com,paddle-ci.gz.bcebos.com,apiin.im.baidu.com,baidu-int.com,.baidu.com,aliyun.com,gitee.com,pypi.tuna.tsinghua.edu.cn,.tuna.tsinghua.edu.cn" \
           --gpus '"device='"${DEVICES}"'"' ${docker_image} /bin/bash -xc '
-          python -m pip install paddlepaddle-gpu==3.5.0.dev20260417 -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
+          python -m pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
 
           pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
 

--- a/.github/workflows/_base_test.yml
+++ b/.github/workflows/_base_test.yml
@@ -213,7 +213,7 @@ jobs:
           -e TZ="Asia/Shanghai" \
           -e "no_proxy=localhost,127.0.0.1,0.0.0.0,bcebos.com,.bcebos.com,bj.bcebos.com,su.bcebos.com,paddle-ci.gz.bcebos.com,apiin.im.baidu.com,baidu-int.com,.baidu.com,aliyun.com,gitee.com,pypi.tuna.tsinghua.edu.cn,.tuna.tsinghua.edu.cn" \
           --gpus '"device='"${DEVICES}"'"' ${docker_image} /bin/bash -xc '
-          python -m pip install paddlepaddle-gpu==3.5.0.dev20260417 -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
+          python -m pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
 
           pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
 

--- a/.github/workflows/_build_linux.yml
+++ b/.github/workflows/_build_linux.yml
@@ -196,7 +196,7 @@ jobs:
             elif [[ "${PADDLEVERSION}" != "" ]];then
               python -m pip install paddlepaddle-gpu==${PADDLEVERSION} -i https://www.paddlepaddle.org.cn/packages/stable/cu126/
             else
-              python -m pip install paddlepaddle-gpu==3.5.0.dev20260417 -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
+              python -m pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
             fi
 
             pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple

--- a/.github/workflows/_build_linux_cu129.yml
+++ b/.github/workflows/_build_linux_cu129.yml
@@ -183,7 +183,7 @@ jobs:
             elif [[ "${PADDLEVERSION}" != "" ]];then
               python -m pip install paddlepaddle-gpu==${PADDLEVERSION} -i https://www.paddlepaddle.org.cn/packages/stable/cu129/
             else
-              python -m pip install paddlepaddle-gpu==3.5.0.dev20260417 -i https://www.paddlepaddle.org.cn/packages/nightly/cu129/
+              python -m pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu129/
             fi
 
             pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple

--- a/.github/workflows/_build_linux_cu130.yml
+++ b/.github/workflows/_build_linux_cu130.yml
@@ -183,7 +183,7 @@ jobs:
             elif [[ "${PADDLEVERSION}" != "" ]];then
               python -m pip install paddlepaddle-gpu==${PADDLEVERSION} -i https://www.paddlepaddle.org.cn/packages/stable/cu130/
             else
-              python -m pip install paddlepaddle-gpu==3.5.0.dev20260417 -i https://www.paddlepaddle.org.cn/packages/nightly/cu130/
+              python -m pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu130/
             fi
 
             pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple

--- a/.github/workflows/_build_linux_rl.yml
+++ b/.github/workflows/_build_linux_rl.yml
@@ -166,7 +166,8 @@ jobs:
             cd FastDeploy
 
             python -m pip uninstall paddlepaddle-gpu -y || true
-            python -m pip install paddlepaddle-gpu==3.5.0.dev20260417 -i https://www.paddlepaddle.org.cn/packages/nightly/cu129/
+            wget -q --no-proxy https://paddle-qa.bj.bcebos.com/paddle-pipeline/Develop-TagBuild-Training-Linux-Gpu-Cuda12.9-Cudnn9.9-Trt10.5-Mkl-Avx-Gcc11-SelfBuiltPypiUse/latest/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
+            python -m pip install paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl
 
             pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
 

--- a/.github/workflows/_golang_router_test.yml
+++ b/.github/workflows/_golang_router_test.yml
@@ -212,7 +212,7 @@ jobs:
           git config --global --add safe.directory /workspace/FastDeploy
           cd FastDeploy
 
-          python -m pip install paddlepaddle-gpu==3.5.0.dev20260417 -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
+          python -m pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
           pip config set global.extra-index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
 
           python -m pip install -r scripts/unittest_requirement.txt

--- a/.github/workflows/_gpu_4cards_case_test.yml
+++ b/.github/workflows/_gpu_4cards_case_test.yml
@@ -218,7 +218,7 @@ jobs:
           cd FastDeploy
           git diff origin/${BASE_REF}..HEAD --unified=0 > diff.txt
 
-          python -m pip install paddlepaddle-gpu==3.5.0.dev20260417 -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
+          python -m pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
           pip config set global.extra-index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
 
           python -m pip install -r scripts/unittest_requirement.txt

--- a/.github/workflows/_logprob_test_linux.yml
+++ b/.github/workflows/_logprob_test_linux.yml
@@ -189,7 +189,7 @@ jobs:
           -e TZ="Asia/Shanghai" \
           -e "no_proxy=localhost,127.0.0.1,0.0.0.0,bcebos.com,.bcebos.com,bj.bcebos.com,su.bcebos.com,paddle-ci.gz.bcebos.com,apiin.im.baidu.com,baidu-int.com,.baidu.com,aliyun.com,gitee.com,pypi.tuna.tsinghua.edu.cn,.tuna.tsinghua.edu.cn" \
           --gpus '"device='"${DEVICES}"'"' ${docker_image} /bin/bash -xc '
-          python -m pip install paddlepaddle-gpu==3.5.0.dev20260417 -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
+          python -m pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
 
           pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
 

--- a/.github/workflows/_pre_ce_test.yml
+++ b/.github/workflows/_pre_ce_test.yml
@@ -201,7 +201,7 @@ jobs:
           --gpus "\"device=${DEVICES}\"" ${docker_image} /bin/bash -c '
           git config --global --add safe.directory /workspace/FastDeploy
           cd FastDeploy
-          python -m pip install paddlepaddle-gpu==3.5.0.dev20260417 -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
+          python -m pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
           python -m pip install ${fd_wheel_url}
           bash scripts/run_pre_ce.sh
           '

--- a/.github/workflows/_stable_test.yml
+++ b/.github/workflows/_stable_test.yml
@@ -193,7 +193,7 @@ jobs:
           -e TZ="Asia/Shanghai" \
           -e "no_proxy=localhost,127.0.0.1,0.0.0.0,bcebos.com,.bcebos.com,bj.bcebos.com,su.bcebos.com,paddle-ci.gz.bcebos.com,apiin.im.baidu.com,baidu-int.com,.baidu.com,aliyun.com,gitee.com,pypi.tuna.tsinghua.edu.cn,.tuna.tsinghua.edu.cn" \
           --gpus '"device='"${DEVICES}"'"' ${docker_image} /bin/bash -xc '
-          python -m pip install paddlepaddle-gpu==3.5.0.dev20260417 -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
+          python -m pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
 
           pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
 

--- a/.github/workflows/_unit_test_coverage.yml
+++ b/.github/workflows/_unit_test_coverage.yml
@@ -224,7 +224,7 @@ jobs:
           git config --global --add safe.directory /workspace/FastDeploy
           cd FastDeploy
           git diff origin/${BASE_REF}..HEAD --unified=0 > diff.txt
-          python -m pip install paddlepaddle-gpu==3.5.0.dev20260417 -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
+          python -m pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu126/
           pip config set global.extra-index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
 
           python -m pip install -r scripts/unittest_requirement.txt

--- a/scripts/coverage_run.sh
+++ b/scripts/coverage_run.sh
@@ -43,17 +43,31 @@ classify_tests() {
     fi
 
     # Rule 5: high-risk OOM tests (treat as multi_gpu for sequential execution)
+    # Note: Flash Attention / operators requiring more pinned memory
     if [[ "$test_file" =~ ^tests/entrypoints/cli/ ||
-          "$test_file" == "tests/layers/test_append_attention_with_output.py" ||
-          "$test_file" == "tests/operators/test_get_position_ids_and_mask_encoder_batch.py" ||
-          "$test_file" == "tests/operators/test_group_swiglu_with_masked.py" ||
-          "$test_file" == "tests/operators/test_hybrid_mtp_ngram.py" ||
-          "$test_file" == "tests/operators/test_moe_top_k_select.py" ||
-          "$test_file" == "tests/operators/test_noaux_tc.py" ||
-          "$test_file" == "tests/operators/test_qk_rmsnorm_fused.py" ||
-          "$test_file" == "tests/output/test_get_save_output_v1.py" ||
-          "$test_file" == "tests/output/test_process_batch_draft_tokens.py" ||
-          "$test_file" == "tests/output/test_process_batch_output.py" ]]; then
+        "$test_file" == "tests/deterministic/test_penalty_kernel_determinism.py" ||
+        "$test_file" == "tests/deterministic/test_flash_attn_determinism.py" ||
+        "$test_file" == "tests/entrypoints/test_vllm_run_engine.py" ||
+        "$test_file" == "tests/input/test_preprocess.py" ||
+        "$test_file" == "tests/input/test_qwen3_vl_processor.py" ||
+        "$test_file" == "tests/layers/test_append_attention_with_output.py" ||
+        "$test_file" == "tests/layers/test_flash_attn_func.py" ||
+        "$test_file" == "tests/layers/test_native_paddle_backend.py" ||
+        "$test_file" == "tests/model_executor/test_ernie_tokenizer.py" ||
+        "$test_file" == "tests/operators/test_fused_get_rotary_embedding.py" ||
+        "$test_file" == "tests/operators/test_get_position_ids_and_mask_encoder_batch.py" ||
+        "$test_file" == "tests/operators/test_group_swiglu_with_masked.py" ||
+        "$test_file" == "tests/operators/test_hybrid_mtp_ngram.py" ||
+        "$test_file" == "tests/operators/test_moe_top_k_select.py" ||
+        "$test_file" == "tests/operators/test_naive_update_model_status.py" ||
+        "$test_file" == "tests/operators/test_noaux_tc.py" ||
+        "$test_file" == "tests/operators/test_qk_rmsnorm_fused.py" ||
+        "$test_file" == "tests/operators/test_tree_mask.py" ||
+        "$test_file" == "tests/operators/test_flash_mask_attn.py" ||
+        "$test_file" == "tests/output/test_get_save_output_v1.py" ||
+        "$test_file" == "tests/output/test_process_batch_draft_tokens.py" ||
+        "$test_file" == "tests/output/test_process_batch_output.py" ||
+        "$test_file" == "tests/reasoning/test_qwen3_reasoning_parser.py" ]]; then
         echo "multi_gpu"
         return
     fi


### PR DESCRIPTION
Reverts PaddlePaddle/FastDeploy#7486

<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

1. The temporary pin of `paddlepaddle-gpu` to `3.5.0.dev20260417` is no longer required. The underlying issue has been resolved or is no longer impacting CI, so keeping the pin would unnecessarily block version upgrades.
2. Some tests involving Flash Attention and related operators require higher pinned memory usage, which may exceed the limits of single-GPU environments and lead to instability or failures in CI.

## Modifications

- Reverted the previous change that pinned `paddlepaddle-gpu` to `3.5.0.dev20260417`.
- Restored default version resolution behavior in CI.
- Allowed CI to use newer Paddle versions going forward.
- Extended the test classification logic to include additional test cases under the `multi_gpu` category.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.