### PR TITLE
[BugFix] fix preempted token id not returned when a full batch is aborted

### DIFF
--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -2248,10 +2248,14 @@ class GPUModelRunner(ModelRunnerBase):
             self.execute_model_overlap(model_forward_batch, num_running_requests)
 
     def _make_preempted_batch_output(self):
+        preempted_indices = paddle.nonzero(self.share_inputs["preempted_idx"] == 1)
+        bsz = int(preempted_indices[-1][0].item()) + 1
 
-        bsz = int(getattr(self.share_inputs, "num_running_requests", 0))
-        fill_value = PREEMPTED_TOKEN_ID  # if envs.FD_USE_GET_SAVE_OUTPUT_V1 else 0
-        fake_sampled_token_ids = paddle.full([bsz, 1], fill_value=fill_value, dtype="int64", device="cpu")
+        fake_sampled_token_ids = paddle.where(
+            self.share_inputs["preempted_idx"][:bsz] == 1,
+            PREEMPTED_TOKEN_ID,
+            -1,
+        ).astype("int64")
         self.share_inputs["sampled_token_ids"][:bsz].copy_(fake_sampled_token_ids, False)
 
         fake_logprobs_tensors = None
@@ -2336,6 +2340,7 @@ class GPUModelRunner(ModelRunnerBase):
                 and self.parallel_config.use_ep
             ):
                 self._execute_empty_mtp_input(self.forward_meta)
