### PR TITLE
[Speculative Decoding]【Hackathon 10th Spring No.54】ngram 端到端验证 -part

### DIFF
--- a/custom_ops/gpu_ops/cpp_extensions.cc
+++ b/custom_ops/gpu_ops/cpp_extensions.cc
@@ -941,9 +941,7 @@ void SpeculateScheduleCache(const paddle::Tensor& draft_tokens,
                             const int block_size,
                             const int max_draft_tokens);
 
-void NgramMatch(const paddle::Tensor& input_ids,
-                const paddle::Tensor& input_ids_len,
-                const paddle::Tensor& token_ids_all,
+void NgramMatch(const paddle::Tensor& token_ids_all,
                 const paddle::Tensor& prompt_lens,
                 const paddle::Tensor& step_idx,
                 const paddle::Tensor& draft_token_num,

--- a/custom_ops/gpu_ops/speculate_decoding/ngram_match.cu
+++ b/custom_ops/gpu_ops/speculate_decoding/ngram_match.cu
@@ -27,9 +27,7 @@
 // the tentative new seq_lens_this_time to a copy buffer.
 // Phase 2 will decide which ones to keep (threshold logic).
 // ============================================================
-__global__ void ngram_match_search_kernel(const int64_t *input_ids,
-                                          const int64_t *input_ids_len,
-                                          const int64_t *token_ids_all,
+__global__ void ngram_match_search_kernel(const int64_t *token_ids_all,
                                           const int64_t *prompt_lens,
                                           const int64_t *step_idx,
                                           const int *draft_token_num,
@@ -38,7 +36,6 @@ __global__ void ngram_match_search_kernel(const int64_t *input_ids,
                                           const int64_t *max_dec_len,
                                           int64_t *draft_tokens_copy,
                                           int32_t *seq_lens_this_time_copy,
-                                          int64_t input_ids_stride,
                                           int64_t max_model_len,
                                           int64_t draft_tokens_stride,
                                           int64_t max_batch_size,
@@ -63,9 +60,9 @@ __global__ void ngram_match_search_kernel(const int64_t *input_ids,
   // Active decoder item: at least the base token.
   if (threadIdx.x == 0) seq_lens_this_time_copy[batch_idx] = 1;
 
-  const int64_t *cur_input_ids = input_ids + batch_idx * input_ids_stride;
-  const int64_t cur_input_ids_len = input_ids_len[batch_idx];
   const int64_t prompt_len = prompt_lens[batch_idx];
+  const int64_t *cur_input_ids = token_ids_all + batch_idx * max_model_len;
+  const int64_t cur_input_ids_len = prompt_len;
   const int64_t *cur_pre_ids =
       token_ids_all + batch_idx * max_model_len + prompt_len;
   const int64_t cur_step_idx = step_idx[batch_idx];
@@ -79,7 +76,7 @@ __global__ void ngram_match_search_kernel(const int64_t *input_ids,
   for (int ngram_size = max_ngram_size; ngram_size >= 1; --ngram_size) {
     if (cur_step_idx < ngram_size) continue;
 
-    const int64_t *ngram = cur_pre_ids + (cur_step_idx + 1 - ngram_size);
+    const int64_t *ngram = cur_pre_ids + (cur_step_idx - ngram_size);
 
     int64_t pos = parallel_ngram_search(
         cur_input_ids, cur_input_ids_len, ngram, ngram_size, &s_min_pos);
@@ -235,9 +232,7 @@ static int sum_cpu(const int *value, int num) {
   return sum_value;
 }
 
-static void find_candidate_pred_tokens(const int64_t *input_ids,
-                                       const int64_t *input_ids_len,
-                                       const int64_t *token_ids_all,
+static void find_candidate_pred_tokens(const int64_t *token_ids_all,
                                        const int64_t *prompt_lens,
                                        const int64_t *step_idx,
                                        const int *draft_token_num,
@@ -246,7 +241,6 @@ static void find_candidate_pred_tokens(const int64_t *input_ids,
                                        int32_t *seq_lens_encoder,
                                        int32_t *seq_lens_decoder,
                                        int64_t *max_dec_len,
-                                       int64_t input_ids_stride,
                                        int64_t max_model_len,
                                        int64_t draft_tokens_stride,
                                        int64_t max_batch_size,
@@ -274,12 +268,12 @@ static void find_candidate_pred_tokens(const int64_t *input_ids,
       continue;
     }
 
-    const int64_t *cur_input_ids = input_ids + batch_idx * input_ids_stride;
+    const int64_t *cur_input_ids = token_ids_all + batch_idx * max_model_len;
+    const int64_t cur_input_ids_len = prompt_lens[batch_idx];
     int64_t *cur_draft_tokens = draft_tokens + batch_idx * draft_tokens_stride;
     const int64_t *cur_pre_ids =
-        token_ids_all + batch_idx * max_model_len + prompt_lens[batch_idx];
+        token_ids_all + batch_idx * max_model_len + cur_input_ids_len;
     const int64_t cur_step_idx = step_idx[batch_idx];
-    const int64_t cur_input_ids_len = input_ids_len[batch_idx];
     seq_lens_this_time[batch_idx] = 1;
     unprocessed_batch_size--;
 
@@ -301,7 +295,7 @@ static void find_candidate_pred_tokens(const int64_t *input_ids,
       if (cur_step_idx < ngram_size) {
         continue;
       }
-      const int64_t *ngram = cur_pre_ids + (cur_step_idx + 1 - ngram_size);
+      const int64_t *ngram = cur_pre_ids + (cur_step_idx - ngram_size);
 
       bool match_input = false;
       for (int64_t i = 0; i <= cur_input_ids_len - ngram_size; ++i) {
@@ -370,9 +364,7 @@ static void find_candidate_pred_tokens(const int64_t *input_ids,
 // bsz × NGRAM_BLOCK_THREADS threads.  Phase 2 is O(bsz) with scans.
 // ============================================================
 
-void NgramMatch(const paddle::Tensor &input_ids,
-                const paddle::Tensor &input_ids_len,
-                const paddle::Tensor &token_ids_all,
+void NgramMatch(const paddle::Tensor &token_ids_all,
                 const paddle::Tensor &prompt_lens,
                 const paddle::Tensor &step_idx,
                 const paddle::Tensor &draft_token_num,
@@ -383,9 +375,6 @@ void NgramMatch(const paddle::Tensor &input_ids,
                 const paddle::Tensor &max_dec_len,
                 const int max_ngram_size,
                 const int max_draft_tokens) {
-  auto input_ids_shape = input_ids.shape();
-  const int64_t input_ids_stride = input_ids_shape[1];
-
   const int64_t max_model_len = token_ids_all.shape()[1];
 
   auto draft_tokens_shape = draft_tokens.shape();
@@ -399,8 +388,8 @@ void NgramMatch(const paddle::Tensor &input_ids,
     threshold = std::stoi(env_var);
   }
 
-  if (input_ids.is_gpu()) {
-    auto stream = input_ids.stream();
+  if (token_ids_all.is_gpu()) {
+    auto stream = token_ids_all.stream();
 
     // Persistent scratch buffers for Phase 1 → Phase 2 communication.
     // Cached across calls to avoid per-invocation allocation overhead.
@@ -416,9 +405,9 @@ void NgramMatch(const paddle::Tensor &input_ids,
         draft_tokens_stride > s_scratch_stride) {
       s_draft_copy = paddle::empty({max_batch_size, draft_tokens_stride},
                                    paddle::DataType::INT64,
-                                   input_ids.place());
+                                   token_ids_all.place());
       s_seqlens_copy = paddle::empty(
-          {max_batch_size}, paddle::DataType::INT32, input_ids.place());
+          {max_batch_size}, paddle::DataType::INT32, token_ids_all.place());
       s_scratch_batch = max_batch_size;
       s_scratch_stride = draft_tokens_stride;
     }
@@ -435,8 +424,6 @@ void NgramMatch(const paddle::Tensor &input_ids,
                                 NGRAM_BLOCK_THREADS,
                                 0,
                                 stream>>>(
-        input_ids.data<int64_t>(),
-        input_ids_len.data<int64_t>(),
         token_ids_all.data<int64_t>(),
         prompt_lens.data<int64_t>(),
         step_idx.data<int64_t>(),
@@ -446,7 +433,6 @@ void NgramMatch(const paddle::Tensor &input_ids,
         max_dec_len.data<int64_t>(),
         draft_tokens_copy.data<int64_t>(),
         seq_lens_this_time_copy.data<int32_t>(),
-        input_ids_stride,
         max_model_len,
         draft_tokens_stride,
         max_batch_size,
@@ -465,8 +451,6 @@ void NgramMatch(const paddle::Tensor &input_ids,
         threshold);
   } else {
     find_candidate_pred_tokens(
-        input_ids.data<int64_t>(),
-        input_ids_len.data<int64_t>(),
         token_ids_all.data<int64_t>(),
         prompt_lens.data<int64_t>(),
         step_idx.data<int64_t>(),
@@ -476,7 +460,6 @@ void NgramMatch(const paddle::Tensor &input_ids,
         const_cast<int32_t *>(seq_lens_encoder.data<int32_t>()),
         const_cast<int32_t *>(seq_lens_decoder.data<int32_t>()),
         const_cast<int64_t *>(max_dec_len.data<int64_t>()),
-        input_ids_stride,
         max_model_len,
         draft_tokens_stride,
         max_batch_size,
@@ -486,9 +469,7 @@ void NgramMatch(const paddle::Tensor &input_ids,
 }
 
 PD_BUILD_STATIC_OP(ngram_match)
-    .Inputs({"input_ids",
-             "input_ids_len",
-             "token_ids_all",
+    .Inputs({"token_ids_all",
              "prompt_lens",
              "step_idx",
              "draft_token_num",

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -1964,6 +1964,7 @@ class FDConfig:
                     in [
                         SpecMethod.MTP,
                         SpecMethod.SUFFIX,
+                        SpecMethod.NGRAM,
                     ]
                 )
                 else 0

--- a/fastdeploy/spec_decode/ngram.py
+++ b/fastdeploy/spec_decode/ngram.py
@@ -16,8 +16,6 @@
 
 from typing import TYPE_CHECKING
 
-import paddle
-
 from fastdeploy.model_executor.ops.gpu import ngram_match
 
 from .base import Proposer
@@ -36,23 +34,12 @@ class NgramProposer(Proposer):
     def __init__(self, fd_config: "FDConfig"):
         super().__init__(fd_config)
         self.max_ngram_size = self.speculative_config.max_ngram_size
-        self.input_ids_len = paddle.zeros(shape=[self.max_num_seqs, 1], dtype="int64").cpu()
-        self.input_ids_len_gpu = paddle.zeros(shape=[self.max_num_seqs, 1], dtype="int64").cuda()
-
-    def update(self, bid: int, seq_len: int):
-        """
-        update
-        """
-        self.input_ids_len[bid] = seq_len
-        self.input_ids_len_gpu[bid] = seq_len
 
     def _run_impl(self, share_inputs):
         """
         run
         """
         ngram_match(
-            share_inputs["input_ids_cpu"].cuda(),
-            self.input_ids_len_gpu,
             share_inputs["token_ids_all"],
             share_inputs["prompt_lens"],
             share_inputs["step_idx"],

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -2094,7 +2094,11 @@ class GPUModelRunner(ModelRunnerBase):
                     logger.info(
                         f"Warm up the model with the num_tokens:{num_tokens}, expected_decode_len:{expected_decode_len}"
                     )
-            elif self.speculative_decoding and self.spec_method in [SpecMethod.MTP, SpecMethod.SUFFIX]:
+            elif self.speculative_decoding and self.spec_method in [
+                SpecMethod.MTP,
+                SpecMethod.SUFFIX,
+                SpecMethod.NGRAM,
+            ]:
                 for capture_size in sorted(capture_sizes, reverse=True):
                     expected_decode_len = (self.speculative_config.num_speculative_tokens + 1) * 2
                     self._dummy_run(

--- a/tests/e2e/test_ernie_03b_ngram.py
+++ b/tests/e2e/test_ernie_03b_ngram.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+from utils.serving_utils import (
+    FD_API_PORT,
+    FD_CACHE_QUEUE_PORT,
+    FD_ENGINE_QUEUE_PORT,
+    FD_METRICS_PORT,
+    clean,
+    extract_logprobs,
+    get_stream_chunks,
+    is_port_open,
+    send_request,
+)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_and_run_server():
+    print("Pre-test port cleanup...")
+    clean()
+
+    if os.path.exists("log") and os.path.isdir("log"):
+        shutil.rmtree("log")
+
+    base_path = os.getenv("MODEL_PATH")
+    if base_path:
+        model_path = os.path.join(base_path, "ERNIE-4.5-0.3B-Paddle")
+    else:
+        model_path = "baidu/ERNIE-4.5-0.3B-Paddle"
+
+    speculative_config = {
+        "method": "ngram",
+        "num_speculative_tokens": 5,
+        "max_ngram_size": 3,
+        "min_ngram_size": 1,
+    }
+
+    log_path = "server.log"
+    cmd = [
+        sys.executable,
+        "-m",
+        "fastdeploy.entrypoints.openai.api_server",
+        "--model",
+        model_path,
+        "--port",
+        str(FD_API_PORT),
+        "--tensor-parallel-size",
+        "1",
+        "--engine-worker-queue-port",
+        str(FD_ENGINE_QUEUE_PORT),
+        "--metrics-port",
+        str(FD_METRICS_PORT),
+        "--cache-queue-port",
+        str(FD_CACHE_QUEUE_PORT),
+        "--max-model-len",
+        "4096",
+        "--max-num-seqs",
+        "4",
+        "--enable-overlap-schedule",
+        "--enable-logprob",
+        "--speculative-config",
+        json.dumps(speculative_config),
+        "--graph-optimization-config",
+        '{"use_cudagraph":true}',
+    ]
+
+    with open(log_path, "w") as logfile:
+        process = subprocess.Popen(
+            cmd,
+            stdout=logfile,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+
+    for _ in range(300):
+        if is_port_open("127.0.0.1", FD_API_PORT):
+            print(f"Server is up on port {FD_API_PORT}")
+            break
+        time.sleep(1)
+    else:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+            clean()
+        except Exception as e:
+            print(f"Failed to kill process group: {e}")
+        raise RuntimeError(f"API server did not start on port {FD_API_PORT}")
+
+    yield
+
+    print("\n===== Post-test server cleanup... =====")
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+        clean()
+        print(f"server (pid={process.pid}) terminated")
+    except Exception as e:
+        print(f"Failed to terminate API server: {e}")
+
+
+@pytest.fixture(scope="session")
+def api_url():
+    return f"http://0.0.0.0:{FD_API_PORT}/v1/chat/completions"
+
+
+@pytest.fixture(scope="session")
+def metrics_url():
+    return f"http://0.0.0.0:{FD_METRICS_PORT}/metrics"
+
+
+def test_ngram_stream(api_url):
+    """Streaming generation returns non-empty result with valid token counts."""
+    payload = {
+        "model": "default",
+        "messages": [{"role": "user", "content": "牛顿的三大运动定律是什么？"}],
+        "max_tokens": 50,
+        "min_tokens": 10,
+        "temperature": 0,
+        "top_p": 0,
+        "seed": 42,
+        "stream": True,
+        "stream_options": {"include_usage": True, "continuous_usage_stats": True},
+    }
+    response = send_request(url=api_url, payload=payload)
+    chunks = get_stream_chunks(response)
+    result = "".join(x["choices"][0]["delta"]["content"] for x in chunks[:-1])
+    assert result != "", "Generation result is empty"
+    usage = chunks[-1]["usage"]
+    assert usage["completion_tokens"] <= payload["max_tokens"]
+    assert usage["completion_tokens"] >= payload["min_tokens"]
+    assert usage["total_tokens"] == usage["completion_tokens"] + usage["prompt_tokens"]
+
+
+def test_ngram_non_stream(api_url):
+    """Non-streaming generation returns non-empty result with valid token counts."""
+    payload = {
+        "model": "default",
+        "messages": [{"role": "user", "content": "牛顿的三大运动定律是什么？"}],
+        "max_tokens": 50,
+        "min_tokens": 10,
+        "temperature": 0,
+        "top_p": 0,
+        "seed": 42,
+        "stream": False,
+    }
+    response = send_request(url=api_url, payload=payload).json()
+    result = response["choices"][0]["message"]["content"]
+    assert result != "", "Generation result is empty"
+    usage = response["usage"]
+    assert usage["completion_tokens"] <= payload["max_tokens"]
+    assert usage["completion_tokens"] >= payload["min_tokens"]
+    assert usage["total_tokens"] == usage["completion_tokens"] + usage["prompt_tokens"]
+
+
+def test_ngram_speculate_metrics(api_url):
+    """speculate_metrics matches the fixed baseline (deterministic with seed=42)."""
+    baseline = {
+        "accepted_tokens": 100,
+        "rejected_tokens": 314,
+        "accept_ratio": 0.31000000000000005,
+        "average_accept_length": 1.4492753623188406,
+        "accepted_tokens_per_head": [69, 13, 9, 3, 3, 3],
+        "accept_ratio_per_head": [0.18840579710144928, 0.6923076923076923, 0.3333333333333333, 1.0, 1.0],
+    }
+    # Prompt with repeated fragments to increase ngram match rate
+    content = (
+        "请复述以下内容：'牛顿第一定律：物体在不受外力作用时保持静止或匀速直线运动，"
+        "牛顿第二定律：F=ma，牛顿第三定律：作用力与反作用力大小相等方向相反。'"
+        "然后用自己的话解释牛顿第一定律。"
+    )
+    payload = {
+        "model": "default",
+        "messages": [{"role": "user", "content": content}],
+        "max_tokens": 100,
+        "min_tokens": 20,
+        "temperature": 0,
+        "top_p": 0,
+        "seed": 42,
+        "stream": True,
+        "stream_options": {"include_usage": True, "continuous_usage_stats": True},
+    }
+    response = send_request(url=api_url, payload=payload)
+    chunks = get_stream_chunks(response)
+    # chunks[-1] is the usage chunk; chunks[-2] is the last content chunk containing speculate_metrics
+    speculate_metrics = chunks[-2]["choices"][0].get("speculate_metrics")
+    # print(f"\n[test_ngram_speculate_metrics] speculate_metrics: {json.dumps(speculate_metrics, indent=2)}")
+    assert speculate_metrics == baseline, f"speculate_metrics mismatch\ngot: {speculate_metrics}\nbaseline: {baseline}"
+
+
+def test_ngram_speculate_metrics_with_logprobs(api_url):
+    """speculate_metrics and logprobs coexist correctly when logprobs is enabled."""
+    baseline = {
+        "accepted_tokens": 100,
+        "rejected_tokens": 332,
+        "accept_ratio": 0.28,
+        "average_accept_length": 1.3888888888888888,
+        "accepted_tokens_per_head": [72, 12, 8, 3, 3, 2],
+        "accept_ratio_per_head": [0.16666666666666666, 0.6666666666666666, 0.375, 1.0, 0.6666666666666666],
+    }
+    content = (
+        "请复述以下内容：'牛顿第一定律：物体在不受外力作用时保持静止或匀速直线运动，"
+        "牛顿第二定律：F=ma，牛顿第三定律：作用力与反作用力大小相等方向相反。'"
+        "然后用自己的话解释牛顿第一定律。"
+    )
+    payload = {
+        "model": "default",
+        "messages": [{"role": "user", "content": content}],
+        "max_tokens": 100,
+        "min_tokens": 20,
+        "temperature": 0,
+        "top_p": 0,
+        "seed": 42,
+        "stream": True,
+        "stream_options": {"include_usage": True, "continuous_usage_stats": True},
+        "logprobs": True,
+        "top_logprobs": 5,
+    }
+    response = send_request(url=api_url, payload=payload)
+    chunks = get_stream_chunks(response)
+
+    # logprobs are present in each content chunk
+    logprobs_list = extract_logprobs(chunks)
+    assert len(logprobs_list) > 0, "No logprobs received"
+    for logprobs in logprobs_list:
+        assert "content" in logprobs
+        for item in logprobs["content"]:
+            assert "token" in item
+            assert "logprob" in item
+            assert "top_logprobs" in item
+            assert len(item["top_logprobs"]) <= 5
+
+    # speculate_metrics appears in the last content chunk and matches baseline
+    speculate_metrics = chunks[-2]["choices"][0].get("speculate_metrics")
+    # print(f"\n[test_ngram_speculate_metrics_with_logprobs] speculate_metrics: {json.dumps(speculate_metrics, indent=2)}")
+    assert speculate_metrics == baseline, f"speculate_metrics mismatch\ngot: {speculate_metrics}\nbaseline: {baseline}"

--- a/tests/operators/test_ngram_match.py
+++ b/tests/operators/test_ngram_match.py
@@ -26,24 +26,19 @@ class TestNgramMatchOp(unittest.TestCase):
 
     def test_basic_match(self):
         """
-        Case 1: input_ids overlaps with token_ids_all, and can extract draft tokens.
+        Case 1: prompt overlaps with pre_ids, and can extract draft tokens.
         """
         batch_size = 1
-        seq_len = 6
 
-        # Input IDs
-        input_ids = paddle.to_tensor([[10, 20, 30, 40, 50, 60]], dtype="int64")
-        # Length of input IDs
-        input_ids_len = paddle.to_tensor([6], dtype="int64")
-        # Previous IDs
-        token_ids_all = paddle.to_tensor([[10, 20, 30, 40, 0, 0]], dtype="int64")
-        prompt_lens = paddle.zeros([4, 1], dtype="int64")
-        # Current step index
-        step_idx = paddle.to_tensor([3], dtype="int64")
+        # Combined prompt and generated IDs: prompt=[10,20,30,40,50,60], generated=[10,20,30,40,0,0]
+        token_ids_all = paddle.to_tensor([[10, 20, 30, 40, 50, 60, 10, 20, 30, 40, 0, 0]], dtype="int64")
+        prompt_lens = paddle.to_tensor([[6]], dtype="int64")
+        # Current step index: 4 tokens generated (positions 0-3 valid)
+        step_idx = paddle.to_tensor([4], dtype="int64")
         # Number of draft tokens
         draft_token_num = paddle.to_tensor([3], dtype="int32")
         # Placeholder for draft tokens
-        draft_tokens = paddle.zeros([batch_size, seq_len], dtype="int64")
+        draft_tokens = paddle.zeros([batch_size, 6], dtype="int64")
 
         # Sequence lengths for this time step
         seq_lens_this_time = paddle.zeros([batch_size], dtype="int32")
@@ -55,8 +50,6 @@ class TestNgramMatchOp(unittest.TestCase):
         max_dec_len = paddle.to_tensor([10], dtype="int64")
 
         ngram_match(
-            input_ids,
-            input_ids_len,
             token_ids_all,
             prompt_lens,
             step_idx,
@@ -80,14 +73,13 @@ class TestNgramMatchOp(unittest.TestCase):
 
     def test_no_match(self):
         """
-        Case 2: token_ids_all does not match input_ids, should only keep the current token.
+        Case 2: pre_ids does not match prompt, should only keep the current token.
         """
         batch_size = 1
-        input_ids = paddle.to_tensor([[100, 200, 300, 400]], dtype="int64")
-        input_ids_len = paddle.to_tensor([4], dtype="int64")
-        token_ids_all = paddle.to_tensor([[1, 2, 3, 4]], dtype="int64")
-        prompt_lens = paddle.zeros([4, 1], dtype="int64")
-        step_idx = paddle.to_tensor([3], dtype="int64")
+        # Combined prompt and generated IDs: prompt=[100,200,300,400], generated=[1,2,3,4]
+        token_ids_all = paddle.to_tensor([[100, 200, 300, 400, 1, 2, 3, 4]], dtype="int64")
+        prompt_lens = paddle.to_tensor([4], dtype="int64")
+        step_idx = paddle.to_tensor([4], dtype="int64")
         draft_token_num = paddle.to_tensor([2], dtype="int32")
         draft_tokens = paddle.zeros([batch_size, 4], dtype="int64")
 
@@ -97,8 +89,6 @@ class TestNgramMatchOp(unittest.TestCase):
         max_dec_len = paddle.to_tensor([6], dtype="int64")
 
         ngram_match(
-            input_ids,
-            input_ids_len,
             token_ids_all,
             prompt_lens,
             step_idx,

--- a/tests/spec_decode/test_benchmark_ngram_kernel.py
+++ b/tests/spec_decode/test_benchmark_ngram_kernel.py
@@ -48,64 +48,71 @@ def _build_data(batch_size, seq_len, hit_type="low_input", seed=42):
     """
     Build test tensors with controlled ngram hit placement.
 
+    token_ids_all layout: [:seq_len] = prompt (haystack), [seq_len:] = generated tokens.
+    prompt_lens = seq_len so the kernel splits correctly.
+    step_idx = count of generated tokens (positions 0..step_idx-1 are valid in pre_ids).
+
     hit_type controls where the ngram match is found:
-      - high_input: match near start of input_ids (fast find)
-      - high_pre:   match near start of token_ids_all gen tokens
-      - low_input:  match near end of input_ids (worst-case scan)
-      - low_pre:    match near end of token_ids_all gen tokens
+      - high_input: match near start of prompt (fast input scan)
+      - high_pre:   match near start of pre_ids (fast pre scan)
+      - low_input:  match near end of prompt (worst-case input scan)
+      - low_pre:    match near end of pre_ids (worst-case pre scan)
       - none:       no planted match (full scan, no hit)
     """
     rng = np.random.RandomState(seed)
     step_idx_val = max(MAX_NGRAM_SIZE + 2, 20)
-    pre_len = step_idx_val + 1
-    max_model_len = max(seq_len + 64, pre_len + 64)
+    pre_len = step_idx_val + 1  # space for step_idx_val generated tokens
 
+    # Prompt tokens (haystack) and generated tokens (pre_ids) are separate arrays
+    # then merged into a single token_ids_all buffer.
     input_ids = rng.randint(10, 500, (batch_size, seq_len)).astype(np.int64)
-    token_ids_all = rng.randint(10, 500, (batch_size, max_model_len)).astype(np.int64)
+    pre_ids_area = rng.randint(10, 500, (batch_size, pre_len)).astype(np.int64)
+    token_ids_all = np.concatenate([input_ids, pre_ids_area], axis=1)
+
+    # Pattern = what the fixed kernel reads: pre_ids[step_idx - ngram_size : step_idx]
+    #         = token_ids_all[:, seq_len + step_idx_val - MAX_NGRAM_SIZE : seq_len + step_idx_val]
     pattern = np.arange(1001, 1001 + MAX_NGRAM_SIZE, dtype=np.int64)
+    ng_start_in_pre = step_idx_val - MAX_NGRAM_SIZE  # relative to pre_ids start
 
     for b in range(batch_size):
-        # Plant pattern in token_ids_all at step_idx alignment (the ngram to search for)
-        ng_start = step_idx_val + 1 - MAX_NGRAM_SIZE
-        token_ids_all[b, ng_start : step_idx_val + 1] = pattern
+        # Plant pattern at the pre_ids position the kernel reads (after the fix)
+        token_ids_all[b, seq_len + ng_start_in_pre : seq_len + step_idx_val] = pattern
 
         if hit_type == "high_input":
             pos = 5
             if pos + MAX_NGRAM_SIZE + MAX_DRAFT_TOKENS <= seq_len:
-                input_ids[b, pos : pos + MAX_NGRAM_SIZE] = pattern
-                input_ids[b, pos + MAX_NGRAM_SIZE : pos + MAX_NGRAM_SIZE + MAX_DRAFT_TOKENS] = np.arange(
+                token_ids_all[b, pos : pos + MAX_NGRAM_SIZE] = pattern
+                token_ids_all[b, pos + MAX_NGRAM_SIZE : pos + MAX_NGRAM_SIZE + MAX_DRAFT_TOKENS] = np.arange(
                     2001, 2001 + MAX_DRAFT_TOKENS, dtype=np.int64
                 )
 
         elif hit_type == "high_pre":
             pos = 5
-            if pos + MAX_NGRAM_SIZE + MAX_DRAFT_TOKENS < ng_start:
-                token_ids_all[b, pos : pos + MAX_NGRAM_SIZE] = pattern
-                token_ids_all[b, pos + MAX_NGRAM_SIZE : pos + MAX_NGRAM_SIZE + MAX_DRAFT_TOKENS] = np.arange(
-                    2001, 2001 + MAX_DRAFT_TOKENS, dtype=np.int64
-                )
+            if pos + MAX_NGRAM_SIZE + MAX_DRAFT_TOKENS < ng_start_in_pre:
+                token_ids_all[b, seq_len + pos : seq_len + pos + MAX_NGRAM_SIZE] = pattern
+                token_ids_all[
+                    b, seq_len + pos + MAX_NGRAM_SIZE : seq_len + pos + MAX_NGRAM_SIZE + MAX_DRAFT_TOKENS
+                ] = np.arange(2001, 2001 + MAX_DRAFT_TOKENS, dtype=np.int64)
 
         elif hit_type == "low_input":
             pos = seq_len - MAX_NGRAM_SIZE - MAX_DRAFT_TOKENS - 5
             if pos > 0:
-                input_ids[b, pos : pos + MAX_NGRAM_SIZE] = pattern
-                input_ids[b, pos + MAX_NGRAM_SIZE : pos + MAX_NGRAM_SIZE + MAX_DRAFT_TOKENS] = np.arange(
+                token_ids_all[b, pos : pos + MAX_NGRAM_SIZE] = pattern
+                token_ids_all[b, pos + MAX_NGRAM_SIZE : pos + MAX_NGRAM_SIZE + MAX_DRAFT_TOKENS] = np.arange(
                     2001, 2001 + MAX_DRAFT_TOKENS, dtype=np.int64
                 )
 
         elif hit_type == "low_pre":
             pos = step_idx_val - MAX_NGRAM_SIZE - MAX_DRAFT_TOKENS - 5
-            if pos > 0 and pos + MAX_NGRAM_SIZE + MAX_DRAFT_TOKENS < ng_start:
-                token_ids_all[b, pos : pos + MAX_NGRAM_SIZE] = pattern
-                token_ids_all[b, pos + MAX_NGRAM_SIZE : pos + MAX_NGRAM_SIZE + MAX_DRAFT_TOKENS] = np.arange(
-                    2001, 2001 + MAX_DRAFT_TOKENS, dtype=np.int64
-                )
+            if pos > 0 and pos + MAX_NGRAM_SIZE + MAX_DRAFT_TOKENS < ng_start_in_pre:
+                token_ids_all[b, seq_len + pos : seq_len + pos + MAX_NGRAM_SIZE] = pattern
+                token_ids_all[
+                    b, seq_len + pos + MAX_NGRAM_SIZE : seq_len + pos + MAX_NGRAM_SIZE + MAX_DRAFT_TOKENS
+                ] = np.arange(2001, 2001 + MAX_DRAFT_TOKENS, dtype=np.int64)
 
-        elif hit_type == "none":
-            pass  # No match planted — random data only
+        # hit_type == "none": no match planted — random data only
 
-    input_ids_len = np.full((batch_size, 1), seq_len, dtype=np.int64)
-    prompt_lens = np.zeros((batch_size, 1), dtype=np.int64)
+    prompt_lens = np.full((batch_size, 1), seq_len, dtype=np.int64)
     step_idx = np.full((batch_size, 1), step_idx_val, dtype=np.int64)
     draft_token_num = np.full((batch_size, 1), MAX_DRAFT_TOKENS, dtype=np.int32)
     draft_tokens = np.zeros((batch_size, MAX_DRAFT_TOKENS + 1), dtype=np.int64)
@@ -115,8 +122,6 @@ def _build_data(batch_size, seq_len, hit_type="low_input", seed=42):
     max_dec_len = np.full((batch_size, 1), 1048576, dtype=np.int64)
 
     return {
-        "input_ids": input_ids,
-        "input_ids_len": input_ids_len,
         "token_ids_all": token_ids_all,
         "prompt_lens": prompt_lens,
         "step_idx": step_idx,
@@ -139,8 +144,6 @@ def _to_gpu(np_dict):
 def _run_gpu(ngram_match_fn, gpu_data):
     """Run GPU kernel (tensors already on GPU)."""
     ngram_match_fn(
-        gpu_data["input_ids"],
-        gpu_data["input_ids_len"],
         gpu_data["token_ids_all"],
         gpu_data["prompt_lens"],
         gpu_data["step_idx"],

--- a/tests/spec_decode/test_ngram_gpu_kernel.py
+++ b/tests/spec_decode/test_ngram_gpu_kernel.py
@@ -90,7 +90,7 @@ def _cpu_ngram_match(
         for ngram_size in range(max_ngram_size, 0, -1):
             if cur_step < ngram_size:
                 continue
-            ngram = cur_pre_ids[cur_step + 1 - ngram_size : cur_step + 1]
+            ngram = cur_pre_ids[cur_step - ngram_size : cur_step]
 
             # Search in input_ids
             match_input = False
@@ -241,8 +241,8 @@ def _make_ngram_test_data(batch_size=4, input_len=64, max_model_len=256, max_dra
         gen_len = 20
         src = rng.randint(0, max(1, input_len - gen_len))
         token_ids_all[b, input_len : input_len + gen_len] = input_ids[b, src : src + gen_len]
-        # step_idx = last valid position (0-based index)
-        step_idx[b] = gen_len - 1
+        # step_idx = count of generated tokens (positions 0..step_idx-1 are valid)
+        step_idx[b] = gen_len
 
     return {
         "input_ids": input_ids,
@@ -281,7 +281,7 @@ def _make_mixed_test_data(batch_size=4, input_len=64, pre_ids_len=256, max_draft
         gen_len = 20
         src = rng.randint(0, max(1, input_len - gen_len))
         pre_ids[b, :gen_len] = input_ids[b, src : src + gen_len]
-        # step_idx = last valid position (0-based index)
+        # step_idx = last valid position (0-based index), matches hybrid kernel semantics
         step_idx[b] = gen_len - 1
 
     return {
@@ -349,8 +349,6 @@ class TestNgramMatchKernel(unittest.TestCase):
         # GPU kernel
         gpu_data = _to_gpu(data)
         self.ngram_match(
-            gpu_data["input_ids"],
-            gpu_data["input_ids_len"],
             gpu_data["token_ids_all"],
             gpu_data["prompt_lens"],
             gpu_data["step_idx"],
@@ -395,8 +393,6 @@ class TestNgramMatchKernel(unittest.TestCase):
                 )
                 gpu_data = _to_gpu(data)
                 self.ngram_match(
-                    gpu_data["input_ids"],
-                    gpu_data["input_ids_len"],
                     gpu_data["token_ids_all"],
                     gpu_data["prompt_lens"],
                     gpu_data["step_idx"],
@@ -444,8 +440,6 @@ class TestNgramMatchKernel(unittest.TestCase):
         os.environ["INFER_WITH_REFERENCE_TOKENUM_THRESHOLD"] = str(high_threshold)
         try:
             self.ngram_match(
-                gpu_data["input_ids"],
-                gpu_data["input_ids_len"],
                 gpu_data["token_ids_all"],
                 gpu_data["prompt_lens"],
                 gpu_data["step_idx"],
@@ -489,8 +483,6 @@ class TestNgramMatchKernel(unittest.TestCase):
         )
         gpu_data = _to_gpu(data)
         self.ngram_match(
-            gpu_data["input_ids"],
-            gpu_data["input_ids_len"],
             gpu_data["token_ids_all"],
             gpu_data["prompt_lens"],
             gpu_data["step_idx"],
@@ -534,8 +526,6 @@ class TestNgramMatchKernel(unittest.TestCase):
         os.environ["INFER_WITH_REFERENCE_TOKENUM_THRESHOLD"] = str(high_threshold)
         try:
             self.ngram_match(
-                gpu_data["input_ids"],
-                gpu_data["input_ids_len"],
                 gpu_data["token_ids_all"],
                 gpu_data["prompt_lens"],
                 gpu_data["step_idx"],
@@ -563,8 +553,6 @@ class TestNgramMatchKernel(unittest.TestCase):
         for _ in range(1):
             d = _to_gpu(_make_ngram_test_data(batch_size=32, input_len=512, seed=42))
             self.ngram_match(
-                d["input_ids"],
-                d["input_ids_len"],
                 d["token_ids_all"],
                 d["prompt_lens"],
                 d["step_idx"],
@@ -587,8 +575,6 @@ class TestNgramMatchKernel(unittest.TestCase):
         t0 = time.perf_counter()
         for _ in range(n_runs):
             self.ngram_match(
-                gpu_data["input_ids"],
-                gpu_data["input_ids_len"],
                 gpu_data["token_ids_all"],
                 gpu_data["prompt_lens"],
                 gpu_data["step_idx"],
@@ -639,8 +625,6 @@ class TestNgramMatchKernel(unittest.TestCase):
             # Warmup
             for _ in range(1):
                 self.ngram_match(
-                    gpu_data["input_ids"],
-                    gpu_data["input_ids_len"],
                     gpu_data["token_ids_all"],
                     gpu_data["prompt_lens"],
                     gpu_data["step_idx"],
@@ -660,8 +644,6 @@ class TestNgramMatchKernel(unittest.TestCase):
             t0 = time.perf_counter()
             for _ in range(n_runs):
                 self.ngram_match(
-                    gpu_data["input_ids"],
-                    gpu_data["input_ids_len"],
                     gpu_data["token_ids_all"],
                     gpu_data["prompt_lens"],
                     gpu_data["step_idx"],
@@ -744,8 +726,6 @@ class TestNgramMatchKernel(unittest.TestCase):
                 # Warmup
                 for _ in range(1):
                     self.ngram_match(
-                        gpu_data["input_ids"],
-                        gpu_data["input_ids_len"],
                         gpu_data["token_ids_all"],
                         gpu_data["prompt_lens"],
                         gpu_data["step_idx"],
@@ -765,8 +745,6 @@ class TestNgramMatchKernel(unittest.TestCase):
                 t0 = time.perf_counter()
                 for _ in range(n_runs):
                     self.ngram_match(
-                        gpu_data["input_ids"],
-                        gpu_data["input_ids_len"],
                         gpu_data["token_ids_all"],
                         gpu_data["prompt_lens"],
                         gpu_data["step_idx"],

--- a/tests/spec_decode/test_ngram_proposer.py
+++ b/tests/spec_decode/test_ngram_proposer.py
@@ -1,0 +1,182 @@
+"""
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
+import unittest
+
+import numpy as np
+import paddle
+from utils import FakeModelConfig, get_default_test_fd_config
+
+from fastdeploy.config import SpeculativeConfig
+from fastdeploy.spec_decode.ngram import NgramProposer
+
+
+class TestNgramProposer(unittest.TestCase):
+    def setUp(self):
+        if not paddle.is_compiled_with_cuda():
+            raise unittest.SkipTest("CUDA not available")
+        paddle.set_device("gpu")
+        try:
+            import fastdeploy.model_executor.ops.gpu as _gpu_ops
+
+            if getattr(_gpu_ops, "ngram_match", None) is None:
+                raise ImportError("ngram_match op not compiled")
+        except Exception as e:
+            raise unittest.SkipTest(f"Cannot import ngram_match op: {e}")
+
+        fd_config = get_default_test_fd_config()
+        fd_config.model_config = FakeModelConfig()
+        fd_config.model_config.max_model_len = 256
+        fd_config.speculative_config = SpeculativeConfig({})
+        fd_config.speculative_config.method = "ngram"
+        fd_config.speculative_config.num_speculative_tokens = 5
+        fd_config.speculative_config.max_ngram_size = 3
+        fd_config.speculative_config.min_ngram_size = 1
+        fd_config.scheduler_config.max_num_seqs = 2
+        self.fd_config = fd_config
+
+        bsz = fd_config.scheduler_config.max_num_seqs
+        max_draft = fd_config.speculative_config.num_speculative_tokens
+        max_model_len = fd_config.model_config.max_model_len
+        self.bsz = bsz
+        self.max_draft = max_draft
+        self.max_model_len = max_model_len
+
+        self.share_inputs = {
+            "token_ids_all": paddle.zeros([bsz, max_model_len], dtype="int64"),
+            "prompt_lens": paddle.zeros([bsz, 1], dtype="int64"),
+            "step_idx": paddle.zeros([bsz, 1], dtype="int64"),
+            "actual_draft_token_num": paddle.full([bsz, 1], fill_value=max_draft, dtype="int32"),
+            "draft_tokens": paddle.zeros([bsz, max_draft + 1], dtype="int64"),
+            "seq_lens_this_time": paddle.ones([bsz], dtype="int32"),
+            "seq_lens_encoder": paddle.zeros([bsz], dtype="int32"),
+            "seq_lens_decoder": paddle.ones([bsz], dtype="int32"),
+            "max_dec_len": paddle.full([bsz, 1], fill_value=200, dtype="int64"),
+        }
+
+    # Init / config binding
+    def test_init_config_binding(self):
+        """max_ngram_size and max_draft_token_num are correctly read from fd_config."""
+        proposer = NgramProposer(self.fd_config)
+        self.assertEqual(proposer.max_ngram_size, 3)
+        self.assertEqual(proposer.max_draft_token_num, 5)
+
+    # No-proposal scenarios
+    def test_run_no_proposal_step_idx_zero(self):
+        """step_idx=0 means no tokens generated; kernel cannot form any ngram pattern."""
+        proposer = NgramProposer(self.fd_config)
+        self.share_inputs["step_idx"][:] = 0
+        proposer.run(self.share_inputs)
+        paddle.device.synchronize()
+
+        slt = self.share_inputs["seq_lens_this_time"].numpy()
+        np.testing.assert_array_equal(slt, [1, 1], err_msg="seq_lens_this_time should remain 1 when step_idx=0")
+
+    # No-proposal scenarios
+    def test_run_no_proposal_tokens_not_in_prompt(self):
+        """Generated tokens never appear in the prompt → no match, no draft proposals."""
+        proposer = NgramProposer(self.fd_config)
+
+        prompt_len = 6
+        prompt = [1, 2, 3, 4, 5, 6]  # unique tokens
+        generated = [100, 200, 300]  # tokens absent from prompt
+
+        token_ids_all_np = np.zeros((self.bsz, self.max_model_len), dtype=np.int64)
+        for b in range(self.bsz):
+            token_ids_all_np[b, :prompt_len] = prompt
+            token_ids_all_np[b, prompt_len : prompt_len + len(generated)] = generated
+
+        self.share_inputs["token_ids_all"] = paddle.to_tensor(token_ids_all_np, place=paddle.CUDAPlace(0))
+        self.share_inputs["prompt_lens"] = paddle.full([self.bsz, 1], fill_value=prompt_len, dtype="int64")
+        self.share_inputs["step_idx"] = paddle.full([self.bsz, 1], fill_value=len(generated), dtype="int64")
+
+        proposer.run(self.share_inputs)
+        paddle.device.synchronize()
+
+        slt = self.share_inputs["seq_lens_this_time"].numpy()
+        np.testing.assert_array_equal(
+            slt, [1, 1], err_msg="No match expected when generated tokens absent from prompt"
+        )
+
+    # Successful proposal
+    def test_run_with_match_produces_draft_tokens(self):
+        """
+        When the last ngram_size generated tokens reappear in the prompt,
+        the tokens following that match position become draft proposals.
+
+        Setup (max_ngram_size=3, step_idx=3):
+            prompt    = [10, 20, 30, 40, 50, 10, 20, 30]  (prompt_len=8)
+            generated = [40, 50, 10]                        (step_idx=3)
+
+        Pattern = generated[step_idx - 3 : step_idx] = [40, 50, 10]
+        Matches prompt at position 3 → proposals = prompt[6:8] = [20, 30]
+        Expected: seq_lens_this_time = 3, draft_tokens[:, 1:3] = [[20, 30], [20, 30]]
+        """
+        proposer = NgramProposer(self.fd_config)
+
+        prompt_len = 8
+        prompt = [10, 20, 30, 40, 50, 10, 20, 30]
+        generated = [40, 50, 10]
+
+        token_ids_all_np = np.zeros((self.bsz, self.max_model_len), dtype=np.int64)
+        for b in range(self.bsz):
+            token_ids_all_np[b, :prompt_len] = prompt
+            token_ids_all_np[b, prompt_len : prompt_len + len(generated)] = generated
+
+        self.share_inputs["token_ids_all"] = paddle.to_tensor(token_ids_all_np, place=paddle.CUDAPlace(0))
+        self.share_inputs["prompt_lens"] = paddle.full([self.bsz, 1], fill_value=prompt_len, dtype="int64")
+        self.share_inputs["step_idx"] = paddle.full([self.bsz, 1], fill_value=len(generated), dtype="int64")
+
+        proposer.run(self.share_inputs)
+        paddle.device.synchronize()
+
+        slt = self.share_inputs["seq_lens_this_time"].numpy()
+        dt = self.share_inputs["draft_tokens"].numpy()
+
+        # 1 base token + 2 draft tokens = seq_len 3
+        np.testing.assert_array_equal(slt, [3, 3], err_msg="seq_lens_this_time mismatch")
+        # Draft slots 1 and 2 should be [20, 30] for every batch item
+        np.testing.assert_array_equal(dt[:, 1:3], [[20, 30], [20, 30]], err_msg="draft_tokens mismatch")
+
+    # Successful proposal
+    def test_run_with_match_respects_max_dec_len(self):
+        """Draft count is clipped when remaining budget (max_dec_len - step_idx) is exhausted."""
+        proposer = NgramProposer(self.fd_config)
+
+        prompt_len = 8
+        prompt = [10, 20, 30, 40, 50, 10, 20, 30]
+        generated = [40, 50, 10]
+
+        token_ids_all_np = np.zeros((self.bsz, self.max_model_len), dtype=np.int64)
+        for b in range(self.bsz):
+            token_ids_all_np[b, :prompt_len] = prompt
+            token_ids_all_np[b, prompt_len : prompt_len + len(generated)] = generated
+
+        self.share_inputs["token_ids_all"] = paddle.to_tensor(token_ids_all_np, place=paddle.CUDAPlace(0))
+        self.share_inputs["prompt_lens"] = paddle.full([self.bsz, 1], fill_value=prompt_len, dtype="int64")
+        self.share_inputs["step_idx"] = paddle.full([self.bsz, 1], fill_value=len(generated), dtype="int64")
+        # remaining = max_dec_len - step_idx - 1 = 4 - 3 - 1 = 0 → no draft tokens
+        self.share_inputs["max_dec_len"] = paddle.full([self.bsz, 1], fill_value=4, dtype="int64")
+
+        proposer.run(self.share_inputs)
+        paddle.device.synchronize()
+
+        slt = self.share_inputs["seq_lens_this_time"].numpy()
+        np.testing.assert_array_equal(slt, [1, 1], err_msg="No drafts expected when max_dec_len budget exhausted")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation
https://github.com/PaddlePaddle/community/pull/1372
精简 ngram match kernel 接口，将原本分离的 `input_ids`/`input_ids_len` 参数合并到 `token_ids_all`（由 `prompt_lens` 划定 prompt 与 generated tokens 边界），并修复 ngram 指针偏移 bug（`step_idx` 语义由 0-based 末尾位置索引统一为 token 计数语义）。完成 A800 单卡端到端结果验证，确认投机解码 ngram 方法的端到端正确性。

## Modifications
1. **`custom_ops/gpu_ops/speculate_decoding/ngram_match.cu` / `cpp_extensions.cc`**：删除 `input_ids`、`input_ids_len`、`input_ids_stride` 参数；GPU kernel 与 CPU fallback 均改为直接从 `token_ids_all[:, :prompt_len]` 读取 prompt（搜索域）、从 `token_ids_all[:, prompt_len:]` 读取 pre_ids（ngram 来源）；修复 ngram 指针偏移 bug：将 `cur_step_idx + 1 - ngram_size` 改为 `cur_step_idx - ngram_size`。
2. **`fastdeploy/spec_decode/ngram.py`**：删除 `input_ids_len` 相关张量及 `update()` 方法，`_run_impl` 调用签名与新 kernel 接口对齐。
3. **`fastdeploy/config.py`**：将 `SpecMethod.NGRAM` 加入 CUDAGraph capture 的 expected_decode_len 计算逻辑。
4. **`fastdeploy/worker/gpu_model_runner.py`**：`capture_model()` 中为 NGRAM 方法补充 warmup 路径，与 MTP/SUFFIX 保持一致。
5. **测试**：更新 `tests/operators/test_ngram_match.py`、`tests/spec_decode/test_benchmark_ngram_kernel.py`、`tests/spec_decode/test_ngram_gpu_kernel.py`；新增 `tests/spec_decode/test_ngram_proposer.py`、`tests/e2e/test_ernie_03b_ngram.py` 。

## Usage or Command
N/A

## Accuracy Tests
端到端验证（A800 单卡）：通过打印 `token_ids_all` 读写日志确认 prompt 写入与读取一致；验证 `draft_tokens` 均在 `token_ids_all[:prompt_len + step_idx]` 范围内命中；`step_idx` 跨步增量（如 25→31）确认一次 decode 成功接受多个 speculative tokens。

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.