### PR TITLE
【Do Not Merge】 测试dynamic loading用，存储模型pdparams

### DIFF
--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1426,6 +1426,52 @@ class GPUModelRunner(ModelRunnerBase):
         # 4. Init proposer for speculative method
         self._init_speculative_proposer()
 
+        # Usage: FD_SAVE_PDPARAMS=1 FD_SAVE_DIR=/path/to/output python -m fastdeploy...
+        if os.getenv("FD_SAVE_PDPARAMS", "0") == "1":
+            import shutil
+            import glob as glob_mod
+
+            visible_devices = os.getenv("CUDA_VISIBLE_DEVICES", "0").split(",")
+            meta_src_id = int(visible_devices[int(os.getenv("FLAGS_selected_gpus", "0"))])
+            rank = paddle.distributed.get_rank()
+
+            # Determine save directory: FD_SAVE_DIR or default to model directory
+            save_dir = os.getenv("FD_SAVE_DIR", self.fd_config.model_config.model)
+            os.makedirs(save_dir, exist_ok=True)
+
+            # Copy config and tokenizer files (only rank 0 to avoid race)
+            if rank == 0:
+                src_dir = self.fd_config.model_config.model
+                copy_patterns = [
+                    "config.json", "generation_config.json",
+                    "tokenizer*", "added_tokens.json",
+                    "special_tokens_map.json", "chat_template*",
+                ]
+                for pattern in copy_patterns:
+                    for f in glob_mod.glob(os.path.join(src_dir, pattern)):
+                        dst = os.path.join(save_dir, os.path.basename(f))
+                        if not os.path.exists(dst):
+                            shutil.copy2(f, dst)
+
+            # Save model weights (main model + proposer/MTP model if exists)
+            model_state_dict = self.model.state_dict()
+            if hasattr(self, 'proposer') and self.proposer is not None and hasattr(self.proposer, 'model'):
+                proposer_state_dict = self.proposer.model.state_dict()
+                model_state_dict.update(proposer_state_dict)
+                logger.info(f"Including proposer model weights ({len(proposer_state_dict)} params)")
+
+            clean_state_dict = {
+                k: paddle.to_tensor(v.contiguous().numpy())
+                for k, v in model_state_dict.items()
+            }
+            model_path = os.path.join(
+                save_dir,
+                f"model_state.tp{rank}.{meta_src_id}.pdparams",
+            )
+            paddle.save(clean_state_dict, model_path, safetensors=True)
+            del clean_state_dict
+            logger.info(f"Saved model state dict to {model_path}")
+
         # Load RL dynamic model
         if self.fd_config.load_config.dynamic_load_weight:
             from fastdeploy.rl.dynamic_weight_manager import DynamicWeightManager


### PR DESCRIPTION
## Motivation
为 RL 动态加载（dynamic loading）功能开发测试，需要提前保存各 TP rank 的 pdparams 权重文件，以验证 `DynamicWeightManager` 的加载流程正确性。

## Modifications
- `fastdeploy/worker/gpu_model_runner.py`：在 `load_model()` 方法末尾新增保存逻辑
  - 当环境变量 `FD_SAVE_PDPARAMS=1` 时，模型加载完成后自动保存权重
  - 支持 `FD_SAVE_DIR` 指定输出目录（默认为模型目录）
  - rank 0 复制 config / tokenizer 等配置文件
  - 所有 rank 各自保存对应 TP 分片权重，文件命名为 `model_state.tp{rank}.{gpu_id}.pdparams`
  - 若存在 proposer（投机解码），同时合并保存 proposer 模型权重

## Usage or Command
```bash
FD_SAVE_PDPARAMS=1 FD_SAVE_DIR=/path/to/output python -m fastdeploy ...
```

## Accuracy Tests
N/A（本 PR 为测试辅助工具，不影响模型推理精度）

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.