### PR TITLE
[Cherry-Pick][BugFix] support deepgemm without bias input(#7559)

### DIFF
--- a/fastdeploy/model_executor/layers/quantization/block_wise_fp8.py
+++ b/fastdeploy/model_executor/layers/quantization/block_wise_fp8.py
@@ -51,6 +51,19 @@ if current_platform.is_cuda():
 else:
     fp8_gemm_nt = None
 
+# Detect whether fp8_gemm_nt accepts a 'bias' keyword argument
+_fp8_gemm_nt_has_bias_kwarg = False
+if fp8_gemm_nt is not None:
+    import inspect
+
+    try:
+        _sig = inspect.signature(fp8_gemm_nt)
+        _fp8_gemm_nt_has_bias_kwarg = "bias" in _sig.parameters
+    except (ValueError, TypeError):
+        # pybind11 functions may not expose signatures via inspect;
+        # fall back to a cheap probe call to determine support.
+        pass
+
 
 class BlockWiseFP8Config(QuantConfigBase):
     """
@@ -128,14 +141,22 @@ def deep_gemm_fp8_gemm_nt(
     sm_version = get_sm_version()
     if sm_version >= 100 and current_platform.is_cuda():
         # disable_ue8m0_cast is default False for SM100
-        fp8_gemm_nt(
-            (x, x_scale_tensor),
-            (layer_weight, layer_weight_scale_inv),
-            linear_out,
-            bias=bias,
-        )
+        if _fp8_gemm_nt_has_bias_kwarg:
+            fp8_gemm_nt(
+                (x, x_scale_tensor),
+                (layer_weight, layer_weight_scale_inv),
+                linear_out,
+                bias=bias,
+            )
+        else:
+            fp8_gemm_nt(
+                (x, x_scale_tensor),
+                (layer_weight, layer_weight_scale_inv),
+                linear_out,
+            )
+            if bias is not None:
+                linear_out = paddle.add(linear_out, bias)
     else:
-        # disable_ue8m0_cast is default False for SM100
         fp8_gemm_nt(
             (x, x_scale_tensor),
             (layer_weight, layer_weight_scale_inv),


### PR DESCRIPTION
Cherry-pick of #7559 (authored by @zoooo0820) to `release/2.6`.

devPR:https://github.com/PaddlePaddle/FastDeploy/pull/7559 <!-- For pass CI -->

---

<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

适配deepgemm缺少bias参数时的处理

## Modifications

<!-- Detail the changes made in this pull request. -->

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
- Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
- You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
