### PR TITLE
[BugFix] fix: cast image_mask.any() to bool for task queue serialization

### DIFF
--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -802,7 +802,7 @@ class ResourceManagerV1(ResourceManager):
             num_new_tokens = new_end_idx - pre_end_idx
 
             image_mask = input_ids[pre_end_idx:new_end_idx] == image_patch_id
-            request.with_image = image_mask.any()
+            request.with_image = bool(image_mask.any())
             if request.with_image:
                 pre_boundary_idx = np.searchsorted(img_boundaries_idx, pre_end_idx, side="left").item()
                 if pre_boundary_idx == len(img_boundaries_idx):


### PR DESCRIPTION
## Motivation

多模 RL 0 卡场景下，`image_mask.any()` 返回 `numpy.bool_` 类型，通过 task queue 传输时序列化失败导致报错。

## Modifications

- 将 `request.with_image = image_mask.any()` 改为 `request.with_image = bool(image_mask.any())`，转换为 Python 原生 bool 类型

## Usage or Command

无需额外配置，启动多模 RL 推理服务即可验证：

```bash
bash run.sh
```

## Checklist

- [x] Add at least a tag in the PR title. [BugFix]
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. 该修复为类型转换，已有单测覆盖此路径。
- [ ] Provide accuracy results. 不影响模型精度。
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch. (N/A)