### PR TITLE
[Cherry-Pick] [BugFix] [RL] Fix cpu cache for rl (#7764)

### DIFF
--- a/fastdeploy/cache_manager/cache_transfer_manager.py
+++ b/fastdeploy/cache_manager/cache_transfer_manager.py
@@ -748,19 +748,21 @@ class CacheTransferManager:
             while self.cache_ready_signal.value[self.rank] != 0:
                 time.sleep(0.1)
             logger.debug("Stop waiting! gpu runner has unlinked cuda ipc")
-            self.gpu_cache_kvs.clear()
-            self.gpu_cache_k_tensors.clear()
-            self.gpu_cache_v_tensors.clear()
-            if hasattr(self, "gpu_cache_scales_k_tensors"):
-                self.gpu_cache_scales_k_tensors.clear()
-            if hasattr(self, "gpu_cache_scales_v_tensors"):
-                self.gpu_cache_scales_v_tensors.clear()
-            paddle.device.cuda.empty_cache()
         else:
             for name, tensor in self.gpu_cache_kvs.items():
                 unset_data_ipc(tensor, name, True, False)
             logger.debug("Successfully unlinked gpu caches cuda ipc")
             self.cache_ready_signal.value[self.rank] = 0
+
+        self.gpu_cache_kvs.clear()
+        self.gpu_cache_k_tensors.clear()
+        self.gpu_cache_v_tensors.clear()
+        if hasattr(self, "gpu_cache_scales_k_tensors"):
+            self.gpu_cache_scales_k_tensors.clear()
+        if hasattr(self, "gpu_cache_scales_v_tensors"):
+            self.gpu_cache_scales_v_tensors.clear()
+        paddle.set_flags({"FLAGS_selected_gpus": f"{self.device}"})
+        paddle.device.cuda.empty_cache()
 
         while np.sum(self.cache_ready_signal.value) != 0:
             time.sleep(0.1)

--- a/fastdeploy/cache_manager/cache_transfer_manager.py
+++ b/fastdeploy/cache_manager/cache_transfer_manager.py
@@ -743,6 +743,7 @@ class CacheTransferManager:
         logger.info("GPU KV cache is initialized")
 
     def _clear_gpu_cache(self):
+
         if self.create_cache_tensor:
             logger.debug("Waiting for gpu runner to unlink cuda ipc")
             while self.cache_ready_signal.value[self.rank] != 0:
@@ -752,7 +753,6 @@ class CacheTransferManager:
             for name, tensor in self.gpu_cache_kvs.items():
                 unset_data_ipc(tensor, name, True, False)
             logger.debug("Successfully unlinked gpu caches cuda ipc")
-            self.cache_ready_signal.value[self.rank] = 0
 
         self.gpu_cache_kvs.clear()
         self.gpu_cache_k_tensors.clear()
@@ -763,6 +763,9 @@ class CacheTransferManager:
             self.gpu_cache_scales_v_tensors.clear()
         paddle.set_flags({"FLAGS_selected_gpus": f"{self.device}"})
         paddle.device.cuda.empty_cache()
+
+        if not self.create_cache_tensor:
+            self.cache_ready_signal.value[self.rank] = 0
 
         while np.sum(self.cache_ready_signal.value) != 0:
             time.sleep(0.1)

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -2868,16 +2868,16 @@ class GPUModelRunner(ModelRunnerBase):
         )
         local_rank = self.local_rank % self.parallel_config.tensor_parallel_size
 
-        if create_cache_tensor:
-            if not profile:
+        if not profile:
+            if create_cache_tensor:
                 logger.info("Waiting for cache transfer manager to unlink cuda ipc")
                 while self.cache_ready_signal.value[local_rank] != 0:
                     time.sleep(0.1)
                 logger.info("Stop waiting! cache transfer manager has unlinked cuda ipc")
-        else:
-            for name, tensor in self.cache_kvs_map.items():
-                unset_data_ipc(tensor, name, True, False)
-            self.cache_ready_signal.value[local_rank] = 0
+            else:
+                for name, tensor in self.cache_kvs_map.items():
+                    unset_data_ipc(tensor, name, True, False)
+                self.cache_ready_signal.value[local_rank] = 0
 
         self.cache_kvs_map.clear()
         self.share_inputs.pop("caches", None)

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -2868,10 +2868,17 @@ class GPUModelRunner(ModelRunnerBase):
         )
         local_rank = self.local_rank % self.parallel_config.tensor_parallel_size
 
-        if not create_cache_tensor:
+        if create_cache_tensor:
+            if not profile:
+                logger.info("Waiting for cache transfer manager to unlink cuda ipc")
+                while self.cache_ready_signal.value[local_rank] != 0:
+                    time.sleep(0.1)
+                logger.info("Stop waiting! cache transfer manager has unlinked cuda ipc")
+        else:
             for name, tensor in self.cache_kvs_map.items():
                 unset_data_ipc(tensor, name, True, False)
             self.cache_ready_signal.value[local_rank] = 0
+
         self.cache_kvs_map.clear()
         self.share_inputs.pop("caches", None)
         if self.forward_meta is not None:

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -2870,10 +2870,11 @@ class GPUModelRunner(ModelRunnerBase):
 
         if not profile:
             if create_cache_tensor:
-                logger.info("Waiting for cache transfer manager to unlink cuda ipc")
-                while self.cache_ready_signal.value[local_rank] != 0:
-                    time.sleep(0.1)
-                logger.info("Stop waiting! cache transfer manager has unlinked cuda ipc")
+                if self.fd_config.cache_config.num_cpu_blocks > 0:
+                    logger.info("Waiting for cache transfer manager to unlink cuda ipc")
+                    while self.cache_ready_signal.value[local_rank] != 0:
+                        time.sleep(0.1)
+                    logger.info("Stop waiting! cache transfer manager has unlinked cuda ipc")
             else:
                 for name, tensor in self.cache_kvs_map.items():
                     unset_data_ipc(tensor, name, True, False)


### PR DESCRIPTION
## Motivation
RL 场景下存在两处 Bug：1）`cache_transfer_manager._clear_gpu_cache` 中 GPU cache 清理操作（`gpu_cache_kvs.clear()` 等）仅置于 `if` 分支内，`else` 分支不执行清理，导致 GPU cache 未被正确释放；2）`gpu_model_runner.clear_cache` 中 `create_cache_tensor` 条件判断逻辑反转（`if not create_cache_tensor` 应为 `if create_cache_tensor`），导致等待 cuda IPC 解除的同步逻辑走反，引发 CPU cache 清理异常。

## Modifications
- `fastdeploy/cache_manager/cache_transfer_manager.py`：将 `gpu_cache_kvs.clear()`、`gpu_cache_k_tensors.clear()`、`gpu_cache_v_tensors.clear()` 及 `paddle.device.cuda.empty_cache()` 等清理操作从 `if` 块内移至 `if/else` 块之后，确保所有分支均执行清理
- `fastdeploy/worker/gpu_model_runner.py`：将 `if not create_cache_tensor:` 修正为 `if create_cache_tensor:`，修复 cuda IPC 等待逻辑的条件判断错误，同时补充 `profile=False` 时的等待日志

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.