### PR TITLE
[Optimization][DeepSeekV3.2]Precompute the attention_mask_offset for Prefill in the Indexer

### DIFF
--- a/fastdeploy/model_executor/forward_meta.py
+++ b/fastdeploy/model_executor/forward_meta.py
@@ -164,6 +164,7 @@ class ForwardMeta:
 
     # for mla & dsa
     position_ids: Optional[paddle.Tensor] = None
+    indexer_attn_mask_offsets: Optional[paddle.Tensor] = None
     # for kvcache slot
     slot_mapping: Optional[paddle.Tensor] = None
 

--- a/fastdeploy/model_executor/layers/attention/dsa_attention_backend.py
+++ b/fastdeploy/model_executor/layers/attention/dsa_attention_backend.py
@@ -45,6 +45,7 @@ from fastdeploy.model_executor.layers.attention.base_attention_backend import (
     AttentionMetadata,
 )
 from fastdeploy.model_executor.layers.attention.utils import init_rank_and_device_id
+from fastdeploy.model_executor.ops.triton_ops import update_indexer_attn_mask_offsets
 
 
 def yarn_get_mscale(scale=1, mscale=1):
@@ -196,6 +197,16 @@ class DSAAttentionBackend(AttentionBackend):
         result = result.view(num_blocks, block_size, 1, -1)
         return result
 
+    def _update_forward_meta(self, forward_meta: ForwardMeta):
+        """Update forward meta data."""
+        # Indexer attn_mask_offset
+        forward_meta.indexer_attn_mask_offsets = update_indexer_attn_mask_offsets(
+            forward_meta.ids_remove_padding,
+            forward_meta.seq_lens_this_time,
+            forward_meta.seq_lens_encoder,
+            forward_meta.cu_seqlens_k,
+        )
+
     def init_attention_metadata(self, forward_meta: ForwardMeta):
         """Initialize attention metadata hence all layers in the forward pass can reuse it."""
         metadata = DSAAttentionMetadata()
@@ -256,6 +267,7 @@ class DSAAttentionBackend(AttentionBackend):
                 self.rank, int(self.device_id), self.keep_pd_step_flag
             )
 
+        self._update_forward_meta(forward_meta)
         self.attention_metadata: AttentionMetadata = metadata
 
     def get_attention_meta(self) -> AttentionMetadata:

--- a/fastdeploy/model_executor/models/deepseek_v3.py
+++ b/fastdeploy/model_executor/models/deepseek_v3.py
@@ -676,28 +676,8 @@ class Indexer(nn.Layer):
             k_scale_cache_real = k_scale_cache.flatten()[: k.shape[0]].contiguous()
             k_cache = k_fp8_cache.view(paddle.float8_e4m3fn), k_scale_cache_real
 
-            # # TODO(changwenbin): Constructed using maskoffset
-            # # ks,ke = forward_meta.attn_mask_offsets[::2].contiguous(),forward_meta.attn_mask_offsets[1::2].contiguous()
-            # num_tokens = q_fp8.shape[0]
-            # ks = paddle.zeros(num_tokens, dtype=paddle.int32)
-            # ke = paddle.zeros(num_tokens, dtype=paddle.int32)
-
-            # bsz = forward_meta.seq_lens_this_time.shape[0]
-            # for i in range(bsz):
-            #     if forward_meta.seq_lens_encoder[i] > 0:
-            #         token_start_k = forward_meta.cu_seqlens_k[i]
-            #         token_end_k = forward_meta.cu_seqlens_k[i + 1]
-            #         ks[token_start_k:token_end_k] = forward_meta.cu_seqlens_k[i]
-            #         ke[token_start_k:token_end_k] = paddle.arange(token_start_k, token_end_k, dtype=paddle.int32) + 1
-
-            # if forward_meta.indexer_attn_mask_offsets is not None:
-            #     if self.layer_id == 60:
-            #         print("using indexer_attn_mask_offsets")
-            #     assert forward_meta.indexer_attn_mask_offsets.shape[0] == num_tokens * 2
-            #     ks_tmp = forward_meta.indexer_attn_mask_offsets[::2].contiguous()
-            #     ke_tmp = forward_meta.indexer_attn_mask_offsets[1::2].contiguous()
-            #     assert (ks_tmp == ks).all(), ks_tmp - ks
-            #     assert (ke_tmp == ke).all(), ke_tmp - ke
+            # indexer_attn_mask_offsets is pre-computed by the Triton kernel
+            # update_indexer_attn_mask_offsets in dsa_attention_backend and stored in forward_meta.
             ks = forward_meta.indexer_attn_mask_offsets[::2].contiguous()
             ke = forward_meta.indexer_attn_mask_offsets[1::2].contiguous()
             max_seqlen_k = (ke - ks).max().item()

--- a/fastdeploy/model_executor/models/deepseek_v3.py
+++ b/fastdeploy/model_executor/models/deepseek_v3.py
@@ -70,6 +70,8 @@ if current_platform.is_cuda():
         radix_topk_ragged_transform,
     )
 
+    paddle.enable_compat(scope={"deep_gemm": True})
+
 
 class DeepSeekV3MLP(nn.Layer):
     """
@@ -659,7 +661,8 @@ class Indexer(nn.Layer):
             k, self.indexer_cache, forward_meta.slot_mapping, self.quant_block_size, self.scale_fmt
         )
 
-        from fastdeploy.model_executor.layers.quantization.fp8_utils import deep_gemm
+        # from fastdeploy.model_executor.layers.quantization.fp8_utils import deep_gemm
+        import deep_gemm
 
         if forward_meta.max_len_tensor_cpu[1]:
 
@@ -687,6 +690,14 @@ class Indexer(nn.Layer):
                     ks[token_start_k:token_end_k] = forward_meta.cu_seqlens_k[i]
                     ke[token_start_k:token_end_k] = paddle.arange(token_start_k, token_end_k, dtype=paddle.int32) + 1
 
+            if forward_meta.indexer_attn_mask_offsets is not None:
+                if self.layer_id == 60:
+                    print("using indexer_attn_mask_offsets")
+                assert forward_meta.indexer_attn_mask_offsets.shape[0] == num_tokens * 2
+                ks_tmp = forward_meta.indexer_attn_mask_offsets[::2].contiguous()
+                ke_tmp = forward_meta.indexer_attn_mask_offsets[1::2].contiguous()
+                assert (ks_tmp == ks).all(), ks_tmp - ks
+                assert (ke_tmp == ke).all(), ke_tmp - ke
             max_seqlen_k = (ke - ks).max().item()
 
             logits = deep_gemm.fp8_mqa_logits(

--- a/fastdeploy/model_executor/models/deepseek_v3.py
+++ b/fastdeploy/model_executor/models/deepseek_v3.py
@@ -70,8 +70,6 @@ if current_platform.is_cuda():
         radix_topk_ragged_transform,
     )
 
-    paddle.enable_compat(scope={"deep_gemm": True})
-
 
 class DeepSeekV3MLP(nn.Layer):
     """
