### PR TITLE
[BugFix] Fix KSM overlap bug

### DIFF
--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -585,9 +585,7 @@ def save_output_speculate(
 
     # Renormalize logprobs with logz (deferred from post_process for better overlap).
     if sampler_output.logprobs_tensors is not None and sampler_output.logz_per_batch is not None:
-        # TODO (wangyanpeng): Currently, there is a bug when overlap is enabled.
-        # Please ensure overlap is disabled when using this functionality to avoid unexpected behavior.
-        real_token_num = share_inputs["accept_num_cpu"].sum()
+        real_token_num = share_inputs["accept_num"].sum()
         sampler_output.logprobs_tensors = LogprobsTensors(
             logprob_token_ids=sampler_output.logprobs_tensors.logprob_token_ids[:real_token_num],
             logprobs=sampler_output.logprobs_tensors.logprobs[:real_token_num],


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Fix a bug in KSM when overlap is enabled. Since KSM itself introduces synchronization under overlap mode, which breaks the overlap, we temporarily do not consider asynchrony here and only ensure functional correctness.

## Modifications

<!-- Detail the changes made in this pull request. -->

- Changed `accept_num_cpu` to `accept_num` to directly use the GPU-side accept_num for calculation

## Usage or Command

N/A

## Accuracy Tests

N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
