### PR TITLE
[CI] Update build_sm90_rl image and refine coverage reporting

### DIFF
--- a/.github/workflows/_unit_test_coverage.yml
+++ b/.github/workflows/_unit_test_coverage.yml
@@ -394,7 +394,7 @@ jobs:
               wget -O ${filename} ${diff_cov_result_json_url} || echo "Download cov json file failed, but continuing..."
             fi
             if [ -f "${filename}" ];then
-              echo "Failed test cases:"
+              echo "GPU Patch Coverage Details:"
               if command -v jq >/dev/null 2>&1; then
                   jq . "${filename}"
               else

--- a/.github/workflows/ce_job.yml
+++ b/.github/workflows/ce_job.yml
@@ -194,7 +194,7 @@ jobs:
     if: ${{ needs.ce_job_pre_check.outputs.sm8090_match == 'true' }}
     uses: ./.github/workflows/_build_linux_rl.yml
     with:
-      DOCKER_IMAGE: iregistry.baidu-int.com/paddlepaddle/base-images:paddlecloud-ubuntu24.04-gcc13.3-cuda12.9-cudnn9.9-bccl1.4.1.4-nccl2.26.5-openmpi4.1.5-FleetY13.5.0H-rc9
+      DOCKER_IMAGE: iregistry.baidu-int.com/paddlepaddle/base-images:paddlecloud-ubuntu24.04-gcc13.3-cuda12.9-cudnn9.9-bccl1.4.1.4-nccl2.26.5-openmpi4.1.5-FleetY13.4.1H-rc2
       FASTDEPLOY_ARCHIVE_URL: ${{ needs.clone.outputs.repo_archive_url }}
       COMPILE_ARCH: "90"
       WITH_NIGHTLY_BUILD: OFF

--- a/scripts/.coveragerc
+++ b/scripts/.coveragerc
@@ -30,6 +30,7 @@ omit =
     */site-packages/*/fastdeploy/model_executor/ops/gpu*
     */fastdeploy/benchmarks/lib/endpoint_request_func.py
     */fastdeploy/model_executor/graph_optimization/utils.py
+    */fastdeploy/model_executor/layers/sample/ops/top_k_top_p_triton.py
     */fastdeploy/model_executor/ops/gpu/fastdeploy_ops.py
     */fastdeploy/model_executor/ops/gpu/fastdeploy_ops/__init__.py
     */fastdeploy/model_executor/ops/gpu/deep_gemm/utils.py


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
This update improves CI maintainability and coverage reporting consistency.
- The existing `build_sm90_rl` image needs to be updated to align with the latest build environment requirements.
- Some generated/operator-related files are not suitable for meaningful unit test coverage statistics.
- Coverage report wording should better reflect the actual content being displayed.

## Modifications
- Updated the build image used by `build_sm90_rl` to:
  - `iregistry.baidu-int.com/paddlepaddle/base-images:paddlecloud-ubuntu24.04-gcc13.3-cuda12.9-cudnn9.9-bccl1.4.1.4-nccl2.26.5-openmpi4.1.5-FleetY13.4.1H-rc2`
- Excluded:
  - `fastdeploy/model_executor/layers/sample/ops/top_k_top_p_triton.py`
  from unit test coverage statistics.
- Updated coverage check report wording:
  - `"Failed test cases:"`
  → `"GPU Patch Coverage Details"`
- Improved clarity and maintainability of CI coverage reporting.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