@@ -661,8 +659,7 @@ class Indexer(nn.Layer):
             k, self.indexer_cache, forward_meta.slot_mapping, self.quant_block_size, self.scale_fmt
         )
 
-        # from fastdeploy.model_executor.layers.quantization.fp8_utils import deep_gemm
-        import deep_gemm
+        from fastdeploy.model_executor.layers.quantization.fp8_utils import deep_gemm
 
         if forward_meta.max_len_tensor_cpu[1]:
 

--- a/fastdeploy/model_executor/models/deepseek_v3.py
+++ b/fastdeploy/model_executor/models/deepseek_v3.py
@@ -676,28 +676,30 @@ class Indexer(nn.Layer):
             k_scale_cache_real = k_scale_cache.flatten()[: k.shape[0]].contiguous()
             k_cache = k_fp8_cache.view(paddle.float8_e4m3fn), k_scale_cache_real
 
-            # TODO(changwenbin): Constructed using maskoffset
-            # ks,ke = forward_meta.attn_mask_offsets[::2].contiguous(),forward_meta.attn_mask_offsets[1::2].contiguous()
-            num_tokens = q_fp8.shape[0]
-            ks = paddle.zeros(num_tokens, dtype=paddle.int32)
-            ke = paddle.zeros(num_tokens, dtype=paddle.int32)
+            # # TODO(changwenbin): Constructed using maskoffset
+            # # ks,ke = forward_meta.attn_mask_offsets[::2].contiguous(),forward_meta.attn_mask_offsets[1::2].contiguous()
+            # num_tokens = q_fp8.shape[0]
+            # ks = paddle.zeros(num_tokens, dtype=paddle.int32)
+            # ke = paddle.zeros(num_tokens, dtype=paddle.int32)
 
-            bsz = forward_meta.seq_lens_this_time.shape[0]
-            for i in range(bsz):
-                if forward_meta.seq_lens_encoder[i] > 0:
-                    token_start_k = forward_meta.cu_seqlens_k[i]
-                    token_end_k = forward_meta.cu_seqlens_k[i + 1]
-                    ks[token_start_k:token_end_k] = forward_meta.cu_seqlens_k[i]
-                    ke[token_start_k:token_end_k] = paddle.arange(token_start_k, token_end_k, dtype=paddle.int32) + 1
+            # bsz = forward_meta.seq_lens_this_time.shape[0]
+            # for i in range(bsz):
+            #     if forward_meta.seq_lens_encoder[i] > 0:
+            #         token_start_k = forward_meta.cu_seqlens_k[i]
+            #         token_end_k = forward_meta.cu_seqlens_k[i + 1]
+            #         ks[token_start_k:token_end_k] = forward_meta.cu_seqlens_k[i]
+            #         ke[token_start_k:token_end_k] = paddle.arange(token_start_k, token_end_k, dtype=paddle.int32) + 1
 
