### PR TITLE
[BugFix] fix fp8 accuracy problem on sm100 device

### DIFF
--- a/fastdeploy/model_executor/layers/quantization/block_wise_fp8.py
+++ b/fastdeploy/model_executor/layers/quantization/block_wise_fp8.py
@@ -172,7 +172,7 @@ def deep_gemm_fp8_gemm_nt(
                 linear_out,
             )
             if bias is not None:
-                linear_out = paddle.add(linear_out, bias)
+                linear_out.add_(bias)
     else:
         fp8_gemm_nt(
             (x, x_scale_tensor),
@@ -387,7 +387,7 @@ class BlockWiseFP8LinearMethod(QuantMethodBase):
             )
             x_scale_tensor = x_scale_tensor.T[: x.shape[0], ...]
 
-        if get_sm_version() == 100 and current_platform.is_cuda():
+        if get_sm_version() >= 100 and current_platform.is_cuda():
             deep_gemm_fp8_gemm_nt(
                 x,
                 x_scale_tensor,
@@ -408,5 +408,4 @@ class BlockWiseFP8LinearMethod(QuantMethodBase):
             )
             if layer.with_bias:
                 linear_out = paddle.add(linear_out, layer.bias)
-
         return linear_out


### PR DESCRIPTION
## Motivation
1. 修复 `deep_gemm_fp8_gemm_nt` 中 bias 未能正确生效的问题：该函数通过 inplace 方式修改 `linear_out`，调用方不使用返回值；原先的 `paddle.add` 只产生了新 tensor 并赋给局部变量，实际未更新 `linear_out`。改为 `linear_out.add_(bias)` 以 inplace 方式正确叠加 bias。
2. 修复 SM 103 等 SM > 100 架构无法走 deep_gemm 执行路径的问题：原判断 `get_sm_version() == 100` 仅覆盖 SM 100，改为 `>= 100` 以统一处理 Blackwell 及后续架构。

## Modifications
- `fastdeploy/model_executor/layers/quantization/block_wise_fp8.py`
  - `deep_gemm_fp8_gemm_nt`：bias 叠加改为 `linear_out.add_(bias)`（inplace），确保修改作用于原始 tensor
  - `BlockWiseFP8LinearMethod.apply`：SM 版本判断由 `== 100` 改为 `>= 100`，修复 SM 103 路径不一致问题

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.