### PR TITLE
[KVCache][BugFix] Fix cache_controller_v1 crash when value_cache_shape is None

### DIFF
--- a/fastdeploy/cache_manager/v1/cache_controller.py
+++ b/fastdeploy/cache_manager/v1/cache_controller.py
@@ -288,25 +288,31 @@ class CacheController(KVCacheBase):
 
             logger.info(f"..creating kv cache for layer {i}: key:{key_cache_shape}, value:{value_cache_shape}")
 
-            # Create key cache and value cache
+            # Create key cache
             key_cache = paddle.full(shape=key_cache_shape, fill_value=0, dtype=self.model_config.dtype)
             self.cache_kvs_map[cache_names["key"]] = key_cache
 
-            val_cache = paddle.full(shape=value_cache_shape, fill_value=0, dtype=self.model_config.dtype)
-            self.cache_kvs_map[cache_names["value"]] = val_cache
-            cache_kvs_list.extend([key_cache, val_cache])
+            if value_cache_shape:
+                val_cache = paddle.full(shape=value_cache_shape, fill_value=0, dtype=self.model_config.dtype)
+                self.cache_kvs_map[cache_names["value"]] = val_cache
+                cache_kvs_list.extend([key_cache, val_cache])
+            else:
+                cache_kvs_list.extend([key_cache])
 
             # Create scale caches for block_wise_fp8 quantization
             if self._is_fp8_quantization(kv_cache_quant_type) and kv_cache_scale_shape:
                 key_cache_scales = paddle.full(
                     shape=kv_cache_scale_shape, fill_value=0, dtype=paddle.get_default_dtype()
                 )
-                val_cache_scales = paddle.full(
-                    shape=kv_cache_scale_shape, fill_value=0, dtype=paddle.get_default_dtype()
-                )
                 self.cache_kvs_map[cache_names["key_scale"]] = key_cache_scales
-                self.cache_kvs_map[cache_names["value_scale"]] = val_cache_scales
-                cache_kvs_list.extend([key_cache_scales, val_cache_scales])
+                if value_cache_shape:
+                    val_cache_scales = paddle.full(
+                        shape=kv_cache_scale_shape, fill_value=0, dtype=paddle.get_default_dtype()
+                    )
+                    self.cache_kvs_map[cache_names["value_scale"]] = val_cache_scales
+                    cache_kvs_list.extend([key_cache_scales, val_cache_scales])
+                else:
+                    cache_kvs_list.extend([key_cache_scales])
 
         paddle.device.cuda.empty_cache()
         logger.info("kv cache is initialized!")
@@ -366,20 +372,26 @@ class CacheController(KVCacheBase):
             key_cache = paddle.full(shape=key_cache_shape, fill_value=0, dtype=self.model_config.dtype)
             self.cache_kvs_map[cache_names["key"]] = key_cache
 
-            val_cache = paddle.full(shape=value_cache_shape, fill_value=0, dtype=self.model_config.dtype)
-            self.cache_kvs_map[cache_names["value"]] = val_cache
-            cache_kvs_list.extend([key_cache, val_cache])
+            if value_cache_shape:
+                val_cache = paddle.full(shape=value_cache_shape, fill_value=0, dtype=self.model_config.dtype)
+                self.cache_kvs_map[cache_names["value"]] = val_cache
+                cache_kvs_list.extend([key_cache, val_cache])
+            else:
+                cache_kvs_list.extend([key_cache])
 
             if self._is_fp8_quantization(kv_cache_quant_type) and kv_cache_scale_shape:
                 key_cache_scales = paddle.full(
                     shape=kv_cache_scale_shape, fill_value=0, dtype=paddle.get_default_dtype()
                 )
-                val_cache_scales = paddle.full(
-                    shape=kv_cache_scale_shape, fill_value=0, dtype=paddle.get_default_dtype()
-                )
                 self.cache_kvs_map[cache_names["key_scale"]] = key_cache_scales
-                self.cache_kvs_map[cache_names["value_scale"]] = val_cache_scales
-                cache_kvs_list.extend([key_cache_scales, val_cache_scales])
+                if value_cache_shape:
+                    val_cache_scales = paddle.full(
+                        shape=kv_cache_scale_shape, fill_value=0, dtype=paddle.get_default_dtype()
+                    )
+                    self.cache_kvs_map[cache_names["value_scale"]] = val_cache_scales
+                    cache_kvs_list.extend([key_cache_scales, val_cache_scales])
+                else:
+                    cache_kvs_list.extend([key_cache_scales])
 
         paddle.device.cuda.empty_cache()
         logger.info("[CacheController] MTP kv cache initialized!")


### PR DESCRIPTION
## Motivation

`initialize_kv_cache` and `initialize_mtp_kv_cache` in `CacheControllerV1` unconditionally create a value cache tensor.
For attention backends that return `value_cache_shape=None` (e.g. MLA variants), this causes a crash at `paddle.full(shape=None, ...)`.

`gpu_model_runner.py` already handles this case correctly — this PR brings `cache_controller_v1` in line with that logic.

## Modifications

- `initialize_kv_cache`: guard val_cache / val_cache_scales creation behind `if value_cache_shape`; `cache_kvs_list` order is now `[key]` or `[key, val]`, matching `gpu_model_runner.py`.
- `initialize_mtp_kv_cache`: apply the same fix for MTP layers.

## Usage or Command

No special command needed. The fix takes effect automatically when launching FastDeploy with an MLA-style attention backend via `CacheControllerV1`.

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. No unit tests added — the existing `initialize_kv_cache` path is covered by integration tests; a targeted unit test for `value_cache_shape=None` would require mocking the attention backend.
- [ ] Provide accuracy results.