-            if forward_meta.indexer_attn_mask_offsets is not None:
-                if self.layer_id == 60:
-                    print("using indexer_attn_mask_offsets")
-                assert forward_meta.indexer_attn_mask_offsets.shape[0] == num_tokens * 2
-                ks_tmp = forward_meta.indexer_attn_mask_offsets[::2].contiguous()
-                ke_tmp = forward_meta.indexer_attn_mask_offsets[1::2].contiguous()
-                assert (ks_tmp == ks).all(), ks_tmp - ks
-                assert (ke_tmp == ke).all(), ke_tmp - ke
+            # if forward_meta.indexer_attn_mask_offsets is not None:
+            #     if self.layer_id == 60:
+            #         print("using indexer_attn_mask_offsets")
+            #     assert forward_meta.indexer_attn_mask_offsets.shape[0] == num_tokens * 2
+            #     ks_tmp = forward_meta.indexer_attn_mask_offsets[::2].contiguous()
+            #     ke_tmp = forward_meta.indexer_attn_mask_offsets[1::2].contiguous()
+            #     assert (ks_tmp == ks).all(), ks_tmp - ks
+            #     assert (ke_tmp == ke).all(), ke_tmp - ke
+            ks = forward_meta.indexer_attn_mask_offsets[::2].contiguous()
+            ke = forward_meta.indexer_attn_mask_offsets[1::2].contiguous()
             max_seqlen_k = (ke - ks).max().item()
 
             logits = deep_gemm.fp8_mqa_logits(

--- a/fastdeploy/model_executor/ops/triton_ops/__init__.py
+++ b/fastdeploy/model_executor/ops/triton_ops/__init__.py
@@ -15,6 +15,7 @@
 """
 
 try:
+    from .indexer_update_attn_mask_offsets import update_indexer_attn_mask_offsets
     from .pre_token_quant_fp8_kernel import _per_token_group_quant_fp8
     from .qk_rmsnorm_fused_kernel import qk_rmsnorm_fused
     from .repetition_early_stop_kernel import repetition_early_stopper_kernel
@@ -27,6 +28,7 @@ try:
         "repetition_early_stopper_kernel",
         "qk_rmsnorm_fused",
         "_per_token_group_quant_fp8",
+        "update_indexer_attn_mask_offsets",
     ]
 except:
     _TRITON_AVAILABLE = False

--- a/fastdeploy/model_executor/ops/triton_ops/indexer_update_attn_mask_offsets.py
+++ b/fastdeploy/model_executor/ops/triton_ops/indexer_update_attn_mask_offsets.py
@@ -1,5 +1,5 @@
 """
-# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/fastdeploy/model_executor/ops/triton_ops/indexer_update_attn_mask_offsets.py
+++ b/fastdeploy/model_executor/ops/triton_ops/indexer_update_attn_mask_offsets.py
@@ -36,37 +36,29 @@ def update_attn_mask_offsets_kernel(
     seq_lens_this_time: [bsz]
     seq_lens_encoder: [bsz]
     cu_seqlens_k: [bsz+1]
-    attn_mask_offsets: [num_tokens * 2]
-        - 偶数位 = start
-        - 奇数位 = end
+    attn_mask_offsets: [num_tokens * 2], even indices = start, odd indices = end
     """
     batch_id = tl.program_id(0)
 
     seq_len_encoder = tl.load(seq_lens_encoder_ptr + batch_id)
 
-    # decode 请求（seq_lens_encoder == 0）的 token 在 Indexer 中不走 prefill 路径
-    # attn_mask_offsets 对应位置保持 0，无需写入，直接跳过
+    # Skip decode requests (seq_lens_encoder == 0); offsets remain 0
     if seq_len_encoder <= 0:
         return
 
     seq_len_this_time = tl.load(seq_lens_this_time_ptr + batch_id)
-    token_start_k = tl.load(cu_seqlens_k_ptr + batch_id)  # 本 batch 在 flatten token 维度的起始偏移
+    token_start_k = tl.load(cu_seqlens_k_ptr + batch_id)  # start offset in flattened token dim
 
-    # 每个 block 负责一个 batch，内部用 BLOCK_M 分块遍历该 batch 的所有 token
     for block_start in range(0, seq_len_this_time, BLOCK_M):
-        offsets = block_start + tl.arange(0, BLOCK_M)  # 相对于本 batch 起始的 token 局部偏移
+        offsets = block_start + tl.arange(0, BLOCK_M)
         mask = offsets < seq_len_this_time
 
-        # 在 flatten token 维度中的全局 token 索引
         global_token_idx = token_start_k + offsets  # [BLOCK_M]
 
-        # start：causal 窗口左边界 = 本 batch k 序列的起始位置（所有 token 相同）
+        # causal window: start = batch k start (same for all tokens), end = current token + 1
         ks = tl.full((BLOCK_M,), token_start_k, dtype=tl.int32)
-
-        # end：causal 窗口右边界 = 当前 token 的全局索引 + 1（只能 attend 到自身及之前）
         ke = (global_token_idx + 1).to(tl.int32)
 
-        # 写入 attn_mask_offsets，偶数位存 start，奇数位存 end
         tl.store(attn_mask_offsets_ptr + global_token_idx * 2, ks, mask=mask)
         tl.store(attn_mask_offsets_ptr + global_token_idx * 2 + 1, ke, mask=mask)
 
@@ -85,8 +77,7 @@ def update_indexer_attn_mask_offsets(
     bsz = seq_lens_this_time.shape[0]
     attention_mask_offset = paddle.zeros((num_tokens * 2), dtype=paddle.int32)
 
-    # 每个 batch 对应一个 Triton program，BLOCK_SIZE 为每个 program 内处理 token 的粒度
-    BLOCK_SIZE = 128
+    BLOCK_M = 128
     grid = (bsz,)
 
     update_attn_mask_offsets_kernel[grid](
@@ -94,6 +85,6 @@ def update_indexer_attn_mask_offsets(
         seq_lens_encoder,
         cu_seqlens_k,
         attention_mask_offset,
-        BLOCK_M=BLOCK_SIZE,
+        BLOCK_M,
     )
     return attention_mask_offset

--- a/fastdeploy/model_executor/ops/triton_ops/indexer_update_attn_mask_offsets.py
+++ b/fastdeploy/model_executor/ops/triton_ops/indexer_update_attn_mask_offsets.py
@@ -1,0 +1,99 @@
+"""
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
+import paddle
+import triton
+import triton.language as tl
+
+from fastdeploy.model_executor.ops.triton_ops.triton_utils import (
+    enable_compat_on_triton_kernel,
+)
+
+
+@enable_compat_on_triton_kernel
+@triton.jit
+def update_attn_mask_offsets_kernel(
+    seq_lens_this_time_ptr,
+    seq_lens_encoder_ptr,
+    cu_seqlens_k_ptr,
+    attn_mask_offsets_ptr,
+    BLOCK_M: tl.constexpr,
+):
+    """
+    seq_lens_this_time: [bsz]
+    seq_lens_encoder: [bsz]
+    cu_seqlens_k: [bsz+1]
+    attn_mask_offsets: [num_tokens * 2]
+        - 偶数位 = start
+        - 奇数位 = end
+    """
+    batch_id = tl.program_id(0)
+
+    seq_len_encoder = tl.load(seq_lens_encoder_ptr + batch_id)
+
+    # decode 请求（seq_lens_encoder == 0）的 token 在 Indexer 中不走 prefill 路径
+    # attn_mask_offsets 对应位置保持 0，无需写入，直接跳过
+    if seq_len_encoder <= 0:
+        return
+
+    seq_len_this_time = tl.load(seq_lens_this_time_ptr + batch_id)
+    token_start_k = tl.load(cu_seqlens_k_ptr + batch_id)  # 本 batch 在 flatten token 维度的起始偏移
+
+    # 每个 block 负责一个 batch，内部用 BLOCK_M 分块遍历该 batch 的所有 token
+    for block_start in range(0, seq_len_this_time, BLOCK_M):
+        offsets = block_start + tl.arange(0, BLOCK_M)  # 相对于本 batch 起始的 token 局部偏移
+        mask = offsets < seq_len_this_time
+
+        # 在 flatten token 维度中的全局 token 索引
+        global_token_idx = token_start_k + offsets  # [BLOCK_M]
+
+        # start：causal 窗口左边界 = 本 batch k 序列的起始位置（所有 token 相同）
+        ks = tl.full((BLOCK_M,), token_start_k, dtype=tl.int32)
+
+        # end：causal 窗口右边界 = 当前 token 的全局索引 + 1（只能 attend 到自身及之前）
+        ke = (global_token_idx + 1).to(tl.int32)
+
+        # 写入 attn_mask_offsets，偶数位存 start，奇数位存 end
+        tl.store(attn_mask_offsets_ptr + global_token_idx * 2, ks, mask=mask)
+        tl.store(attn_mask_offsets_ptr + global_token_idx * 2 + 1, ke, mask=mask)
+
+
+def update_indexer_attn_mask_offsets(
+    ids_remove_padding,
+    seq_lens_this_time,
+    seq_lens_encoder,
+    cu_seqlens_k,
+):
+    assert ids_remove_padding.ndim == 1
+    assert seq_lens_this_time.ndim == 1
+    assert seq_lens_encoder.ndim == 1
+    assert cu_seqlens_k.ndim == 1
+    num_tokens = ids_remove_padding.shape[0]
+    bsz = seq_lens_this_time.shape[0]
+    attention_mask_offset = paddle.zeros((num_tokens * 2), dtype=paddle.int32)
+
+    # 每个 batch 对应一个 Triton program，BLOCK_SIZE 为每个 program 内处理 token 的粒度
+    BLOCK_SIZE = 128
+    grid = (bsz,)
+
+    update_attn_mask_offsets_kernel[grid](
+        seq_lens_this_time,
+        seq_lens_encoder,
+        cu_seqlens_k,
+        attention_mask_offset,
+        BLOCK_M=BLOCK_SIZE,
+    )
+    return attention_mask_offset

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -88,6 +88,9 @@ else:
         get_position_ids_and_mask_encoder_batch,
         update_attn_mask_offsets,
     )
+    from fastdeploy.model_executor.ops.triton_ops import (
+        update_indexer_attn_mask_offsets,
+    )
 
 import zmq
 
@@ -1335,6 +1338,15 @@ class GPUModelRunner(ModelRunnerBase):
             )
             self.share_inputs["attn_mask_offsets"].copy_(attn_mask_offsets, False)
 
