### PR TITLE
[BugFix] fix paddle optional get assert in sm103

### DIFF
--- a/custom_ops/setup_ops.py
+++ b/custom_ops/setup_ops.py
@@ -174,6 +174,12 @@ def get_gencode_flags(archs):
                 "-gencode",
                 f"arch=compute_{arch_code},code=sm_{arch_code}",
             ]
+        elif cc_val == 103:
+            arch_code = "103a"
+            flags += [
+                "-gencode",
+                f"arch=compute_{arch_code},code=sm_{arch_code}",
+            ]
         else:
             flags += ["-gencode", f"arch=compute_{cc_val},code=sm_{cc_val}"]
     return flags
@@ -477,9 +483,10 @@ elif paddle.is_compiled_with_cuda():
         # of them instead of only the highest one.
         has_sm90 = 90 in sm_versions
         has_sm100 = 100 in sm_versions and nvcc_version >= 12.9
-        has_generic_fp8 = not has_sm90 and not has_sm100  # SM89 or other
+        has_sm103 = 103 in sm_versions and nvcc_version >= 13.0
+        has_generic_fp8 = not has_sm90 and not has_sm100 and not has_sm103  # SM89 or other
 
-        if has_sm90 or has_sm100:
+        if has_sm90 or has_sm100 or has_sm103:
             nvcc_compile_args += [
                 "-O3",
                 "-DNDEBUG",
@@ -502,8 +509,8 @@ elif paddle.is_compiled_with_cuda():
                 "gpu_ops/cutlass_kernels/w8a8/c3x/scaled_mm_azp_sm90_int8.cu",
             ]
 
-        if has_sm100:
-            print("SM100 (Blackwell): Applying SM100 configurations.")
+        if has_sm100 or has_sm103:
+            print("SM100 / 103 (Blackwell): Applying SM100 / SM103 configurations.")
             # Placeholder for SM100-specific kernel auto-generation scripts
             # These might be needed if Blackwell has new FP8 hardware features
             # not covered by existing generic CUTLASS templates or SM90 scripts.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

- 修复sm103下开启FA4出现的paddle optional 相关的assert报错
```
/usr/local/lib/python3.12/site-packages/paddle/include/paddle/utils/optional.h:563: paddle::optional<T>::reference_const_type paddle::optional<T>::get() const [with T = paddle::Tensor; reference_const_type = const paddle::Tensor&]: Assertion `this->is_initialized()' failed.
```

### 问题原因：
1. `gqa_rope_write_cache` 会被FA4调用，其实现中对`cache_k_dequant_scales` 等`paddle::optional<paddle::Tensor> ` 类型，直接使用了`cache_k_dequant_scales.get()`而没有检查是否为null；此问题在此前测试中已经暴露，并针对这个kernel在2.5分支中做了修复 https://github.com/PaddlePaddle/FastDeploy/pull/7311/changes  ，但没有同步到dev/2.6分支
2. sm103才出现上述问题的原因：针对sm90/100的编译中有"-DNDEBUG"选项，但未对sm103添加，该选项会移除标准 assert，所以在其他设备上未遇到此问题。
3. 在同时存在多个编译架构时，如[90,100,103]，由于90/100已经添加上述编译选项，在sm103上运行也不存在问题；但单独执行 build.sh 或 单独指定架构 [103]会触发上述Bug

### 修复考虑：
类似问题1，可能还有较多其他kernel存在对`paddle::optional<paddle::Tensor> ` 类型的不规范调用，潜在修改影响面较大，需要进一步筛查并修改；先为sm103完善编译选项适配，同样能解决问题

## Modifications

<!-- Detail the changes made in this pull request. -->

为sm103 增加编译适配 ` "-DNDEBUG" `

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
