### PR TITLE
[Cherry-Pick][RL] Remove redundant barrier and optimize model weights signal broadcast(#7545)

### DIFF
--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -316,10 +316,9 @@ class PaddleDisWorkerProc:
         self.experts_manager.tensor_infos = None
 
     def _broadcast_model_weights_signal(self, src: int, group) -> int:
-        model_weights_signal_tensor = paddle.full(shape=[1], fill_value=self.model_weights_signal[0], dtype="int32")
-        paddle.distributed.broadcast(model_weights_signal_tensor, src=src, group=group)
-        value = model_weights_signal_tensor.numpy()[0]
-        return int(value)
+        signal_list = [self.model_weights_signal[0]]
+        paddle.distributed.broadcast_object_list(signal_list, src=src, group=group)
+        return int(signal_list[0])
 
     def _tp_barrier_wait(self):
         if current_platform.is_xpu() or self.enable_overlap_schedule:
@@ -507,9 +506,9 @@ class PaddleDisWorkerProc:
             self._tp_barrier_wait() if tp_size > 1 else None
 
             if self.fd_config.load_config.dynamic_load_weight and not envs.FD_ENABLE_V1_UPDATE_WEIGHTS:
-                if self.ranks > 1:
-                    paddle.distributed.barrier()
                 if self.model_weights_signal[0] != ModelWeightsStatus.NORMAL:
+                    if self.ranks > 1:
+                        paddle.distributed.barrier()
                     logger.info(
                         f"Rank: {self.local_rank} to update or clear parameters, signal is {self.model_weights_signal[0]}, [-1:clear, 1:update]"
                     )


### PR DESCRIPTION
Cherry-pick of #7545 (authored by @Sunny-bot1) to `release/2.6`.

devPR:https://github.com/PaddlePaddle/FastDeploy/pull/7545 <!-- For pass CI -->

---

<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

在 dynamic_load_weight 场景下，`_broadcast_model_weights_signal` 使用 GPU tensor
进行 broadcast，CPU端使用这个值后会触发`.numpy()` 的 DtoH 同步；同时在dynamic_load_weight
分支下无条件调用 `paddle.distributed.barrier()`，会引入不必要的全局同步开销。

## Modifications

<!-- Detail the changes made in this pull request. -->

**1. 优化 `_broadcast_model_weights_signal`**
- 将 GPU tensor + `paddle.distributed.broadcast` + `.numpy()` 的方式替换为 `paddle.distributed.broadcast_object_list`
- 避免了 GPU tensor 的创建 以及DtoH 同步开销

**2. 移除冗余的 `paddle.distributed.barrier()`**
- 将 barrier 移入 `model_weights_signal != NORMAL` 分支内，仅在异常情况下才做全局同步


## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
- Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
- You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.