+        if self.use_dsa:
+            indexer_attn_mask_offsets = update_indexer_attn_mask_offsets(
+                self.share_inputs["ids_remove_padding"],
+                self.share_inputs["seq_lens_this_time"],
+                self.share_inputs["seq_lens_encoder"],
+                self.share_inputs["cu_seqlens_k"],
+            )
+            self.share_inputs["indexer_attn_mask_offsets"] = indexer_attn_mask_offsets
+
         # Initialize forward meta data
         self.initialize_forward_meta(is_dummy_or_profile_run=is_dummy_or_profile_run)
         self.forward_meta.real_bsz = real_bsz
@@ -1472,6 +1484,7 @@ class GPUModelRunner(ModelRunnerBase):
             kv_tile_ids_per_batch=self.share_inputs["kv_tile_ids_per_batch"],
             kv_num_blocks_x_cpu=self.share_inputs["kv_num_blocks_x_cpu"],
             attn_mask_offsets=self.share_inputs["attn_mask_offsets"] if self.enable_mm else None,
+            indexer_attn_mask_offsets=self.share_inputs["indexer_attn_mask_offsets"] if self.use_dsa else None,
             routing_replay_table=routing_replay_table,
         )
 
@@ -1737,7 +1750,7 @@ class GPUModelRunner(ModelRunnerBase):
             encoder_block_shape_q=encoder_block_shape_q,
             decoder_block_shape_q=decoder_block_shape_q,
         )
-
+        self.use_dsa = True if isinstance(attn_backend, DSAAttentionBackend) else False
         self.attn_backends.append(attn_backend)
 
     def _dummy_pooler_run_task(

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -88,9 +88,6 @@ else:
         get_position_ids_and_mask_encoder_batch,
         update_attn_mask_offsets,
     )
-    from fastdeploy.model_executor.ops.triton_ops import (
-        update_indexer_attn_mask_offsets,
-    )
 
 import zmq
 
@@ -1338,15 +1335,6 @@ class GPUModelRunner(ModelRunnerBase):
             )
             self.share_inputs["attn_mask_offsets"].copy_(attn_mask_offsets, False)
 
-        if self.use_dsa:
-            indexer_attn_mask_offsets = update_indexer_attn_mask_offsets(
-                self.share_inputs["ids_remove_padding"],
-                self.share_inputs["seq_lens_this_time"],
-                self.share_inputs["seq_lens_encoder"],
-                self.share_inputs["cu_seqlens_k"],
-            )
-            self.share_inputs["indexer_attn_mask_offsets"] = indexer_attn_mask_offsets
-
         # Initialize forward meta data
         self.initialize_forward_meta(is_dummy_or_profile_run=is_dummy_or_profile_run)
         self.forward_meta.real_bsz = real_bsz
@@ -1484,7 +1472,6 @@ class GPUModelRunner(ModelRunnerBase):
             kv_tile_ids_per_batch=self.share_inputs["kv_tile_ids_per_batch"],
             kv_num_blocks_x_cpu=self.share_inputs["kv_num_blocks_x_cpu"],
             attn_mask_offsets=self.share_inputs["attn_mask_offsets"] if self.enable_mm else None,
-            indexer_attn_mask_offsets=self.share_inputs["indexer_attn_mask_offsets"] if self.use_dsa else None,
             routing_replay_table=routing_replay_table,
         )
 
@@ -1750,7 +1737,6 @@ class GPUModelRunner(ModelRunnerBase):
             encoder_block_shape_q=encoder_block_shape_q,
             decoder_block_shape_q=decoder_block_shape_q,
         )
