### PR TITLE
[KVCache] Support only flush FD GPU Cache index by AttentionStore

### DIFF
--- a/fastdeploy/cache_manager/cache_tasks.py
+++ b/fastdeploy/cache_manager/cache_tasks.py
@@ -15,7 +15,7 @@
 """
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -35,3 +35,8 @@ class ReadStorageTask(CacheTask):
 @dataclass(frozen=True, kw_only=True)
 class WriteStorageTask(CacheTask):
     timeout: float = 30.0
+    # Used in FD_AS_ONLY_FLUSH mode to indicate whether cache is present on this node.
+    # True = cache exists (request finish), False = cache gone (CPU eviction), None = not applicable.
+    flush_cache_exists: Optional[bool] = None
+    # Block index to start the write/flush operation from. Defaults to 0 (all blocks).
+    start_write_block_idx: int = 0

--- a/fastdeploy/cache_manager/cache_transfer_manager.py
+++ b/fastdeploy/cache_manager/cache_transfer_manager.py
@@ -323,7 +323,8 @@ class CacheTransferManager:
         try:
             # TODO: support cache scale for other backend
             if self.has_cache_scale and self.storage_backend_type is not None:
-                if self.storage_backend_type not in ["mooncake"]:
+                is_as_only_flush = envs.FD_AS_ONLY_FLUSH and self.storage_backend_type == "attention_store"
+                if not is_as_only_flush and self.storage_backend_type not in ["mooncake"]:
                     raise ValueError(
                         f"Unsupported storage backend ({self.storage_backend_type}) "
                         "when cache quantization is block_wise_fp8"
@@ -949,6 +950,34 @@ class CacheTransferManager:
             )
             return 0
 
+    def _flush_only_storage_task(self, task: WriteStorageTask):
+        """
+        AS-only flush mode: skip actual storage write, only report cache index to AttentionStore.
+        Used when FD_AS_ONLY_FLUSH is enabled — AS acts as index-only (no data storage).
+
+        Args:
+            task: WriteStorageTask with flush_cache_exists indicating cache state:
+                  True/None = cache present on this node (request finish)
+                  False = cache gone from this node (eviction)
+        """
+        try:
+            if (self.rank == 0) and self.storage_backend_type == "attention_store":
+                reside_in_gpu = task.flush_cache_exists if task.flush_cache_exists is not None else True
+                self.storage_backend.flush_token_index(
+                    task.task_id, task.token_ids, task.start_write_block_idx, reside_in_gpu
+                )
+                logger.info(
+                    f"[AS_ONLY_FLUSH] flush token index reside_in_gpu={reside_in_gpu} "
+                    f"start_block_idx={task.start_write_block_idx} for task {task.task_id}"
+                )
+        except Exception as e:
+            logger.warning(f"[AS_ONLY_FLUSH] Failed to flush token index for task {task.task_id}, error: {e}")
+        result = (CacheStatus.GPU2STORAGE, task.task_id, task.keys, [])
+        self.cache_task_queue.swap_to_storage_barrier.wait()
+        if self.rank == 0:
+            self.cache_task_queue.swap_to_storage_barrier.reset()
+            self.cache_task_queue.put_transfer_done_signal(result)
+
     def write_back_storage_task(self, task: WriteStorageTask):
         """
         Write cache to the storage backend from the GPU memory.
@@ -956,6 +985,9 @@ class CacheTransferManager:
         assert (
             self.storage_backend
         ), f"storage_backend not initialized, storage_backend_type: {self.storage_backend_type}"
+
+        if envs.FD_AS_ONLY_FLUSH:
+            return self._flush_only_storage_task(task)
 
         try:
             gpu_block_ids = task.gpu_block_ids.copy()

--- a/fastdeploy/cache_manager/prefix_cache_manager.py
+++ b/fastdeploy/cache_manager/prefix_cache_manager.py
@@ -306,6 +306,7 @@ class PrefixCacheManager:
                     + visible_devices
                     + " NCCL_MAX_NCHANNELS=1 NCCL_BUFFSIZE=0"
                     + f" FD_ENABLE_SWAP_SPACE_CLEARING={envs.FD_ENABLE_SWAP_SPACE_CLEARING}"
+                    + f" FD_AS_ONLY_FLUSH={int(envs.FD_AS_ONLY_FLUSH)}"
                     + f" {sys.executable} {py_path}"
                     + f" --device_id {int(device_ids[i])}"
                     + f" --rank {i}"
