### PR TITLE
[Docs] Fix router parameters typo

### DIFF
--- a/docs/online_serving/router.md
+++ b/docs/online_serving/router.md
@@ -169,7 +169,7 @@ The Router exposes a set of HTTP services to provide unified request scheduling,
 ### Configuration File Preparation
 
 Before using `--config_path`, prepare a configuration file that conforms to the Router specification.
-The configuration file is typically written in YAML format. For detailed parameters, refer to [Configuration Parameteres](#configuration-parameteres)。You may copy and modify the configuration template (example available at examples/run_with_config)：
+The configuration file is typically written in YAML format. For detailed parameters, refer to [Configuration Parameters](#configuration-parameters)。You may copy and modify the configuration template (example available at examples/run_with_config)：
 ```bash
 cp config/config.example.yaml config/config.yaml
 ```
@@ -180,7 +180,7 @@ cp config/config.example.yaml config/config.yaml
 cp config/register.example.yaml config/register.yaml
 ```
 
-### Configuration Parameteres
+### Configuration Parameters
 
 config.yaml example:
 ```yaml


### PR DESCRIPTION
## Motivation

  Fix a typo in the Router documentation.

  ## Modifications

  This PR corrects Parameteres to Parameters in docs/online_serving/router.md, including the section title and its internal anchor link.

  ## Usage or Command

  Documentation-only change. No runtime command is required.

  Validation command:

      pre-commit run --files docs/online_serving/router.md

  ## Accuracy Tests

  This is a documentation-only typo fix and does not affect model accuracy or runtime behavior.

  Validation result:

      pre-commit run --files docs/online_serving/router.md
      # Passed

  ## Checklist

  - [x] Add at least a tag in the PR title.
  - [x] Format your code, run pre-commit before commit.
  - [x] Add unit tests. Please write the reason in this PR if no unit tests.
  - [x] Provide accuracy results.
  - [x] If the current PR is submitting to the release branch, make sure the PR has been submitted to the develop branch, then cherry-pick it to the release branch with the [Cherry-Pick] PR tag.