-        self.use_dsa = True if isinstance(attn_backend, DSAAttentionBackend) else False
         self.attn_backends.append(attn_backend)
 
     def _dummy_pooler_run_task(

--- a/fastdeploy/worker/input_batch.py
+++ b/fastdeploy/worker/input_batch.py
@@ -206,6 +206,7 @@ class InputBatch:
         self.kv_batch_ids = None
         self.kv_tile_ids_per_batch = None
         self.kv_num_blocks_x_cpu = None  # CPU
+        self.indexer_attn_mask_offsets = None  # For Indexer in DSA Backend
 
         # Initialize thinking related buffers
         self.enable_thinking = paddle.full(shape=[max_num_seqs, 1], fill_value=True, dtype="bool")

--- a/fastdeploy/worker/input_batch.py
+++ b/fastdeploy/worker/input_batch.py
@@ -206,7 +206,6 @@ class InputBatch:
         self.kv_batch_ids = None
         self.kv_tile_ids_per_batch = None
         self.kv_num_blocks_x_cpu = None  # CPU
-        self.indexer_attn_mask_offsets = None  # For Indexer in DSA Backend
 
         # Initialize thinking related buffers
         self.enable_thinking = paddle.full(shape=[max_num_seqs, 1], fill_value=True, dtype="bool")

--- a/tests/model_executor/ops/triton_ops/test_indexer_update_attn_mask_offsets.py
+++ b/tests/model_executor/ops/triton_ops/test_indexer_update_attn_mask_offsets.py
@@ -239,6 +239,90 @@ class TestIndexerUpdateAttnMaskOffsets(unittest.TestCase):
         k_lens = seq_lens_this_time  # cu_seqlens_k = cumsum(seq_lens_this_time)
         self._run_and_compare(seq_lens_this_time, seq_lens_encoder, k_lens)
 
+    # ------------------------------------------------------------------
+    # Extreme scenario stress test cases
+    # ------------------------------------------------------------------
+
+    def test_very_large_seq_len(self):
+        """Single sequence with 4096 tokens to stress-test multi-block tiling."""
+        seq_len = 4096
+        self._run_and_compare(
+            seq_lens_this_time_list=[seq_len],
+            seq_lens_encoder_list=[seq_len],
+            k_lens_list=[seq_len],
+        )
+
+    def test_very_large_batch_size(self):
+        """Batch size of 256 with short sequences to stress-test grid-level parallelism."""
+        bsz = 256
+        seq_lens = [4] * bsz
+        self._run_and_compare(
+            seq_lens_this_time_list=seq_lens,
+            seq_lens_encoder_list=seq_lens,
+            k_lens_list=seq_lens,
+        )
+
+    def test_large_batch_long_seq(self):
+        """Large batch (bsz=64) each with long sequences (len=256) to stress both dimensions."""
+        bsz = 64
+        seq_lens = [256] * bsz
+        self._run_and_compare(
+            seq_lens_this_time_list=seq_lens,
+            seq_lens_encoder_list=seq_lens,
+            k_lens_list=seq_lens,
+        )
+
+    def test_highly_variable_seq_lens(self):
+        """Batch with highly variable sequence lengths spanning 1 to 512 tokens.
+        Tests correctness when per-batch token counts differ by orders of magnitude.
+        """
+        import random
+
+        random.seed(42)
+        bsz = 32
+        seq_lens = [random.choice([1, 2, 8, 64, 128, 256, 512]) for _ in range(bsz)]
+        seq_lens_encoder = [s if random.random() > 0.3 else 0 for s in seq_lens]
+        # For decode slots, use q_len=1 as k_len; for prefill slots keep original length.
+        k_lens = [seq_lens[i] if seq_lens_encoder[i] > 0 else 1 for i in range(bsz)]
+        # Align seq_lens_this_time with k_lens so cu_seqlens_k stays consistent.
+        seq_lens_this_time = k_lens
+        self._run_and_compare(seq_lens_this_time, seq_lens_encoder, k_lens)
+
+    def test_large_batch_all_decode(self):
+        """Large all-decode batch (bsz=128); every output position must be zero."""
+        bsz = 128
+        seq_lens_this_time = [1] * bsz
+        seq_lens_encoder = [0] * bsz
+        k_lens = [1] * bsz
+        self._run_and_compare(seq_lens_this_time, seq_lens_encoder, k_lens)
+
+    def test_single_extreme_long_seq(self):
+        """Single prefill sequence with 8192 tokens to cover large BLOCK_M tile boundaries."""
+        seq_len = 8192
+        self._run_and_compare(
+            seq_lens_this_time_list=[seq_len],
+            seq_lens_encoder_list=[seq_len],
+            k_lens_list=[seq_len],
+        )
+
+    def test_large_mixed_uneven_lens(self):
+        """Large mixed batch (bsz=64) where prefill sequences have uneven lengths.
+        Decode slots are scattered at every third position.
+        """
+        bsz = 64
+        seq_lens_this_time = []
+        seq_lens_encoder = []
+        for i in range(bsz):
+            if i % 3 == 0:
+                seq_lens_this_time.append(1)
+                seq_lens_encoder.append(0)
+            else:
+                length = (i % 16) + 1  # lengths cycle 1..16 for prefill slots
+                seq_lens_this_time.append(length)
+                seq_lens_encoder.append(length)
+        k_lens = seq_lens_this_time
+        self._run_and_compare(seq_lens_this_time, seq_lens_encoder, k_lens)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/model_executor/ops/triton_ops/test_indexer_update_attn_mask_offsets.py
+++ b/tests/model_executor/ops/triton_ops/test_indexer_update_attn_mask_offsets.py
@@ -1,5 +1,5 @@
 """
-# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,11 +25,11 @@ from fastdeploy.model_executor.ops.triton_ops.indexer_update_attn_mask_offsets i
 
 
 def ref_update_attn_mask_offsets(seq_lens_this_time, seq_lens_encoder, cu_seqlens_k):
-    """Python 参考实现，与 deepseek_v3.py 中的原始循环语义对齐。
-    返回 attn_mask_offsets: [num_tokens * 2], 偶数位=start, 奇数位=end
+    """Python reference implementation aligned with the original loop semantics in deepseek_v3.py.
+    Returns attn_mask_offsets: [num_tokens * 2], even positions = start, odd positions = end
 
-    注意：cu_seqlens_k 在 Indexer 中是 Q 侧的累积长度（cumsum of seq_lens_this_time），
-    因此 num_tokens 应取 sum(seq_lens_this_time) 而非 cu_seqlens_k[-1]。
+    Note: cu_seqlens_k in Indexer is the cumulative length on the Q side (cumsum of seq_lens_this_time),
+    so num_tokens should be sum(seq_lens_this_time) rather than cu_seqlens_k[-1].
     """
     num_tokens = int(sum(int(s.numpy()) for s in seq_lens_this_time))
     result = np.zeros(num_tokens * 2, dtype=np.int32)
@@ -40,13 +40,13 @@ def ref_update_attn_mask_offsets(seq_lens_this_time, seq_lens_encoder, cu_seqlen
             token_start_k = int(cu_seqlens_k[i].numpy())
             token_end_k = int(cu_seqlens_k[i + 1].numpy())
             for t in range(token_start_k, token_end_k):
-                result[t * 2] = token_start_k  # start: 本 batch 的 k 起始偏移
-                result[t * 2 + 1] = t + 1  # end: 当前 token 全局索引 + 1
+                result[t * 2] = token_start_k  # start: k start offset of current batch
+                result[t * 2 + 1] = t + 1  # end: global token index + 1
     return result
 
 
 def make_cu_seqlens(seq_lens):
-    """从每个序列的长度列表构造 cu_seqlens（前缀和）。"""
+    """Build cu_seqlens (prefix sum) from a list of sequence lengths."""
     cu = [0]
     for s in seq_lens:
         cu.append(cu[-1] + s)
@@ -56,7 +56,7 @@ def make_cu_seqlens(seq_lens):
 class TestIndexerUpdateAttnMaskOffsets(unittest.TestCase):
 
     def _run_and_compare(self, seq_lens_this_time_list, seq_lens_encoder_list, k_lens_list):
-        """构造输入，运行 Triton kernel 和参考实现，对比结果。"""
+        """Build inputs, run the Triton kernel and reference implementation, then compare results."""
         seq_lens_this_time = paddle.to_tensor(seq_lens_this_time_list, dtype=paddle.int32)
         seq_lens_encoder = paddle.to_tensor(seq_lens_encoder_list, dtype=paddle.int32)
         cu_seqlens_k = make_cu_seqlens(k_lens_list)
@@ -80,11 +80,11 @@ class TestIndexerUpdateAttnMaskOffsets(unittest.TestCase):
         )
 
     # ------------------------------------------------------------------
-    # 基础功能用例
+    # Basic functional test cases
     # ------------------------------------------------------------------
 
     def test_single_prefill_seq(self):
-        """单条 prefill 序列，4 个 token。"""
+        """Single prefill sequence with 4 tokens."""
         self._run_and_compare(
             seq_lens_this_time_list=[4],
             seq_lens_encoder_list=[4],
@@ -92,7 +92,7 @@ class TestIndexerUpdateAttnMaskOffsets(unittest.TestCase):
         )
 
     def test_single_token_prefill(self):
-        """边界：只有 1 个 token 的 prefill 序列。"""
+        """Edge case: prefill sequence with only 1 token."""
         self._run_and_compare(
             seq_lens_this_time_list=[1],
             seq_lens_encoder_list=[1],
@@ -100,7 +100,7 @@ class TestIndexerUpdateAttnMaskOffsets(unittest.TestCase):
         )
 
     def test_single_decode_seq(self):
-        """单条 decode 序列，所有输出应全为 0（decode 路径不写 offsets）。"""
+        """Single decode sequence; all outputs should be 0 (decode path does not write offsets)."""
         self._run_and_compare(
             seq_lens_this_time_list=[1],
             seq_lens_encoder_list=[0],
@@ -108,11 +108,11 @@ class TestIndexerUpdateAttnMaskOffsets(unittest.TestCase):
         )
 
     # ------------------------------------------------------------------
-    # 多 batch 用例
+    # Multi-batch test cases
     # ------------------------------------------------------------------
 
     def test_multi_prefill_batch(self):
-        """多条 prefill 序列，长度不同。"""
+        """Multiple prefill sequences with different lengths."""
         self._run_and_compare(
             seq_lens_this_time_list=[3, 5, 2],
             seq_lens_encoder_list=[3, 5, 2],
@@ -120,8 +120,8 @@ class TestIndexerUpdateAttnMaskOffsets(unittest.TestCase):
         )
 
     def test_all_decode_batch(self):
-        """全 decode batch，所有偶数/奇数位均应为 0。
-        decode 请求的 k_len = seq_lens_this_time（Q 侧长度），不是 KV cache 历史长度。
+        """All-decode batch; all even/odd positions should be 0.
+        For decode requests, k_len = seq_lens_this_time (Q-side length), not KV cache history length.
         """
         self._run_and_compare(
             seq_lens_this_time_list=[1, 1, 1],
@@ -130,8 +130,8 @@ class TestIndexerUpdateAttnMaskOffsets(unittest.TestCase):
         )
 
     def test_mixed_prefill_decode_batch(self):
-        """混合 batch：第 0 条是 prefill，第 1 条是 decode，第 2 条是 prefill。
-        decode 请求 k_len = seq_lens_this_time = 1（Q 侧长度）。
+        """Mixed batch: index 0 is prefill, index 1 is decode, index 2 is prefill.
+        For decode requests, k_len = seq_lens_this_time = 1 (Q-side length).
         """
         self._run_and_compare(
             seq_lens_this_time_list=[4, 1, 3],
@@ -140,14 +140,14 @@ class TestIndexerUpdateAttnMaskOffsets(unittest.TestCase):
         )
 
     # ------------------------------------------------------------------
-    # 数值正确性校验
+    # Numerical correctness verification
     # ------------------------------------------------------------------
 
     def test_prefill_ks_ke_values(self):
-        """精确验证 prefill token 的 start/end 值。
+        """Exactly verify the start/end values for prefill tokens.
 
-        场景：bsz=1, seq=[0,1,2], k_start=0
-        期望：
+        Scenario: bsz=1, seq=[0,1,2], k_start=0
+        Expected:
             token 0: start=0, end=1
             token 1: start=0, end=2
             token 2: start=0, end=3
@@ -166,12 +166,12 @@ class TestIndexerUpdateAttnMaskOffsets(unittest.TestCase):
         np.testing.assert_array_equal(out, expected)
 
     def test_prefill_with_nonzero_k_start(self):
-        """验证 k_start 非 0 时 start 偏移正确传播。
+        """Verify that start offset propagates correctly when k_start is non-zero.
 
-        场景：bsz=2，第 0 条 decode（q_len=1），第 1 条 prefill（q_len=3）
+        Scenario: bsz=2, index 0 is decode (q_len=1), index 1 is prefill (q_len=3)
         cu_seqlens_k = cumsum(seq_lens_this_time) = [0, 1, 4]
-        第 1 条 k_start=1，全局 token 索引 = 1,2,3
-        期望：
+        k_start=1 for index 1, global token indices = 1, 2, 3
+        Expected:
             token 0 (decode): start=0, end=0
             token 1: start=1, end=2
             token 2: start=1, end=3
@@ -192,7 +192,7 @@ class TestIndexerUpdateAttnMaskOffsets(unittest.TestCase):
         np.testing.assert_array_equal(out, expected)
 
     def test_decode_tokens_remain_zero(self):
-        """decode token 对应的位置必须保持 0，不被 kernel 改写。"""
+        """Decode token positions must remain 0 and must not be overwritten by the kernel."""
         seq_lens_this_time = paddle.to_tensor([1, 4], dtype=paddle.int32)
         seq_lens_encoder = paddle.to_tensor([0, 4], dtype=paddle.int32)
         cu_seqlens_k = paddle.to_tensor([0, 1, 5], dtype=paddle.int32)
@@ -202,16 +202,16 @@ class TestIndexerUpdateAttnMaskOffsets(unittest.TestCase):
             ids_remove_padding, seq_lens_this_time, seq_lens_encoder, cu_seqlens_k
         ).numpy()
 
