### PR TITLE
[BugFix] Fix KSM bug in MTP and Overlap

### DIFF
--- a/fastdeploy/model_executor/layers/sample/sampler.py
+++ b/fastdeploy/model_executor/layers/sample/sampler.py
@@ -238,9 +238,7 @@ def _extract_sparse_indices(
     """
     Extract per-request sparse retained-token indices from CPU numpy arrays.
 
-    This is the CPU-side counterpart of _compute_sampling_mask. It should be
-    called after the sampling_mask_event has been synchronized, so that the
-    async D2H copy is guaranteed to be complete.
+    This is the CPU-side counterpart of _compute_sampling_mask.
 
     Args:
         indices_window_cpu: [B, max_k] int64 numpy array of sorted vocab indices.
@@ -708,9 +706,7 @@ class Sampler(nn.Layer):
         # All GPU ops; D2H is done via async copy_ with event sync in save_output.
         sampling_mask = None
         logz_per_batch = None
-        sampling_mask_event = None
         if sampling_metadata.keep_sampling_mask:
-            sampling_mask_event = paddle.device.cuda.create_event()
             indices_window_gpu, mask_window_gpu, logz_per_batch, mask_bsz = _compute_sampling_mask(
                 probs,
                 sampling_metadata.top_p,
@@ -726,8 +722,6 @@ class Sampler(nn.Layer):
             ).pin_memory()
             indices_window_cpu.copy_(indices_window_gpu, False)
             mask_window_cpu.copy_(mask_window_gpu, False)
-            # Record event — sync this event before reading CPU buffers
-            sampling_mask_event.record()
             # Store deferred GPU→CPU data; sparse extraction happens in save_output
             sampling_mask = (indices_window_cpu, mask_window_cpu, mask_bsz)
 
@@ -756,7 +750,6 @@ class Sampler(nn.Layer):
             logits=logits,
             sampling_mask=sampling_mask,
             logz_per_batch=logz_per_batch,
-            sampling_mask_event=sampling_mask_event,
         )
 
         return sampler_output
@@ -1245,20 +1238,16 @@ class SpeculativeSampler(nn.Layer):
                 target_logits = target_logits[: accept_nums.sum()]
                 # Derive target probs from already-extracted target_logits; avoids a second kernel call.
                 target_probs = F.softmax(target_logits, axis=-1)
-                # Compute sampling mask at accepted token positions.
-                # Expand top_p from [batch, 1] to [total_accepted, 1].
-                accept_top_p = (
-                    sampling_metadata.top_p[:real_bsz].squeeze(1).repeat_interleave(accept_nums).unsqueeze(1)
+                accept_top_p, accept_top_k, _ = build_sampling_params(
+                    sampling_metadata.top_p,
+                    sampling_metadata.top_k,
+                    sampling_metadata.seed,
+                    share_inputs["seq_lens_this_time"],
+                    share_inputs["cu_seqlens_q_output"],
+                    token_num_output_cpu,
+                    increment_value,
                 )
-                accept_top_k = None
-                if (
-                    sampling_metadata.top_k is not None
-                    and sampling_metadata.top_k_list
-                    and any(x > 0 for x in sampling_metadata.top_k_list)
-                ):
-                    accept_top_k = (
-                        sampling_metadata.top_k[:real_bsz].squeeze(1).repeat_interleave(accept_nums).unsqueeze(1)
-                    )
+
                 indices_window_gpu, mask_window_gpu, logz_per_batch, mask_bsz = _compute_sampling_mask(
                     target_probs,
                     accept_top_p,
@@ -1274,11 +1263,8 @@ class SpeculativeSampler(nn.Layer):
                 ).pin_memory()
                 indices_window_cpu.copy_(indices_window_gpu, False)
                 mask_window_cpu.copy_(mask_window_gpu, False)
-                sampling_mask_event = paddle.device.cuda.create_event()
-                sampling_mask_event.record()
                 sampler_output.sampling_mask = (indices_window_cpu, mask_window_cpu, mask_bsz)
                 sampler_output.logz_per_batch = logz_per_batch
-                sampler_output.sampling_mask_event = sampling_mask_event
         return sampler_output
 
     def forward_xpu(

--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -394,17 +394,12 @@ def save_output_normal(
     save_each_rank: bool = False,
     sampling_mask_async_queue: Optional[queue.Queue] = None,
 ):
-    # Resolve deferred async D2H: sync event once at the top so all paths below
-    # can safely read sampling_mask and logz_per_batch.
-    if sampler_output.sampling_mask_event is not None:
-        sampler_output.sampling_mask_event.synchronize()
-        # Extract sparse indices from pinned CPU buffers
-        if sampler_output.sampling_mask is not None:
-            indices_window_cpu, mask_window_cpu, mask_bsz = sampler_output.sampling_mask
-            sampler_output.sampling_mask = _extract_sparse_indices(
-                indices_window_cpu.numpy(), mask_window_cpu.numpy(), mask_bsz
-            )
-        sampler_output.sampling_mask_event = None
+    # Extract sparse indices from pinned CPU buffers
+    if sampler_output.sampling_mask is not None:
+        indices_window_cpu, mask_window_cpu, mask_bsz = sampler_output.sampling_mask
+        sampler_output.sampling_mask = _extract_sparse_indices(
+            indices_window_cpu.numpy(), mask_window_cpu.numpy(), mask_bsz
+        )
 
     # Renormalize logprobs with logz (deferred from post_process for better overlap).
     if sampler_output.logprobs_tensors is not None and sampler_output.logz_per_batch is not None:
@@ -574,24 +569,20 @@ def save_output_speculate(
 ):
     # Resolve deferred async D2H: sync event once at the top so all paths below
     # can safely read sampling_mask and logz_per_batch.
-    if sampler_output.sampling_mask_event is not None:
-        sampler_output.sampling_mask_event.synchronize()
-        if sampler_output.sampling_mask is not None:
-            indices_window_cpu, mask_window_cpu, mask_bsz = sampler_output.sampling_mask
-            sampler_output.sampling_mask = _extract_sparse_indices(
-                indices_window_cpu.numpy(), mask_window_cpu.numpy(), mask_bsz
-            )
-        sampler_output.sampling_mask_event = None
+    mask_bsz = None
+    if sampler_output.sampling_mask is not None:
+        indices_window_cpu, mask_window_cpu, mask_bsz = sampler_output.sampling_mask
+        sampler_output.sampling_mask = _extract_sparse_indices(
+            indices_window_cpu.numpy(), mask_window_cpu.numpy(), mask_bsz
+        )
 
     # Renormalize logprobs with logz (deferred from post_process for better overlap).
     if sampler_output.logprobs_tensors is not None and sampler_output.logz_per_batch is not None:
-        # TODO (wangyanpeng): Currently, there is a bug when overlap is enabled.
-        # Please ensure overlap is disabled when using this functionality to avoid unexpected behavior.
-        real_token_num = share_inputs["accept_num_cpu"].sum()
+        assert mask_bsz is not None
         sampler_output.logprobs_tensors = LogprobsTensors(
-            logprob_token_ids=sampler_output.logprobs_tensors.logprob_token_ids[:real_token_num],
-            logprobs=sampler_output.logprobs_tensors.logprobs[:real_token_num],
-            selected_token_ranks=sampler_output.logprobs_tensors.selected_token_ranks[:real_token_num],
+            logprob_token_ids=sampler_output.logprobs_tensors.logprob_token_ids[:mask_bsz],
+            logprobs=sampler_output.logprobs_tensors.logprobs[:mask_bsz],
+            selected_token_ranks=sampler_output.logprobs_tensors.selected_token_ranks[:mask_bsz],
         )
         sampler_output.logprobs_tensors = logprobs_renormalize_with_logz(
             sampler_output.logprobs_tensors.logprobs,

--- a/fastdeploy/worker/output.py
+++ b/fastdeploy/worker/output.py
@@ -180,11 +180,6 @@ class SamplerOutput:
     cu_batch_token_offset: Optional[paddle.Tensor] = None
     logits: Optional[paddle.Tensor] = None
     # Sparse sampling mask for top_p/top_k:
-    #   Before sampling_mask_event sync: stored as a deferred tuple
-    #     (indices_window_cpu, mask_window_cpu, real_bsz) where the CPU tensors
-    #     are pinned-memory targets of async D2H copies.
-    #   After event sync + _extract_sparse_indices: converted to the final
-    #     List[np.ndarray] format below.
     #   - Non-speculative decoding: per-request mask. This is a list of length
     #     num_reqs, where element i is a 1-D int32 numpy array of vocab indices
     #     retained by top_p/top_k for request i. Replaces the previous dense
@@ -202,9 +197,6 @@ class SamplerOutput:
     # Used for renormalizing logprobs to match the truncated sampling distribution.
     # Shape: [num_reqs]
     logz_per_batch: Optional[np.ndarray] = None
-    # CUDA event that guards async D2H copy of sampling_mask / logz_per_batch.
-    # Must be synchronized before reading sampling_mask or logz_per_batch.
-    sampling_mask_event: Optional[object] = None
 
 
 @dataclass


### PR DESCRIPTION
## Motivation

修复 KSM（Kernel Sampling Mask）在 MTP（Multi-Token Prediction）投机解码与 Overlap 模式同时启用时的计算错误。

问题根因：
1. `sampling_mask_event` CUDA 事件同步冗余：`copy_(..., non_blocking=False)` 本身为同步 D2H 拷贝，在 `forward_cuda` 返回前 CPU buffer 已就绪，保留 event 不影响正确性但在 Overlap 路径下引发同步顺序问题。
2. MTP forward 中手动展开 `accept_top_p`/`accept_top_k` 的逻辑引入同步内容，影响性能，使用 `build_sampling_params` 替换。
3. `save_output_speculate` 中使用 `accept_num.sum()`（计算的是当前批次的接收token数） 截断 logprobs，与采样 mask 实际 batch size（`mask_bsz`上一个批次的实际接收的token数）不匹配，在 Overlap 启用时产生结果偏差。

## Modifications

- `sampler.py`：
  - 移除 `sampling_mask_event` 的创建与 `record()` 调用
  - MTP `forward_cuda` 中改用 `build_sampling_params()` 统一构造 `accept_top_p`/`accept_top_k`，替换原手动 `repeat_interleave` 展开逻辑
  - 移除 `sampler_output.sampling_mask_event` 赋值
- `pre_and_post_process.py`：
  - `save_output_normal`：去除 event 同步，直接从 pinned CPU buffer 提取稀疏索引
  - `save_output_speculate`：同上，并将 logprobs 截断从 `accept_num_cpu.sum()` 改为使用 `mask_bsz`，修复 Overlap 模式下的偏差
- `output.py`：从 `SamplerOutput` dataclass 移除 `sampling_mask_event` 字段及相关注释

## Usage or Command

N/A（Bug 修复，无新增命令行接口）

## Accuracy Tests

N/A（行为修复，未影响模型输出精度）

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.