### PR TITLE
[BugFix] Fix ZMQ multipart frame interleaving in Splitwise connector

### DIFF
--- a/fastdeploy/splitwise/splitwise_connector.py
+++ b/fastdeploy/splitwise/splitwise_connector.py
@@ -15,10 +15,11 @@
 """
 
 import pickle
+import threading
 import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import zmq
 
@@ -58,6 +59,8 @@ class SplitwiseConnector:
         if self.cfg.scheduler_config.splitwise_role != "mixed":
             self.zmq_ctx = zmq.Context()
             self.push_sockets: Dict[str, zmq.Socket] = {}
+            self._push_socket_locks: Dict[str, threading.Lock] = {}
+            self._push_sockets_meta_lock = threading.Lock()
             self.pull_socket = None
             self.io_executor = ThreadPoolExecutor(max_workers=4)
             self._init_network()
@@ -105,13 +108,20 @@ class SplitwiseConnector:
                 self.logger.error(f"start_receiver: Receiver error: {e}, {str(traceback.format_exc())}")
                 time.sleep(1)
 
-    def _get_push_socket(self, addr):
-        """获取或创建 DEALER socket"""
+    def _get_push_socket(self, addr) -> Tuple[zmq.Socket, threading.Lock]:
+        """
+        获取或创建 DEALER socket 及其发送锁。
 
-        if addr in self.push_sockets:
-            sock = self.push_sockets[addr]
-            if not sock.closed:
-                return sock
+        Returns:
+            Tuple[zmq.Socket, threading.Lock]: 目标地址对应的 socket 和保护 multipart 发送的锁。
+        """
+        with self._push_sockets_meta_lock:
+            if addr in self.push_sockets:
+                sock = self.push_sockets[addr]
+                if not sock.closed:
+                    return sock, self._push_socket_locks[addr]
+                del self.push_sockets[addr]
+                self._push_socket_locks.pop(addr, None)
 
         try:
             self.logger.info(f"_get_push_socket: Establishing new connection to {addr}")
@@ -129,8 +139,17 @@ class SplitwiseConnector:
 
             sock.connect(f"tcp://{addr}")
 
-            self.push_sockets[addr] = sock
-            return sock
+            with self._push_sockets_meta_lock:
+                if addr in self.push_sockets:
+                    existing_sock = self.push_sockets[addr]
+                    if not existing_sock.closed:
+                        sock.close()
+                        return existing_sock, self._push_socket_locks[addr]
+                    del self.push_sockets[addr]
+                    self._push_socket_locks.pop(addr, None)
+                self.push_sockets[addr] = sock
+                self._push_socket_locks[addr] = threading.Lock()
+                return sock, self._push_socket_locks[addr]
 
         except zmq.ZMQError as e:
             self.logger.error(f"_get_push_socket: Connection to {addr} failed: {e}, {traceback.format_exc()}")
@@ -144,8 +163,11 @@ class SplitwiseConnector:
             message = self._serialize_message(msg_type, payload)
             try:
                 self.logger.info(f"_send_message: msg_type={msg_type} addr={addr}")
-                sock = self._get_push_socket(addr)
-                sock.send_multipart(message)
+                sock, lock = self._get_push_socket(addr)
+                with lock:
+                    if sock.closed:
+                        raise ConnectionError(f"Connection to {addr} is closed")
+                    sock.send_multipart(message)
 
                 self.logger.info(f"Sent {msg_type} to {addr}")
 
@@ -164,9 +186,19 @@ class SplitwiseConnector:
         """
         Close the connection to the specified address.
         """
-        if addr in self.push_sockets:
-            self.push_sockets[addr].close()
-            del self.push_sockets[addr]
+        sock = None
+        lock = None
+        with self._push_sockets_meta_lock:
+            if addr in self.push_sockets:
+                sock = self.push_sockets.pop(addr)
+                lock = self._push_socket_locks.pop(addr, None)
+
+        if sock is not None:
+            if lock is not None:
+                with lock:
+                    sock.close()
+            else:
+                sock.close()
 
     def send_splitwise_tasks(self, tasks: List[Request], current_id):
         """

--- a/tests/splitwise/test_splitwise_connector.py
+++ b/tests/splitwise/test_splitwise_connector.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from threading import Lock
 from typing import Any, Dict, List
 from unittest.mock import Mock, patch
 
@@ -84,6 +85,10 @@ def _build_connector() -> SplitwiseConnector:
     connector = SplitwiseConnector(cfg=DummyCfg(), worker_queue=DummyWorkerQueue(), resource_manager=None)
     if not hasattr(connector, "push_sockets"):
         connector.push_sockets = {}
+    if not hasattr(connector, "_push_socket_locks"):
+        connector._push_socket_locks = {}
+    if not hasattr(connector, "_push_sockets_meta_lock"):
+        connector._push_sockets_meta_lock = Lock()
     return connector
 
 
@@ -240,6 +245,7 @@ def test_init_non_mixed_creates_network_state():
     assert connector.local_data_parallel_id == 1
     assert connector.pull_socket is None
     assert connector.push_sockets == {}
