### PR TITLE
[Cherry-Pick][Optimization] Deduplicate reasoning_status reset in insert_tasks_v1

### DIFF
--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -849,9 +849,9 @@ class GPUModelRunner(ModelRunnerBase):
                         enable_thinking = bool(request.get("enable_thinking"))
                         logger.debug(f"request {request.request_id} with {enable_thinking=} at idx {idx}")
                         self.share_inputs["enable_thinking"][idx : idx + 1, :] = enable_thinking
+                        async_set_value(self.share_inputs["reasoning_status"][idx : idx + 1], 0)
                         if enable_thinking:
                             self.share_inputs["limit_think_status"][idx : idx + 1, :] = 0
-                            self.share_inputs["reasoning_status"][idx : idx + 1, :] = 0
                             if request.get("reasoning_max_tokens") is not None:
                                 # Enable thinking
                                 self.share_inputs["max_think_lens"][idx : idx + 1, :] = request.get(
@@ -871,7 +871,6 @@ class GPUModelRunner(ModelRunnerBase):
                             self.share_inputs["max_think_lens"][idx : idx + 1, :] = -1
                             self.share_inputs["max_reply_lens"][idx : idx + 1, :] = -1
                             self.share_inputs["limit_think_status"][idx : idx + 1, :] = 0
-                            self.share_inputs["reasoning_status"][idx : idx + 1, :] = 0
 
                 if isinstance(request.prompt_token_ids, np.ndarray):
                     prompt_token_ids = request.prompt_token_ids.tolist()

--- a/fastdeploy/worker/metax_model_runner.py
+++ b/fastdeploy/worker/metax_model_runner.py
@@ -719,9 +719,9 @@ class MetaxModelRunner(ModelRunnerBase):
                         enable_thinking = bool(request.get("enable_thinking"))
                         logger.debug(f"request {request.request_id} with {enable_thinking=} at idx {idx}")
                         self.share_inputs["enable_thinking"][idx : idx + 1, :] = enable_thinking
+                        self.share_inputs["reasoning_status"][idx : idx + 1, :] = 0
                         if enable_thinking:
                             self.share_inputs["limit_think_status"][idx : idx + 1, :] = 0
-                            self.share_inputs["reasoning_status"][idx : idx + 1, :] = 0
                             if request.get("reasoning_max_tokens") is not None:
                                 # Enable thinking
                                 self.share_inputs["max_think_lens"][idx : idx + 1, :] = request.get(
@@ -741,7 +741,6 @@ class MetaxModelRunner(ModelRunnerBase):
                             self.share_inputs["max_think_lens"][idx : idx + 1, :] = -1
                             self.share_inputs["max_reply_lens"][idx : idx + 1, :] = -1
                             self.share_inputs["limit_think_status"][idx : idx + 1, :] = 0
-                            self.share_inputs["reasoning_status"][idx : idx + 1, :] = 0
 
                 if isinstance(request.prompt_token_ids, np.ndarray):
                     prompt_token_ids = request.prompt_token_ids.tolist()

--- a/fastdeploy/worker/xpu_model_runner.py
+++ b/fastdeploy/worker/xpu_model_runner.py
@@ -595,16 +595,15 @@ class XPUModelRunner(ModelRunnerBase):
                 prefill_start_index = request.prefill_start_index
                 prefill_end_index = request.prefill_end_index
                 length = prefill_end_index - prefill_start_index
+                self.share_inputs["reasoning_status"][idx : idx + 1, :] = 0
                 if request.get("enable_thinking", False) and request.get("reasoning_max_tokens", None) is not None:
                     # Enable thinking
                     self.share_inputs["max_think_lens"][idx : idx + 1, :] = request.get("reasoning_max_tokens")
                     self.share_inputs["limit_think_status"][idx : idx + 1, :] = 0
-                    self.share_inputs["reasoning_status"][idx : idx + 1, :] = 0
                 else:
                     # Disable thinking
                     self.share_inputs["max_think_lens"][idx : idx + 1, :] = -1
                     self.share_inputs["limit_think_status"][idx : idx + 1, :] = 0
-                    self.share_inputs["reasoning_status"][idx : idx + 1, :] = 0
 
                 if (
                     hasattr(request, "sampling_params")
@@ -796,16 +795,15 @@ class XPUModelRunner(ModelRunnerBase):
                     )[0]
                     self.share_inputs["seq_lens_decoder"][idx : idx + 1] = 0
 
+                self.share_inputs["reasoning_status"][idx : idx + 1, :] = 0
                 if request.get("enable_thinking", False) and request.get("reasoning_max_tokens", None) is not None:
                     # Enable thinking
                     self.share_inputs["max_think_lens"][idx : idx + 1, :] = request.get("reasoning_max_tokens")
                     self.share_inputs["limit_think_status"][idx : idx + 1, :] = 0
-                    self.share_inputs["reasoning_status"][idx : idx + 1, :] = 0
                 else:
                     # Disable thinking
                     self.share_inputs["max_think_lens"][idx : idx + 1, :] = -1
                     self.share_inputs["limit_think_status"][idx : idx + 1, :] = 0
-                    self.share_inputs["reasoning_status"][idx : idx + 1, :] = 0
 
             def get_attr_from_request(request, attr, default_value=None):
                 res = request.get(attr, default_value)


### PR DESCRIPTION
## Motivation

#7660 合入后，`reasoning_status[idx]=0` 在 `if enable_thinking:` 和 `else:` 两个分支中重复出现，且 XPU/Metax 中未使用 `async_set_value` 导致新增同步开销。

## Modifications

- 将 `reasoning_status[idx]=0` 从 if/else 两个分支中提到判断之前，消除重复代码
- GPU runner 中使用 `async_set_value` 避免新增同步（与同文件其他 per-request 状态初始化方式一致）
- Metax/XPU runner 中使用直接赋值（与同文件其他赋值方式一致，这些文件未导入 `async_set_value`）

## Accuracy Tests

无逻辑变更，仅为代码优化，功能与 #7660 完全等价。
