### PR TITLE
[Feature] Support MLA dummy load & optimize MLA value padding memory

### DIFF
--- a/fastdeploy/model_executor/layers/linear.py
+++ b/fastdeploy/model_executor/layers/linear.py
@@ -1010,6 +1010,23 @@ class KVBatchLinear(nn.Layer):
         # Override weight keys to use the combined kv_b_proj
         self.weight_key = f"{prefix}.weight"  # e.g., "kv_b_proj.weight"
 
+        if self.fd_config.load_config.load_choices == "dummy":
+            # Create K projection weight
+            self.k_b_proj_weight = self.create_parameter(
+                shape=[self.num_heads_per_partition, qk_nope_head_dim, kv_lora_rank],
+                dtype=self.weight_dtype,
+                is_bias=False,
+                default_initializer=paddle.nn.initializer.Constant(0),
+            )
+
+            # Create V projection weight
+            self.v_b_proj_weight = self.create_parameter(
+                shape=[self.num_heads_per_partition, kv_lora_rank, v_head_dim],
+                dtype=self.weight_dtype,
+                is_bias=False,
+                default_initializer=paddle.nn.initializer.Constant(0),
+            )
+
     def process_weights_after_loading(self):
         if self.fd_config.load_config.dynamic_load_weight:
             return

--- a/fastdeploy/model_executor/models/deepseek_v3.py
+++ b/fastdeploy/model_executor/models/deepseek_v3.py
@@ -420,7 +420,8 @@ class DeepseekV3MLAAttention(nn.Layer):
             key = paddle.empty([full_k_pe.shape[0], self.num_attention_heads_tp, self.qk_head_dim], dtype=query.dtype)
             key[..., : self.qk_nope_head_dim] = key_nope
             key[..., self.qk_nope_head_dim :] = full_k_pe.unsqueeze(1)
-            value = paddle.nn.functional.pad(value, [0, self.qk_head_dim - self.v_head_dim], value=0)
+            if self.qk_head_dim - self.v_head_dim != 0:
+                value = paddle.nn.functional.pad(value, [0, self.qk_head_dim - self.v_head_dim], value=0)
 
             fmha_out = self.mla_attn(
                 q=query,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
MLA KV 投影层（`MLAKVCombinedProjection`）在 dummy 加载模式（`load_choices == "dummy"`）下，`k_b_proj_weight` 和 `v_b_proj_weight` 未在 `__init__` 中创建，导致后续推理时访问未定义属性而报错。此外，当 `qk_head_dim == v_head_dim` 时，对 value 执行 0-padding 是无效操作，浪费内存带宽。

## Modifications
- `fastdeploy/model_executor/layers/linear.py`：在 `__init__` 中，当 `load_choices == "dummy"` 时，创建形状分别为 `[num_heads_per_partition, qk_nope_head_dim, kv_lora_rank]` 和 `[num_heads_per_partition, kv_lora_rank, v_head_dim]` 的零初始化 `k_b_proj_weight` / `v_b_proj_weight` 参数。
- `fastdeploy/model_executor/models/deepseek_v3.py`：MLA prefill 路径中，仅当 `qk_head_dim != v_head_dim` 时执行 value padding，避免零长度 pad 操作。

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
