### PR TITLE
[Cherry-Pick][Cleanup] Replace torch proxy alias with public compat API (#7348)

### DIFF
--- a/fastdeploy/model_executor/layers/attention/flash_attn_backend.py
+++ b/fastdeploy/model_executor/layers/attention/flash_attn_backend.py
@@ -84,7 +84,7 @@ def init_flash_attn_version():
         sm_version = get_sm_version()
         if sm_version >= 100:
             try:
-                paddle.compat.enable_torch_proxy(scope={"cutlass"})
+                paddle.enable_compat(scope={"cutlass"})
                 from flash_mask.cute.interface import flashmask_attention as fa4
 
                 global flashmask_attention_v4

--- a/fastdeploy/model_executor/layers/attention/mla_attention_backend.py
+++ b/fastdeploy/model_executor/layers/attention/mla_attention_backend.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import paddle
 
-paddle.enable_compat(scope={"flash_mla"})  # Enable torch proxy before importing flash_mla
+paddle.enable_compat(scope={"flash_mla"})  # Enable paddle.enable_compat before importing flash_mla
 import math
 import os
 from dataclasses import dataclass, field

--- a/fastdeploy/model_executor/layers/batch_invariant_ops/batch_invariant_ops.py
+++ b/fastdeploy/model_executor/layers/batch_invariant_ops/batch_invariant_ops.py
@@ -805,9 +805,9 @@ def enable_batch_invariant_mode():
     if _batch_invariant_MODE:
         return
 
-    if hasattr(paddle, "compat") and hasattr(paddle.compat, "enable_torch_proxy"):
-        paddle.compat.enable_torch_proxy()
-        # TODO(liujundong): Enabling torch proxy here has a global effect.
+    if hasattr(paddle, "enable_compat"):
+        paddle.enable_compat()
+        # TODO(liujundong): Enabling paddle.enable_compat() here has a global effect.
         # Do NOT call this function from module import time,
         # otherwise it may affect other test cases during pytest collection.
         # (ex: Could not import module 'PretrainedTokenizer' or No module named 'paddle.distributed.tensor')

--- a/fastdeploy/model_executor/layers/moe/ep.py
+++ b/fastdeploy/model_executor/layers/moe/ep.py
@@ -40,8 +40,8 @@ def load_deep_ep() -> ModuleType:
 
     try:
         if envs.FD_USE_PFCC_DEEP_EP:
-            # Enable torch proxy before importing deep_ep (required by PFCC/PaddleFleet variants)
-            paddle.compat.enable_torch_proxy(scope={"deep_ep"})
+            # Enable paddle.enable_compat before importing deep_ep (required by PFCC/PaddleFleet variants)
+            paddle.enable_compat(scope={"deep_ep"})
             try:
                 import paddlefleet.ops.deep_ep as deep_ep  # type: ignore
 

--- a/fastdeploy/model_executor/layers/moe/flashinfer_cutedsl_moe.py
+++ b/fastdeploy/model_executor/layers/moe/flashinfer_cutedsl_moe.py
@@ -18,7 +18,7 @@ from typing import Any, Optional
 
 import paddle
 
-paddle.compat.enable_torch_proxy(scope={"flashinfer"})
+paddle.enable_compat(scope={"flashinfer"})
 
 
 def _dtype_str(dtype) -> str:

--- a/fastdeploy/model_executor/layers/quantization/fp8_utils.py
+++ b/fastdeploy/model_executor/layers/quantization/fp8_utils.py
@@ -67,7 +67,7 @@ def load_deep_gemm():
     if current_platform.is_cuda():
         if get_sm_version() >= 100:
             # SM100 should use PFCC DeepGemm
-            paddle.compat.enable_torch_proxy(scope={"deep_gemm"})
+            paddle.enable_compat(scope={"deep_gemm"})
             try:
                 import logging
 

--- a/fastdeploy/model_executor/layers/quantization/mxfp4.py
+++ b/fastdeploy/model_executor/layers/quantization/mxfp4.py
@@ -35,7 +35,7 @@ from fastdeploy.utils import get_logger
 from ..moe import FusedMoE
 from .quant_base import QuantConfigBase, QuantMethodBase
 
-paddle.compat.enable_torch_proxy(scope={"flashinfer"})
+paddle.enable_compat(scope={"flashinfer"})
 
 logger = get_logger("config", "config.log")
 

--- a/fastdeploy/model_executor/layers/quantization/nvfp4.py
+++ b/fastdeploy/model_executor/layers/quantization/nvfp4.py
@@ -33,7 +33,7 @@ from fastdeploy.model_executor.utils import (
 
 from .quant_base import QuantConfigBase, QuantMethodBase
 
-paddle.compat.enable_torch_proxy(scope={"flashinfer"})
+paddle.enable_compat(scope={"flashinfer"})
 
 from fastdeploy.platforms import current_platform
 

--- a/fastdeploy/worker/worker_process.py
+++ b/fastdeploy/worker/worker_process.py
@@ -1317,7 +1317,7 @@ def run_worker_proc() -> None:
 
     # Enable batch-invariant mode for deterministic inference.
     # This must happen AFTER worker creation but BEFORE model loading,
-    # because enable_batch_invariant_mode() calls paddle.compat.enable_torch_proxy()
+    # because enable_batch_invariant_mode() calls paddle.enable_compat()
     # which makes torch appear available via proxy. If called before worker creation,
     # the gpu_model_runner import chain (ernie4_5_vl_processor → paddleformers →
     # transformers) will fail when transformers tries to query torch metadata.

--- a/tests/cache_manager/test_cache_messager.py
+++ b/tests/cache_manager/test_cache_messager.py
@@ -19,8 +19,8 @@ import numpy as np
 import paddle
 import pytest
 
-if not hasattr(paddle, "compat"):
-    paddle.compat = types.SimpleNamespace(enable_torch_proxy=lambda *args, **kwargs: None)
+if not hasattr(paddle, "enable_compat"):
+    paddle.enable_compat = lambda *args, **kwargs: None
 
 from fastdeploy.cache_manager import cache_messager
 

--- a/tests/cache_manager/test_cache_transfer_manager.py
+++ b/tests/cache_manager/test_cache_transfer_manager.py
@@ -21,15 +21,9 @@ from unittest.mock import MagicMock, Mock, patch
 
 import paddle
 
-# Ensure paddle exposes compat.enable_torch_proxy for fastdeploy import compatibility.
-if not hasattr(paddle, "compat"):
-
-    class _DummyCompat:
-        @staticmethod
-        def enable_torch_proxy(scope=None):
-            return None
-
-    paddle.compat = _DummyCompat()
+# Ensure paddle exposes enable_compat for fastdeploy import compatibility.
+if not hasattr(paddle, "enable_compat"):
+    paddle.enable_compat = lambda scope=None: None
 
 # Add the root directory to Python path so we can import fastdeploy
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))

