### PR TITLE
fix: cast image_mask.any() to bool for task queue serialization

### DIFF
--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -802,7 +802,7 @@ class ResourceManagerV1(ResourceManager):
             num_new_tokens = new_end_idx - pre_end_idx
 
             image_mask = input_ids[pre_end_idx:new_end_idx] == image_patch_id
-            request.with_image = image_mask.any()
+            request.with_image = bool(image_mask.any())
             if request.with_image:
                 pre_boundary_idx = np.searchsorted(img_boundaries_idx, pre_end_idx, side="left").item()
                 if pre_boundary_idx == len(img_boundaries_idx):


### PR DESCRIPTION
## Summary
- `image_mask.any()` 返回 `numpy.bool_`，在 task queue 序列化传输多模 RL 请求时会出错
- 改为 `bool(image_mask.any())` 转换为 Python 原生 bool 类型

## Test plan
- [ ] 多模 RL 0 卡场景 task queue 传输不再报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)