### PR TITLE
[PD] Remove recode info for request when finish sending cache

### DIFF
--- a/fastdeploy/output/token_processor.py
+++ b/fastdeploy/output/token_processor.py
@@ -585,6 +585,7 @@ class TokenProcessor:
                             f"PD Error: prefill failed to send cache to decode, "
                             f"{task_id}, {self.prefill_result_status[task_id]}"
                         )
+                    self.prefill_result_status.pop(task_id)
                     log_request(
                         RequestLogLevel.STAGES,
                         message="wait for sending cache, request_id: {request_id}, cost seconds: {cost_seconds}",


### PR DESCRIPTION
PR 概述：在 PD 分离模式下，prefill 完成 cache 发送后立即清除 prefill_result_status 中对应 task_id 的记录，修复状态残留问题。
变更范围：fastdeploy/output/token_processor.py
影响面 Tag：[PD Disaggregation] [DataProcessor]