### PR TITLE
[Cherry-Pick][BugFix] Fix pause drain hang caused by stale abort markers(#7825)

### DIFF
--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -1278,17 +1278,30 @@ class EngineService(EngineServicePrepareMixin):
     def _wait_inflight_drained(self):
         """
         Wait until resource_manager.requests is completely empty.
-        No timeout — abort pipeline will complete. Aligned with SGLang's poll-until-drained.
+        No timeout — abort pipeline will complete.
+        Logs a warning every 30 seconds while waiting to help diagnose potential hangs.
         """
-        start_time = time.time()
-        while (
-            self.resource_manager.requests
-            or self.scheduler.requests
-            or self.resource_manager.waiting_abort_req_id_set
-            or self.resource_manager.to_be_aborted_req_id_set
-        ):
+        start_time = time.monotonic()
+        next_warn_time = start_time + 30
+
+        while self.resource_manager.requests or self.scheduler.requests:
+            now = time.monotonic()
+
+            if now >= next_warn_time:
+                self.llm_logger.warning(
+                    "Still waiting for inflight requests to drain, "
+                    f"elapsed: {now - start_time:.3f} seconds, "
+                    f"resource_manager.requests: {len(self.resource_manager.requests)}, "
+                    f"scheduler.requests: {len(self.scheduler.requests)}",
+                )
+                next_warn_time = now + 30
+
             time.sleep(0.005)
-        self.llm_logger.info(f"All inflight requests drained, take time: {time.time() - start_time:.3f} seconds")
+
+        self.llm_logger.info(
+            "All inflight requests drained, take time: %.3f seconds",
+            time.monotonic() - start_time,
+        )
 
     def _control_resume(self, control_request: ControlRequest) -> Optional[dict]:
         """Control function for resuming request generation.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

In RL serving, `pause` aborts inflight requests before the engine enters the paused state. The previous pause drain condition also waited for `ResourceManagerV1.waiting_abort_req_id_set` and `ResourceManagerV1.to_be_aborted_req_id_set` to become empty.

Those two sets are abort-pipeline bookkeeping, not authoritative live-request state. They can become stale when an abort request races with normal request completion:

1. `finish_requests()` recycles the request and removes it from `resource_manager.requests`.
2. An abort message for the same request arrives immediately after that.
3. `add_abort_req_ids()` adds the id into `waiting_abort_req_id_set`.
4. No later `_trigger_abort()` or `recycle_abort_task()` can consume the marker because the request is no longer alive in ResourceManager.

In that state, `pause` can hang even when both `resource_manager.requests` and `scheduler.requests` are already empty.

## Modifications

### `fastdeploy/engine/common_engine.py`

| Change | Description |
|--------|-------------|
| `_wait_inflight_drained()` drain predicate | Wait only on authoritative live request containers: `resource_manager.requests` and `scheduler.requests` |
| Remove abort marker sets from pause wait condition | Avoid infinite wait on stale `waiting_abort_req_id_set` / `to_be_aborted_req_id_set` entries created by abort-vs-finish races |
| Periodic drain warning | Log live request counts every 30 seconds while waiting, so future real drain stalls are easier to diagnose |

### Execution flow

```text
_control_pause:
  ├─ _rejecting_new_requests = True
  ├─ collect all live request ids from ResourceManager and scheduler
  ├─ add_abort_req_ids(live request ids)
  ├─ _wait_inflight_drained()
  │    └─ wait until resource_manager.requests and scheduler.requests are empty
  ├─ is_paused = True
  └─ reset cache state
```

This keeps the existing abort design unchanged: scheduler-only requests are still allowed to enter ResourceManager normally, where they are caught by `_trigger_abort()` and returned through the normal abort path.

## Usage or Command

```bash
# Pause, aborting inflight requests before entering paused state.
curl -X POST http://localhost:8180/v1/pause

# Check paused state.
curl http://localhost:8180/v1/is_paused

# Resume request generation.
curl -X POST http://localhost:8180/v1/resume
```

## Accuracy Tests

| Case | Result | Details |
|------|--------|---------|
| Bare pause/resume | PASS | `pause -> is_paused -> resume -> is_paused` no longer hangs when stale abort markers exist and live request counts are already zero |
| Pause after concurrent streaming requests | PASS | Running/inflight requests are aborted through the existing abort pipeline; post-pause `num_requests_running == 0` and `num_requests_waiting == 0` |
| Requests while paused | PASS | New requests are rejected while the engine is paused |
| Resume after pause | PASS | Engine accepts new requests after `/v1/resume` |

## Checklist

- [x] Add at least a tag in the PR title: `[RL]`, `[Engine]`
- [x] Format your code, run `pre-commit` before commit.
- [x] Add or update tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch.

