### PR TITLE
fix ksm in tool_call

### DIFF
--- a/fastdeploy/entrypoints/openai/serving_chat.py
+++ b/fastdeploy/entrypoints/openai/serving_chat.py
@@ -227,6 +227,9 @@ class OpenAIServingChat:
         num_cached_tokens = 0
         num_image_tokens = [0] * num_choices
         tool_called = [False] * num_choices
+        pending_sampling_masks: list[list] = [[] for _ in range(num_choices)]
+        pending_logprobs: list[list] = [[] for _ in range(num_choices)]
+        pending_draft_logprobs: list[list] = [[] for _ in range(num_choices)]
         inference_start_time = [0] * num_choices
         max_streaming_response_tokens = (
             request.max_streaming_response_tokens
@@ -407,8 +410,31 @@ class OpenAIServingChat:
                     if output["tool_calls"] is not None:
                         tool_called[idx] = True
 
+                    # Accumulate per-token metadata before the skip check so
+                    # that data from buffered (skipped) steps is not lost.
+                    if output.get("sampling_mask") is not None:
+                        pending_sampling_masks[idx].extend(
+                            self._make_sampling_mask_list(output["sampling_mask"])
+                        )
+                    if logprobs_res is not None and logprobs_res.content:
+                        pending_logprobs[idx].extend(logprobs_res.content)
+                    if draft_logprobs_res is not None and draft_logprobs_res.content:
+                        pending_draft_logprobs[idx].extend(draft_logprobs_res.content)
+
                     if output["skipped"] and not request.return_token_ids:
                         continue
+
+                    # Flush accumulated per-token metadata into the current chunk.
+                    flushed_sampling_mask = pending_sampling_masks[idx] or None
+                    pending_sampling_masks[idx] = []
+
+                    flushed_logprobs = LogProbs(content=pending_logprobs[idx]) if pending_logprobs[idx] else logprobs_res
+                    pending_logprobs[idx] = []
+
+                    flushed_draft_logprobs = (
+                        LogProbs(content=pending_draft_logprobs[idx]) if pending_draft_logprobs[idx] else draft_logprobs_res
+                    )
+                    pending_draft_logprobs[idx] = []
 
                     delta_message = DeltaMessage(
                         reasoning_content=output["reasoning_content"],
@@ -430,13 +456,9 @@ class OpenAIServingChat:
                     choice = ChatCompletionResponseStreamChoice(
                         index=idx,
                         delta=delta_message,
-                        logprobs=logprobs_res,
-                        draft_logprobs=draft_logprobs_res,
-                        sampling_mask=(
-                            self._make_sampling_mask_list(output["sampling_mask"])
-                            if output.get("sampling_mask") is not None
-                            else None
-                        ),
+                        logprobs=flushed_logprobs,
+                        draft_logprobs=flushed_draft_logprobs,
+                        sampling_mask=flushed_sampling_mask,
                         arrival_time=arrival_time,
                         speculate_metrics=output_speculate_metrics,
                     )


### PR DESCRIPTION
## Motivation

Streaming 模式下，当 tool parser 处于缓冲状态时，`text_processor` 会将中间 step 标记为 `skipped=True`，`serving_chat.py` 对这些 step 直接 `continue` 跳过。这导致被跳过 step 携带的 `sampling_mask`、`logprobs`、`draft_logprobs` 等 per-token 元数据全部丢失，客户端收到的 `sampling_mask` 字段为 `None`。

## Modifications

在 `serving_chat.py` 的 streaming 路径中：

1. 新增 3 个 per-choice 累积缓冲区：`pending_sampling_masks`、`pending_logprobs`、`pending_draft_logprobs`。
2. 在 `skipped` 导致 `continue` **之前**，将当前 step 的 per-token 元数据 `extend` 到缓冲区，确保即使 step 被跳过，数据也不会丢失。
3. 在下一个非 skip 的 chunk 中，将缓冲区数据 flush 到 `ChatCompletionResponseStreamChoice`，随 chunk 一并发送给客户端。

安全性保证：当 `is_end=True` 时，`text_processor` 不会设置 `skipped=True`（`if not is_end:` 保护），因此最后一步一定会触发 flush，不会有残留数据。

## Usage or Command

启用 `--enable_keep_sampling_mask` 参数，使用带 tool call 的 streaming chat 请求即可验证 `sampling_mask` 不再为 `None`。

## Accuracy Tests

本次修改不影响模型计算逻辑，仅修复 streaming 响应中 per-token 元数据的传递链路，无精度影响。

## Checklist

- [x] Add at least a tag in the PR title.
  - `[BugFix][APIServer]`
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
  - 该 bug 涉及 streaming tool call 的端到端链路，需要完整的 engine + API server 环境，难以用单元测试覆盖，建议通过集成测试验证。
- [x] Provide accuracy results.
  - 不涉及模型精度变更。
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
