### PR TITLE
[BugFix] Fix stop token sequence pointer offset and actual length computation

### DIFF
--- a/custom_ops/gpu_ops/stop_generation_multi_ends.cu
+++ b/custom_ops/gpu_ops/stop_generation_multi_ends.cu
@@ -79,8 +79,9 @@ __global__ void set_value_by_flags(bool *stop_flags,
     // dealing stop_seqs
     const int stop_seq_len = (stop_seqs_len + bid * stop_seqs_bs)[tid];
     if (stop_seq_len <= 0) return;
-    const int64_t *stop_seq_now =
-        stop_seqs + bid * stop_seqs_bs + tid * stop_seqs_max_len;
+    const int64_t *stop_seq_now = stop_seqs +
+                                  bid * stop_seqs_bs * stop_seqs_max_len +
+                                  tid * stop_seqs_max_len;
     const int64_t *pre_ids_now =
         token_ids_all + bid * max_model_len + prompt_lens[bid];
     const int64_t step_idx_now = step_idx[bid];

--- a/fastdeploy/input/utils/common.py
+++ b/fastdeploy/input/utils/common.py
@@ -82,6 +82,7 @@ def process_stop_token_ids(
     update_stop_seq_fn: Callable[[List[str]], Tuple[List[List[int]], List[int]]],
 ) -> None:
     stop_token_ids_final = []
+    stop_seqs_len_final = []
 
     if request.get("stop_token_ids") is not None:
         stop_token_ids = request.get("stop_token_ids")
@@ -89,17 +90,19 @@ def process_stop_token_ids(
             if isinstance(stop_token_ids[0], int):
                 # List[int] -> List[List[int]]
                 stop_token_ids_final.extend([[t] for t in stop_token_ids])
+                stop_seqs_len_final.extend([1] * len(stop_token_ids))
             elif isinstance(stop_token_ids[0], list):
                 # Already List[List[int]]
                 stop_token_ids_final.extend(stop_token_ids)
+                stop_seqs_len_final.extend([len(seq) for seq in stop_token_ids])
 
     stop_sequences = request.get("stop", [])
     if stop_sequences:
-        stop_seqs, _ = update_stop_seq_fn(stop_sequences)
+        stop_seqs, stop_seqs_actual_lens = update_stop_seq_fn(stop_sequences)
         stop_token_ids_final.extend(stop_seqs)
+        stop_seqs_len_final.extend(stop_seqs_actual_lens)
 
     # Update request
     if stop_token_ids_final:
-        stop_seqs_len = [len(seq) for seq in stop_token_ids_final]
         request["stop_token_ids"] = stop_token_ids_final
-        request["stop_seqs_len"] = stop_seqs_len
+        request["stop_seqs_len"] = stop_seqs_len_final

--- a/tests/input/test_process_stop_token_ids.py
+++ b/tests/input/test_process_stop_token_ids.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for process_stop_token_ids in fastdeploy.input.utils.common."""
+
+from fastdeploy.input.utils.common import process_stop_token_ids
+
+
+def _mock_update_stop_seq_fn(stop_sequences):
+    """Mock update_stop_seq that simulates tokenization and padding.
+
+    Simulates: "```" -> [101], "end" -> [201, 202]
+    Returns padded sequences and actual lengths.
+    """
+    token_map = {
+        "```": [101],
+        "end": [201, 202],
+        "\n\n": [301, 302, 303],
+        "stop": [401],
+    }
+    seqs = [token_map.get(s, [999]) for s in stop_sequences]
+    actual_lens = [len(s) for s in seqs]
+    # Simulate pad_batch_data: pad to max length with -1
+    max_len = max(len(s) for s in seqs) if seqs else 0
+    padded = [s + [-1] * (max_len - len(s)) for s in seqs]
+    return padded, actual_lens
+
+
+def test_stop_token_ids_list_int():
+    """stop_token_ids as List[int] should produce length-1 sequences."""
+    request = {"stop_token_ids": [100, 200, 300]}
+    process_stop_token_ids(request, _mock_update_stop_seq_fn)
+
+    assert request["stop_token_ids"] == [[100], [200], [300]]
+    assert request["stop_seqs_len"] == [1, 1, 1]
+
+
+def test_stop_token_ids_list_list_int():
+    """stop_token_ids as List[List[int]] should preserve actual lengths."""
+    request = {"stop_token_ids": [[10, 20], [30]]}
+    process_stop_token_ids(request, _mock_update_stop_seq_fn)
+
+    assert request["stop_token_ids"] == [[10, 20], [30]]
+    assert request["stop_seqs_len"] == [2, 1]
+
+
+def test_stop_strings_uses_actual_lengths():
+    """stop strings with different tokenized lengths should use actual lengths, not padded."""
+    request = {"stop": ["```", "end"]}
+    process_stop_token_ids(request, _mock_update_stop_seq_fn)
+
+    # "```" -> [101, -1] (padded), actual len 1
+    # "end" -> [201, 202], actual len 2
+    assert request["stop_token_ids"] == [[101, -1], [201, 202]]
+    assert request["stop_seqs_len"] == [1, 2]
+
+
+def test_mixed_stop_token_ids_and_stop_strings():
+    """Both stop_token_ids and stop strings should have correct lengths."""
+    request = {
+        "stop_token_ids": [100],
+        "stop": ["```", "\n\n"],
+    }
+    process_stop_token_ids(request, _mock_update_stop_seq_fn)
+
+    # stop_token_ids: [100] -> [[100]], len [1]
+    # "```" -> [101, -1, -1] (padded to 3), actual len 1
+    # "\n\n" -> [301, 302, 303], actual len 3
+    assert request["stop_token_ids"] == [[100], [101, -1, -1], [301, 302, 303]]
+    assert request["stop_seqs_len"] == [1, 1, 3]
+
+
+def test_empty_request():
+    """No stop tokens or strings should leave request unchanged."""
+    request = {}
+    process_stop_token_ids(request, _mock_update_stop_seq_fn)
+
+    assert "stop_token_ids" not in request
+    assert "stop_seqs_len" not in request
+
+
+def test_stop_token_ids_none():
+    """stop_token_ids=None should be treated as absent."""
+    request = {"stop_token_ids": None, "stop": ["stop"]}
+    process_stop_token_ids(request, _mock_update_stop_seq_fn)
+
+    assert request["stop_token_ids"] == [[401]]
+    assert request["stop_seqs_len"] == [1]
+
+
+def test_stop_token_ids_empty_list():
+    """stop_token_ids=[] should be treated as absent."""
+    request = {"stop_token_ids": []}
+    process_stop_token_ids(request, _mock_update_stop_seq_fn)
+
+    assert "stop_seqs_len" not in request
+
+
+if __name__ == "__main__":
+    test_stop_token_ids_list_int()
+    test_stop_token_ids_list_list_int()
+    test_stop_strings_uses_actual_lengths()
+    test_mixed_stop_token_ids_and_stop_strings()
+    test_empty_request()
+    test_stop_token_ids_none()
+    test_stop_token_ids_empty_list()
+    print("All tests passed.")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
1. CUDA kernel `set_value_by_flags` 中，`stop_seqs` 是一个形状为 `[bs, stop_seqs_bs, stop_seqs_max_len]` 的三维张量，
   原指针偏移 `bid * stop_seqs_bs` 少乘了 `stop_seqs_max_len`，导致跨 batch 时读取错误内存，stop 判断完全失效。
2. Python 层 `process_stop_token_ids` 原先用 `len(seq)` 计算 `stop_seqs_len`，
   对于由字符串 stop 序列转换而来的 token 序列（可能已 padding），会返回 padding 后的长度而非实际长度，
   导致 CUDA kernel 逐 token 匹配时范围错误。

## Modifications
- `custom_ops/gpu_ops/stop_generation_multi_ends.cu`：将 `bid * stop_seqs_bs` 修正为 `bid * stop_seqs_bs * stop_seqs_max_len`。
- `fastdeploy/input/utils/common.py`：分路径单独维护 `stop_seqs_len_final`，
  对字符串 stop 序列使用 `update_stop_seq_fn` 返回的实际长度，而非 padding 后长度。
## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