+
             if paddle.sum(self.share_inputs["preempted_idx"]) > 0:
                 logger.info(
                     f"All requests in batch are preempted, real_bsz: {real_bsz} preempted: {paddle.sum(self.share_inputs['preempted_idx'])}"
@@ -2344,14 +2349,14 @@ class GPUModelRunner(ModelRunnerBase):
                 self.share_inputs["last_preempted_idx"].copy_(self.share_inputs["preempted_idx"])
                 self.share_inputs["preempted_idx"][:] = 0
                 self._save_model_output(model_output_data, sampler_output)
-            return
-        model_output_data, sampler_output, post_process_event = self._postprocess(
-            model_output, p_done_idxs, model_forward_batch, num_running_requests, real_bsz
-        )
-        if model_output_data is not None:
-            # synchronizes the async DtoH copies of sampled_token_ids.
-            post_process_event.synchronize()
-            self._save_model_output(model_output_data, sampler_output)
+        else:
+            model_output_data, sampler_output, post_process_event = self._postprocess(
+                model_output, p_done_idxs, model_forward_batch, num_running_requests, real_bsz
+            )
+            if model_output_data is not None:
+                # synchronizes the async DtoH copies of sampled_token_ids.
+                post_process_event.synchronize()
+                self._save_model_output(model_output_data, sampler_output)
 
     def execute_model_overlap(
         self,

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -2228,25 +2228,6 @@ class GPUModelRunner(ModelRunnerBase):
         for _ in range(self.fd_config.speculative_config.num_model_steps):
             self.proposer.model.empty_input_forward(forward_meta)
 
-    def execute_model(
-        self,
-        model_forward_batch: Optional[List[Request]] = None,
-        num_running_requests: int = None,
-    ) -> None:
-        """
-        The Entrance of model execute.
-        Args:
-            model_forward_batch: 'Request' contains information related to prompt and is an abstract
-            class at the server level, which is too granular for ModelRunner.
-            We plan to replace it with 'ModelForwardBatch'.
-            intermediate_tensors:
-            num_running_requests: batch_size
-        """
-        if not self.enable_overlap_schedule:
-            self.execute_model_normal(model_forward_batch, num_running_requests)
-        else:
-            self.execute_model_overlap(model_forward_batch, num_running_requests)
-
     def _make_preempted_batch_output(self):
         preempted_indices = paddle.nonzero(self.share_inputs["preempted_idx"] == 1)
         bsz = int(preempted_indices[-1][0].item()) + 1
@@ -2324,6 +2305,25 @@ class GPUModelRunner(ModelRunnerBase):
             enable_pd_reorder=getattr(self.share_inputs, "enable_pd_reorder", False),
         )
         return model_output_data, sampler_output
+
+    def execute_model(
+        self,
+        model_forward_batch: Optional[List[Request]] = None,
+        num_running_requests: int = None,
+    ) -> None:
+        """
+        The Entrance of model execute.
+        Args:
+            model_forward_batch: 'Request' contains information related to prompt and is an abstract
+            class at the server level, which is too granular for ModelRunner.
+            We plan to replace it with 'ModelForwardBatch'.
+            intermediate_tensors:
+            num_running_requests: batch_size
+        """
+        if not self.enable_overlap_schedule:
+            self.execute_model_normal(model_forward_batch, num_running_requests)
+        else:
+            self.execute_model_overlap(model_forward_batch, num_running_requests)
 
     def execute_model_normal(
         self,

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -116,7 +116,12 @@ from fastdeploy.worker.model_runner_base import (
     DistributedStatus,
     ModelRunnerBase,
 )
-from fastdeploy.worker.output import LogprobsTensors, ModelOutputData, ModelRunnerOutput
+from fastdeploy.worker.output import (
+    LogprobsTensors,
+    ModelOutputData,
+    ModelRunnerOutput,
+    SamplerOutput,
+)
 
 
 class GPUModelRunner(ModelRunnerBase):
@@ -2242,6 +2247,80 @@ class GPUModelRunner(ModelRunnerBase):
         else:
             self.execute_model_overlap(model_forward_batch, num_running_requests)
 
+    def _make_preempted_batch_output(self):
+
+        bsz = int(getattr(self.share_inputs, "num_running_requests", 0))
+        fill_value = PREEMPTED_TOKEN_ID  # if envs.FD_USE_GET_SAVE_OUTPUT_V1 else 0
+        fake_sampled_token_ids = paddle.full([bsz, 1], fill_value=fill_value, dtype="int64", device="cpu")
+        self.share_inputs["sampled_token_ids"][:bsz].copy_(fake_sampled_token_ids, False)
+
+        fake_logprobs_tensors = None
+        if self.enable_logprob:
+            fake_logprobs_tensors = LogprobsTensors(
+                logprob_token_ids=paddle.zeros([bsz, 1], dtype="int64", device="cpu"),
+                logprobs=paddle.zeros([bsz, 1], dtype="float32", device="cpu"),
+                selected_token_ranks=paddle.zeros([bsz], dtype="int64", device="cpu"),
+            )
+
+        if self.speculative_decoding:
+            self.share_inputs["accept_tokens_cpu"][:bsz].fill_(0)
+            self.share_inputs["accept_num_cpu"][:bsz].fill_(0)
+            self.share_inputs["seq_lens_decoder_cpu"][:bsz].copy_(self.share_inputs["seq_lens_decoder"][:bsz], False)
+            self.share_inputs["prompt_lens_cpu"][:bsz].copy_(self.share_inputs["prompt_lens"][:bsz], False)
+            sampler_output = SamplerOutput(
+                sampled_token_ids=fake_sampled_token_ids,
+                logprobs_tensors=fake_logprobs_tensors,
+                token_num_per_batch=(self.share_inputs["accept_num_cpu"][:bsz] if self.enable_logprob else None),
+                cu_batch_token_offset=(
+                    paddle.zeros([bsz + 1], dtype="int32", device="cpu") if self.enable_logprob else None
+                ),
+            )
+        else:
+            sampler_output = SamplerOutput(
+                sampled_token_ids=fake_sampled_token_ids,
+                logprobs_tensors=fake_logprobs_tensors,
+            )
+
+        index_to_batch_id = {
+            i: self.share_inputs["index_to_batch_id"][i]
+            for i in range(bsz)
+            if i in self.share_inputs["index_to_batch_id"]
+        }
+        model_output_data = ModelOutputData(
+            next_tokens=self.share_inputs["next_tokens"],
+            stop_flags=self.share_inputs["stop_flags"],
+            step_idx=self.share_inputs["step_idx"],
+            max_dec_len=self.share_inputs["max_dec_len"],
+            seq_lens_this_time=self.share_inputs["seq_lens_this_time"],
+            eos_token_id=self.share_inputs["eos_token_id"],
+            not_need_stop=self.share_inputs["not_need_stop"],
+            not_need_stop_device=self.share_inputs["not_need_stop_device"],
+            input_ids=self.share_inputs["input_ids"],
+            seq_lens_encoder=self.share_inputs["seq_lens_encoder"],
+            seq_lens_decoder=self.share_inputs["seq_lens_decoder"],
+            is_block_step=self.share_inputs["is_block_step"],
+            full_hidden_states=None,
+            msg_queue_id=self.parallel_config.msg_queue_id,
+            mp_rank=self.parallel_config.tensor_parallel_rank,
+            use_ep=self.parallel_config.use_ep,
+            draft_tokens=(self.share_inputs["draft_tokens"] if self.speculative_decoding else None),
+            actual_draft_token_num=(
+                self.share_inputs["actual_draft_token_num"] if self.speculative_decoding else None
+            ),
+            token_ids_all=self.share_inputs["token_ids_all"],
+            accept_tokens=(self.share_inputs["accept_tokens"] if self.speculative_decoding else None),
+            accept_num=(self.share_inputs["accept_num"] if self.speculative_decoding else None),
+            stop_token_ids=self.share_inputs["stop_seqs"],
+            stop_seqs_len=self.share_inputs["stop_seqs_len"],
+            min_tokens=self.share_inputs["min_dec_len"],
+            prompt_lens=self.share_inputs["prompt_lens"],
+            mask_rollback=self.share_inputs["mask_rollback"],
+            prompt_logprobs_list=None,
+            index_to_batch_id=index_to_batch_id,
+            enable_pd_reorder=getattr(self.share_inputs, "enable_pd_reorder", False),
+        )
+        return model_output_data, sampler_output
+
     def execute_model_normal(
         self,
         model_forward_batch: Optional[List[Request]] = None,
@@ -2257,6 +2336,14 @@ class GPUModelRunner(ModelRunnerBase):
                 and self.parallel_config.use_ep
             ):
                 self._execute_empty_mtp_input(self.forward_meta)
+            if paddle.sum(self.share_inputs["preempted_idx"]) > 0:
+                logger.info(
+                    f"All requests in batch are preempted, real_bsz: {real_bsz} preempted: {paddle.sum(self.share_inputs['preempted_idx'])}"
+                )
+                model_output_data, sampler_output = self._make_preempted_batch_output()
+                self.share_inputs["last_preempted_idx"].copy_(self.share_inputs["preempted_idx"])
+                self.share_inputs["preempted_idx"][:] = 0
+                self._save_model_output(model_output_data, sampler_output)
             return
         model_output_data, sampler_output, post_process_event = self._postprocess(
             model_output, p_done_idxs, model_forward_batch, num_running_requests, real_bsz
@@ -2305,6 +2392,16 @@ class GPUModelRunner(ModelRunnerBase):
                 and self.parallel_config.use_ep
             ):
                 self._execute_empty_mtp_input(self.forward_meta)
+
+            if paddle.sum(self.share_inputs["preempted_idx"]) > 0:
+                logger.info(
+                    f"All requests in batch are preempted, real_bsz: {real_bsz} preempted: {paddle.sum(self.share_inputs['preempted_idx'])}"
+                )
+                model_output_data, sampler_output = self._make_preempted_batch_output()
+                self.share_inputs["last_preempted_idx"].copy_(self.share_inputs["preempted_idx"])
+                self.share_inputs["preempted_idx"][:] = 0
+                self._save_model_output(model_output_data, sampler_output)
+
             self._cached_model_output_data = None
             self._cached_sampler_output = None
             self._cached_post_process_event = None

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -2229,6 +2229,13 @@ class GPUModelRunner(ModelRunnerBase):
             self.proposer.model.empty_input_forward(forward_meta)
 
     def _make_preempted_batch_output(self):
+        """Build a minimal batch-shaped control output for preempted slots.
+
+        This is used when the current step contains only preempted/aborted
+        requests and therefore produces no normal model tokens. The helper
+        fabricates a lightweight batch output so the existing save_output path
+        can still return PREEMPTED_TOKEN_ID for the affected slots.
+        """
         preempted_indices = paddle.nonzero(self.share_inputs["preempted_idx"] == 1)
         bsz = int(preempted_indices[-1][0].item()) + 1
 

--- a/tests/worker/test_gpu_model_runner.py
+++ b/tests/worker/test_gpu_model_runner.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, Mock, patch
 import numpy as np
 import paddle
 
+from fastdeploy.config import PREEMPTED_TOKEN_ID
 from fastdeploy.engine.request import ImagePosition
 from fastdeploy.spec_decode import SpecMethod
 from fastdeploy.worker.gpu_model_runner import GPUModelRunner
@@ -748,6 +749,55 @@ class TestInsertTasksV1SplitwiseSuffix(unittest.TestCase):
         req = self._make_prefill_request(idx=0, draft_token_ids=[42])
         with self.assertRaises(ValueError):
             runner.insert_tasks_v1([req], num_running_requests=1)
+
+
+class TestMakePreemptedBatchOutput(unittest.TestCase):
+    def _make_runner(self):
+        runner = GPUModelRunner.__new__(GPUModelRunner)
+        runner.speculative_decoding = False
+        runner.enable_logprob = False
+        runner.parallel_config = Mock(msg_queue_id=0, tensor_parallel_rank=0, use_ep=False)
+
+        class _ShareInputs(dict):
+            enable_pd_reorder = False
+
+        share_inputs = _ShareInputs()
+        share_inputs["preempted_idx"] = paddle.to_tensor(
+            [[0], [0], [0], [1], [0], [0], [1], [0], [0], [0]], dtype="int32"
+        )
+        share_inputs["sampled_token_ids"] = paddle.zeros([10, 1], dtype="int64")
+        share_inputs["index_to_batch_id"] = {i: i for i in range(10)}
+        share_inputs["next_tokens"] = paddle.zeros([10, 1], dtype="int64")
+        share_inputs["stop_flags"] = paddle.zeros([10, 1], dtype="bool")
+        share_inputs["step_idx"] = 0
+        share_inputs["max_dec_len"] = 16
+        share_inputs["seq_lens_this_time"] = paddle.zeros([10, 1], dtype="int32")
+        share_inputs["eos_token_id"] = paddle.zeros([1], dtype="int64")
+        share_inputs["not_need_stop"] = False
+        share_inputs["not_need_stop_device"] = paddle.zeros([1], dtype="bool")
+        share_inputs["input_ids"] = paddle.zeros([10, 1], dtype="int64")
+        share_inputs["seq_lens_encoder"] = paddle.zeros([10, 1], dtype="int32")
+        share_inputs["seq_lens_decoder"] = paddle.zeros([10, 1], dtype="int32")
+        share_inputs["is_block_step"] = paddle.zeros([10, 1], dtype="bool")
+        share_inputs["token_ids_all"] = paddle.zeros([10, 1], dtype="int64")
+        share_inputs["stop_seqs"] = paddle.zeros([10, 1], dtype="int64")
+        share_inputs["stop_seqs_len"] = paddle.zeros([10, 1], dtype="int32")
+        share_inputs["min_dec_len"] = paddle.zeros([10, 1], dtype="int64")
+        share_inputs["prompt_lens"] = paddle.zeros([10, 1], dtype="int32")
+        share_inputs["mask_rollback"] = paddle.zeros([10, 1], dtype="bool")
+        runner.share_inputs = share_inputs
+        return runner
+
+    def test_make_preempted_batch_output_emits_sparse_preempt_mask(self):
+        runner = self._make_runner()
+
+        model_output_data, sampler_output = runner._make_preempted_batch_output()
+
+        expected = [-1, -1, -1, PREEMPTED_TOKEN_ID, -1, -1, PREEMPTED_TOKEN_ID]
+        self.assertEqual(sampler_output.sampled_token_ids.shape, [7, 1])
+        self.assertEqual(sampler_output.sampled_token_ids.numpy().reshape([-1]).tolist(), expected)
+        self.assertEqual(runner.share_inputs["sampled_token_ids"][:7].numpy().reshape([-1]).tolist(), expected)
+        self.assertEqual(model_output_data.index_to_batch_id, {i: i for i in range(7)})
 
 
 if __name__ == "__main__":

--- a/tests/worker/test_gpu_model_runner.py
+++ b/tests/worker/test_gpu_model_runner.py
@@ -752,10 +752,10 @@ class TestInsertTasksV1SplitwiseSuffix(unittest.TestCase):
 
 
 class TestMakePreemptedBatchOutput(unittest.TestCase):
-    def _make_runner(self):
+    def _make_runner(self, speculative_decoding=False, enable_logprob=False):
         runner = GPUModelRunner.__new__(GPUModelRunner)
-        runner.speculative_decoding = False
-        runner.enable_logprob = False
+        runner.speculative_decoding = speculative_decoding
+        runner.enable_logprob = enable_logprob
         runner.parallel_config = Mock(msg_queue_id=0, tensor_parallel_rank=0, use_ep=False)
 
         class _ShareInputs(dict):
@@ -785,6 +785,14 @@ class TestMakePreemptedBatchOutput(unittest.TestCase):
         share_inputs["min_dec_len"] = paddle.zeros([10, 1], dtype="int64")
         share_inputs["prompt_lens"] = paddle.zeros([10, 1], dtype="int32")
         share_inputs["mask_rollback"] = paddle.zeros([10, 1], dtype="bool")
+        share_inputs["accept_tokens_cpu"] = paddle.full([10, 1], fill_value=-1, dtype="int64")
+        share_inputs["accept_num_cpu"] = paddle.full([10, 1], fill_value=-1, dtype="int32")
+        share_inputs["seq_lens_decoder_cpu"] = paddle.full([10, 1], fill_value=-1, dtype="int32")
+        share_inputs["prompt_lens_cpu"] = paddle.full([10, 1], fill_value=-1, dtype="int32")
+        share_inputs["draft_tokens"] = paddle.zeros([10, 1], dtype="int64")
+        share_inputs["actual_draft_token_num"] = paddle.zeros([10, 1], dtype="int32")
+        share_inputs["accept_tokens"] = paddle.zeros([10, 1], dtype="int64")
+        share_inputs["accept_num"] = paddle.zeros([10, 1], dtype="int32")
         runner.share_inputs = share_inputs
         return runner
 
@@ -798,6 +806,129 @@ class TestMakePreemptedBatchOutput(unittest.TestCase):
         self.assertEqual(sampler_output.sampled_token_ids.numpy().reshape([-1]).tolist(), expected)
         self.assertEqual(runner.share_inputs["sampled_token_ids"][:7].numpy().reshape([-1]).tolist(), expected)
         self.assertEqual(model_output_data.index_to_batch_id, {i: i for i in range(7)})
+
+    def test_make_preempted_batch_output_speculative_logprob(self):
+        runner = self._make_runner(speculative_decoding=True, enable_logprob=True)
+        runner.share_inputs["seq_lens_decoder"][:7] = paddle.arange(7, dtype="int32").reshape([7, 1])
+        runner.share_inputs["prompt_lens"][:7] = paddle.arange(10, 17, dtype="int32").reshape([7, 1])
+
+        model_output_data, sampler_output = runner._make_preempted_batch_output()
+
+        self.assertEqual(sampler_output.sampled_token_ids.shape, [7, 1])
+        self.assertIsNotNone(sampler_output.logprobs_tensors)
+        self.assertEqual(sampler_output.logprobs_tensors.logprob_token_ids.shape, [7, 1])
+        self.assertEqual(sampler_output.token_num_per_batch.shape, [7, 1])
+        self.assertEqual(sampler_output.cu_batch_token_offset.shape, [8])
+        self.assertEqual(runner.share_inputs["accept_tokens_cpu"][:7].numpy().reshape([-1]).tolist(), [0] * 7)
+        self.assertEqual(runner.share_inputs["accept_num_cpu"][:7].numpy().reshape([-1]).tolist(), [0] * 7)
+        self.assertEqual(
+            runner.share_inputs["seq_lens_decoder_cpu"][:7].numpy().reshape([-1]).tolist(),
+            list(range(7)),
+        )
+        self.assertEqual(
+            runner.share_inputs["prompt_lens_cpu"][:7].numpy().reshape([-1]).tolist(),
+            list(range(10, 17)),
+        )
+        self.assertIsNotNone(model_output_data.accept_tokens)
+        self.assertIsNotNone(model_output_data.accept_num)
+
+
+class TestExecuteModel(unittest.TestCase):
+    def _make_runner(self):
+        runner = GPUModelRunner.__new__(GPUModelRunner)
+        runner.speculative_decoding = False
+        runner.parallel_config = Mock(use_ep=False)
+        runner.fd_config = Mock()
+        runner.fd_config.speculative_config = Mock(method=None)
+        runner.proposer = Mock(model=Mock())
+        runner.forward_meta = Mock()
+        runner._save_model_output = Mock()
+        runner._make_preempted_batch_output = Mock(return_value=("model_output", "sampler_output"))
+        runner._postprocess = Mock()
+        runner._execute_empty_mtp_input = Mock()
+        runner._cached_launch_token_num = 0
+        runner._cached_real_bsz = 0
+
+        class _ShareInputs(dict):
+            pass
+
+        share_inputs = _ShareInputs()
+        share_inputs["seq_lens_this_time_cpu"] = paddle.zeros([2, 1], dtype="int32")
+        share_inputs["preempted_idx"] = paddle.to_tensor([[1], [0]], dtype="int32")
+        share_inputs["last_preempted_idx"] = paddle.zeros([2, 1], dtype="int32")
+        runner.share_inputs = share_inputs
+        return runner
+
+    def test_execute_model_dispatches_to_normal_path(self):
+        runner = self._make_runner()
+        runner.enable_overlap_schedule = False
+        runner.execute_model_normal = Mock()
+        runner.execute_model_overlap = Mock()
+
+        runner.execute_model(model_forward_batch=["req"], num_running_requests=1)
+
+        runner.execute_model_normal.assert_called_once_with(["req"], 1)
+        runner.execute_model_overlap.assert_not_called()
+
+    def test_execute_model_dispatches_to_overlap_path(self):
+        runner = self._make_runner()
+        runner.enable_overlap_schedule = True
+        runner.execute_model_normal = Mock()
+        runner.execute_model_overlap = Mock()
+
+        runner.execute_model(model_forward_batch=["req"], num_running_requests=1)
+
+        runner.execute_model_overlap.assert_called_once_with(["req"], 1)
+        runner.execute_model_normal.assert_not_called()
+
+    def test_execute_model_normal_zero_output_flushes_preempted_batch(self):
+        runner = self._make_runner()
+        runner._preprocess = Mock(return_value=("model_inputs", "done_idxs", None))
+        runner._execute = Mock(return_value=None)
+
+        runner.execute_model_normal()
+
+        runner._make_preempted_batch_output.assert_called_once_with()
+        np.testing.assert_array_equal(runner.share_inputs["last_preempted_idx"].numpy(), np.array([[1], [0]]))
+        np.testing.assert_array_equal(runner.share_inputs["preempted_idx"].numpy(), np.array([[0], [0]]))
+        runner._save_model_output.assert_called_once_with("model_output", "sampler_output")
+
+    def test_execute_model_normal_postprocess_saves_output_after_sync(self):
+        runner = self._make_runner()
+        runner.share_inputs["seq_lens_this_time_cpu"] = paddle.to_tensor([[1], [0]], dtype="int32")
+        runner._preprocess = Mock(return_value=("model_inputs", "done_idxs", None))
+        runner._execute = Mock(return_value="model_output")
+        post_process_event = Mock()
+        runner._postprocess.return_value = ("model_output_data", "sampler_output", post_process_event)
+
+        runner.execute_model_normal(model_forward_batch=["req"], num_running_requests=1)
+
+        runner._make_preempted_batch_output.assert_not_called()
+        post_process_event.synchronize.assert_called_once_with()
+        runner._save_model_output.assert_called_once_with("model_output_data", "sampler_output")
+
+    def test_execute_model_overlap_zero_output_flushes_preempted_batch(self):
+        runner = self._make_runner()
+        token_num_event = Mock()
+        runner._preprocess = Mock(return_value=("model_inputs", "done_idxs", token_num_event))
+        runner._execute = Mock(return_value=None)
+        runner._predict_next_launch_token_num = Mock(return_value=(11, 22))
+        runner._cached_model_output_data = None
+        runner._cached_sampler_output = "cached_sampler"
+        runner._cached_post_process_event = "cached_event"
+
+        runner.execute_model_overlap()
+
+        token_num_event.synchronize.assert_called_once_with()
+        runner._make_preempted_batch_output.assert_called_once_with()
+        np.testing.assert_array_equal(runner.share_inputs["last_preempted_idx"].numpy(), np.array([[1], [0]]))
+        np.testing.assert_array_equal(runner.share_inputs["preempted_idx"].numpy(), np.array([[0], [0]]))
+        runner._save_model_output.assert_called_once_with("model_output", "sampler_output")
+        self.assertIsNone(runner._cached_model_output_data)
+        self.assertIsNone(runner._cached_sampler_output)
+        self.assertIsNone(runner._cached_post_process_event)
+        self.assertEqual(runner._cached_launch_token_num, 11)
+        self.assertEqual(runner._cached_real_bsz, 22)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fix a bug where an all-preempted/aborted batch may fail to emit `PREEMPTED_TOKEN_ID (-9)` immediately. In that case, the abort/preempt signal is delayed until a later normal request arrives, which prevents timely upstream request-slot recycling.

## Modifications

- Add `_make_preempted_batch_output()` in `GPUModelRunner` to build a minimal batch-shaped control output for preempted requests.
- Trigger the fake output path in zero-output branches so fully preempted batches can still return `-9`.
- Fill fake sampled tokens with `-1` by default and only mark preempted slots as `-9`.
- Add a unit test for sparse `preempted_idx` handling in `tests/worker/test_gpu_model_runner.py`.

## Usage or Command

N/A. This change does not introduce a new user-facing function. Validation was done with unit tests and local reproduction.

## Accuracy Tests

N/A. This change only affects abort/preempt control-token emission and request-slot recycling, and does not change normal model output accuracy.

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.