### PR TITLE
[Benchmark] 兼容SGL 0.5.11 首包无usage字段

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -476,9 +476,11 @@ async def async_request_eb_openai_chat_completions(
                                     ttft = timestamp - st
                                     output.ttft = ttft
                                     # cached_tokens
-                                    if data["usage"] and data["usage"].get("prompt_tokens_details", {}):
-                                        output.prompt_len = (
-                                            data["usage"].get("prompt_tokens_details", {}).get("cached_tokens", 0)
+                                    usage = data.get("usage") or {}
+
+                                    if usage.get("prompt_tokens_details"):
+                                        output.prompt_len = usage.get("prompt_tokens_details", {}).get(
+                                            "cached_tokens", 0
                                         )
                                     else:
                                         output.prompt_len = 0
@@ -504,11 +506,9 @@ async def async_request_eb_openai_chat_completions(
                             elif usage := data.get("usage", {}):
                                 output.output_tokens = usage.get("completion_tokens", 0)
                                 output.prompt_tokens = usage.get("prompt_tokens", 0)
+                                prompt_tokens_details = usage.get("prompt_tokens_details") or {}
                                 if output.prompt_len == 0:
-                                    if data["usage"] and data["usage"].get("prompt_tokens_details", {}):
-                                        output.prompt_len = (
-                                            data["usage"].get("prompt_tokens_details", {}).get("cached_tokens", 0)
-                                        )
+                                    output.prompt_len = prompt_tokens_details.get("cached_tokens", 0)
 
                             most_recent_timestamp = timestamp
                             token_timestamps.append(time.time())
@@ -517,12 +517,12 @@ async def async_request_eb_openai_chat_completions(
                     # 在流式结束时，记录最后一个 chunk 收到的时间戳
                     output.end_timestamp = most_recent_timestamp
                     # 截断case
-                    usage = data.get("usage", {})
+                    usage = data.get("usage") or {}
                     output.output_tokens = usage.get("completion_tokens", 0)
                     output.prompt_tokens = usage.get("prompt_tokens", 0)
+                    prompt_tokens_details = usage.get("prompt_tokens_details") or {}
                     if output.prompt_len == 0:
-                        if data["usage"] and data["usage"].get("prompt_tokens_details", {}):
-                            output.prompt_len = data["usage"].get("prompt_tokens_details", {}).get("cached_tokens", 0)
+                        output.prompt_len = prompt_tokens_details.get("cached_tokens", 0)
 
                     if tool_call_buffer:
                         for _, tc in tool_call_buffer.items():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

Fix benchmark parsing logic when `usage` field is missing or `None`.

This improves compatibility with SGLang 0.20.1 and avoids:
- KeyError: 'usage'
- AttributeError on NoneType

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications

Changes:
- replace direct `data["usage"]` access with safe `.get()`
- add defensive handling for `usage=None`

## Usage or Command

As before

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
