### PR TITLE
[XPU] fix local scheduler _recycle

### DIFF
--- a/fastdeploy/scheduler/local_scheduler.py
+++ b/fastdeploy/scheduler/local_scheduler.py
@@ -130,11 +130,14 @@ class LocalScheduler:
         if request_id is not None:
             self.requests.pop(request_id, None)
             self.responses.pop(request_id, None)
-            idx = self.ids.index(request_id)
-            self.ids.pop(idx)
-            if idx < self.ids_read_cursor:
-                self.ids_read_cursor -= 1
-            scheduler_logger.debug(f"request_id : {request_id} has been recycled")
+            try:
+                idx = self.ids.index(request_id)
+                self.ids.pop(idx)
+                if idx < self.ids_read_cursor:
+                    self.ids_read_cursor -= 1
+            except ValueError:
+                scheduler_logger.warning(f"_recycle error, request_id:{request_id} is not found in ids")
+                pass
             return
 
         if self.max_size <= 0:
@@ -151,10 +154,10 @@ class LocalScheduler:
                 break
             expired_ids.append(request.request_id)
 
-        for i, expired_id in enumerate(expired_ids):
+        for expired_id in expired_ids:
             self.requests.pop(expired_id, None)
             self.responses.pop(expired_id, None)
-            self.ids.pop(i)
+        self.ids = self.ids[len(expired_ids) :]
 
         if len(expired_ids) > 0:
             if len(expired_ids) - 1 >= self.ids_read_cursor:
@@ -237,6 +240,9 @@ class LocalScheduler:
         return (token_num + block_size - 1) // block_size
 
     def get_unhandled_request_num(self):
+        scheduler_logger.debug(
+            f"get_unhandled_request_num len(self.ids):{len(self.ids)}, self.ids_read_cursor:{self.ids_read_cursor}"
+        )
         return len(self.ids) - self.ids_read_cursor
 
     def get_requests(


### PR DESCRIPTION
## Motivation
修复 `local_scheduler._recycle()` 中的两处 Bug：
1. 精确删除路径（`request_id != None`）中，`ids_read_cursor` 无条件 `-= 1`，导致被删元素位于游标之后时游标发生错位。
2. 批量过期删除路径中使用 `self.ids.pop(i)`（枚举索引），列表缩短后后续索引漂移，导致部分过期请求未从 `ids` 中删除。
3. `request_id` 不存在于 `ids` 中时，`list.index()` 抛出 `ValueError` 导致调用方异常。

## Modifications
- `fastdeploy/scheduler/local_scheduler.py`
  - `_recycle`（精确删除路径）：先获取 `idx = self.ids.index(request_id)`，仅当 `idx < self.ids_read_cursor` 时才执行 `-= 1`；捕获 `ValueError` 并输出 warning，避免崩溃。
  - `_recycle`（批量过期路径）：将逐元素 `pop(i)` 改为 `self.ids = self.ids[len(expired_ids):]` 切片删除，消除索引漂移。
  - `get_unhandled_request_num`：新增 debug 日志，便于排查游标与 ids 长度异常。

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.