### PR TITLE
[BugFix][Speculate Decoding] Reset reasoning_status in insert when new request starts

### DIFF
--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -880,6 +880,7 @@ class GPUModelRunner(ModelRunnerBase):
                         enable_thinking = bool(request.get("enable_thinking"))
                         logger.debug(f"request {request.request_id} with {enable_thinking=} at idx {idx}")
                         self.share_inputs["enable_thinking"][idx : idx + 1, :] = enable_thinking
+                        async_set_value(self.share_inputs["reasoning_status"][idx : idx + 1], 0)
                         if enable_thinking:
                             self.share_inputs["limit_think_status"][idx : idx + 1, :] = 0
                             if request.get("reasoning_max_tokens") is not None:

--- a/fastdeploy/worker/metax_model_runner.py
+++ b/fastdeploy/worker/metax_model_runner.py
@@ -719,6 +719,7 @@ class MetaxModelRunner(ModelRunnerBase):
                         enable_thinking = bool(request.get("enable_thinking"))
                         logger.debug(f"request {request.request_id} with {enable_thinking=} at idx {idx}")
                         self.share_inputs["enable_thinking"][idx : idx + 1, :] = enable_thinking
+                        self.share_inputs["reasoning_status"][idx : idx + 1, :] = 0
                         if enable_thinking:
                             self.share_inputs["limit_think_status"][idx : idx + 1, :] = 0
                             if request.get("reasoning_max_tokens") is not None:

--- a/fastdeploy/worker/xpu_model_runner.py
+++ b/fastdeploy/worker/xpu_model_runner.py
@@ -599,6 +599,7 @@ class XPUModelRunner(ModelRunnerBase):
                     enable_thinking = bool(request.get("enable_thinking"))
                     logger.debug(f"request {request.request_id} with {enable_thinking=} at idx {idx}")
                     self.share_inputs["enable_thinking"][idx : idx + 1, :] = enable_thinking
+                    self.share_inputs["reasoning_status"][idx : idx + 1, :] = 0
                     if enable_thinking:
                         self.share_inputs["limit_think_status"][idx : idx + 1, :] = 0
                         if request.get("reasoning_max_tokens") is not None:
@@ -811,6 +812,7 @@ class XPUModelRunner(ModelRunnerBase):
                     )[0]
                     self.share_inputs["seq_lens_decoder"][idx : idx + 1] = 0
 
+                self.share_inputs["reasoning_status"][idx : idx + 1, :] = 0
                 if request.get("enable_thinking", False) and request.get("reasoning_max_tokens", None) is not None:
                     # Enable thinking
                     self.share_inputs["max_think_lens"][idx : idx + 1, :] = request.get("reasoning_max_tokens")


### PR DESCRIPTION
## Motivation

`reasoning_phase_token_constraint` kernel 的状态机有 4 个状态（0→1→2→3），当 `reasoning_status=3` 时直接 return 跳过处理。Bug 是请求结束后 `reasoning_status` 没有重置，新请求复用同一 batch slot 时继承了 `status=3`，导致 token constraint 永远不生效，模型在 thinking 结束后直接输出 `<|im_end|>` 而不是 `<response>`。

## Modifications

在 `insert_tasks_v1()` / `insert_prefill_inputs()` 中，新请求进入 batch slot 时将 `reasoning_status[idx]` 重置为 0，与 `limit_think_status` 等其他 per-request 状态变量的初始化模式保持一致。

- `fastdeploy/worker/gpu_model_runner.py`：`insert_tasks_v1()` 中 enable_thinking=True 和 False 两个分支均添加 `reasoning_status[idx:idx+1,:]=0`
- `fastdeploy/worker/metax_model_runner.py`：同上
- `fastdeploy/worker/xpu_model_runner.py`：`insert_tasks_v1()` 和 `insert_prefill_inputs()` 中对应的 4 个分支均添加

## Usage or Command

影响 Speculate Decoding 路径下启用 reasoning（如 DeepSeek-R1 等）的模型推理，无需额外命令，修复后 reasoning 状态机可正常工作。

## Accuracy Tests

修复前：启用 reasoning 的 speculate decoding 场景，thinking 结束后模型输出 `<|im_end|>` 而非 `<response>`，token constraint 未生效。
修复后：`reasoning_status` 在新请求进入 slot 时正确重置为 0，token constraint 正常生效，模型按预期输出 `<response>`。
