### PR TITLE
[CI] Improve error log grep by excluding pytest_*_error.log noise

### DIFF
--- a/scripts/run_gpu_4cards.sh
+++ b/scripts/run_gpu_4cards.sh
@@ -44,7 +44,7 @@ for test_file in "${test_files[@]}"; do
 
         if [ -d "${REPO_ROOT}/log" ]; then
             echo ">>> grep error in ${REPO_ROOT}/log/"
-            grep -Rni --color=auto "error" "${REPO_ROOT}/log/" || true
+            grep -Rni --color=auto "error" "${REPO_ROOT}/log/" --exclude="pytest_*_error.log" || true
         else
             echo "${REPO_ROOT}/log directory not found"
         fi

--- a/scripts/run_pre_ce.sh
+++ b/scripts/run_pre_ce.sh
@@ -38,7 +38,7 @@ for subdir in "$run_path"*/; do
                 if [ $exit_code -ne 0 ]; then
                     if [ -d "${subdir%/}/log" ]; then
                         echo ">>> grep error in ${subdir%/}/log/"
-                        grep -Rni --color=auto "error" "${subdir%/}/log/" || true
+                        grep -Rni --color=auto "error" "${subdir%/}/log/" --exclude="pytest_*_error.log" || true
                     else
                         echo "${subdir%/}/log directory not found"
                     fi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
The original log scanning command captures all files containing "error", including `pytest_*_error.log`, which often introduces duplicated or noisy results. This makes it harder to identify the actual root cause from CI logs.

To improve signal-to-noise ratio and make log inspection more efficient, these redundant files should be excluded.

## Modifications

- Added a log prefix message for clarity:
  - `echo ">>> grep error in ${log_dir}"`
- Updated grep command to exclude pytest-generated error logs:
  - Added `--exclude="pytest_*_error.log"`
- Improved readability and effectiveness of CI log analysis.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.