### PR TITLE
[CI] Use tsinghua Ubuntu mirrors to avoid docker_build timeout

### DIFF
--- a/tools/dockerfile/Dockerfile.ci
+++ b/tools/dockerfile/Dockerfile.ci
@@ -1,5 +1,8 @@
 FROM ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddle:cuda126-dev
-RUN apt update && apt install -y jq psmisc
+RUN sed -i 's/archive.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list && \
+    sed -i 's/security.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list && \
+    apt update && \
+    apt install -y jq psmisc
 COPY ../../requirements.txt ./requirements.txt
 RUN python -m pip install --no-cache-dir -r requirements.txt -i https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
 COPY ./unittest_requirement.txt ./unittest_requirement.txt
@@ -9,9 +12,6 @@ RUN python -m pip install --no-cache-dir -r requirements_paddle_nv.txt -i https:
 
 RUN wget -q --no-proxy https://paddle-qa.bj.bcebos.com/FastDeploy/MLNX_OFED_LINUX-24.10-2.1.8.0-ubuntu22.04-x86_64.tgz \
     && tar xf MLNX_OFED_LINUX-24.10-2.1.8.0-ubuntu22.04-x86_64.tgz
-
-RUN rm -f /etc/apt/sources.list  \
-    && echo "deb http://archive.ubuntu.com/ubuntu jammy main restricted universe multiverse\ndeb http://archive.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse\ndeb http://archive.ubuntu.com/ubuntu jammy-security main restricted universe multiverse" | tee /etc/apt/sources.list > /dev/null
 
 RUN cd MLNX_OFED_LINUX-24.10-2.1.8.0-ubuntu22.04-x86_64  \
     && apt clean \


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

The `ci_images` build stage occasionally encounters timeout and connectivity issues when accessing the default Ubuntu package sources (`archive.ubuntu.com` and `security.ubuntu.com`).

These network-related failures can cause unstable CI behavior and unnecessary build interruptions.

## Modifications

- Replaced default Ubuntu apt sources with TUNA mirror sources:
  - `archive.ubuntu.com` → `mirrors.tuna.tsinghua.edu.cn`
  - `security.ubuntu.com` → `mirrors.tuna.tsinghua.edu.cn`
- Improved package download stability and reduced timeout risk during image build.
- Enhanced reliability of the `ci_images` build stage in CI environments.
## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.