### PR TITLE
[Cherry-Pick][BugFix][KVCache][Speculative Decoding] Fix get_max_chunk_tokens for PD-split decode node in MTP scenario(#7756)

### DIFF
--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -2484,7 +2484,13 @@ class FDConfig:
             if paddle.is_compiled_with_xpu():
                 num_tokens = self.scheduler_config.max_num_batched_tokens
             else:
-                num_tokens = self.scheduler_config.max_num_seqs
+                # In MTP scenario, each sequence generates (num_speculative_tokens + 1) tokens per step
+                mtp_steps = (
+                    (getattr(self.speculative_config, "num_speculative_tokens", 0) + 1)
+                    if self.speculative_config is not None and self.speculative_config.method is not None
+                    else 1
+                )
+                num_tokens = self.scheduler_config.max_num_seqs * mtp_steps
         else:
             num_tokens = self.scheduler_config.max_num_batched_tokens
             if self.enable_mm_runtime and mm_max_tokens_per_item is not None:


### PR DESCRIPTION
Cherry-pick of #7756 (authored by @kevincheng2) to `release/2.6`.

devPR:https://github.com/PaddlePaddle/FastDeploy/pull/7756 <!-- For pass CI -->

---

## Motivation

在 PD 分离 + MTP（Multi-Token Prediction）场景下，D 节点的 `get_max_chunk_tokens()` 返回值计算有误。

当前代码对 D 节点直接返回 `max_num_seqs`，未考虑 MTP 场景下每条 sequence 每个 decode step 实际处理 `num_speculative_tokens + 1` 个 token 的情况

## Modifications

`fastdeploy/config.py` `get_max_chunk_tokens()` 方法中，D 节点 non-XPU 分支：

- 修改前：`num_tokens = self.scheduler_config.max_num_seqs`
- 修改后：`num_tokens = self.scheduler_config.max_num_seqs * mtp_steps`

其中 `mtp_steps = num_speculative_tokens + 1`（非 MTP 时为 1，完全向后兼容），与同文件 `_check_max_num_batched_tokens` 中 `tokens_per_seq` 的计算逻辑保持一致。

## Usage or Command

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. 该修复为单行逻辑修正，与现有 speculative + PD 分离相关测试覆盖场景对齐；独立单元测试需要 MTP+PD 分离联合环境，暂未新增。
- [ ] Provide accuracy results.