-        # 第 0 条 decode：token 0 的 start/end 均应为 0
+        # Decode request at index 0: start/end of token 0 should both be 0
         self.assertEqual(out[0], 0, "decode token start should be 0")
         self.assertEqual(out[1], 0, "decode token end should be 0")
 
     # ------------------------------------------------------------------
-    # 大序列压力用例
+    # Large sequence stress test cases
     # ------------------------------------------------------------------
 
     def test_large_seq_len(self):
-        """较长序列，确保 BLOCK_M 分块循环逻辑正确。"""
+        """Long sequence to verify correctness of the BLOCK_M tiled loop logic."""
         seq_len = 512
         self._run_and_compare(
             seq_lens_this_time_list=[seq_len],
@@ -220,7 +220,7 @@ class TestIndexerUpdateAttnMaskOffsets(unittest.TestCase):
         )
 
     def test_large_batch(self):
-        """较大 batch，验证多 program 并行结果正确。"""
+        """Large batch to verify correctness of multi-program parallel results."""
         bsz = 32
         seq_lens = [8] * bsz
         self._run_and_compare(
@@ -230,8 +230,8 @@ class TestIndexerUpdateAttnMaskOffsets(unittest.TestCase):
         )
 
     def test_large_mixed_batch(self):
-        """大规模混合 batch，交替 prefill/decode。
-        decode 请求 k_len = seq_lens_this_time = 1。
+        """Large-scale mixed batch with alternating prefill/decode.
+        For decode requests, k_len = seq_lens_this_time = 1.
         """
         bsz = 20
         seq_lens_this_time = [6 if i % 2 == 0 else 1 for i in range(bsz)]

--- a/tests/model_executor/ops/triton_ops/test_indexer_update_attn_mask_offsets.py
+++ b/tests/model_executor/ops/triton_ops/test_indexer_update_attn_mask_offsets.py
@@ -1,0 +1,244 @@
+"""
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
+import unittest
+
+import numpy as np
+import paddle
+
+from fastdeploy.model_executor.ops.triton_ops.indexer_update_attn_mask_offsets import (
+    update_indexer_attn_mask_offsets,
+)
+
+
+def ref_update_attn_mask_offsets(seq_lens_this_time, seq_lens_encoder, cu_seqlens_k):
+    """Python 参考实现，与 deepseek_v3.py 中的原始循环语义对齐。
+    返回 attn_mask_offsets: [num_tokens * 2], 偶数位=start, 奇数位=end
+
+    注意：cu_seqlens_k 在 Indexer 中是 Q 侧的累积长度（cumsum of seq_lens_this_time），
+    因此 num_tokens 应取 sum(seq_lens_this_time) 而非 cu_seqlens_k[-1]。
+    """
+    num_tokens = int(sum(int(s.numpy()) for s in seq_lens_this_time))
+    result = np.zeros(num_tokens * 2, dtype=np.int32)
+
+    bsz = len(seq_lens_this_time)
+    for i in range(bsz):
+        if int(seq_lens_encoder[i].numpy()) > 0:
+            token_start_k = int(cu_seqlens_k[i].numpy())
+            token_end_k = int(cu_seqlens_k[i + 1].numpy())
+            for t in range(token_start_k, token_end_k):
+                result[t * 2] = token_start_k  # start: 本 batch 的 k 起始偏移
+                result[t * 2 + 1] = t + 1  # end: 当前 token 全局索引 + 1
+    return result
+
+
+def make_cu_seqlens(seq_lens):
+    """从每个序列的长度列表构造 cu_seqlens（前缀和）。"""
+    cu = [0]
+    for s in seq_lens:
+        cu.append(cu[-1] + s)
+    return paddle.to_tensor(cu, dtype=paddle.int32)
+
+
+class TestIndexerUpdateAttnMaskOffsets(unittest.TestCase):
+
+    def _run_and_compare(self, seq_lens_this_time_list, seq_lens_encoder_list, k_lens_list):
+        """构造输入，运行 Triton kernel 和参考实现，对比结果。"""
+        seq_lens_this_time = paddle.to_tensor(seq_lens_this_time_list, dtype=paddle.int32)
+        seq_lens_encoder = paddle.to_tensor(seq_lens_encoder_list, dtype=paddle.int32)
+        cu_seqlens_k = make_cu_seqlens(k_lens_list)
+
+        num_tokens = int(sum(seq_lens_this_time_list))
+        ids_remove_padding = paddle.zeros([num_tokens], dtype=paddle.int32)
+
+        triton_out = update_indexer_attn_mask_offsets(
+            ids_remove_padding,
+            seq_lens_this_time,
+            seq_lens_encoder,
+            cu_seqlens_k,
+        ).numpy()
+
+        ref_out = ref_update_attn_mask_offsets(seq_lens_this_time, seq_lens_encoder, cu_seqlens_k)
+
+        np.testing.assert_array_equal(
+            triton_out,
+            ref_out,
+            err_msg=f"Mismatch!\ntriton: {triton_out}\nref:    {ref_out}",
+        )
+
+    # ------------------------------------------------------------------
+    # 基础功能用例
+    # ------------------------------------------------------------------
+
+    def test_single_prefill_seq(self):
+        """单条 prefill 序列，4 个 token。"""
+        self._run_and_compare(
+            seq_lens_this_time_list=[4],
+            seq_lens_encoder_list=[4],
+            k_lens_list=[4],
+        )
+
+    def test_single_token_prefill(self):
+        """边界：只有 1 个 token 的 prefill 序列。"""
+        self._run_and_compare(
+            seq_lens_this_time_list=[1],
+            seq_lens_encoder_list=[1],
+            k_lens_list=[1],
+        )
+
+    def test_single_decode_seq(self):
+        """单条 decode 序列，所有输出应全为 0（decode 路径不写 offsets）。"""
+        self._run_and_compare(
+            seq_lens_this_time_list=[1],
+            seq_lens_encoder_list=[0],
+            k_lens_list=[1],
+        )
+
+    # ------------------------------------------------------------------
+    # 多 batch 用例
+    # ------------------------------------------------------------------
+
+    def test_multi_prefill_batch(self):
+        """多条 prefill 序列，长度不同。"""
+        self._run_and_compare(
+            seq_lens_this_time_list=[3, 5, 2],
+            seq_lens_encoder_list=[3, 5, 2],
+            k_lens_list=[3, 5, 2],
+        )
+
+    def test_all_decode_batch(self):
+        """全 decode batch，所有偶数/奇数位均应为 0。
+        decode 请求的 k_len = seq_lens_this_time（Q 侧长度），不是 KV cache 历史长度。
+        """
+        self._run_and_compare(
+            seq_lens_this_time_list=[1, 1, 1],
+            seq_lens_encoder_list=[0, 0, 0],
+            k_lens_list=[1, 1, 1],
+        )
+
+    def test_mixed_prefill_decode_batch(self):
+        """混合 batch：第 0 条是 prefill，第 1 条是 decode，第 2 条是 prefill。
+        decode 请求 k_len = seq_lens_this_time = 1（Q 侧长度）。
+        """
+        self._run_and_compare(
+            seq_lens_this_time_list=[4, 1, 3],
+            seq_lens_encoder_list=[4, 0, 3],
+            k_lens_list=[4, 1, 3],
+        )
+
+    # ------------------------------------------------------------------
+    # 数值正确性校验
+    # ------------------------------------------------------------------
+
+    def test_prefill_ks_ke_values(self):
+        """精确验证 prefill token 的 start/end 值。
+
+        场景：bsz=1, seq=[0,1,2], k_start=0
+        期望：
+            token 0: start=0, end=1
+            token 1: start=0, end=2
+            token 2: start=0, end=3
+        """
+        seq_lens_this_time = paddle.to_tensor([3], dtype=paddle.int32)
+        seq_lens_encoder = paddle.to_tensor([3], dtype=paddle.int32)
+        cu_seqlens_k = paddle.to_tensor([0, 3], dtype=paddle.int32)
+        ids_remove_padding = paddle.zeros([3], dtype=paddle.int32)
+
+        out = update_indexer_attn_mask_offsets(
+            ids_remove_padding, seq_lens_this_time, seq_lens_encoder, cu_seqlens_k
+        ).numpy()
+
+        # [ks0, ke0, ks1, ke1, ks2, ke2]
+        expected = np.array([0, 1, 0, 2, 0, 3], dtype=np.int32)
+        np.testing.assert_array_equal(out, expected)
+
+    def test_prefill_with_nonzero_k_start(self):
+        """验证 k_start 非 0 时 start 偏移正确传播。
+
+        场景：bsz=2，第 0 条 decode（q_len=1），第 1 条 prefill（q_len=3）
+        cu_seqlens_k = cumsum(seq_lens_this_time) = [0, 1, 4]
+        第 1 条 k_start=1，全局 token 索引 = 1,2,3
+        期望：
+            token 0 (decode): start=0, end=0
+            token 1: start=1, end=2
+            token 2: start=1, end=3
+            token 3: start=1, end=4
+        """
+        seq_lens_this_time = paddle.to_tensor([1, 3], dtype=paddle.int32)
+        seq_lens_encoder = paddle.to_tensor([0, 3], dtype=paddle.int32)
+        cu_seqlens_k = paddle.to_tensor([0, 1, 4], dtype=paddle.int32)
+        ids_remove_padding = paddle.zeros([4], dtype=paddle.int32)  # 1+3 tokens
+
+        out = update_indexer_attn_mask_offsets(
+            ids_remove_padding, seq_lens_this_time, seq_lens_encoder, cu_seqlens_k
+        ).numpy()
+
+        # token 0 (decode): [0, 0]
+        # token 1,2,3 (prefill): start=1; end=2,3,4
+        expected = np.array([0, 0, 1, 2, 1, 3, 1, 4], dtype=np.int32)
+        np.testing.assert_array_equal(out, expected)
+
+    def test_decode_tokens_remain_zero(self):
+        """decode token 对应的位置必须保持 0，不被 kernel 改写。"""
+        seq_lens_this_time = paddle.to_tensor([1, 4], dtype=paddle.int32)
+        seq_lens_encoder = paddle.to_tensor([0, 4], dtype=paddle.int32)
+        cu_seqlens_k = paddle.to_tensor([0, 1, 5], dtype=paddle.int32)
+        ids_remove_padding = paddle.zeros([5], dtype=paddle.int32)  # 1+4 tokens
+
+        out = update_indexer_attn_mask_offsets(
+            ids_remove_padding, seq_lens_this_time, seq_lens_encoder, cu_seqlens_k
+        ).numpy()
+
+        # 第 0 条 decode：token 0 的 start/end 均应为 0
+        self.assertEqual(out[0], 0, "decode token start should be 0")
+        self.assertEqual(out[1], 0, "decode token end should be 0")
+
+    # ------------------------------------------------------------------
+    # 大序列压力用例
+    # ------------------------------------------------------------------
+
+    def test_large_seq_len(self):
+        """较长序列，确保 BLOCK_M 分块循环逻辑正确。"""
+        seq_len = 512
+        self._run_and_compare(
+            seq_lens_this_time_list=[seq_len],
+            seq_lens_encoder_list=[seq_len],
+            k_lens_list=[seq_len],
+        )
+
+    def test_large_batch(self):
+        """较大 batch，验证多 program 并行结果正确。"""
+        bsz = 32
+        seq_lens = [8] * bsz
+        self._run_and_compare(
+            seq_lens_this_time_list=seq_lens,
+            seq_lens_encoder_list=seq_lens,
+            k_lens_list=seq_lens,
+        )
+
+    def test_large_mixed_batch(self):
+        """大规模混合 batch，交替 prefill/decode。
+        decode 请求 k_len = seq_lens_this_time = 1。
+        """
+        bsz = 20
+        seq_lens_this_time = [6 if i % 2 == 0 else 1 for i in range(bsz)]
+        seq_lens_encoder = [6 if i % 2 == 0 else 0 for i in range(bsz)]
+        k_lens = seq_lens_this_time  # cu_seqlens_k = cumsum(seq_lens_this_time)
+        self._run_and_compare(seq_lens_this_time, seq_lens_encoder, k_lens)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
In DeepSeekV3.2's Indexer Prefill stage, the `attention_mask_offset` (i.e., the causal attention window `[ks, ke)` for each token) was previously computed via Python loops on CPU — iterating batch by batch and token by token. This becomes a bottleneck on the critical forward path when handling large batch sizes or long sequences.