@@ -828,7 +829,7 @@ class PrefixCacheManager:
                 storage_match_token_num = 0
                 match_storage_block_ids = []
 
-                if self.kvcache_storage_backend and no_match_token_num >= block_size:
+                if self.kvcache_storage_backend and no_match_token_num >= block_size and not envs.FD_AS_ONLY_FLUSH:
                     if not self.can_allocate_gpu_blocks(num_blocks=no_match_block_num, try_free_gpu_blocks=False):
                         raise Exception(
                             "request_match_blocks: Not enough GPU memory to allocate cache for matched Storage Cache"
@@ -1240,14 +1241,15 @@ class PrefixCacheManager:
         if self.kvcache_storage_backend is None:
             return
 
-        if len(task.keys) != len(task.gpu_block_ids):
+        if not envs.FD_AS_ONLY_FLUSH and len(task.keys) != len(task.gpu_block_ids):
             err_msg = (
                 f"write_back_storage error: hash_keys({len(task.keys)}) != gpu_block_ids({len(task.gpu_block_ids)})"
             )
             logger.error(err_msg)
             raise ValueError(err_msg)
 
-        self.task_write_back_event[task.task_id] = Event()
+        if is_sync:
+            self.task_write_back_event[task.task_id] = Event()
         self.cache_task_queue.put_transfer_task((CacheStatus.GPU2STORAGE, task))
         if is_sync:
             self.wait_write_storage_task(task.task_id)
@@ -1434,6 +1436,7 @@ class PrefixCacheManager:
 
                 hash_value_swap_node_ids_map = defaultdict(list)
                 hash_value_gpu_block_ids_map = defaultdict(list)
+                hash_value_flush_info = {}  # {input_hash_value: (token_ids, min_depth)}
                 total_gpu_free_count = 0
 
                 while True:
@@ -1446,6 +1449,10 @@ class PrefixCacheManager:
                     self.gpu_lru_leaf_set.remove(node)
                     if self.cache_config.num_cpu_blocks < need_block_num:
                         if node.shared_count == 0 and node.is_gpu_leaf_node:  # 直接回收
+                            if envs.FD_AS_ONLY_FLUSH and self.kvcache_storage_backend == "attention_store":
+                                key = node.input_hash_value
+                                if key not in hash_value_flush_info or node.depth < hash_value_flush_info[key][1]:
+                                    hash_value_flush_info[key] = (node.input_ids, node.depth)
                             self._handle_free_gpu_node_without_cpu(node)
                             total_gpu_free_count += 1
                             cur_node = node
@@ -1494,6 +1501,22 @@ class PrefixCacheManager:
                 logger.info(
                     f"free_block_ids_async: need_block_num {need_block_num}, free_block_num {total_gpu_free_count}."
                 )
+
+                if (
+                    envs.FD_AS_ONLY_FLUSH
+                    and self.kvcache_storage_backend == "attention_store"
+                    and hash_value_flush_info
+                ):
+                    for input_hash_value, (token_ids, min_depth) in hash_value_flush_info.items():
+                        flush_task = WriteStorageTask(
+                            task_id=str(uuid.uuid4()),
+                            keys=[input_hash_value],
+                            token_ids=token_ids,
+                            gpu_block_ids=[],
+                            flush_cache_exists=False,
+                            start_write_block_idx=min_depth - 1,
+                        )
+                        self.issue_write_back_storage_task(flush_task, is_sync=False)
 
                 # swap cache to cpu
                 if hash_value_gpu_block_ids_map:

--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -154,6 +154,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "FD_ENABLE_MODEL_LOAD_CACHE": lambda: bool(int(os.getenv("FD_ENABLE_MODEL_LOAD_CACHE", "0"))),
     # Whether to clear cpu cache when clearing model weights.
     "FD_ENABLE_SWAP_SPACE_CLEARING": lambda: int(os.getenv("FD_ENABLE_SWAP_SPACE_CLEARING", "0")),
+    # AS-only flush mode: AttentionStore only reports cache index without storing actual data.
+    "FD_AS_ONLY_FLUSH": lambda: bool(int(os.getenv("FD_AS_ONLY_FLUSH", "0"))),
     # enable return text, used when FD_ENABLE_INTERNAL_ADAPTER=1
     "FD_ENABLE_RETURN_TEXT": lambda: bool(int(os.getenv("FD_ENABLE_RETURN_TEXT", "0"))),
     # Used to truncate the string inserted during thinking when reasoning in a model. (</think> for ernie-45-vl, \n</think>\n\n for ernie-x1)

--- a/tests/cache_manager/test_prefix_cache_manager.py
+++ b/tests/cache_manager/test_prefix_cache_manager.py
@@ -1544,6 +1544,46 @@ class TestPrefixCacheManagerCoverage(unittest.TestCase):
         manager.reset()
         self.assertEqual(manager.cpu_free_block_list, [])
 
+    @patch("fastdeploy.cache_manager.prefix_cache_manager.envs")
+    def test_free_gpu_block_ids_flushes_cache_gone_with_as_only_flush(self, mock_envs):
+        """Verify GPU-only eviction sends flush(flush_cache_exists=False) with correct start_write_block_idx."""
+        mock_envs.FD_AS_ONLY_FLUSH = True
+        manager = _create_manager(num_gpu_blocks=4, num_cpu_blocks=0)
+        manager.kvcache_storage_backend = "attention_store"
+
+        gpu_hash = get_hash_str([9, 10])
+        node = BlockNode(
+            91,
+            [9, 10],
+            gpu_hash,
+            3,
+            0,
+            2,
+            gpu_hash,
+            0,
+            parent=manager.radix_tree_root,
+            cache_status=CacheStatus.GPU,
+        )
+        node.shared_count = 0
+        node.block_id = 12
+        manager.radix_tree_root.children[gpu_hash] = node
+        manager.node_map[node.node_id] = node
+        manager.gpu_lru_leaf_heap.append(node)
+        manager.gpu_lru_leaf_set.add(node)
+
+        captured_tasks = []
+        manager.issue_write_back_storage_task = lambda task, is_sync=True: captured_tasks.append(task)
+
+        manager.free_block_ids_async(1)
+
+        self.assertEqual(len(captured_tasks), 1)
+        flush_task = captured_tasks[0]
+        self.assertFalse(flush_task.flush_cache_exists)
+        self.assertEqual(flush_task.keys, [gpu_hash])
+        self.assertEqual(flush_task.token_ids, [9, 10])
+        self.assertEqual(flush_task.gpu_block_ids, [])
+        self.assertEqual(flush_task.start_write_block_idx, 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

This PR improves the `FD_AS_ONLY_FLUSH` flow for AttentionStore so FastDeploy can flush KV cache index state when GPU cache blocks are evicted, especially in pure-GPU cache deployments without CPU cache.

It adds the required flush metadata to support more accurate AttentionStore index updates for GPU eviction.

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications

- Extend `WriteStorageTask` with:
  - `flush_cache_exists` to indicate whether cache still exists on the current node in `FD_AS_ONLY_FLUSH` mode.
  - `start_write_block_idx` to support partial flush/write from a specified block index.
- Update `cache_transfer_manager` AS-only flush path to call `AttentionStore.flush_token_index(...)` with both `start_write_block_idx` and `reside_in_gpu`.
- Propagate `FD_AS_ONLY_FLUSH` to the cache transfer manager subprocess.
- Update `prefix_cache_manager.free_block_ids_async(...)` to emit flush-only tasks when GPU cache blocks are directly evicted in `FD_AS_ONLY_FLUSH` + `attention_store` mode.
- Add `FD_AS_ONLY_FLUSH` environment variable entry in `fastdeploy/envs.py`.
- Add unit test coverage for GPU eviction flush behavior, including:
  - `flush_cache_exists=False`
  - empty `gpu_block_ids` in flush-only mode
  - correct `start_write_block_idx=depth-1`
## Usage or Command

For `FD_AS_ONLY_FLUSH` mode with AttentionStore:

```bash
export FD_AS_ONLY_FLUSH=1
```

Reference test command:

```bash
python3 -m pytest tests/cache_manager/test_prefix_cache_manager.py -q
```


## Accuracy Tests

N/A. This PR does not change model forward results or kernel numerical behavior. It only updates KV cache index flush metadata and adds unit tests for cache manager behavior.

## Checklist

- [x] Add at least a tag in the PR title.
  - Suggested title: `[KVCache] Support flush FD GPU/CPU Cache index by AttentionStore`
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag. (N/A for current `develop` PR)
