### PR TITLE
[CI] Add retry for OOM/Kill in run_tests_with_coverage

### DIFF
--- a/scripts/coverage_run.sh
+++ b/scripts/coverage_run.sh
@@ -42,46 +42,18 @@ classify_tests() {
         fi
     fi
 
-    # Rule 5: high-risk OOM tests (treat as multi_gpu for sequential execution)
-    # Note: Flash Attention / operators requiring more pinned memory
-    if [[ "$test_file" =~ ^tests/entrypoints/cli/ ||
-        "$test_file" == "tests/deterministic/test_penalty_kernel_determinism.py" ||
-        "$test_file" == "tests/deterministic/test_flash_attn_determinism.py" ||
-        "$test_file" == "tests/entrypoints/test_vllm_run_engine.py" ||
-        "$test_file" == "tests/input/test_preprocess.py" ||
-        "$test_file" == "tests/input/test_qwen3_vl_processor.py" ||
-        "$test_file" == "tests/layers/test_append_attention_with_output.py" ||
-        "$test_file" == "tests/layers/test_flash_attn_func.py" ||
-        "$test_file" == "tests/layers/test_native_paddle_backend.py" ||
-        "$test_file" == "tests/model_executor/test_ernie_tokenizer.py" ||
-        "$test_file" == "tests/operators/test_fused_get_rotary_embedding.py" ||
-        "$test_file" == "tests/operators/test_get_position_ids_and_mask_encoder_batch.py" ||
-        "$test_file" == "tests/operators/test_group_swiglu_with_masked.py" ||
-        "$test_file" == "tests/operators/test_hybrid_mtp_ngram.py" ||
-        "$test_file" == "tests/operators/test_moe_top_k_select.py" ||
-        "$test_file" == "tests/operators/test_naive_update_model_status.py" ||
-        "$test_file" == "tests/operators/test_noaux_tc.py" ||
-        "$test_file" == "tests/operators/test_qk_rmsnorm_fused.py" ||
-        "$test_file" == "tests/operators/test_tree_mask.py" ||
-        "$test_file" == "tests/operators/test_flash_mask_attn.py" ||
-        "$test_file" == "tests/output/test_get_save_output_v1.py" ||
-        "$test_file" == "tests/output/test_process_batch_draft_tokens.py" ||
-        "$test_file" == "tests/output/test_process_batch_output.py" ||
-        "$test_file" == "tests/reasoning/test_qwen3_reasoning_parser.py" ]]; then
-        echo "multi_gpu"
-        return
-    fi
-
     # ========== Single-GPU tests (no port required, can run in parallel) ==========
     echo "single_gpu"
 }
 
 # ============================================================
-# Run Test With Logging
+# Run Test With Logging (with retry for OOM/Kill)
 # ============================================================
 run_test_with_logging() {
     local test_file=$1
     local log_prefix=$2
+    local max_retries=3  # Max retries for OOM/Kill issues
+    local retry_count=0
     local status
 
     echo "Running pytest file: $test_file"
@@ -97,14 +69,37 @@ run_test_with_logging() {
     # Set FD_LOG_DIR to isolate logs for each test
     export FD_LOG_DIR="$isolated_log_dir"
 
-    # Run test
-    timeout 600 python -m coverage run -m pytest -c ${PYTEST_INI} "$test_file" -vv -s
-    status=$?
+    # Retry loop for OOM/Kill issues (only handle "Killed" / SIGKILL)
+    while [ $retry_count -le $max_retries ]; do
+        if [ $retry_count -gt 0 ]; then
+            echo ""
+            echo "==================== Retrying (${retry_count}/${max_retries}) ===================="
+            echo "Previous attempt was Killed, retrying..."
+            # Clean up before retry
+            sleep 5  # Wait a bit to let resources be released
+        fi
+
+        # Run test
+        timeout 600 python -m coverage run -m pytest -c ${PYTEST_INI} "$test_file" -vv -s
+        status=$?
+
+        # Exit code 137 = SIGKILL (Killed / OOM)
+        if [ "$status" -eq 137 ] && [ $retry_count -lt $max_retries ]; then
+            retry_count=$((retry_count + 1))
+            continue
+        fi
+
+        # Break loop on success or non-Kill error or max retries reached
+        break
+    done
 
     if [ "$status" -ne 0 ]; then
         echo "$test_file" >> "$log_prefix"
         echo ""
         echo "==================== Test Failed: $test_file ===================="
+        if [ $retry_count -gt 0 ]; then
+            echo "Total attempts: $((retry_count + 1))"
+        fi
 
         # Use isolated log directory for this test
         if [ -d "$isolated_log_dir" ]; then


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
Some tests may intermittently fail due to `OOM` or process kill issues, especially under constrained CI resources. Previously, a high-risk OOM test list was maintained to mitigate this, but it increases maintenance overhead.

Introducing a retry mechanism provides a more robust and scalable solution to handle transient failures without excluding tests.

## Modifications
- Added retry logic for tests in `Run Test With Logging` stage in `run_tests_with_coverage` to handle `OOM/Kill` failures.
- Removed the manually maintained high-risk OOM tests list.
- Improved CI stability while preserving broader test coverage.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.