### PR TITLE
[KVCache][BugFix] fix cache_manager_v1 submit_swap_tasks crash when enable_mm=True

### DIFF
--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -806,7 +806,7 @@ class GPUModelRunner(ModelRunnerBase):
         }
         if self.enable_mm:
             # Sort by idx to ensure attention mask offsets are filled in order during mm prefill
-            req_dicts = sorted(req_dicts, key=lambda r: r.idx)
+            req_dicts.requests.sort(key=lambda r: r.idx)
         if self.enable_cache_manager_v1:
             # submit_swap_tasks handles:
             # 1. Waiting for pending evict handlers before submitting new evict


### PR DESCRIPTION
## Motivation

当 `enable_mm=True` 且 `enable_cache_manager_v1=True` 同时开启时（即 VLM 模型 + cache manager v1），`gpu_model_runner.py` 中存在必现的 `AttributeError` crash：

```python
# gpu_model_runner.py
if self.enable_mm:
    req_dicts = sorted(req_dicts, key=lambda r: r.idx)  # BatchRequest → 普通 list
if self.enable_cache_manager_v1:
    # ❌ 此时 req_dicts 已是 list，没有 cache_evict_metadata 属性
    self.cache_controller.submit_swap_tasks(req_dicts.cache_evict_metadata, req_dicts.cache_swap_metadata)
```

**错误信息**：`AttributeError: 'list' object has no attribute 'cache_evict_metadata'`

## Modifications

- **`worker/gpu_model_runner.py`**：将 `req_dicts = sorted(...)` 替换为 `req_dicts.requests.sort(...)`，原地排序保留 `BatchRequest` 类型，后续 `submit_swap_tasks` 调用无需改动

## Usage or Command

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. 该 bug 为运行时崩溃，单元测试难以覆盖多进程 worker 层调用链。
- [ ] Provide accuracy results.