--- a/tests/cache_manager/test_prefix_cache_manager.py
+++ b/tests/cache_manager/test_prefix_cache_manager.py
@@ -30,8 +30,8 @@ pytestmark = pytest.mark.filterwarnings(
     "ignore:ast.Num is deprecated and will be removed in Python 3.14; use ast.Constant instead:DeprecationWarning"
 )
 
-if not hasattr(paddle, "compat"):
-    paddle.compat = types.SimpleNamespace(enable_torch_proxy=lambda **_: None)
+if not hasattr(paddle, "enable_compat"):
+    paddle.enable_compat = lambda **_: None
 
 warnings.filterwarnings(
     "ignore",

--- a/tests/engine/test_common_engine.py
+++ b/tests/engine/test_common_engine.py
@@ -30,14 +30,8 @@ import numpy as np
 import paddle
 from e2e.utils.serving_utils import clean_ports
 
-if not hasattr(paddle, "compat"):
-
-    class _PaddleCompat:
-        @staticmethod
-        def enable_torch_proxy(scope=None):
-            return None
-
-    paddle.compat = _PaddleCompat()
+if not hasattr(paddle, "enable_compat"):
+    paddle.enable_compat = lambda scope=None: None
 
 from fastdeploy.cache_manager.cache_data import CacheStatus
 from fastdeploy.engine.args_utils import EngineArgs

--- a/tests/inter_communicator/test_e2w_queue.py
+++ b/tests/inter_communicator/test_e2w_queue.py
@@ -16,14 +16,13 @@
 
 import threading
 import time
-import types
 import unittest
 
 import numpy as np
 import paddle
 
-if not hasattr(paddle, "compat"):
-    paddle.compat = types.SimpleNamespace(enable_torch_proxy=lambda **_: None)
+if not hasattr(paddle, "enable_compat"):
+    paddle.enable_compat = lambda **_: None
 
 from fastdeploy import envs
 from fastdeploy.engine.request import Request

--- a/tests/inter_communicator/test_zmq_server.py
+++ b/tests/inter_communicator/test_zmq_server.py
@@ -6,7 +6,6 @@ import os
 import tempfile
 import threading
 import time
-import types
 import unittest
 from collections import defaultdict
 from unittest import mock
@@ -16,8 +15,8 @@ import paddle
 import zmq
 from zmq.utils import jsonapi
 
-if not hasattr(paddle, "compat"):
-    paddle.compat = types.SimpleNamespace(enable_torch_proxy=lambda **kwargs: None)
+if not hasattr(paddle, "enable_compat"):
+    paddle.enable_compat = lambda **kwargs: None
 
 from fastdeploy import envs
 from fastdeploy.inter_communicator.zmq_server import (

--- a/tests/layers/test_fused_moe_cutlass_backend.py
+++ b/tests/layers/test_fused_moe_cutlass_backend.py
@@ -23,8 +23,8 @@ import numpy as np
 import paddle
 import pytest
 
-if not hasattr(paddle, "compat"):
-    paddle.compat = types.SimpleNamespace(enable_torch_proxy=lambda *args, **kwargs: None)
+if not hasattr(paddle, "enable_compat"):
+    paddle.enable_compat = lambda *args, **kwargs: None
 
 iluvatar_stub = types.ModuleType("fastdeploy.model_executor.ops.iluvatar")
 iluvatar_stub.moe_expert_ffn = lambda *args, **kwargs: None

--- a/tests/layers/test_fused_moe_triton_backend.py
+++ b/tests/layers/test_fused_moe_triton_backend.py
@@ -23,8 +23,8 @@ import types
 import paddle
 import pytest
 
-if not hasattr(paddle, "compat"):
-    paddle.compat = types.SimpleNamespace(enable_torch_proxy=lambda scope=None: None)
+if not hasattr(paddle, "enable_compat"):
+    paddle.enable_compat = lambda scope=None: None
 if not hasattr(paddle.nn.functional, "swiglu"):
     paddle.nn.functional.swiglu = lambda x: x
 

--- a/tests/layers/test_sampler.py
+++ b/tests/layers/test_sampler.py
@@ -26,8 +26,8 @@ import pytest
 
 import fastdeploy  # noqa: F401
 
-if not hasattr(paddle, "compat"):
-    paddle.compat = types.SimpleNamespace(enable_torch_proxy=lambda *args, **kwargs: None)
+if not hasattr(paddle, "enable_compat"):
+    paddle.enable_compat = lambda *args, **kwargs: None
 
 # Optional runtime deps are intentionally stubbed for unit isolation.
 if "triton" not in sys.modules:

--- a/tests/quantization/test_modelopt_nvfp4.py
+++ b/tests/quantization/test_modelopt_nvfp4.py
@@ -22,6 +22,9 @@ from unittest import mock
 
 import paddle
 
+if not hasattr(paddle, "enable_compat"):
+    paddle.enable_compat = lambda *args, **kwargs: None
+
 import fastdeploy.model_executor.layers.quantization.nvfp4 as nvfp4_module
 from fastdeploy.model_executor.layers.linear import QKVParallelLinear
 from fastdeploy.model_executor.layers.moe import FusedMoE
@@ -133,7 +136,7 @@ class TestModelOptNvFp4ModuleInit(unittest.TestCase):
         """Test module reloading when flashinfer is available."""
         mock_flashinfer = types.ModuleType("flashinfer")
         with mock.patch.dict(sys.modules, {"flashinfer": mock_flashinfer}):
-            with mock.patch("paddle.compat.enable_torch_proxy"):
+            with mock.patch("paddle.enable_compat"):
                 importlib.reload(nvfp4_module)
 
 

--- a/tests/splitwise/test_splitwise_connector.py
+++ b/tests/splitwise/test_splitwise_connector.py
@@ -25,13 +25,8 @@ import paddle
 import pytest
 import zmq
 
-if not hasattr(paddle, "compat"):
-
-    class _CompatStub:
-        def enable_torch_proxy(self, scope=None):
-            return None
-
-    paddle.compat = _CompatStub()
+if not hasattr(paddle, "enable_compat"):
+    paddle.enable_compat = lambda scope=None: None
 
 from fastdeploy import envs
 from fastdeploy.engine.request import Request, RequestMetrics, RequestOutput

--- a/tests/v1/test_resource_manager_v1.py
+++ b/tests/v1/test_resource_manager_v1.py
@@ -24,8 +24,8 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import paddle
 
-if not hasattr(paddle, "compat"):
-    paddle.compat = SimpleNamespace(enable_torch_proxy=lambda scope: None)
+if not hasattr(paddle, "enable_compat"):
+    paddle.enable_compat = lambda scope=None: None
 
 from fastdeploy.config import CacheConfig, FDConfig, ParallelConfig, SchedulerConfig
 from fastdeploy.engine.args_utils import EngineArgs


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

## Motivation

Cherry-pick of `d65909941580f511950f64aeaff1512541be5fb4` to `release/2.6`.

This replaces deprecated/internal `paddle.compat.enable_torch_proxy` usages with the public `paddle.enable_compat` API, keeping `release/2.6` aligned with the current Paddle compat interface.

The original PR `#7348` is currently not resolvable from GitHub, so this PR is based on the merged commit and its patch content.

## Modifications

- Replace runtime calls of `paddle.compat.enable_torch_proxy(...)` with `paddle.enable_compat(...)`.
- Update related tests to stub/mock `paddle.enable_compat` directly.
- Resolve the same old API residue in `release/2.6` code so `paddle.compat.enable_torch_proxy` has no remaining usage under `fastdeploy` and `tests`.

## Usage or Command

N/A

## Accuracy Tests

N/A. This is an API migration and does not change model math or outputs.

## Validation

```bash
source /Users/nyakku/.local/share/meowda/venvs/paddle-py310/bin/activate
pre-commit run --files $(git show --name-only --format= HEAD | sed '/^$/d')
rg -n 'paddle\.compat|enable_torch_proxy|compat\.enable' fastdeploy tests
```

`pre-commit` passed. The residue search returned no matches.

## Checklist

- [x] Add at least a tag in the PR title.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.

<div align="right">
   <sup>This PR is authored by @codex (gpt-5.5 xhigh)</sup>
</div>
