### PR TITLE
[Cherry-Pick][KVCache] Support environment variable overrides for AttentionStore config(#7455)

### DIFF
--- a/fastdeploy/cache_manager/cache_transfer_manager.py
+++ b/fastdeploy/cache_manager/cache_transfer_manager.py
@@ -554,6 +554,7 @@ class CacheTransferManager:
                     * self.cache_item_bytes,
                     device_id=self.device,
                     dp_id=self.local_data_parallel_id,
+                    splitwise_role=getattr(args, "splitwise_role", "mixed"),
                 )
                 logger.info("Initialized attention store successfully!")
             elif args.kvcache_storage_backend == "file":

--- a/fastdeploy/cache_manager/transfer_factory/mooncake_store/attention_store.py
+++ b/fastdeploy/cache_manager/transfer_factory/mooncake_store/attention_store.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """
 
+import os
 import time
 import traceback
 from dataclasses import dataclass
@@ -51,6 +52,7 @@ class AttentionStoreConfig:
     bytes_per_shard_layer_per_block: int = 1024
     device_id: int = 0
     dp_id: int = 0
+    splitwise_role: str = "mixed"
 
 
 class AttentionStore(KVCacheStorage):
@@ -62,6 +64,13 @@ class AttentionStore(KVCacheStorage):
         self.config = AttentionStoreConfig(**args)
 
         try:
+            self.config.namespace = os.getenv("AS_NAMESPACE", self.config.namespace)
+            self.config.pod_name = os.getenv("AS_POD_NAME", self.config.pod_name)
+            if int(os.getenv("ENABLE_EP_DP_IN_FD", "1")):
+                self.config.pod_name = (
+                    self.config.pod_name + "_" + self.config.splitwise_role + "_" + str(self.config.dp_id)
+                )
+            self.config.model_version = os.getenv("AS_MODEL_VERSION", self.config.model_version)
             logger.info(f"[INIT] Start initializing AttentionStoreSDK with config: {self.config}")
             self.sdk = AttentionStoreSDK(
                 self.config.namespace,

--- a/tests/cache_manager/test_cache_transfer_manager.py
+++ b/tests/cache_manager/test_cache_transfer_manager.py
@@ -65,6 +65,7 @@ class Args:
     kvcache_storage_backend = None
     write_policy = "write_through"
     model_path = "test_model"
+    splitwise_role = "mixed"
     routing_replay_config = MagicMock(enable_routing_replay=False)
 
 
@@ -724,6 +725,7 @@ class TestCacheTransferManager(unittest.TestCase):
             * manager.cache_item_bytes,
             device_id=manager.device,
             dp_id=manager.local_data_parallel_id,
+            splitwise_role=LocalArgs.splitwise_role,
         )
 
     def test_invalid_write_policy_raises(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

AttentionStore's `namespace`, `pod_name`, and `model_version` are currently only configurable via constructor arguments. In K8s deployments, these values are typically derived from Pod environment variables (e.g., `AS_NAMESPACE`, `AS_POD_NAME`, `AS_MODEL_VERSION`). Without environment variable overrides, deployment configuration is inflexible.

## Modifications

**Modified file:** `fastdeploy/cache_manager/transfer_factory/mooncake_store/attention_store.py`

Added environment variable overrides for `AttentionStoreConfig` fields before SDK initialization in `AttentionStore.__init__`:

```python
self.config.namespace = os.getenv("AS_NAMESPACE", self.config.namespace)
self.config.pod_name = os.getenv("AS_POD_NAME", self.config.pod_name)
if int(os.getenv("ENABLE_EP_DP_IN_FD", "1")):
    self.config.pod_name = (
        self.config.pod_name + "_" + self.config.splitwise_role + "_" + str(self.config.dp_id)
    )
self.config.model_version = os.getenv("AS_MODEL_VERSION", self.config.model_version)
```

- When environment variables are not set, the original constructor defaults are preserved (no behavior change).
- Environment variables take precedence over constructor arguments when set.

## Usage or Command

Set the corresponding environment variables before launching the service:

```bash
export AS_NAMESPACE=my-model
export AS_POD_NAME=my-pod-0
export AS_MODEL_VERSION=v1
```

## Accuracy Tests

Not applicable — this change does not affect model outputs.

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
