### PR TITLE
[Cherry-Pick][BugFix][Speculative Decoding] Fix tokens_per_seq min value calculation for non-MTP speculative methods(#7623)

### DIFF
--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -2271,7 +2271,7 @@ class FDConfig:
         ), f"max_num_seqs: {self.scheduler_config.max_num_seqs} should be larger than 1"
         tokens_per_seq = (
             (getattr(self.speculative_config, "num_speculative_tokens", 0) + 1)
-            if self.speculative_config is not None
+            if self.speculative_config is not None and self.speculative_config.method is not None
             else 1
         )
         assert self.scheduler_config.max_num_batched_tokens >= self.scheduler_config.max_num_seqs * tokens_per_seq, (

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -776,7 +776,7 @@ class ResourceManagerV1(ResourceManager):
             error_reqs: list[tuple[str, str]] = []
             tokens_per_seq = (
                 (self.config.speculative_config.num_speculative_tokens + 1)
-                if self.config.speculative_config is not None
+                if self.config.speculative_config is not None and self.config.speculative_config.method is not None
                 else 1
             )
             num_running_decode_reqs = sum(1 for req in self.running if self._is_decoding(req))


### PR DESCRIPTION
Cherry-pick of #7623 (authored by @kevincheng2) to `release/2.6`.

devPR:https://github.com/PaddlePaddle/FastDeploy/pull/7623 <!-- For pass CI -->

---

## Motivation

当使用非 MTP 的 speculative decoding 方法（如 NGRAM）时，`speculative_config` 不为 None 且 `num_speculative_tokens` 也有值。

但原来 `tokens_per_seq` 的计算只判断了 `speculative_config is not None`，导致非 MTP 场景下：
- `max_num_batched_tokens` 的最小值校验变为 `max_num_seqs * (num_speculative_tokens + 1)`
- 实际上非 MTP 方法不需要在 batch token 预算中为 speculative tokens 额外预留空间
- 导致合法的 `max_num_batched_tokens` 配置被错误拦截

## Modifications

- `fastdeploy/config.py`：`check()` 方法中 `tokens_per_seq` 计算增加 `method == SpecMethod.MTP` 条件，只有 MTP 方法才将 speculative tokens 计入每序列 token 数
- `fastdeploy/engine/sched/resource_manager_v1.py`：同上，保持两处逻辑一致

## Usage or Command

非 MTP speculative decoding（如 NGRAM）场景下，原来会触发如下断言错误：
```
AssertionError: max_num_batched_tokens: X should be larger than or equal to max_num_seqs: Y * tokens_per_seq: Z
```
修复后该场景可正常启动。

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.