+    assert connector._push_socket_locks == {}
     mock_init.assert_called_once_with()
 
 
@@ -248,9 +254,11 @@ def test_get_push_socket_reuses_existing_and_handles_zmq_error():
     open_socket = Mock()
     open_socket.closed = False
     connector.push_sockets["127.0.0.1:8000"] = open_socket
+    connector._push_socket_locks["127.0.0.1:8000"] = Lock()
 
-    same_socket = connector._get_push_socket("127.0.0.1:8000")
+    same_socket, same_lock = connector._get_push_socket("127.0.0.1:8000")
     assert same_socket is open_socket
+    assert same_lock is connector._push_socket_locks["127.0.0.1:8000"]
 
     connector.zmq_ctx = Mock()
     connector.zmq_ctx.socket.side_effect = zmq.ZMQError("boom")
@@ -265,9 +273,10 @@ def test_get_push_socket_creates_and_configures_socket():
     new_socket.closed = False
     connector.zmq_ctx.socket.return_value = new_socket
 
-    socket = connector._get_push_socket("127.0.0.1:7000")
+    socket, lock = connector._get_push_socket("127.0.0.1:7000")
 
     assert socket is new_socket
+    assert lock is connector._push_socket_locks["127.0.0.1:7000"]
     new_socket.connect.assert_called_once_with("tcp://127.0.0.1:7000")
     assert connector.push_sockets["127.0.0.1:7000"] is new_socket
 
@@ -275,7 +284,8 @@ def test_get_push_socket_creates_and_configures_socket():
 def test_send_message_serializes_and_sends_payload():
     connector = _build_connector()
     mock_socket = Mock()
-    connector._get_push_socket = Mock(return_value=mock_socket)
+    mock_socket.closed = False
+    connector._get_push_socket = Mock(return_value=(mock_socket, Lock()))
     request = Request(
         request_id="req-send",
         prompt=None,
@@ -312,16 +322,20 @@ def test_send_message_handles_missing_addr_and_errors():
     connector._send_message("127.0.0.1:7000", "prefill", [])
 
     failing_socket = Mock()
+    failing_socket.closed = False
     failing_socket.send_multipart.side_effect = zmq.Again()
-    connector._get_push_socket = Mock(return_value=failing_socket)
+    connector._get_push_socket = Mock(return_value=(failing_socket, Lock()))
     connector._send_message("127.0.0.1:7001", "prefill", [])
 
     crash_socket = Mock()
+    crash_socket.closed = False
     crash_socket.send_multipart.side_effect = RuntimeError("boom")
-    connector._get_push_socket = Mock(return_value=crash_socket)
+    connector._get_push_socket = Mock(return_value=(crash_socket, Lock()))
     connector.push_sockets["127.0.0.1:7002"] = crash_socket
+    connector._push_socket_locks["127.0.0.1:7002"] = Lock()
     connector._send_message("127.0.0.1:7002", "prefill", [])
     assert "127.0.0.1:7002" not in connector.push_sockets
+    assert "127.0.0.1:7002" not in connector._push_socket_locks
 
 
 def test_send_splitwise_tasks_updates_roles_and_tracks_ids():


### PR DESCRIPTION
## Motivation

Related PR: https://github.com/PaddlePaddle/FastDeploy/pull/7763

在 Splitwise / PD 分离场景下，P 节点向 D 节点发送 `decode` / `prefill` / `cache_sync` 消息时，复用了按地址缓存的 ZMQ `DEALER` socket。

当前代码中 `push_sockets` 的获取、创建和 `send_multipart()` 发送均未加锁。由于 ZMQ socket 不是线程安全的，当多个线程同时通过同一个 `DEALER` socket 发送 multipart 消息时，可能出现不同消息的 frame 交织。

在 R3 开启后，`routing_data` 等大 numpy 数组会通过 pickle protocol 5 产生 out-of-band buffer frames，使单条 ZMQ 消息从单帧变为多帧。并发发送时，D 节点可能收到错位的 `main_bytes` 和 buffer frames，导致反序列化失败，例如：

- `cannot reshape array of size ... into shape ...`
- `invalid load key, 'n'`

## Modifications

`fastdeploy/splitwise/splitwise_connector.py` 中：

- 新增 `threading` 依赖
- 新增 `_push_sockets_meta_lock`，用于保护 `push_sockets` 和 `_push_socket_locks` 的并发访问、创建、删除
- 新增 `_push_socket_locks: Dict[str, threading.Lock]`，为每个 `addr` 对应的 `DEALER` socket 维护独立发送锁
- 修改 `_get_push_socket()`，在 meta lock 内完成 socket / lock 的 check-then-act，避免并发创建或访问不一致
- 修改 `_send_message()`，对同一 socket 的 `send_multipart()` 加锁，保证 multipart frames 原子性发送，避免帧交织
- 修改 `_close_connection()`，关闭 socket 时同步清理对应的发送锁

## Usage or Command

N/A

## Accuracy Tests

N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. 该修复为 ZMQ socket 并发发送保护，问题依赖多线程并发、multipart frame 和 R3 routing_data 大 buffer 触发；暂未新增稳定可复现的单元测试。
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.