This PR precomputes `attention_mask_offset` using a Triton kernel on GPU during `init_attention_metadata`, eliminating the CPU-side Python loop overhead and improving Prefill throughput for the Indexer attention backend.
<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications
- **`fastdeploy/model_executor/ops/triton_ops/indexer_update_attn_mask_offsets.py`** *(new file)*
  Implements the Triton kernel `update_indexer_attn_mask_offsets` that batch-computes the causal attention window `[ks, ke)` for all prefill tokens in a single GPU kernel launch. Also provides a Python reference implementation `ref_update_attn_mask_offsets` for correctness verification.
- **`fastdeploy/model_executor/layers/attention/dsa_attention_backend.py`**
  Adds a `_update_forward_meta` method that calls `update_indexer_attn_mask_offsets` to precompute `attention_mask_offset` and stores the result into `forward_meta.indexer_attn_mask_offsets`.
- **`fastdeploy/model_executor/forward_meta.py`**
  Adds `indexer_attn_mask_offsets` field to `ForwardMeta` to carry the precomputed offsets.

<!-- Detail the changes made in this pull request. -->

## Usage or Command
No API changes. The optimization is transparent to users. To verify correctness, run:
```
python -m pytest tests/model_executor/ops/triton_ops/test_indexer_update_attn_mask_offsets.py -v
```
<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests
The new Triton kernel is validated against the Python reference implementation `ref_update_attn_mask_offsets` in the unit tests, covering:
- Edge cases (single token, empty sequences)
- Mixed-batch scenarios with varying sequence lengths
No changes to model forward logic or kernel math — accuracy of model outputs is unaffected.
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
