### PR TITLE
[Cherry-Pick][Optimization] Support async D2H copy for MTP logprobs & Clean up overlap schedule condition checks  (#7521)

### DIFF
--- a/fastdeploy/engine/args_utils.py
+++ b/fastdeploy/engine/args_utils.py
@@ -579,12 +579,7 @@ class EngineArgs:
             and not current_platform.is_maca()
         ):
             self.enable_prefix_caching = False
-        if (
-            not current_platform.is_cuda()
-            or (self.speculative_config is not None and self.enable_logprob)
-            or self.splitwise_role == "prefill"
-            or self.dynamic_load_weight
-        ):
+        if not current_platform.is_cuda() or self.splitwise_role == "prefill":
             self.enable_overlap_schedule = False
         if self.enable_logprob:
             if not current_platform.is_cuda() and not current_platform.is_xpu():

--- a/fastdeploy/model_executor/layers/sample/logprobs.py
+++ b/fastdeploy/model_executor/layers/sample/logprobs.py
@@ -123,7 +123,18 @@ def gather_logprobs(
         indices = token_ids
         top_logprobs = token_logprobs
 
-    return LogprobsTensors(indices.cpu(), top_logprobs.cpu(), token_ranks.cpu())
+    if current_platform.is_cuda():
+        indices_cpu = paddle.empty_like(indices, device="cpu").pin_memory()
+        top_logprobs_cpu = paddle.empty_like(top_logprobs, device="cpu").pin_memory()
+        token_ranks_cpu = paddle.empty_like(token_ranks, device="cpu").pin_memory()
+        indices_cpu.copy_(indices, False)
+        top_logprobs_cpu.copy_(top_logprobs, False)
+        token_ranks_cpu.copy_(token_ranks, False)
+    else:
+        indices_cpu = indices.cpu()
+        top_logprobs_cpu = top_logprobs.cpu()
+        token_ranks_cpu = token_ranks.cpu()
+    return LogprobsTensors(indices_cpu, top_logprobs_cpu, token_ranks_cpu)
 
 
 def build_output_logprobs(

--- a/fastdeploy/model_executor/layers/sample/sampler.py
+++ b/fastdeploy/model_executor/layers/sample/sampler.py
@@ -948,7 +948,18 @@ class SpeculativeSampler(nn.Layer):
             indices = token_ids
             top_logprobs = token_logprobs
 
-        return LogprobsTensors(indices, top_logprobs, token_ranks)
+        if current_platform.is_cuda():
+            indices_cpu = paddle.empty_like(indices, device="cpu").pin_memory()
+            top_logprobs_cpu = paddle.empty_like(top_logprobs, device="cpu").pin_memory()
+            token_ranks_cpu = paddle.empty_like(token_ranks, device="cpu").pin_memory()
+            indices_cpu.copy_(indices, False)
+            top_logprobs_cpu.copy_(top_logprobs, False)
+            token_ranks_cpu.copy_(token_ranks, False)
+        else:
+            indices_cpu = indices.cpu()
+            top_logprobs_cpu = top_logprobs.cpu()
+            token_ranks_cpu = token_ranks.cpu()
+        return LogprobsTensors(indices_cpu, top_logprobs_cpu, token_ranks_cpu)
 
     def _verify_and_sample(
         self,
@@ -1488,7 +1499,18 @@ class MTPSampler(nn.Layer):
             indices = token_ids
             top_logprobs = token_logprobs
 
-        return LogprobsTensors(indices, top_logprobs, token_ranks)
+        if current_platform.is_cuda():
+            indices_cpu = paddle.empty_like(indices, device="cpu").pin_memory()
+            top_logprobs_cpu = paddle.empty_like(top_logprobs, device="cpu").pin_memory()
+            token_ranks_cpu = paddle.empty_like(token_ranks, device="cpu").pin_memory()
+            indices_cpu.copy_(indices, False)
+            top_logprobs_cpu.copy_(top_logprobs, False)
+            token_ranks_cpu.copy_(token_ranks, False)
+        else:
+            indices_cpu = indices.cpu()
+            top_logprobs_cpu = top_logprobs.cpu()
+            token_ranks_cpu = token_ranks.cpu()
+        return LogprobsTensors(indices_cpu, top_logprobs_cpu, token_ranks_cpu)
 
     def forward_cuda(
         self,


### PR DESCRIPTION
Cherry-pick of #7521 (authored by @Sunny-bot1) to `release/2.6`.

devPR:https://github.com/PaddlePaddle/FastDeploy/pull/7521 <!-- For pass CI -->

---

<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications

<!-- Detail the changes made in this pull request. -->

fastdeploy/engine/args_utils.py
- 移除 enable_overlap_schedule 的限制条件：不再因为 speculative_config is not None and enable_logprob 或 dynamic_load_weight 而强制关闭 overlap schedule。

fastdeploy/model_executor/layers/sample/logprobs.py
fastdeploy/model_executor/layers/sample/sampler.py（SpeculativeSampler 和 MTPSampler）
- 在 CUDA 平台上，使用 pinned memory + 非阻塞拷贝（copy_(blocking=False)）替换同步的 .cpu() 调用，实现 logprob 张量的异步 D2H 传输。
- 非 CUDA 平台保持原有同步拷贝行为不变。

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
- Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
- You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.