### PR TITLE
Add benchmark-compare skill from #7803

### DIFF
--- a/.claude/skills/benchmark-compare/README.md
+++ b/.claude/skills/benchmark-compare/README.md
@@ -1,0 +1,147 @@
+# Benchmark Skill — FastDeploy vs SGLang 性能对比测试
+
+## 概述
+
+自动完成 FastDeploy 与 SGLang 两个推理框架的性能对比测试，包括环境安装、服务启动、benchmark 执行、指标提取和可视化 HTML 报告生成。最终输出带有量化/并发选择器的交互式 HTML 报告。
+
+## 使用方法
+
+### 触发方式
+
+在 Ducc（Claude Code）中使用 `/benchmark` 命令，或直接用自然语言描述需求：
+
+```
+根据benchmark_compare_skill，完成FastDeploy和SGLang性能测试对比：
+模型：<path_to_model>
+数据集：<path_to_dataset>
+并发：64，512
+量化：不量化（BF16），FP8（Block-Wise）
+使用GPU5和GPU6
+```
+
+### 参数说明
+
+| 参数 | 是否必需 | 说明 | 示例 |
+|------|---------|------|------|
+| 模型路径 | 是 | 模型权重目录的完整路径 | `/path/to/GLM-4.7-Flash` |
+| 数据集 | 否（有默认值） | JSONL 格式的测试数据集 | `/path/to/data.jsonl` |
+| 并发 | 否（默认 32） | 一个或多个并发数，逗号分隔 | `64，512` |
+| 量化 | 否（默认 BF16） | 一种或多种量化方式，FD 使用 Block-Wise FP8，SG 使用 Per-Tensor FP8 | `不量化（BF16），FP8` |
+| GPU | 否（自动选空闲卡） | 指定使用哪些 GPU | `使用GPU0-7` |
+| TP | 否（默认 1） | tensor-parallel 大小 | `TP=4` |
+| DP | 否（默认 1） | data-parallel 大小 | `DP=2` |
+| EP | 否（默认不启用） | expert-parallel 大小，MoE 模型专用 | `EP=8` |
+
+### 使用示例
+
+**最简用法**（使用全部默认值）：
+```
+/benchmark
+```
+
+**指定模型和并发**：
+```
+帮我跑 benchmark，模型用 /path/to/Qwen2.5-72B，TP=4，并发 64
+```
+
+**TP+DP+EP 组合**（MoE 模型 8 卡全并行）：
+```
+对比测试 GLM-4.7-Flash，TP=4，DP=2，EP=8，并发 64 和 512，量化 BF16 和 FP8
+```
+
+**多场景对比**（多种量化 × 多种并发）：
+```
+对比测试 GLM-4.7-Flash，并发 64 和 512，量化 BF16 和 FP8（Block-Wise）
+```
+
+**仅生成报告**（已有测试数据）：
+```
+帮我用 benchmark_results 目录下的日志文件生成 HTML 报告
+```
+
+## 工作流程
+
+Agent 会自动执行以下步骤：
+
+1. **参数解析** — 从用户 prompt 提取模型、并发、量化等参数
+2. **环境检查** — 检查 FastDeploy / SGLang 是否已安装
+3. **环境安装** — 如未安装，自动完成编译安装（Python 3.10）
+4. **GPU 分配** — 查找空闲 GPU 或使用用户指定的卡
+5. **启动 FastDeploy** — 部署 FD 推理服务
+6. **启动 SGLang** — 部署 SG 推理服务
+7. **健康检查** — 轮询等待服务就绪
+8. **运行 FD Benchmark** — 对 FD 执行压测
+9. **运行 SG Benchmark** — 对 SG 执行压测
+10. **提取指标** — 从结果文件解析性能数据
+11. **生成 HTML 报告** — 输出可视化交互报告
+12. **展示摘要** — 输出 Markdown 对比表格，清理服务进程
+
+多种并发 × 多种量化时，Agent 会逐场景执行步骤 5-9，最终合并所有结果生成一份统一报告。
+
+## 输出结果
+
+- **HTML 报告**：`benchmark_results/benchmark_report.html`
+  - 支持量化方式切换（BF16 / FP8 Block-Wise）
+  - 支持并发数切换（64 / 512 等）
+  - 明暗主题切换
+  - Chart.js 可视化图表
+  - 完整指标对比表格
+- **原始日志**：`benchmark_results/GLM-4.7-Flash_long_bs<N>_[<quant>_]<fd|sg>.txt`
+- **指标 JSON**：`benchmark_results/metrics_<quant>_bs<N>.json`
+
+## 目录结构
+
+```
+benchmark-compare/
+├── SKILL.md                    # 主技能定义（工作流编排 + 参数表 + 决策树）
+├── README.md                   # 本文件（使用指南）
+├── scripts/
+│   ├── launch_service.sh       # 通用服务启动脚本（支持 FD/SG, TP/DP/PD）
+│   ├── health_check.sh         # 服务健康检查（轮询 /v1/models）
+│   ├── run_benchmark.sh        # Benchmark 执行封装
+│   ├── extract_metrics.py      # 从结果文件提取指标 → JSON
+│   └── generate_report.py      # 生成多模式 HTML 可视化报告
+└── references/
+    ├── html_template.md        # HTML 报告设计规范
+    └── model_profiles.md       # 模型推荐部署参数表
+```
+
+## 支持的部署模式
+
+| 模式 | 说明 | GPU 需求 | 触发条件 |
+|------|------|----------|----------|
+| single | 单卡部署，FD 和 SG 各一张 | 2 张 | TP=1（默认） |
+| tp | 多卡 Tensor Parallel | 2 × TP 张 | TP > 1 |
+| tp_dp_ep | TP + DP + EP 全并行（MoE 模型） | TP × DP 张（两框架共用同批卡） | TP > 1 且 DP > 1 且 EP > 0 |
+| pd | PD 分离（仅 FD），SG 标准模式 | TP + 1 + TP 张 | 用户指定 pd |
+| multi-node | 多机部署 | 用户指定 | 用户提供节点 IP |
+
+## 环境依赖
+
+- Python 3.10（PaddlePaddle cp310 wheel 要求）
+- NVIDIA GPU（H800/H100 推荐，SM 架构 [90]）
+- `uv`（Python 包管理器）
+- `curl`, `lsof`, `nvidia-smi`
+
+## 注意事项
+
+- **EP 并行映射差异**：
+  - FastDeploy：`--enable-expert-parallel` 为 flag，EP size 隐式等于 TP × DP
+  - SGLang：`--ep-size N` 为显式数值参数
+  - 典型配置：TP=4, DP=2, EP=8 表示 8 卡全部参与 expert 并行
+- **FP8 量化类型**：用户说"FP8"时，实际对应两种不同实现：
+  - FastDeploy 使用 `--quantization block_wise_fp8`（Block-Wise FP8，按 block 粒度量化，精度损失更小）
+  - SGLang 使用 `--quantization fp8`（Per-Tensor FP8，粗粒度量化）
+  - 报告中会明确标注为 "Block-Wise FP8" 以区分，避免误解为相同量化方式
+- **GPU 显存**：MoE 模型必须使用 `--gpu-memory-utilization 0.97`，否则加载失败
+- **GPU 隔离**：两个框架不能共用同一张 GPU，需各占独立卡
+- **FP8 并发限制**：FD 的 FP8 模式下 `--max-num-seqs` 建议设为 32（设 64 会导致 worker crash），benchmark 的 `--max-concurrency` 可以更高（请求排队）
+- **服务重启**：每个 benchmark 场景前建议重启服务，避免前一轮残留状态导致 crash
+- **加载时间**：MoE 模型加载约需 2-4 分钟，请耐心等待
+- **测试时长**：830 条请求 × 并发 64 约需 5-6 分钟
+
+## 扩展指南
+
+- **添加新模型**：编辑 `references/model_profiles.md` 增加模型配置
+- **修改报告样式**：编辑 `references/html_template.md` 或 `scripts/generate_report.py`
+- **添加新框架**：在各 script 中添加新的 `--framework` 分支

--- a/.claude/skills/benchmark-compare/SKILL.md
+++ b/.claude/skills/benchmark-compare/SKILL.md
@@ -1,0 +1,539 @@
+---
+name: benchmark
+description: >
+FastDeploy vs SGLang 推理框架性能对比测试工具。自动完成环境安装、服务启动、
+性能测试、结果可视化全流程。支持单卡/多卡 TP/多机 PD 分离部署模式。
+也支持仅从用户提供的日志/数据生成多模式可视化 HTML 报告（无需启动服务）。
+触发方式：/benchmark 或 "帮我跑 benchmark"、"对比测试 FD 和 SG"、"性能对比"、"生成报告"
+user_invocable: true
+---
+
+# Benchmark 推理框架对比测试
+
+自动完成 FastDeploy 与 SGLang 推理框架的性能对比测试，生成可视化 HTML 报告。
+
+---
+
+## 两种工作模式
+
+### 模式 A：全自动测试（默认）
+
+完整 12 步流程：环境安装 → 服务部署 → 性能测试 → 提取指标 → 生成报告。
+
+### 模式 B：仅生成报告（Report-Only）
+
+用户已有测试数据（日志文件 / 手动结果），只需生成多模式可视化 HTML 报告。
+
+**触发条件**（满足任一）：
+- 用户说 "生成报告"、"出报告"、"整理结果到 HTML"
+- 用户提供了日志文件路径或贴出了 benchmark 结果数据
+- 用户明确说不需要重新跑测试
+
+**模式 B 流程**：跳转到 → [仅生成报告流程](#仅生成报告流程report-only)
+
+---
+
+## 参数表
+
+用户只需提供以下参数（未提供则使用默认值）：
+
+| 参数 | 键名 | 默认值 | 说明 |
+|------|------|--------|------|
+| 模型路径 | `MODEL_PATH` | `<path_to_model>` | 模型权重目录 |
+| 并发数 | `CONCURRENCY` | `32` | 最大并发请求数 |
+| 是否量化 | `QUANTIZATION` | `none` | `none` / `block_wise_fp8`(FD) + `fp8`(SG) / `wint4` / `wint8`。注意：用户说"FP8"时，FD 实际使用 Block-Wise FP8（`--quantization block_wise_fp8`），SG 使用 per-tensor FP8（`--quantization fp8`），两者量化粒度不同，报告中需明确标注 |
+| 数据集路径 | `DATASET_PATH` | `<path_to_dataset>` | JSONL 格式 |
+| TP 大小 | `TP_SIZE` | `1` | tensor-parallel-size |
+| DP 大小 | `DP_SIZE` | `1` | data-parallel-size |
+| EP 大小 | `EP_SIZE` | `0` | expert-parallel-size，MoE 模型专用。FD 映射为 `--enable-expert-parallel`（EP size 隐式=TP×DP），SG 映射为 `--ep-size N` |
+| 部署模式 | `DEPLOY_MODE` | `single` | `single` / `tp` / `tp_dp_ep` / `pd` / `multi-node` |
+| FD 端口 | `FD_PORT` | `8180` | FastDeploy 服务端口 |
+| SG 端口 | `SG_PORT` | `8280` | SGLang 服务端口 |
+| GPU 列表 | `GPU_LIST` | 自动选择空闲卡 | 逗号分隔，如 `0,1,2,3` |
+| 最大序列长度 | `MAX_MODEL_LEN` | `65536` | max-model-len / context-length |
+| 请求数 | `NUM_PROMPTS` | `1024` | benchmark 发送的总请求数 |
+| 输出目录 | `OUTPUT_DIR` | `<SKILL_ROOT>/..` (Ducc 根目录) | 结果文件存放位置 |
+| Hyperparameter YAML | `HYPER_YAML` | 自动匹配（参考 model_profiles） | 请求采样参数配置 |
+
+**示例 prompt：**
+- `/benchmark` — 全部使用默认值
+- `帮我跑 benchmark，模型用 /path/to/Qwen2.5-72B，TP=4，并发 64`
+- `对比测试 GLM-4.7-Flash，开启 fp8 量化`
+
+---
+
+## 部署模式决策树
+
+根据参数自动选择部署策略：
+
+```
+用户指定 DEPLOY_MODE?
+├── YES → 使用指定模式
+└── NO → 根据 TP_SIZE 推断
+    ├── TP_SIZE = 1 → single 模式
+    │   └── 选两张空闲 GPU，FD 和 SG 各占一张
+    ├── TP_SIZE > 1 → tp 模式
+    │   └── 需要 2 × TP_SIZE 张空闲 GPU
+    │       ├── FD: CUDA_VISIBLE_DEVICES=前 TP 张
+    │       └── SG: CUDA_VISIBLE_DEVICES=后 TP 张
+    └── 用户指定 pd → pd 模式
+        └── FD 启动 prefill + decode 两个进程
+            SG 使用标准模式作为对比基线
+
+multi-node 模式:
+  └── 用户需提供各节点 IP
+      ├── FD: 每节点启动一个 worker
+      └── SG: --tp N (跨节点)
+      └── benchmark: --ip-list 参数分发请求
+```
+
+**GPU 选择逻辑：**
+```bash
+nvidia-smi --query-gpu=index,memory.used --format=csv,noheader
+# 选择 memory.used = 0 MiB 的卡
+# 需要的 GPU 数量 = 2 × TP_SIZE（single/tp 模式）
+```
+
+---
+
+## 自动执行流程
+
+```
+步骤 1: 参数解析与模型 Profile 匹配
+步骤 2: 检查环境（FastDeploy / SGLang 是否已安装）
+步骤 3: 如未安装，执行环境安装
+步骤 4: 检查 GPU 空闲情况，分配 GPU
+步骤 5: 启动 FastDeploy 服务（调用 scripts/launch_service.sh）
+步骤 6: 启动 SGLang 服务（调用 scripts/launch_service.sh）
+步骤 7: 等待服务就绪（调用 scripts/health_check.sh）
+步骤 8: 运行 FastDeploy benchmark（调用 scripts/run_benchmark.sh）
+步骤 9: 运行 SGLang benchmark（调用 scripts/run_benchmark.sh）
+步骤 10: 提取指标（调用 scripts/extract_metrics.py）
+步骤 11: 生成 HTML 可视化报告（参考 references/html_template.md）
+步骤 12: 展示对比摘要，清理服务进程
+```
+
+---
+
+## 步骤 1：参数解析与 Profile 匹配
+
+1. 从用户 prompt 中提取参数，未提供的使用默认值
+2. 读取 `references/model_profiles.md`，匹配模型路径对应的推荐配置
+3. 如果 model_profiles 中有该模型，使用推荐的 TP_SIZE / QUANTIZATION / MAX_MODEL_LEN / HYPER_YAML
+4. 用户显式指定的参数优先级高于 profile 推荐值
+
+---
+
+## 步骤 2-3：环境检查与安装
+
+### 检查已安装
+
+```bash
+SKILL_ROOT="$(cd "$(dirname "$0")" && pwd)"
+DUCC_ROOT="$(dirname "$(dirname "$(dirname "$SKILL_ROOT")")")"
+
+# FastDeploy
+ls "$DUCC_ROOT/FastDeploy/.venv/bin/activate" 2>/dev/null && echo "FD_INSTALLED"
+# SGLang
+ls "$DUCC_ROOT/sglang_env/.venv/bin/activate" 2>/dev/null && echo "SG_INSTALLED"
+```
+
+如果已安装则跳过。
+
+### 安装 FastDeploy
+
+**关键：必须使用 Python 3.10**（PaddlePaddle wheel 只有 cp310）。
+
+```bash
+cd "$DUCC_ROOT"
+git clone https://github.com/PaddlePaddle/FastDeploy.git
+cd FastDeploy
+uv venv --python /usr/bin/python3.10
+source .venv/bin/activate
+uv pip install pip
+python -m pip install <paddle_gpu_whl_url>
+pip install -r requirements.txt
+```
+
+设置 LD_LIBRARY_PATH 并编译：
+```bash
+export LD_LIBRARY_PATH=$(python3 -c "
+import site, os
+sp = site.getsitepackages()[0]
+nvidia_dir = os.path.join(sp, 'nvidia')
+libs = [os.path.join(nvidia_dir, d, 'lib') for d in os.listdir(nvidia_dir) if os.path.isdir(os.path.join(nvidia_dir, d, 'lib'))]
+print(':'.join(libs))
+"):$LD_LIBRARY_PATH
+
+bash build.sh 0 python false '[90]'
+pip install -e . --no-build-isolation
+```
+
+安装 FlashMLA：
+```bash
+cd "$DUCC_ROOT"
+git clone https://github.com/PFCCLab/FlashMLA.git
+cd FlashMLA
+git submodule update --init --recursive
+source ../FastDeploy/.venv/bin/activate
+pip install -v . --no-build-isolation
+cd ..
+```
+
+### 代码修改（两个文件都要改）
+
+在 `FastDeploy/benchmarks/backend_request_func.py` 和 `FastDeploy/benchmarks/backend_request_func_swe.py` 中，找到：
+```python
+    if request_func_input.ignore_eos:
+        payload["ignore_eos"] = request_func_input.ignore_eos
+
+    headers = {
+```
+
+替换为：
+```python
+    if request_func_input.ignore_eos:
+        payload["ignore_eos"] = request_func_input.ignore_eos
+
+    metadata = payload.get("metadata")
+    if isinstance(metadata, dict) and "min_tokens" in metadata and "min_tokens" not in payload:
+        payload["min_tokens"] = metadata["min_tokens"]
+
+    fixed_len_mode = (
+        isinstance(payload.get("min_tokens"), int)
+        and isinstance(payload.get("max_tokens"), int)
+        and payload["min_tokens"] == payload["max_tokens"]
+    )
+    if fixed_len_mode:
+        payload.setdefault("ignore_eos", True)
+        payload.setdefault("stop", [])
+
+    headers = {
+```
+
+### 安装 SGLang
+
+```bash
+cd "$DUCC_ROOT"
+mkdir -p sglang_env
+python3.10 -m venv --without-pip sglang_env/.venv
+source sglang_env/.venv/bin/activate
+curl -sS https://bootstrap.pypa.io/get-pip.py | python3
+pip install "sglang[all]==0.5.10.post1"
+```
+
+---
+
+## 步骤 4：GPU 分配
+
+```bash
+nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader
+```
+
+根据部署模式分配：
+- **single (TP=1)**: 选 2 张空闲卡 → `FD_GPUS=<卡1>`, `SG_GPUS=<卡2>`
+- **tp (TP>1)**: 选 `2×TP` 张空闲卡 → `FD_GPUS=<前TP张>`, `SG_GPUS=<后TP张>`
+- **pd**: 选 `TP+1+TP` 张（FD prefill TP张 + FD decode 1张 + SG TP张）
+
+如果用户通过 `GPU_LIST` 指定了具体卡号，直接使用。
+
+---
+
+## 步骤 5-6：启动服务
+
+调用 `scripts/launch_service.sh`：
+
+```bash
+# 启动 FastDeploy
+bash scripts/launch_service.sh \
+  --framework fd \
+  --model "$MODEL_PATH" \
+  --port "$FD_PORT" \
+  --gpus "$FD_GPUS" \
+  --tp "$TP_SIZE" \
+  --concurrency "$CONCURRENCY" \
+  --max-model-len "$MAX_MODEL_LEN" \
+  --quantization "$QUANTIZATION" \
+  --log-file "$OUTPUT_DIR/fd_server.log" \
+  --venv "$DUCC_ROOT/FastDeploy/.venv"
+
+# 启动 SGLang
+bash scripts/launch_service.sh \
+  --framework sg \
+  --model "$MODEL_PATH" \
+  --port "$SG_PORT" \
+  --gpus "$SG_GPUS" \
+  --tp "$TP_SIZE" \
+  --concurrency "$CONCURRENCY" \
+  --max-model-len "$MAX_MODEL_LEN" \
+  --quantization "$QUANTIZATION" \
+  --log-file "$OUTPUT_DIR/sg_server.log" \
+  --venv "$DUCC_ROOT/sglang_env/.venv"
+```
+
+PD 分离模式额外参数：
+```bash
+bash scripts/launch_service.sh \
+  --framework fd \
+  --pd-role prefill \
+  --port "$FD_PORT" \
+  ...
+
+bash scripts/launch_service.sh \
+  --framework fd \
+  --pd-role decode \
+  --port "$((FD_PORT+1))" \
+  ...
+```
+
+---
+
+## 步骤 7：等待服务就绪
+
+```bash
+bash scripts/health_check.sh --host 127.0.0.1 --port "$FD_PORT" --timeout 300 --log-file "$OUTPUT_DIR/fd_server.log"
+bash scripts/health_check.sh --host 127.0.0.1 --port "$SG_PORT" --timeout 300 --log-file "$OUTPUT_DIR/sg_server.log"
+```
+
+---
+
+## 步骤 8-9：运行 Benchmark
+
+```bash
+# 测试 FastDeploy
+bash scripts/run_benchmark.sh \
+  --label fd \
+  --model "$MODEL_PATH" \
+  --port "$FD_PORT" \
+  --dataset "$DATASET_PATH" \
+  --hyperparams "$HYPER_YAML" \
+  --concurrency "$CONCURRENCY" \
+  --num-prompts "$NUM_PROMPTS" \
+  --output "$OUTPUT_DIR/$RESULT_FD"
+
+# 测试 SGLang
+bash scripts/run_benchmark.sh \
+  --label sg \
+  --model "$MODEL_PATH" \
+  --port "$SG_PORT" \
+  --dataset "$DATASET_PATH" \
+  --hyperparams "$HYPER_YAML" \
+  --concurrency "$CONCURRENCY" \
+  --num-prompts "$NUM_PROMPTS" \
+  --output "$OUTPUT_DIR/$RESULT_SG"
+```
+
+**结果文件命名规则：** `<ModelShortName>_long_bs<CONCURRENCY>_[<quant>_]<fd|sg>.txt`
+
+---
+
+## 步骤 10：提取指标
+
+```bash
+python3 scripts/extract_metrics.py \
+  --fd-result "$OUTPUT_DIR/$RESULT_FD" \
+  --sg-result "$OUTPUT_DIR/$RESULT_SG" \
+  --model-path "$MODEL_PATH" \
+  --fd-config '{"gpu":"H800","tp":'$TP_SIZE',"dp":'$DP_SIZE',"ep":'$EP_SIZE',"concurrency":'$CONCURRENCY',"quantization":"'$QUANTIZATION'"}' \
+  --sg-config '{"gpu":"H800","tp":'$TP_SIZE',"dp":'$DP_SIZE',"ep":'$EP_SIZE',"concurrency":'$CONCURRENCY',"quantization":"'$QUANTIZATION'"}' \
+  --output "$OUTPUT_DIR/metrics.json"
+```
+
+---
+
+## 步骤 11：生成 HTML 报告
+
+使用 `scripts/generate_report.py` 生成多模式可视化报告：
+
+```bash
+python3 scripts/generate_report.py \
+  --data-json "$OUTPUT_DIR/metrics.json" \
+  --output "$OUTPUT_DIR/benchmark_report.html" \
+  --model-name "$MODEL_NAME" \
+  --gpu-type "H800" \
+  --tp $TP_SIZE \
+  --dp $DP_SIZE \
+  --ep $EP_SIZE \
+  --default-quant "$QUANTIZATION" \
+  --default-bs "$CONCURRENCY"
+```
+
+如果只跑了单个场景（单种量化 + 单种并发），报告仍然正确——选择器只有一个选项。
+
+如果跑了多个场景（如多种并发或同时 BF16+FP8），先将各场景指标合并为一个 JSON（格式见下文），再调用 generate_report.py。
+
+**合并 JSON 格式**：
+```json
+{
+  "bf16_bs32": {"fd": {...metrics...}, "sg": {...metrics...}},
+  "fp8_bs64": {"fd": {...metrics...}, "sg": {...metrics...}}
+}
+```
+
+**报告设计规范详见** `references/html_template.md`。
+
+---
+
+## 步骤 12：展示结果与清理
+
+展示 Markdown 对比表格：
+
+```
+| 指标 | FastDeploy | SGLang | 差异 | 胜出 |
+|------|-----------|--------|------|------|
+| Total Token Throughput (tok/s) | xxx | xxx | ±x% | ... |
+| Mean TTFT (ms) | xxx | xxx | ±x% | ... |
+| Mean TPOT (ms) | xxx | xxx | ±x% | ... |
+| Mean ITL (ms) | xxx | xxx | ±x% | ... |
+| Mean E2EL (ms) | xxx | xxx | ±x% | ... |
+```
+
+清理：
+```bash
+# 停止服务进程
+kill $(lsof -t -i :$FD_PORT) 2>/dev/null
+kill $(lsof -t -i :$SG_PORT) 2>/dev/null
+```
+
+告知用户 HTML 报告路径。
+
+---
+
+## 关键注意事项
+
+| # | 问题 | 解决方案 |
+|---|------|----------|
+| 1 | Python 版本 | **必须用 3.10**，`uv venv --python /usr/bin/python3.10` |
+| 2 | OOM | **必须加 `--gpu-memory-utilization 0.97`**（MoE 模型权重大） |
+| 3 | uv venv 无 pip | 创建后先 `uv pip install pip` |
+| 4 | FlashMLA 编译 | 需先设置 `LD_LIBRARY_PATH`（NVIDIA 库路径） |
+| 5 | 两框架不能共用 GPU | 各占独立卡，否则显存不够 |
+| 6 | 端口冲突 | 启动前检查并 kill 占用进程 |
+| 7 | 模型加载慢 | MoE 约 2-4 分钟，耐心轮询 `/v1/models` |
+| 8 | SM 架构号 | H800/H100 用 `[90]`，A100 用 `[80]` |
+| 9 | benchmark 耗时 | 1024 prompts × 并发 32 约 5-8 分钟 |
+| 10 | 代码修改位置 | `backend_request_func.py` 和 `_swe.py` 都要改 |
+| 11 | 多卡 TP GPU 数 | 需要 `2×TP` 张空闲 GPU（FD + SG 各 TP 张） |
+| 12 | PD 分离 | 仅 FD 支持，SG 作为标准模式基线 |
+| 13 | FP8 量化类型差异 | FD 使用 `block_wise_fp8`（分块量化，粒度更细），SG 使用 `fp8`（per-tensor）。报告中需明确标注为 "Block-Wise FP8"，避免用户误解为同一种 FP8 实现 |
+| 14 | FP8 并发限制 | FD 的 FP8 模式下 `--max-num-seqs` 建议设为 32（设 64 会导致 MoE 模型 worker crash）。benchmark 的 `--max-concurrency` 可以更高（请求在服务端排队） |
+| 15 | **CUDA Graph 必须开启** | **两个框架都必须开启 CUDA Graph**（各自默认行为），这是测试最优性能的前提。FD 默认开启（不要设 `FLAGS_use_cuda_graph=0`）；SG 默认开启（不要加 `--disable-cuda-graph`）。如果 OOM，应通过降低 `max-num-seqs` 或 `gpu-memory-utilization` 来解决，而不是禁用 CUDA Graph |
+| 16 | SGLang DP 端口冲突 | SGLang 在 DP>1 时，torch.distributed 初始化可能与系统服务（18xxx 端口范围）冲突。解决方案：启动前 `export MASTER_PORT=45000`（`launch_service.sh` 已自动处理）|
+| 17 | 报告展示部署方式 | HTML 报告中必须显示 TP/DP/EP 配置。使用 `generate_report.py --tp N --dp N --ep N` 参数传入 |
+
+---
+
+## 仅生成报告流程（Report-Only）
+
+当用户已有测试数据，无需重新跑测试，只需生成 HTML 报告时使用。
+
+### 数据输入方式
+
+Agent 需要从以下任一来源获取数据：
+
+**方式 1：用户提供日志文件路径**
+- 日志文件是 `benchmark_serving.py` 的标准输出
+- Agent 使用 `extract_metrics.py` 或直接正则解析
+- 文件命名约定：`*_bs<N>_[<quant>_]<fd|sg>.txt`
+
+**方式 2：用户直接贴出数据/表格**
+- Agent 从用户消息中提取关键指标
+- 构建 JSON 数据对象
+
+**方式 3：用户提供 JSON 文件**
+- 直接使用已整理好的 metrics JSON
+
+### 执行步骤
+
+```
+步骤 R1: 确认数据来源和场景维度（哪些量化 × 哪些并发）
+步骤 R2: 从日志/数据中提取各场景的 FD 和 SG 指标
+步骤 R3: 构建合并 JSON（格式：{quant}_bs{concurrency}）
+步骤 R4: 确认模型信息和部署配置（向用户确认或从日志推断）
+步骤 R5: 调用 generate_report.py 或直接内联生成 HTML
+步骤 R6: 输出 HTML 报告路径
+```
+
+### 步骤 R2 详细：从日志文件解析指标
+
+```bash
+# 方法 A：使用 extract_metrics.py 逐场景提取
+python3 scripts/extract_metrics.py \
+  --fd-result /path/to/fd_result.txt \
+  --sg-result /path/to/sg_result.txt \
+  --model-path /path/to/model \
+  --output /tmp/metrics_scene1.json
+
+# 方法 B：使用 generate_report.py 自动扫描目录
+python3 scripts/generate_report.py \
+  --log-dir /path/to/log_directory \
+  --model-name "GLM-4.7-Flash" \
+  --output benchmark_report.html
+```
+
+日志文件扫描规则（`generate_report.py --log-dir`）：
+- 递归扫描目录下所有 `.txt` 文件
+- 从文件名正则匹配 `_bs<N>_[<quant>_]<fd|sg>.txt`
+- 自动归类到对应场景
+
+### 步骤 R4 详细：向用户确认的信息
+
+如果无法从数据/日志中推断，需要向用户确认：
+- 模型名称
+- GPU 型号和数量
+- TP 大小
+- FD/SG 的 Attention Backend
+- SGLang 版本
+- 默认展示的量化和并发
+
+### 步骤 R5 详细：生成报告
+
+```bash
+python3 scripts/generate_report.py \
+  --data-json all_metrics.json \
+  --output benchmark_report.html \
+  --model-name "GLM-4.7-Flash" \
+  --model-type "MoE (glm4_moe_lite)" \
+  --model-size "~58.2 GB" \
+  --model-experts "64R + 1S (Active: 4)" \
+  --model-layers-hidden "47 / 2048" \
+  --gpu-type H800 --tp 1 --dp 1 --ep 0 \
+  --max-model-len 65536 \
+  --fd-attention "MLA_ATTN (FlashAttn v3)" \
+  --sg-attention "flashmla" \
+  --sg-version "0.5.10.post1" \
+  --default-quant bf16 --default-bs 512 \
+  --dataset-url "https://..." \
+  --dataset-desc "browsecomp_plus (830 samples)" \
+  --test-date "2026-05-07"
+```
+
+### 注意事项
+
+- 如果用户只提供了部分场景的数据，报告选择器中只会出现有数据的选项
+- 如果某个场景只有 FD 或只有 SG 的数据，该场景会被跳过（需要配对）
+- Agent 也可以不调用脚本，直接根据 `references/html_template.md` 的规范生成完整 HTML 内联到文件中（适合数据已在对话上下文中的情况）
+
+---
+
+## 扩展指南
+
+### 添加新模型
+
+1. 在 `references/model_profiles.md` 添加一行模型配置
+2. 如需特殊 hyperparameter，在 `FastDeploy/benchmarks/yaml/request_yaml/` 新建 YAML
+3. 运行 `/benchmark --model <新模型路径>` 即可
+
+### 添加新框架
+
+1. 在 `scripts/launch_service.sh` 添加新的 `--framework` 分支
+2. 在 `scripts/run_benchmark.sh` 添加对应的 backend 类型
+3. 在 `scripts/extract_metrics.py` 添加结果解析逻辑
+4. 更新 `references/html_template.md` 支持多框架对比
+
+### 多机部署
+
+1. 用户需提供 `--node-list <ip1,ip2,...>`
+2. `launch_service.sh` 通过 SSH 在各节点启动 worker
+3. `run_benchmark.sh` 使用 `--ip-list` 分发到多个 endpoint
+4. 需要 RDMA/IPC 配置（参考 FD service YAML 中的 `cache_transfer_protocol`）

--- a/.claude/skills/benchmark-compare/references/html_template.md
+++ b/.claude/skills/benchmark-compare/references/html_template.md
@@ -1,0 +1,292 @@
+# HTML 报告模板（多模式版）
+
+本文件包含 Benchmark 对比报告的 HTML 模板规范。报告支持多种测试场景（量化方式 × 并发数）切换。
+
+## 架构概述
+
+报告采用 **数据驱动 + 动态渲染** 模式：
+1. 所有场景的指标数据嵌入为 JavaScript 对象 `benchmarkData`
+2. 用户通过 Segmented Control 选择量化方式和并发数
+3. 选择变化时，JS 动态更新所有 UI 组件（指标卡片、图表、表格、结论）
+4. 选择状态持久化到 `localStorage`
+
+**不再使用 `{{PLACEHOLDER}}` 占位符模式。** Agent 生成报告时直接从数据源（日志文件 / metrics.json）读取指标并嵌入为 JSON。
+
+---
+
+## 规则
+
+- **百分比符号规则**：正数+绿色=FD 领先，负数+红色=FD 落后
+  - 吞吐类指标（越高越好）：`diff = (fd - sg) / sg * 100`
+  - 延迟类指标（越低越好）：`diff = (sg - fd) / fd * 100`
+  - 正值用 `m-better` class（绿色），负值用 `m-worse` class（红色）
+- **配置卡片对齐**：FD 和 SG 卡片同一行位置放置对等概念（GPU/TP、并发/长度、Attention/量化、版本信息）
+- **数据集链接**：Params Bar 中数据集需带下载链接和「（点击可下载）」后缀
+- **默认主题**：明亮模式 (`data-theme="light"`)
+- **默认选择**：bf16 + 并发512（或由数据源决定的最大并发），持久化到 localStorage
+- **中文界面**，技术术语保留英文（TTFT、TPOT、ITL、E2EL、Throughput、Decode、MoE）
+
+---
+
+## 数据结构
+
+### benchmarkData 对象
+
+```javascript
+const benchmarkData = {
+  "bf16_bs1": {
+    "fd": { "successful_requests": 830, "benchmark_duration": 4568.59, "total_token_throughput": 177.79, ... },
+    "sg": { "successful_requests": 830, "benchmark_duration": 3228.47, "total_token_throughput": 251.59, ... }
+  },
+  "bf16_bs32": { "fd": {...}, "sg": {...} },
+  "bf16_bs64": { "fd": {...}, "sg": {...} },
+  "bf16_bs512": { "fd": {...}, "sg": {...} },
+  "fp8_bs1": { "fd": {...}, "sg": {...} },
+  "fp8_bs32": { "fd": {...}, "sg": {...} },
+  "fp8_bs64": { "fd": {...}, "sg": {...} },
+  "fp8_bs512": { "fd": {...}, "sg": {...} }
+};
+```
+
+Key 格式：`{quant}_bs{concurrency}`
+
+每个 framework 对象包含的完整指标字段：
+```
+successful_requests, benchmark_duration,
+total_input_tokens, total_generated_tokens,
+request_throughput, output_token_throughput, total_token_throughput,
+mean_ttft, median_ttft, p80_ttft, p95_ttft, p99_ttft,
+mean_tpot, median_tpot, p80_tpot, p95_tpot, p99_tpot,
+mean_itl, median_itl, p80_itl, p95_itl, p99_itl,
+mean_e2el, median_e2el, p80_e2el, p95_e2el, p99_e2el,
+mean_decode, median_decode
+```
+
+---
+
+## UI 结构
+
+### 1. Segmented Control（选择器）
+
+```html
+<div class="selector-bar">
+    <div class="selector-group">
+        <span class="selector-label">量化</span>
+        <div class="seg-control" id="quant-selector">
+            <div class="seg-btn" data-val="bf16" onclick="setQuant('bf16')">BF16</div>
+            <div class="seg-btn" data-val="fp8" onclick="setQuant('fp8')">FP8</div>
+        </div>
+    </div>
+    <div class="selector-group">
+        <span class="selector-label">并发</span>
+        <div class="seg-control" id="bs-selector">
+            <div class="seg-btn" data-val="1" onclick="setBS('1')">1</div>
+            <div class="seg-btn" data-val="32" onclick="setBS('32')">32</div>
+            <div class="seg-btn" data-val="64" onclick="setBS('64')">64</div>
+            <div class="seg-btn" data-val="512" onclick="setBS('512')">512</div>
+        </div>
+    </div>
+</div>
+```
+
+### 2. 动态组件
+
+以下组件需在选择变化时动态更新：
+- **Badge 行**：量化方式 & 并发数 badge
+- **配置卡片**：FD/SG 量化方式 & 并发数字段
+- **Params Bar**：请求数（根据数据变化）
+- **指标卡片** (8 cards)：值 + diff 百分比 + diff class
+- **图表** (4 charts)：全部 destroy + rebuild
+- **表格行**：全部 innerHTML 替换
+- **结论段落**：根据数据动态生成
+
+### 3. 指标卡片定义
+
+```javascript
+const metricDefs = [
+    { key: 'total_token_throughput', title: 'Total Token Throughput', unit: 'tok/s', hint: '越高越好', higher: true },
+    { key: 'output_token_throughput', title: 'Output Token Throughput', unit: 'tok/s', hint: '越高越好', higher: true },
+    { key: 'mean_ttft', title: 'Mean TTFT (首 Token 延迟)', unit: 'ms', hint: '越低越好', higher: false },
+    { key: 'mean_tpot', title: 'Mean TPOT (Token 间延迟)', unit: 'ms', hint: '越低越好', higher: false },
+    { key: 'mean_itl', title: 'Mean ITL (Inter-Token Latency)', unit: 'ms', hint: '越低越好', higher: false },
+    { key: 'mean_e2el', title: 'Mean E2EL (端到端延迟)', unit: 'ms', hint: '越低越好', higher: false },
+    { key: 'mean_decode', title: 'Decode Speed', unit: 'tok/s', hint: '越高越好', higher: true },
+    { key: 'request_throughput', title: 'Request Throughput', unit: 'req/s', hint: '越高越好', higher: true },
+];
+```
+
+### 4. 表格指标列表
+
+```javascript
+const tableMetrics = [
+    { key: 'successful_requests', label: '成功请求数', higher: true },
+    { key: 'benchmark_duration', label: '测试总时长 (s)', higher: false },
+    { key: 'total_token_throughput', label: '总 Token Throughput (tok/s)', higher: true },
+    { key: 'output_token_throughput', label: '输出 Token Throughput (tok/s)', higher: true },
+    { key: 'request_throughput', label: 'Request Throughput (req/s)', higher: true },
+    { key: 'mean_ttft', label: 'Mean TTFT (ms)', higher: false },
+    { key: 'median_ttft', label: 'Median TTFT (ms)', higher: false },
+    { key: 'p99_ttft', label: 'P99 TTFT (ms)', higher: false },
+    { key: 'mean_tpot', label: 'Mean TPOT (ms)', higher: false },
+    { key: 'p99_tpot', label: 'P99 TPOT (ms)', higher: false },
+    { key: 'mean_itl', label: 'Mean ITL (ms)', higher: false },
+    { key: 'p99_itl', label: 'P99 ITL (ms)', higher: false },
+    { key: 'mean_e2el', label: 'Mean E2EL (ms)', higher: false },
+    { key: 'p99_e2el', label: 'P99 E2EL (ms)', higher: false },
+    { key: 'mean_decode', label: 'Decode Speed (tok/s)', higher: true },
+];
+```
+
+---
+
+## Diff 计算逻辑
+
+```javascript
+function computeDiff(fdVal, sgVal, higherIsBetter) {
+    if (higherIsBetter) {
+        return sgVal !== 0 ? ((fdVal - sgVal) / sgVal * 100) : 0;
+    } else {
+        return fdVal !== 0 ? ((sgVal - fdVal) / fdVal * 100) : 0;
+    }
+}
+// 正值 → FD 领先 → 绿色 (m-better / diff-good)
+// 负值 → FD 落后 → 红色 (m-worse / diff-bad)
+```
+
+---
+
+## 图表规范
+
+4 个 Chart.js 图表：
+
+| 图表 | 类型 | X 轴 | 说明 |
+|------|------|------|------|
+| 吞吐量对比 | bar | Total Token, Output Token, Request (×scale) | scale 根据 request_throughput 大小决定 |
+| 延迟对比 | bar | TTFT, TPOT (×10), ITL (×10), E2EL (/10) | 归一化到同一量级展示 |
+| TTFT 分位 | line | Mean, Median, P80, P95, P99 | fill area |
+| ITL 分位 | line | Mean, Median, P80, P95, P99 | fill area |
+
+切换主题或切换数据时均需 `destroy()` 旧图表后重建。
+
+---
+
+## CSS：Segmented Control 样式
+
+```css
+.selector-bar {
+    display: flex; justify-content: center; align-items: center; gap: 24px;
+    margin-bottom: 40px; flex-wrap: wrap;
+}
+.selector-group { display: flex; align-items: center; gap: 10px; }
+.selector-label { font-size: 0.78rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.8px; font-weight: 600; }
+.seg-control {
+    display: flex; background: var(--bg-card); border: 1px solid var(--border);
+    border-radius: 12px; padding: 4px; gap: 2px;
+    transition: background var(--transition), border-color var(--transition);
+}
+.seg-btn {
+    padding: 8px 18px; border-radius: 9px; font-size: 0.82rem; font-weight: 600;
+    cursor: pointer; border: none; background: transparent;
+    color: var(--text-muted); transition: all 0.2s ease; user-select: none;
+}
+.seg-btn:hover { color: var(--text-secondary); }
+.seg-btn.active {
+    background: var(--fd-primary); color: #fff;
+    box-shadow: 0 2px 8px rgba(99,102,241,0.3);
+}
+```
+
+---
+
+## 结论动态生成
+
+结论段落由 JS 根据当前数据动态生成，包含：
+1. **测试条件**：模型名、GPU、量化方式、并发数
+2. **整体表现**：统计 tableMetrics 中各指标胜出方，报告胜出比例
+3. **吞吐量**：Total Token Throughput 数值对比和比率
+4. **成功率**：FD 成功请求数 / 最大请求数
+
+---
+
+## localStorage 持久化
+
+| Key | 说明 | 默认值 |
+|-----|------|--------|
+| `bench-quant` | 当前量化选择 | `bf16` |
+| `bench-bs` | 当前并发选择 | `512` |
+| `benchmark-theme` | 主题 | `light` |
+
+---
+
+## 数据来源
+
+Agent 从以下来源获取 benchmark 指标：
+1. **日志文件**：`benchmark_serving.py` 的标准输出文件，使用正则提取数值
+2. **metrics.json**：由 `extract_metrics.py` 脚本生成的结构化 JSON
+3. **手动提供**：用户直接给出数值
+
+日志文件解析正则模式参考 `extract_metrics.py` 中的 `patterns` 字典。
+
+---
+
+## 设计规范
+
+- **配色方案：**
+  - FastDeploy: Indigo 系 (#6366f1 / #4f46e5)
+  - SGLang: Amber 系 (#f59e0b / #d97706)
+  - FD 领先: Emerald (#10b981)
+  - FD 落后: Red (#ef4444)
+- **图表：** 切换主题或数据时自动重建（destroy + rebuild）
+- **过渡动画：** 0.35s cubic-bezier(0.4,0,0.2,1) 平滑切换
+- **响应式：** `@media (max-width: 1000px)` config-grid 单列，`@media (max-width: 900px)` charts-grid 单列
+- **字体：** 'Inter', -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'PingFang SC', sans-serif
+
+---
+
+## 完整模板结构（伪代码）
+
+```html
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme="light">
+<head>
+    <!-- Chart.js CDN -->
+    <style>/* 全部 CSS 内联，包含 theme variables、selector、cards、table 等 */</style>
+</head>
+<body>
+    <!-- Theme Toggle (fixed, top-right) -->
+    <div class="container">
+        <!-- Header: h1 + subtitle + badge-row (dynamic badges for quant/bs) -->
+        <!-- Selector Bar: quant segmented control + bs segmented control -->
+        <!-- Config Cards: Model (static) + FD (dynamic quant/bs) + SG (dynamic quant/bs) -->
+        <!-- Params Bar: request count (dynamic) + dataset link + hyperparams -->
+        <!-- Legend: FD dot + SG dot -->
+        <!-- Metric Cards: 8 cards, innerHTML dynamically generated -->
+        <!-- Charts Grid: 4 canvas elements, rebuilt on data/theme change -->
+        <!-- Detail Table: thead static, tbody dynamically generated -->
+        <!-- Conclusion: dynamically generated -->
+        <!-- Footer -->
+    </div>
+    <script>
+        const benchmarkData = { /* ALL scenario data embedded */ };
+        let currentQuant = localStorage.getItem('bench-quant') || 'bf16';
+        let currentBS = localStorage.getItem('bench-bs') || '512';
+        // setQuant(), setBS(), updateAll()
+        // updateSelectors(), updateMetricCards(), updateTable(), updateConclusion()
+        // Chart functions: getChartColors(), rebuildCharts(), buildCharts()
+        // Theme: toggleTheme(), restore from localStorage
+        updateAll(); // initial render
+    </script>
+</body>
+</html>
+```
+
+---
+
+## 生成报告的步骤
+
+1. 收集所有场景的 benchmark 日志/数据
+2. 解析每个场景的 FD + SG 指标（使用 `extract_metrics.py` 或手动正则）
+3. 构建 `benchmarkData` JSON 对象
+4. 将 JSON 嵌入 HTML 模板的 `<script>` 部分
+5. 确认模型信息、配置信息（GPU、TP、Attention、版本等）
+6. 输出为 `benchmark_report.html`

--- a/.claude/skills/benchmark-compare/references/model_profiles.md
+++ b/.claude/skills/benchmark-compare/references/model_profiles.md
@@ -1,0 +1,74 @@
+# 模型部署配置表 (Model Profiles)
+
+本文件记录各模型在 FastDeploy 和 SGLang 上的推荐部署参数。Agent 在步骤 1 中根据 `MODEL_PATH` 匹配模型名称，获取推荐配置。
+
+**匹配规则：** 取 `MODEL_PATH` 的最后一级目录名，模糊匹配下表中的 "匹配关键词" 列。
+
+---
+
+## 配置表
+
+| 模型名 | 匹配关键词 | 最小 TP | 推荐量化 | max-model-len | FD Attention Backend | FD 环境变量 | SG Attention Backend | gpu-memory-utilization | Hyperparameter YAML | 备注 |
+|--------|-----------|---------|----------|---------------|---------------------|-------------|---------------------|----------------------|-------------------|------|
+| GLM-4.7-Flash | `GLM-4.7`, `GLM4.7`, `glm-4.7` | 1 | none | 65536 | MLA_ATTN | `USE_FLASH_MLA=1`, `FLAGS_flash_attn_version=3`, `FD_SAMPLING_CLASS=rejection` | flashmla | 0.97 | `GLM-32k.yaml` | MoE 模型 ~59GB，单卡 H800 刚好放下 |
+| DeepSeek-V2 | `DeepSeek-V2`, `deepseek-v2` | 1 | none/fp8 | 65536 | MLA_ATTN | `USE_FLASH_MLA=1`, `FLAGS_flash_attn_version=3`, `FD_SAMPLING_CLASS=rejection` | flashmla | 0.97 | `deepseek-32k.yaml` | MoE + MLA |
+| DeepSeek-V3 | `DeepSeek-V3`, `deepseek-v3` | 8 | fp8 | 32768 | MLA_ATTN | `USE_FLASH_MLA=1`, `FLAGS_flash_attn_version=3`, `FD_SAMPLING_CLASS=rejection` | flashmla | 0.95 | `deepseek-32k.yaml` | 671B MoE，需多机或 PD 分离 |
+| DeepSeek-R1 | `DeepSeek-R1`, `deepseek-r1` | 8 | fp8 | 32768 | MLA_ATTN | `USE_FLASH_MLA=1`, `FLAGS_flash_attn_version=3`, `FD_SAMPLING_CLASS=rejection` | flashmla | 0.95 | `deepseek-32k.yaml` | 671B，同 V3 架构 |
+| Qwen2.5-7B | `Qwen2.5-7B`, `qwen2.5-7b` | 1 | none | 32768 | - | `FD_SAMPLING_CLASS=rejection` | - | 0.90 | `qwen2-32k.yaml` | Dense 7B，单卡轻松 |
+| Qwen2.5-72B | `Qwen2.5-72B`, `qwen2.5-72b` | 4 | wint4/fp8 | 32768 | - | `FD_SAMPLING_CLASS=rejection` | - | 0.95 | `qwen2-32k.yaml` | Dense 72B |
+| Qwen3-235B | `Qwen3-235B`, `qwen3-235b` | 4 | fp8 | 32768 | - | `FD_SAMPLING_CLASS=rejection` | - | 0.95 | `qwen3-32k.yaml` | MoE 235B，EP 可选 |
+| Qwen3-30B-A3B | `Qwen3-30B`, `qwen3-30b` | 1 | none/fp8 | 32768 | - | `FD_SAMPLING_CLASS=rejection` | - | 0.95 | `qwen3-32k.yaml` | MoE 30B (3B active) |
+| ERNIE-4.5 | `ernie-4.5`, `ERNIE-4.5`, `eb45` | 1 | none | 32768 | - | `FD_SAMPLING_CLASS=rejection` | - | 0.90 | `eb45-32k.yaml` | 快速验证用 |
+| Llama-3.1-70B | `Llama-3.1-70B`, `llama-3.1-70b` | 4 | fp8 | 32768 | - | `FD_SAMPLING_CLASS=rejection` | - | 0.95 | `request.yaml` | Dense 70B |
+| Llama-3.1-8B | `Llama-3.1-8B`, `llama-3.1-8b` | 1 | none | 32768 | - | `FD_SAMPLING_CLASS=rejection` | - | 0.90 | `request.yaml` | Dense 8B |
+
+---
+
+## 字段说明
+
+| 字段 | 说明 |
+|------|------|
+| **最小 TP** | 模型权重能装入 GPU 所需的最小 tensor-parallel 数。80GB H800 为基准 |
+| **推荐量化** | `none`=BF16 全精度；`fp8`/`block_wise_fp8`=FP8 量化；`wint4`/`wint8`=权重量化 |
+| **max-model-len** | FD 的 `--max-model-len` / SG 的 `--context-length` |
+| **FD Attention Backend** | FD 的 `FD_ATTENTION_BACKEND` 环境变量。MLA 架构模型用 `MLA_ATTN` |
+| **FD 环境变量** | 启动 FD 时需额外设置的环境变量 |
+| **SG Attention Backend** | SG 的 `--attention-backend` 参数。MLA 架构用 `flashmla`；默认 `-` 表示不指定 |
+| **gpu-memory-utilization** | MoE 大模型建议 0.97；Dense 模型 0.90-0.95 |
+| **Hyperparameter YAML** | benchmark 使用的 request hyperparameter 文件（相对于 `FastDeploy/benchmarks/yaml/request_yaml/`） |
+
+---
+
+## 如何添加新模型
+
+1. 在上表中新增一行
+2. 如果模型需要新的 hyperparameter 配置，在 `FastDeploy/benchmarks/yaml/request_yaml/` 创建对应 YAML
+3. 如果模型使用新的 attention 机制，确认 FD 和 SG 的 attention backend 参数
+4. 如果是 MoE 模型，注意 `gpu-memory-utilization` 需设高（0.95-0.97）
+
+---
+
+## 部署模式参考
+
+### 单卡 (TP=1)
+- 适用：≤80GB 的模型（如 GLM-4.7-Flash ~59GB, Qwen2.5-7B ~14GB）
+- GPU 需求：2 张（FD 1张 + SG 1张）
+
+### 多卡 TP (TP>1)
+- 适用：>80GB 的 Dense 模型（如 Qwen2.5-72B 需 TP=4）
+- GPU 需求：2×TP 张
+- FD: `--tensor-parallel-size N`
+- SG: `--tp N`
+
+### PD 分离 (Prefill-Decode Separation)
+- 适用：超大模型需极致吞吐（如 DeepSeek-V3）
+- 仅 FD 支持：
+  - Prefill 实例：`--splitwise-role prefill`
+  - Decode 实例：`--splitwise-role decode`
+  - 需配置 RDMA/IPC 通信
+- SG 作为标准模式对比基线
+
+### 多机 (Multi-Node)
+- 适用：单机放不下的模型（如 DeepSeek-V3 671B 需 8×H800）
+- 需用户提供各节点 IP 和 SSH 配置
+- Benchmark 使用 `--ip-list` 分发请求

--- a/.claude/skills/benchmark-compare/scripts/extract_metrics.py
+++ b/.claude/skills/benchmark-compare/scripts/extract_metrics.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""extract_metrics.py — 从 benchmark 结果文件提取指标，输出结构化 JSON
+
+用法:
+    python3 extract_metrics.py \
+        --fd-result <FD_RESULT.txt> \
+        --sg-result <SG_RESULT.txt> \
+        --model-path <MODEL_PATH> \
+        --fd-config '{"gpu":"H800","tp":1,"concurrency":32}' \
+        --sg-config '{"gpu":"H800","tp":1,"concurrency":32}' \
+        --output <metrics.json>
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+
+def parse_benchmark_result(filepath):
+    """解析 benchmark_serving.py 的输出文件，提取所有指标"""
+    metrics = {}
+    if not os.path.isfile(filepath):
+        print(f"[WARN] 结果文件不存在: {filepath}", file=sys.stderr)
+        return metrics
+
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    patterns = {
+        "successful_requests": r"Successful requests:\s+([\d.]+)",
+        "benchmark_duration": r"Benchmark duration \(s\):\s+([\d.]+)",
+        "total_input_tokens": r"Total input tokens:\s+([\d.]+)",
+        "total_generated_tokens": r"Total generated tokens:\s+([\d.]+)",
+        "request_throughput": r"Request throughput \(req/s\):\s+([\d.]+)",
+        "output_token_throughput": r"Output token throughput \(tok/s\):\s+([\d.]+)",
+        "total_token_throughput": r"Total Token throughput \(tok/s\):\s+([\d.]+)",
+        "mean_ttft": r"Mean TTFT \(ms\):\s+([\d.]+)",
+        "median_ttft": r"Median TTFT \(ms\):\s+([\d.]+)",
+        "p80_ttft": r"P80 TTFT \(ms\):\s+([\d.]+)",
+        "p95_ttft": r"P95 TTFT \(ms\):\s+([\d.]+)",
+        "p99_ttft": r"P99 TTFT \(ms\):\s+([\d.]+)",
+        "mean_tpot": r"Mean TPOT \(ms\):\s+([\d.]+)",
+        "median_tpot": r"Median TPOT \(ms\):\s+([\d.]+)",
+        "p80_tpot": r"P80 TPOT \(ms\):\s+([\d.]+)",
+        "p95_tpot": r"P95 TPOT \(ms\):\s+([\d.]+)",
+        "p99_tpot": r"P99 TPOT \(ms\):\s+([\d.]+)",
+        "mean_itl": r"Mean ITL \(ms\):\s+([\d.]+)",
+        "median_itl": r"Median ITL \(ms\):\s+([\d.]+)",
+        "p80_itl": r"P80 ITL \(ms\):\s+([\d.]+)",
+        "p95_itl": r"P95 ITL \(ms\):\s+([\d.]+)",
+        "p99_itl": r"P99 ITL \(ms\):\s+([\d.]+)",
+        "mean_e2el": r"Mean E2EL \(ms\):\s+([\d.]+)",
+        "median_e2el": r"Median E2EL \(ms\):\s+([\d.]+)",
+        "p80_e2el": r"P80 E2EL \(ms\):\s+([\d.]+)",
+        "p95_e2el": r"P95 E2EL \(ms\):\s+([\d.]+)",
+        "p99_e2el": r"P99 E2EL \(ms\):\s+([\d.]+)",
+        "mean_decode": r"Mean Decode \(tok/s\):\s+([\d.]+)",
+        "median_decode": r"Median Decode \(tok/s\):\s+([\d.]+)",
+        "p80_decode": r"P80 Decode \(tok/s\):\s+([\d.]+)",
+        "p95_decode": r"P95 Decode \(tok/s\):\s+([\d.]+)",
+        "p99_decode": r"P99 Decode \(tok/s\):\s+([\d.]+)",
+    }
+
+    for key, pattern in patterns.items():
+        match = re.search(pattern, content)
+        if match:
+            metrics[key] = float(match.group(1))
+
+    return metrics
+
+
+def get_model_info(model_path):
+    """从模型目录读取配置信息"""
+    info = {
+        "name": os.path.basename(model_path),
+        "path": model_path,
+        "model_type": "unknown",
+        "hidden_size": 0,
+        "num_layers": 0,
+        "n_routed_experts": 0,
+        "n_shared_experts": 0,
+        "num_experts_per_tok": 0,
+        "size_gb": 0,
+    }
+
+    config_path = os.path.join(model_path, "config.json")
+    if os.path.isfile(config_path):
+        with open(config_path, "r") as f:
+            config = json.load(f)
+        info["model_type"] = config.get("model_type", "unknown")
+        info["hidden_size"] = config.get("hidden_size", 0)
+        info["num_layers"] = config.get("num_hidden_layers", 0)
+        info["n_routed_experts"] = config.get("n_routed_experts", 0)
+        info["n_shared_experts"] = config.get("n_shared_experts", 0)
+        info["num_experts_per_tok"] = config.get("num_experts_per_tok", 0)
+        info["vocab_size"] = config.get("vocab_size", 0)
+
+    # 获取模型大小
+    try:
+        result = subprocess.run(["du", "-sb", model_path], capture_output=True, text=True, timeout=60)
+        if result.returncode == 0:
+            size_bytes = int(result.stdout.split()[0])
+            info["size_gb"] = round(size_bytes / (1024**3), 1)
+    except Exception:
+        pass
+
+    return info
+
+
+def compute_comparison(fd_metrics, sg_metrics):
+    """计算对比指标（差异百分比、胜出方）"""
+    comparison = {}
+
+    # 吞吐类指标：越高越好
+    higher_is_better = {
+        "total_token_throughput",
+        "output_token_throughput",
+        "request_throughput",
+        "mean_decode",
+        "median_decode",
+        "p80_decode",
+        "p95_decode",
+        "p99_decode",
+    }
+
+    # 延迟类指标：越低越好
+    lower_is_better = {
+        "mean_ttft",
+        "median_ttft",
+        "p80_ttft",
+        "p95_ttft",
+        "p99_ttft",
+        "mean_tpot",
+        "median_tpot",
+        "p80_tpot",
+        "p95_tpot",
+        "p99_tpot",
+        "mean_itl",
+        "median_itl",
+        "p80_itl",
+        "p95_itl",
+        "p99_itl",
+        "mean_e2el",
+        "median_e2el",
+        "p80_e2el",
+        "p95_e2el",
+        "p99_e2el",
+        "benchmark_duration",
+    }
+
+    all_keys = set(fd_metrics.keys()) | set(sg_metrics.keys())
+
+    for key in sorted(all_keys):
+        fd_val = fd_metrics.get(key)
+        sg_val = sg_metrics.get(key)
+
+        if fd_val is None or sg_val is None:
+            continue
+
+        entry = {"fd": fd_val, "sg": sg_val}
+
+        # 计算差异百分比 (FD 相对于 SG)
+        if sg_val != 0:
+            diff_pct = round((fd_val - sg_val) / sg_val * 100, 2)
+        else:
+            diff_pct = 0
+        entry["diff_pct"] = diff_pct
+
+        # 判断胜出方
+        if key in higher_is_better:
+            entry["winner"] = "fd" if fd_val > sg_val else "sg"
+        elif key in lower_is_better:
+            entry["winner"] = "fd" if fd_val < sg_val else "sg"
+        else:
+            entry["winner"] = "tie"
+
+        comparison[key] = entry
+
+    return comparison
+
+
+def main():
+    parser = argparse.ArgumentParser(description="从 benchmark 结果提取指标并生成对比 JSON")
+    parser.add_argument("--fd-result", required=True, help="FastDeploy 结果文件路径")
+    parser.add_argument("--sg-result", required=True, help="SGLang 结果文件路径")
+    parser.add_argument("--model-path", required=True, help="模型权重目录路径")
+    parser.add_argument("--fd-config", default="{}", help="FD 部署配置 JSON 字符串")
+    parser.add_argument("--sg-config", default="{}", help="SG 部署配置 JSON 字符串")
+    parser.add_argument("--output", default="metrics.json", help="输出 JSON 路径")
+    args = parser.parse_args()
+
+    print(f"[INFO] 解析 FD 结果: {args.fd_result}")
+    fd_metrics = parse_benchmark_result(args.fd_result)
+    print(f"[INFO] 解析 SG 结果: {args.sg_result}")
+    sg_metrics = parse_benchmark_result(args.sg_result)
+
+    print(f"[INFO] 读取模型信息: {args.model_path}")
+    model_info = get_model_info(args.model_path)
+
+    print("[INFO] 计算对比指标...")
+    comparison = compute_comparison(fd_metrics, sg_metrics)
+
+    # 解析部署配置
+    fd_config = json.loads(args.fd_config) if args.fd_config else {}
+    sg_config = json.loads(args.sg_config) if args.sg_config else {}
+
+    output = {
+        "model": model_info,
+        "config": {
+            "fd": fd_config,
+            "sg": sg_config,
+        },
+        "raw_metrics": {
+            "fd": fd_metrics,
+            "sg": sg_metrics,
+        },
+        "comparison": comparison,
+    }
+
+    with open(args.output, "w") as f:
+        json.dump(output, f, indent=2, ensure_ascii=False)
+
+    print(f"[INFO] 指标已写入: {args.output}")
+
+    # 打印摘要
+    key_metrics = [
+        "total_token_throughput",
+        "output_token_throughput",
+        "mean_ttft",
+        "mean_tpot",
+        "mean_itl",
+        "mean_e2el",
+        "mean_decode",
+        "benchmark_duration",
+    ]
+    print("\n========== 核心指标摘要 ==========")
+    print(f"{'Metric':<30} {'FD':>12} {'SG':>12} {'Diff%':>8} {'Winner':>8}")
+    print("-" * 72)
+    for key in key_metrics:
+        if key in comparison:
+            c = comparison[key]
+            print(f"{key:<30} {c['fd']:>12.2f} {c['sg']:>12.2f} {c['diff_pct']:>+7.1f}% {c['winner']:>8}")
+    print("=" * 72)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/benchmark-compare/scripts/generate_report.py
+++ b/.claude/skills/benchmark-compare/scripts/generate_report.py
@@ -1,0 +1,906 @@
+#!/usr/bin/env python3
+"""generate_report.py — 从多场景 benchmark 结果生成多模式 HTML 报告
+
+用法:
+    python3 generate_report.py \
+        --data-json all_metrics.json \
+        --output benchmark_report.html \
+        [--model-name "GLM-4.7-Flash"] \
+        [--default-quant bf16] \
+        [--default-bs 512]
+
+或者从多个日志文件解析:
+    python3 generate_report.py \
+        --log-dir /path/to/logs \
+        --model-name "GLM-4.7-Flash" \
+        --output benchmark_report.html
+
+数据 JSON 格式:
+{
+  "bf16_bs1": {"fd": {...metrics...}, "sg": {...metrics...}},
+  "bf16_bs32": {"fd": {...}, "sg": {...}},
+  ...
+}
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+
+def parse_benchmark_log(filepath):
+    """解析 benchmark_serving.py 的日志文件，提取所有指标"""
+    metrics = {}
+    if not os.path.isfile(filepath):
+        print(f"[WARN] 文件不存在: {filepath}", file=sys.stderr)
+        return metrics
+
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    patterns = {
+        "successful_requests": r"Successful requests:\s+([\d.]+)",
+        "benchmark_duration": r"Benchmark duration \(s\):\s+([\d.]+)",
+        "total_input_tokens": r"Total input tokens:\s+([\d.]+)",
+        "total_generated_tokens": r"Total generated tokens:\s+([\d.]+)",
+        "request_throughput": r"Request throughput \(req/s\):\s+([\d.]+)",
+        "output_token_throughput": r"Output token throughput \(tok/s\):\s+([\d.]+)",
+        "total_token_throughput": r"Total Token throughput \(tok/s\):\s+([\d.]+)",
+        "mean_ttft": r"Mean TTFT \(ms\):\s+([\d.]+)",
+        "median_ttft": r"Median TTFT \(ms\):\s+([\d.]+)",
+        "p80_ttft": r"P80 TTFT \(ms\):\s+([\d.]+)",
+        "p95_ttft": r"P95 TTFT \(ms\):\s+([\d.]+)",
+        "p99_ttft": r"P99 TTFT \(ms\):\s+([\d.]+)",
+        "mean_tpot": r"Mean TPOT \(ms\):\s+([\d.]+)",
+        "median_tpot": r"Median TPOT \(ms\):\s+([\d.]+)",
+        "p80_tpot": r"P80 TPOT \(ms\):\s+([\d.]+)",
+        "p95_tpot": r"P95 TPOT \(ms\):\s+([\d.]+)",
+        "p99_tpot": r"P99 TPOT \(ms\):\s+([\d.]+)",
+        "mean_itl": r"Mean ITL \(ms\):\s+([\d.]+)",
+        "median_itl": r"Median ITL \(ms\):\s+([\d.]+)",
+        "p80_itl": r"P80 ITL \(ms\):\s+([\d.]+)",
+        "p95_itl": r"P95 ITL \(ms\):\s+([\d.]+)",
+        "p99_itl": r"P99 ITL \(ms\):\s+([\d.]+)",
+        "mean_e2el": r"Mean E2EL \(ms\):\s+([\d.]+)",
+        "median_e2el": r"Median E2EL \(ms\):\s+([\d.]+)",
+        "p80_e2el": r"P80 E2EL \(ms\):\s+([\d.]+)",
+        "p95_e2el": r"P95 E2EL \(ms\):\s+([\d.]+)",
+        "p99_e2el": r"P99 E2EL \(ms\):\s+([\d.]+)",
+        "mean_decode": r"Mean Decode \(tok/s\):\s+([\d.]+)",
+        "median_decode": r"Median Decode \(tok/s\):\s+([\d.]+)",
+        "p80_decode": r"P80 Decode \(tok/s\):\s+([\d.]+)",
+        "p95_decode": r"P95 Decode \(tok/s\):\s+([\d.]+)",
+        "p99_decode": r"P99 Decode \(tok/s\):\s+([\d.]+)",
+    }
+
+    for key, pattern in patterns.items():
+        match = re.search(pattern, content)
+        if match:
+            metrics[key] = float(match.group(1))
+
+    return metrics
+
+
+def scan_log_dir(log_dir):
+    """扫描日志目录，自动识别场景并提取指标
+
+    文件命名约定: *_bs<N>_[<quant>_]<fd|sg>.txt
+    例如: GLM-4.7-Flash_long_bs32_fd.txt, GLM-4.7-Flash_long_bs512_fp8_sg.txt
+    """
+    data = {}
+    if not os.path.isdir(log_dir):
+        print(f"[ERROR] 日志目录不存在: {log_dir}", file=sys.stderr)
+        return data
+
+    for root, dirs, files in os.walk(log_dir):
+        for fname in files:
+            if not fname.endswith(".txt"):
+                continue
+            filepath = os.path.join(root, fname)
+
+            # 尝试从文件名解析场景信息
+            # 格式: *_bs<N>_[<quant>_]<fd|sg>.txt
+            m = re.search(r"_bs(\d+)_(?:(fp8|bf16|wint4|wint8)_)?(fd|sg)\.txt$", fname, re.IGNORECASE)
+            if not m:
+                # 也尝试无 quant 的模式 (默认 bf16)
+                m = re.search(r"_bs(\d+)_(fd|sg)\.txt$", fname, re.IGNORECASE)
+                if m:
+                    bs = m.group(1)
+                    quant = "bf16"
+                    framework = m.group(2).lower()
+                else:
+                    continue
+            else:
+                bs = m.group(1)
+                quant = (m.group(2) or "bf16").lower()
+                framework = m.group(3).lower()
+
+            key = f"{quant}_bs{bs}"
+            if key not in data:
+                data[key] = {}
+
+            metrics = parse_benchmark_log(filepath)
+            if metrics:
+                data[key][framework] = metrics
+                print(f"[INFO] 解析成功: {fname} -> {key}/{framework} ({len(metrics)} metrics)")
+
+    return data
+
+
+def generate_html(benchmark_data, config):
+    """生成完整的多模式 HTML 报告"""
+
+    # 确定可用的量化方式和并发数
+    quants = sorted(set(k.split("_bs")[0] for k in benchmark_data.keys()))
+    bs_values = sorted(set(k.split("_bs")[1] for k in benchmark_data.keys()), key=int)
+
+    model_name = config.get("model_name", "Unknown Model")
+    default_quant = config.get("default_quant", quants[0] if quants else "bf16")
+    default_bs = config.get("default_bs", bs_values[-1] if bs_values else "32")
+    gpu_type = config.get("gpu_type", "H800")
+    tp_size = config.get("tp_size", 1)
+    dp_size = config.get("dp_size", 1)
+    ep_size = config.get("ep_size", 0)
+    fd_attention = config.get("fd_attention", "MLA_ATTN (FlashAttn v3)")
+    sg_attention = config.get("sg_attention", "flashmla")
+    sg_version = config.get("sg_version", "0.5.10.post1")
+    fd_commit_date = config.get("fd_commit_date", "")
+    fd_commit_short = config.get("fd_commit_short", "")
+    fd_commit_full = config.get("fd_commit_full", "")
+    max_model_len = config.get("max_model_len", 65536)
+    dataset_url = config.get("dataset_url", "")
+    dataset_desc = config.get("dataset_desc", "")
+    test_date = config.get("test_date", "")
+    model_type = config.get("model_type", "")
+    model_size = config.get("model_size", "")
+    model_experts = config.get("model_experts", "")
+    model_layers_hidden = config.get("model_layers_hidden", "")
+
+    # 生成量化选择器按钮
+    def quant_btn_label(q):
+        if q == "fp8":
+            return "FP8 (Block-Wise)"
+        return q.upper()
+
+    quant_buttons = "\n".join(
+        f'                <div class="seg-btn" data-val="{q}" onclick="setQuant(\'{q}\')" title="{"FD: block_wise_fp8 / SG: fp8" if q == "fp8" else ""}">{quant_btn_label(q)}</div>'
+        for q in quants
+    )
+
+    # 生成并发选择器按钮
+    bs_buttons = "\n".join(
+        f'                <div class="seg-btn" data-val="{bs}" onclick="setBS(\'{bs}\')">{bs}</div>'
+        for bs in bs_values
+    )
+
+    data_json = json.dumps(benchmark_data, ensure_ascii=False)
+
+    html = f"""<!DOCTYPE html>
+<html lang="zh-CN" data-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FastDeploy vs SGLang - {model_name} 性能对比报告</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <style>
+        :root {{
+            --fd-primary: #6366f1;
+            --fd-light: #818cf8;
+            --fd-glow: rgba(99,102,241,0.3);
+            --sg-primary: #f59e0b;
+            --sg-light: #fbbf24;
+            --sg-glow: rgba(245,158,11,0.3);
+            --success: #10b981;
+            --danger: #ef4444;
+            --radius: 20px;
+            --transition: 0.35s cubic-bezier(0.4,0,0.2,1);
+        }}
+        [data-theme="dark"] {{
+            --bg-primary: #0a0a0f;
+            --bg-card: rgba(15,15,25,0.85);
+            --bg-card-hover: rgba(20,20,35,0.95);
+            --bg-table-header: rgba(255,255,255,0.03);
+            --border: rgba(255,255,255,0.06);
+            --border-hover: rgba(255,255,255,0.14);
+            --text-primary: #f1f5f9;
+            --text-secondary: #94a3b8;
+            --text-muted: #64748b;
+            --chart-grid: rgba(255,255,255,0.04);
+            --shadow-card: 0 8px 40px rgba(0,0,0,0.4);
+            --gradient-bg: radial-gradient(ellipse 80% 60% at 20% 10%, rgba(99,102,241,0.08) 0%, transparent 60%),
+                           radial-gradient(ellipse 60% 40% at 80% 90%, rgba(245,158,11,0.06) 0%, transparent 50%);
+        }}
+        [data-theme="light"] {{
+            --bg-primary: #f8fafc;
+            --bg-card: rgba(255,255,255,0.9);
+            --bg-card-hover: rgba(255,255,255,1);
+            --bg-table-header: rgba(0,0,0,0.02);
+            --border: rgba(0,0,0,0.08);
+            --border-hover: rgba(0,0,0,0.15);
+            --text-primary: #1e293b;
+            --text-secondary: #475569;
+            --text-muted: #94a3b8;
+            --chart-grid: rgba(0,0,0,0.06);
+            --shadow-card: 0 4px 24px rgba(0,0,0,0.08);
+            --gradient-bg: radial-gradient(ellipse 80% 60% at 20% 10%, rgba(99,102,241,0.04) 0%, transparent 60%),
+                           radial-gradient(ellipse 60% 40% at 80% 90%, rgba(245,158,11,0.03) 0%, transparent 50%);
+            --fd-light: #4f46e5;
+            --sg-light: #d97706;
+        }}
+        * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+        body {{
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'PingFang SC', sans-serif;
+            background: var(--bg-primary); color: var(--text-primary);
+            min-height: 100vh; padding: 60px 24px; line-height: 1.6;
+            transition: background var(--transition), color var(--transition);
+        }}
+        body::before {{
+            content: ''; position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+            background: var(--gradient-bg); pointer-events: none; z-index: 0;
+            transition: background var(--transition);
+        }}
+        .container {{ max-width: 1440px; margin: 0 auto; position: relative; z-index: 1; }}
+        .theme-toggle {{
+            position: fixed; top: 24px; right: 24px; z-index: 999;
+            width: 52px; height: 28px; border-radius: 100px;
+            background: var(--bg-card); border: 1px solid var(--border);
+            cursor: pointer; display: flex; align-items: center; padding: 3px;
+            transition: background var(--transition), border-color var(--transition);
+            backdrop-filter: blur(12px);
+        }}
+        .theme-toggle:hover {{ border-color: var(--border-hover); }}
+        .theme-toggle .toggle-knob {{
+            width: 22px; height: 22px; border-radius: 50%;
+            background: var(--fd-primary);
+            transition: transform var(--transition), background var(--transition);
+            display: flex; align-items: center; justify-content: center; font-size: 12px;
+        }}
+        [data-theme="dark"] .toggle-knob {{ transform: translateX(0); }}
+        [data-theme="light"] .toggle-knob {{ transform: translateX(24px); background: var(--sg-primary); }}
+        .toggle-knob::after {{ content: '\\1F319'; font-size: 11px; }}
+        [data-theme="light"] .toggle-knob::after {{ content: '\\2600\\FE0F'; }}
+        .header {{ text-align: center; margin-bottom: 40px; }}
+        .header h1 {{
+            font-size: 3.2rem; font-weight: 800; letter-spacing: -0.03em;
+            background: linear-gradient(135deg, var(--fd-light) 0%, #a78bfa 40%, var(--sg-light) 100%);
+            -webkit-background-clip: text; -webkit-text-fill-color: transparent; margin-bottom: 12px;
+        }}
+        .header .subtitle {{ font-size: 1.1rem; color: var(--text-secondary); font-weight: 400; }}
+        .header .badge-row {{ display: flex; justify-content: center; gap: 12px; margin-top: 20px; flex-wrap: wrap; }}
+        .badge {{
+            padding: 6px 16px; border-radius: 100px; font-size: 0.78rem; font-weight: 600;
+            letter-spacing: 0.3px; border: 1px solid var(--border); background: var(--bg-card);
+            color: var(--text-secondary); transition: background var(--transition), border-color var(--transition), color var(--transition);
+        }}
+        .selector-bar {{
+            display: flex; justify-content: center; align-items: center; gap: 24px;
+            margin-bottom: 40px; flex-wrap: wrap;
+        }}
+        .selector-group {{ display: flex; align-items: center; gap: 10px; }}
+        .selector-label {{ font-size: 0.78rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.8px; font-weight: 600; }}
+        .seg-control {{
+            display: flex; background: var(--bg-card); border: 1px solid var(--border);
+            border-radius: 12px; padding: 4px; gap: 2px;
+            transition: background var(--transition), border-color var(--transition);
+        }}
+        .seg-btn {{
+            padding: 8px 18px; border-radius: 9px; font-size: 0.82rem; font-weight: 600;
+            cursor: pointer; border: none; background: transparent;
+            color: var(--text-muted); transition: all 0.2s ease; user-select: none;
+        }}
+        .seg-btn:hover {{ color: var(--text-secondary); }}
+        .seg-btn.active {{
+            background: var(--fd-primary); color: #fff;
+            box-shadow: 0 2px 8px rgba(99,102,241,0.3);
+        }}
+        .config-grid {{ display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; margin-bottom: 48px; }}
+        @media (max-width: 1000px) {{ .config-grid {{ grid-template-columns: 1fr; }} }}
+        .config-card {{
+            background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius);
+            padding: 32px; backdrop-filter: blur(20px);
+            transition: background var(--transition), border-color var(--transition), box-shadow var(--transition);
+        }}
+        .config-card:hover {{ border-color: var(--border-hover); box-shadow: var(--shadow-card); }}
+        .config-card .card-tag {{
+            display: inline-flex; align-items: center; gap: 8px;
+            margin-bottom: 20px; padding: 6px 14px; border-radius: 10px;
+            font-size: 0.75rem; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase;
+        }}
+        .config-card.model .card-tag {{ background: rgba(168,85,247,0.12); color: #c084fc; }}
+        .config-card.fd .card-tag {{ background: rgba(99,102,241,0.12); color: var(--fd-light); }}
+        .config-card.sg .card-tag {{ background: rgba(245,158,11,0.12); color: var(--sg-light); }}
+        .config-grid-inner {{ display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }}
+        .config-item .label {{ font-size: 0.68rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.8px; margin-bottom: 4px; }}
+        .config-item .value {{ font-size: 0.95rem; color: var(--text-primary); font-weight: 600; }}
+        .config-item.full {{ grid-column: 1 / -1; }}
+        .params-bar {{
+            display: flex; justify-content: center; flex-wrap: wrap; gap: 16px 32px;
+            margin-bottom: 48px; padding: 20px 32px;
+            background: var(--bg-card); border: 1px solid var(--border); border-radius: 14px;
+            transition: background var(--transition), border-color var(--transition);
+        }}
+        .param-item {{ display: flex; align-items: center; gap: 10px; }}
+        .param-item .p-label {{ font-size: 0.72rem; color: var(--text-muted); letter-spacing: 0.5px; text-transform: uppercase; }}
+        .param-item .p-value {{
+            font-size: 0.88rem; color: var(--text-primary); font-weight: 600;
+            padding: 4px 12px; background: var(--bg-table-header); border: 1px solid var(--border); border-radius: 8px;
+        }}
+        .param-item .p-value a {{ color: var(--text-primary); text-decoration: underline; text-underline-offset: 3px; }}
+        .legend {{ display: flex; justify-content: center; gap: 40px; margin-bottom: 40px; }}
+        .legend-item {{ display: flex; align-items: center; gap: 10px; font-size: 0.9rem; font-weight: 500; color: var(--text-secondary); }}
+        .legend-dot {{ width: 14px; height: 14px; border-radius: 4px; }}
+        .legend-dot.fd {{ background: var(--fd-primary); box-shadow: 0 0 12px var(--fd-glow); }}
+        .legend-dot.sg {{ background: var(--sg-primary); box-shadow: 0 0 12px var(--sg-glow); }}
+        .metrics-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 20px; margin-bottom: 48px; }}
+        .metric-card {{
+            background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius);
+            padding: 28px; transition: transform 0.25s cubic-bezier(0.4,0,0.2,1), box-shadow 0.25s, border-color 0.25s, background var(--transition);
+        }}
+        .metric-card:hover {{ transform: translateY(-6px); border-color: var(--border-hover); box-shadow: var(--shadow-card); }}
+        .metric-card .m-title {{ font-size: 0.78rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.8px; margin-bottom: 20px; font-weight: 600; }}
+        .metric-card .m-values {{ display: flex; justify-content: space-between; align-items: center; }}
+        .metric-card .m-fw {{ text-align: center; }}
+        .metric-card .m-fw .m-name {{ font-size: 0.68rem; color: var(--text-muted); margin-bottom: 6px; font-weight: 500; }}
+        .metric-card .m-fw .m-num {{ font-size: 1.8rem; font-weight: 800; letter-spacing: -0.02em; }}
+        .fd-c {{ color: var(--fd-light); }}
+        .sg-c {{ color: var(--sg-light); }}
+        .metric-card .m-diff {{ font-size: 0.75rem; padding: 5px 12px; border-radius: 100px; font-weight: 700; letter-spacing: 0.3px; }}
+        .m-better {{ background: rgba(16,185,129,0.12); color: var(--success); border: 1px solid rgba(16,185,129,0.2); }}
+        .m-worse {{ background: rgba(239,68,68,0.12); color: var(--danger); border: 1px solid rgba(239,68,68,0.2); }}
+        .metric-card .m-hint {{ text-align: center; margin-top: 12px; font-size: 0.7rem; color: var(--text-muted); }}
+        .charts-row {{ display: grid; grid-template-columns: repeat(4, 1fr); gap: 20px; margin-bottom: 48px; }}
+        @media (max-width: 1000px) {{ .charts-row {{ grid-template-columns: 1fr 1fr; }} }}
+        @media (max-width: 700px) {{ .charts-row {{ grid-template-columns: 1fr; }} }}
+        .chart-card {{
+            background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius); padding: 28px;
+            transition: background var(--transition), border-color var(--transition);
+        }}
+        .chart-card h3 {{ font-size: 0.9rem; color: var(--text-secondary); margin-bottom: 20px; font-weight: 600; }}
+        .table-wrap {{
+            background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius);
+            padding: 36px; overflow-x: auto; margin-bottom: 40px;
+            transition: background var(--transition), border-color var(--transition);
+        }}
+        .table-wrap h2 {{ font-size: 1.4rem; font-weight: 700; margin-bottom: 24px; color: var(--text-primary); }}
+        table {{ width: 100%; border-collapse: collapse; }}
+        th {{ padding: 14px 16px; text-align: center; font-size: 0.7rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 1px; font-weight: 600; border-bottom: 1px solid var(--border); background: var(--bg-table-header); }}
+        td {{ padding: 14px 16px; text-align: center; font-size: 0.92rem; border-bottom: 1px solid var(--border); color: var(--text-secondary); transition: background var(--transition); }}
+        tr:hover td {{ background: var(--bg-table-header); }}
+        td.winner-fd {{ color: var(--fd-light); font-weight: 700; }}
+        td.winner-sg {{ color: var(--sg-light); font-weight: 700; }}
+        td.diff-good {{ color: var(--success); font-weight: 600; }}
+        td.diff-bad {{ color: var(--danger); font-weight: 600; }}
+        td.win-label-fd {{ color: var(--fd-light); font-weight: 600; font-size: 0.8rem; }}
+        td.win-label-sg {{ color: var(--sg-light); font-weight: 600; font-size: 0.8rem; }}
+        .conclusion {{
+            background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius);
+            padding: 40px; margin-bottom: 40px;
+            transition: background var(--transition), border-color var(--transition);
+        }}
+        .conclusion h2 {{ font-size: 1.4rem; font-weight: 700; margin-bottom: 20px; }}
+        .conclusion p {{ color: var(--text-secondary); margin-bottom: 14px; font-size: 0.95rem; }}
+        .conclusion strong {{ color: var(--text-primary); }}
+        .highlight-fd {{ color: var(--fd-light); font-weight: 600; }}
+        .highlight-sg {{ color: var(--sg-light); font-weight: 600; }}
+        .footer {{ text-align: center; padding: 24px; color: var(--text-muted); font-size: 0.8rem; border-top: 1px solid var(--border); }}
+    </style>
+</head>
+<body>
+<div class="theme-toggle" onclick="toggleTheme()" title="切换明暗模式">
+    <div class="toggle-knob"></div>
+</div>
+<div class="container">
+    <div class="header">
+        <h1>FastDeploy vs SGLang</h1>
+        <p class="subtitle">{model_name} 推理性能基准测试报告</p>
+        <div class="badge-row">
+            <span class="badge">{gpu_type} x{tp_size * dp_size}</span>
+            <span class="badge">TP={tp_size}{f' DP={dp_size}' if dp_size > 1 else ''}{f' EP={ep_size}' if ep_size > 0 else ''}</span>
+            <span class="badge" id="badge-quant">{default_quant.upper()}</span>
+            <span class="badge" id="badge-bs">并发 {default_bs}</span>
+            {f'<span class="badge">{test_date}</span>' if test_date else ''}
+        </div>
+    </div>
+
+    <!-- Mode Selector -->
+    <div class="selector-bar">
+        <div class="selector-group">
+            <span class="selector-label">量化</span>
+            <div class="seg-control" id="quant-selector">
+{quant_buttons}
+            </div>
+        </div>
+        <div class="selector-group">
+            <span class="selector-label">并发</span>
+            <div class="seg-control" id="bs-selector">
+{bs_buttons}
+            </div>
+        </div>
+    </div>
+
+    <!-- Config Cards -->
+    <div class="config-grid">
+        <div class="config-card model">
+            <div class="card-tag">Model</div>
+            <div class="config-grid-inner">
+                <div class="config-item full"><div class="label">模型名称</div><div class="value">{model_name}</div></div>
+                {f'<div class="config-item"><div class="label">架构</div><div class="value">{model_type}</div></div>' if model_type else ''}
+                {f'<div class="config-item"><div class="label">权重大小</div><div class="value">{model_size}</div></div>' if model_size else ''}
+                {f'<div class="config-item"><div class="label">Expert</div><div class="value">{model_experts}</div></div>' if model_experts else ''}
+                {f'<div class="config-item"><div class="label">Layers / Hidden</div><div class="value">{model_layers_hidden}</div></div>' if model_layers_hidden else ''}
+            </div>
+        </div>
+        <div class="config-card fd">
+            <div class="card-tag">FastDeploy</div>
+            <div class="config-grid-inner">
+                <div class="config-item"><div class="label">GPU</div><div class="value">{gpu_type} x{tp_size * dp_size}</div></div>
+                <div class="config-item"><div class="label">部署方式</div><div class="value">TP={tp_size}{f' DP={dp_size}' if dp_size > 1 else ''}{' EP' if ep_size > 0 else ''}</div></div>
+                <div class="config-item"><div class="label">并发</div><div class="value" id="cfg-fd-bs">{default_bs}</div></div>
+                <div class="config-item"><div class="label">Max Len</div><div class="value">{max_model_len}</div></div>
+                <div class="config-item"><div class="label">Attention</div><div class="value">{fd_attention}</div></div>
+                <div class="config-item"><div class="label">量化</div><div class="value" id="cfg-fd-quant">{default_quant.upper()}</div></div>
+                {f'<div class="config-item"><div class="label">代码日期</div><div class="value">{fd_commit_date}</div></div>' if fd_commit_date else ''}
+                {f'<div class="config-item"><div class="label">Commit</div><div class="value" title="{fd_commit_full}">{fd_commit_short}</div></div>' if fd_commit_short else ''}
+            </div>
+        </div>
+        <div class="config-card sg">
+            <div class="card-tag">SGLang</div>
+            <div class="config-grid-inner">
+                <div class="config-item"><div class="label">GPU</div><div class="value">{gpu_type} x{tp_size * dp_size}</div></div>
+                <div class="config-item"><div class="label">部署方式</div><div class="value">TP={tp_size}{f' DP={dp_size}' if dp_size > 1 else ''}{f' EP={ep_size}' if ep_size > 0 else ''}</div></div>
+                <div class="config-item"><div class="label">并发</div><div class="value" id="cfg-sg-bs">{default_bs}</div></div>
+                <div class="config-item"><div class="label">Context Len</div><div class="value">{max_model_len}</div></div>
+                <div class="config-item"><div class="label">Attention</div><div class="value">{sg_attention}</div></div>
+                <div class="config-item"><div class="label">量化</div><div class="value" id="cfg-sg-quant">{default_quant.upper()}</div></div>
+                {f'<div class="config-item"><div class="label">版本</div><div class="value">{sg_version}</div></div>' if sg_version else ''}
+                <div class="config-item"></div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Params Bar -->
+    <div class="params-bar">
+        <div class="param-item"><span class="p-label">请求数</span><span class="p-value" id="param-reqs">1024</span></div>
+        {f'<div class="param-item"><span class="p-label">数据集</span><span class="p-value"><a href="{dataset_url}" target="_blank">{dataset_desc}（点击可下载）</a></span></div>' if dataset_url else ''}
+    </div>
+
+    <!-- Legend -->
+    <div class="legend">
+        <div class="legend-item"><div class="legend-dot fd"></div><span>FastDeploy</span></div>
+        <div class="legend-item"><div class="legend-dot sg"></div><span>SGLang</span></div>
+    </div>
+
+    <!-- Metric Cards -->
+    <div class="metrics-grid" id="metrics-grid"></div>
+
+    <div class="charts-row">
+        <div class="chart-card"><h3>吞吐量对比 (tok/s)</h3><canvas id="throughputChart"></canvas></div>
+        <div class="chart-card"><h3>TTFT (ms)</h3><canvas id="ttftChart"></canvas></div>
+        <div class="chart-card"><h3>TPOT & ITL (ms)</h3><canvas id="tpotItlChart"></canvas></div>
+        <div class="chart-card"><h3>E2EL (ms)</h3><canvas id="e2elChart"></canvas></div>
+    </div>
+
+    <!-- Table -->
+    <div class="table-wrap">
+        <h2>详细指标对比</h2>
+        <table>
+            <thead><tr><th style="text-align:left">指标</th><th>FastDeploy</th><th>SGLang</th><th>FD 优势</th><th>胜出</th></tr></thead>
+            <tbody id="table-body"></tbody>
+        </table>
+    </div>
+
+    <!-- Conclusion -->
+    <div class="conclusion" id="conclusion-section"></div>
+
+    <!-- Quantization Note (only shown when fp8 is available) -->
+    {'<div class="config-card" style="margin-bottom:40px; padding:28px 36px;" id="quant-note"><div class="card-tag" style="background:rgba(245,158,11,0.12);color:var(--sg-light);margin-bottom:16px;">&#9888; 量化说明</div><div style="color:var(--text-secondary);font-size:0.9rem;line-height:1.8;"><p style="margin-bottom:10px;"><strong style="color:var(--text-primary);">本报告中 FP8 量化指的是 Block-Wise FP8（分块量化）</strong>，不同于 Per-Tensor FP8 或 Per-Channel FP8。</p><ul style="padding-left:20px;"><li><strong>FastDeploy</strong>：使用 <code style="background:var(--bg-table-header);padding:2px 6px;border-radius:4px;font-size:0.85em;">--quantization block_wise_fp8</code>，对权重按 block 粒度进行 FP8 量化</li><li><strong>SGLang</strong>：使用 <code style="background:var(--bg-table-header);padding:2px 6px;border-radius:4px;font-size:0.85em;">--quantization fp8</code>，默认为 per-tensor FP8 量化方式</li></ul><p style="margin-top:10px;color:var(--text-muted);font-size:0.82rem;">两者量化粒度不完全相同，FD 的 block-wise 粒度更细、精度损失更小，但计算开销略高。对比结果需结合量化方式差异理解。</p></div></div>' if 'fp8' in quants else ''}
+
+    <div class="footer">Generated by Ducc Benchmark Skill &middot; {model_name} &middot; {gpu_type}</div>
+</div>
+
+<script>
+const benchmarkData = {data_json};
+const availableQuants = {json.dumps(quants)};
+const availableBS = {json.dumps(bs_values)};
+let currentQuant = localStorage.getItem('bench-quant') || '{default_quant}';
+let currentBS = localStorage.getItem('bench-bs') || '{default_bs}';
+if (!availableQuants.includes(currentQuant)) currentQuant = availableQuants[0];
+if (!availableBS.includes(currentBS)) currentBS = availableBS[availableBS.length - 1];
+
+function getKey() {{ return currentQuant + '_bs' + currentBS; }}
+function getData() {{ return benchmarkData[getKey()] || null; }}
+
+function setQuant(q) {{
+    currentQuant = q;
+    localStorage.setItem('bench-quant', q);
+    updateAll();
+}}
+function setBS(bs) {{
+    currentBS = bs;
+    localStorage.setItem('bench-bs', bs);
+    updateAll();
+}}
+
+function updateSelectors() {{
+    document.querySelectorAll('#quant-selector .seg-btn').forEach(btn => {{
+        btn.classList.remove('active');
+        if (btn.dataset.val === currentQuant) btn.classList.add('active');
+    }});
+    document.querySelectorAll('#bs-selector .seg-btn').forEach(btn => {{
+        btn.classList.remove('active');
+        if (btn.dataset.val === currentBS) btn.classList.add('active');
+    }});
+    const quantLabel = currentQuant === 'bf16' ? 'BF16' : currentQuant.toUpperCase();
+    document.getElementById('badge-quant').textContent = quantLabel;
+    document.getElementById('badge-bs').textContent = '\\u5e76\\u53d1 ' + currentBS;
+    document.getElementById('cfg-fd-bs').textContent = currentBS;
+    document.getElementById('cfg-sg-bs').textContent = currentBS;
+    document.getElementById('cfg-fd-quant').textContent = currentQuant === 'bf16' ? 'BF16' : 'Block-Wise FP8 (block_wise_fp8)';
+    document.getElementById('cfg-sg-quant').textContent = currentQuant === 'bf16' ? 'BF16' : 'FP8 (per-tensor)';
+    const d = getData();
+    if (d && d.fd) {{
+        document.getElementById('param-reqs').textContent = Math.round(d.fd.successful_requests || 1024);
+    }}
+}}
+
+const metricDefs = [
+    {{ key: 'total_token_throughput', title: 'Total Token Throughput', unit: 'tok/s', hint: '越高越好', higher: true }},
+    {{ key: 'output_token_throughput', title: 'Output Token Throughput', unit: 'tok/s', hint: '越高越好', higher: true }},
+    {{ key: 'mean_ttft', title: 'Mean TTFT (首 Token 延迟)', unit: 'ms', hint: '越低越好', higher: false }},
+    {{ key: 'mean_tpot', title: 'Mean TPOT (Token 间延迟)', unit: 'ms', hint: '越低越好', higher: false }},
+    {{ key: 'mean_itl', title: 'Mean ITL (Inter-Token Latency)', unit: 'ms', hint: '越低越好', higher: false }},
+    {{ key: 'mean_e2el', title: 'Mean E2EL (端到端延迟)', unit: 'ms', hint: '越低越好', higher: false }},
+    {{ key: 'mean_decode', title: 'Decode Speed', unit: 'tok/s', hint: '越高越好', higher: true }},
+    {{ key: 'request_throughput', title: 'Request Throughput', unit: 'req/s', hint: '越高越好', higher: true }},
+];
+
+function fmtNum(v) {{
+    if (v >= 10000) return Math.round(v).toLocaleString();
+    if (v >= 100) return Math.round(v).toString();
+    if (v >= 10) return v.toFixed(1);
+    return v.toFixed(2);
+}}
+
+function updateMetricCards() {{
+    const d = getData();
+    if (!d) return;
+    const grid = document.getElementById('metrics-grid');
+    let html = '';
+    metricDefs.forEach(def => {{
+        const fdVal = d.fd[def.key] || 0;
+        const sgVal = d.sg[def.key] || 0;
+        let diffPct;
+        if (def.higher) {{
+            diffPct = sgVal !== 0 ? ((fdVal - sgVal) / sgVal * 100) : 0;
+        }} else {{
+            diffPct = fdVal !== 0 ? ((sgVal - fdVal) / fdVal * 100) : 0;
+        }}
+        const isBetter = diffPct > 0;
+        const diffClass = isBetter ? 'm-better' : 'm-worse';
+        const diffText = (isBetter ? '+' : '') + diffPct.toFixed(1) + '%';
+        html += '<div class="metric-card">' +
+            '<div class="m-title">' + def.title + '</div>' +
+            '<div class="m-values">' +
+            '<div class="m-fw"><div class="m-name">FastDeploy</div><div class="m-num fd-c">' + fmtNum(fdVal) + '</div></div>' +
+            '<div class="m-diff ' + diffClass + '">' + diffText + '</div>' +
+            '<div class="m-fw"><div class="m-name">SGLang</div><div class="m-num sg-c">' + fmtNum(sgVal) + '</div></div>' +
+            '</div>' +
+            '<div class="m-hint">' + def.unit + ' \\u00b7 ' + def.hint + '</div></div>';
+    }});
+    grid.innerHTML = html;
+}}
+
+const tableMetrics = [
+    {{ key: 'successful_requests', label: '成功请求数', higher: true }},
+    {{ key: 'benchmark_duration', label: '测试总时长 (s)', higher: false }},
+    {{ key: 'total_token_throughput', label: '总 Token Throughput (tok/s)', higher: true }},
+    {{ key: 'output_token_throughput', label: '输出 Token Throughput (tok/s)', higher: true }},
+    {{ key: 'request_throughput', label: 'Request Throughput (req/s)', higher: true }},
+    {{ key: 'mean_decode', label: 'Mean Decode Speed (tok/s)', higher: true }},
+    {{ key: 'mean_ttft', label: 'Mean TTFT (ms)', higher: false }},
+    {{ key: 'p80_ttft', label: 'P80 TTFT (ms)', higher: false }},
+    {{ key: 'p95_ttft', label: 'P95 TTFT (ms)', higher: false }},
+    {{ key: 'p99_ttft', label: 'P99 TTFT (ms)', higher: false }},
+    {{ key: 'mean_tpot', label: 'Mean TPOT (ms)', higher: false }},
+    {{ key: 'p80_tpot', label: 'P80 TPOT (ms)', higher: false }},
+    {{ key: 'p95_tpot', label: 'P95 TPOT (ms)', higher: false }},
+    {{ key: 'p99_tpot', label: 'P99 TPOT (ms)', higher: false }},
+    {{ key: 'mean_itl', label: 'Mean ITL (ms)', higher: false }},
+    {{ key: 'p80_itl', label: 'P80 ITL (ms)', higher: false }},
+    {{ key: 'p95_itl', label: 'P95 ITL (ms)', higher: false }},
+    {{ key: 'p99_itl', label: 'P99 ITL (ms)', higher: false }},
+    {{ key: 'mean_e2el', label: 'Mean E2EL (ms)', higher: false }},
+    {{ key: 'p80_e2el', label: 'P80 E2EL (ms)', higher: false }},
+    {{ key: 'p95_e2el', label: 'P95 E2EL (ms)', higher: false }},
+    {{ key: 'p99_e2el', label: 'P99 E2EL (ms)', higher: false }},
+];
+
+function updateTable() {{
+    const d = getData();
+    if (!d) return;
+    const tbody = document.getElementById('table-body');
+    let html = '';
+    tableMetrics.forEach(m => {{
+        const fdVal = d.fd[m.key];
+        const sgVal = d.sg[m.key];
+        if (fdVal == null || sgVal == null) return;
+        let fdWins;
+        if (m.higher) {{ fdWins = fdVal > sgVal; }}
+        else {{ fdWins = fdVal < sgVal; }}
+        const fdClass = fdWins ? 'winner-fd' : '';
+        const sgClass = !fdWins ? 'winner-sg' : '';
+        let diffPct;
+        if (m.higher) {{
+            diffPct = sgVal !== 0 ? ((fdVal - sgVal) / sgVal * 100) : 0;
+        }} else {{
+            diffPct = fdVal !== 0 ? ((sgVal - fdVal) / fdVal * 100) : 0;
+        }}
+        const diffClass = diffPct >= 0 ? 'diff-good' : 'diff-bad';
+        const diffText = (diffPct >= 0 ? '+' : '') + diffPct.toFixed(1) + '%';
+        const winner = fdWins ? 'FastDeploy' : 'SGLang';
+        const winClass = fdWins ? 'win-label-fd' : 'win-label-sg';
+        html += '<tr><td style="text-align:left">' + m.label + '</td>' +
+            '<td class="' + fdClass + '">' + fmtNum(fdVal) + '</td>' +
+            '<td class="' + sgClass + '">' + fmtNum(sgVal) + '</td>' +
+            '<td class="' + diffClass + '">' + diffText + '</td>' +
+            '<td class="' + winClass + '">' + winner + '</td></tr>';
+    }});
+    tbody.innerHTML = html;
+}}
+
+function updateConclusion() {{
+    const d = getData();
+    if (!d) return;
+    const fdTPS = d.fd.total_token_throughput || 0;
+    const sgTPS = d.sg.total_token_throughput || 0;
+    const fdWinsTPS = fdTPS > sgTPS;
+    const quantLabel = currentQuant === 'bf16' ? 'BF16 无量化' : 'Block-Wise FP8 在线量化 (FD: block_wise_fp8, SG: fp8)';
+    const section = document.getElementById('conclusion-section');
+    let wins = {{ fd: 0, sg: 0 }};
+    tableMetrics.forEach(m => {{
+        const fv = d.fd[m.key], sv = d.sg[m.key];
+        if (fv == null || sv == null) return;
+        if (m.higher) {{ fv > sv ? wins.fd++ : wins.sg++; }}
+        else {{ fv < sv ? wins.fd++ : wins.sg++; }}
+    }});
+    const overallWinner = wins.fd > wins.sg ? 'FastDeploy' : 'SGLang';
+    const winnerClass = wins.fd > wins.sg ? 'highlight-fd' : 'highlight-sg';
+    section.innerHTML = '<h2>结论与分析</h2>' +
+        '<p><strong>测试条件：</strong>{model_name}，{gpu_type} x{tp_size}，' + quantLabel + '，并发 ' + currentBS + '</p>' +
+        '<p><strong>整体表现：</strong>在该配置下，<span class="' + winnerClass + '">' + overallWinner +
+        ' 在 ' + Math.max(wins.fd, wins.sg) + '/' + (wins.fd + wins.sg) + ' 项指标上领先</span>。' +
+        'Total Token Throughput: FD=' + fmtNum(fdTPS) + ' vs SG=' + fmtNum(sgTPS) + ' tok/s。</p>';
+}}
+
+let charts = {{}};
+function getChartColors() {{
+    const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+    return {{
+        fdColor: isDark ? 'rgba(129,140,248,0.85)' : 'rgba(79,70,229,0.8)',
+        sgColor: isDark ? 'rgba(251,191,36,0.85)' : 'rgba(217,119,6,0.8)',
+        fdBorder: isDark ? '#818cf8' : '#4f46e5',
+        sgBorder: isDark ? '#fbbf24' : '#d97706',
+        fdFill: isDark ? 'rgba(99,102,241,0.12)' : 'rgba(79,70,229,0.08)',
+        sgFill: isDark ? 'rgba(245,158,11,0.12)' : 'rgba(217,119,6,0.08)',
+        gridColor: isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.06)',
+        textColor: isDark ? '#94a3b8' : '#475569',
+    }};
+}}
+
+function rebuildCharts() {{
+    Object.values(charts).forEach(c => c.destroy());
+    charts = {{}};
+    buildCharts();
+}}
+
+function buildCharts() {{
+    const d = getData();
+    if (!d) return;
+    const c = getChartColors();
+    Chart.defaults.color = c.textColor;
+    Chart.defaults.borderColor = c.gridColor;
+    Chart.defaults.font.family = "'Inter', sans-serif";
+    const barOpts = {{ responsive: true, plugins: {{ legend: {{ labels: {{ usePointStyle: true, padding: 20 }} }} }}, scales: {{ y: {{ beginAtZero: true, grid: {{ color: c.gridColor }} }}, x: {{ grid: {{ display: false }} }} }} }};
+
+    const reqScale = d.fd.request_throughput < 50 ? 100 : 1;
+    charts.throughput = new Chart(document.getElementById('throughputChart'), {{
+        type: 'bar',
+        data: {{
+            labels: ['Total Token', 'Output Token', 'Request (x' + reqScale + ')'],
+            datasets: [
+                {{ label: 'FastDeploy', data: [d.fd.total_token_throughput, d.fd.output_token_throughput, d.fd.request_throughput * reqScale], backgroundColor: c.fdColor, borderColor: c.fdBorder, borderWidth: 2, borderRadius: 6 }},
+                {{ label: 'SGLang', data: [d.sg.total_token_throughput, d.sg.output_token_throughput, d.sg.request_throughput * reqScale], backgroundColor: c.sgColor, borderColor: c.sgBorder, borderWidth: 2, borderRadius: 6 }}
+            ]
+        }},
+        options: barOpts
+    }});
+
+    charts.ttft = new Chart(document.getElementById('ttftChart'), {{
+        type: 'bar',
+        data: {{
+            labels: ['Mean TTFT'],
+            datasets: [
+                {{ label: 'FastDeploy', data: [d.fd.mean_ttft], backgroundColor: c.fdColor, borderColor: c.fdBorder, borderWidth: 2, borderRadius: 6 }},
+                {{ label: 'SGLang', data: [d.sg.mean_ttft], backgroundColor: c.sgColor, borderColor: c.sgBorder, borderWidth: 2, borderRadius: 6 }}
+            ]
+        }},
+        options: barOpts
+    }});
+
+    charts.tpotItl = new Chart(document.getElementById('tpotItlChart'), {{
+        type: 'bar',
+        data: {{
+            labels: ['Mean TPOT', 'Mean ITL'],
+            datasets: [
+                {{ label: 'FastDeploy', data: [d.fd.mean_tpot, d.fd.mean_itl], backgroundColor: c.fdColor, borderColor: c.fdBorder, borderWidth: 2, borderRadius: 6 }},
+                {{ label: 'SGLang', data: [d.sg.mean_tpot, d.sg.mean_itl], backgroundColor: c.sgColor, borderColor: c.sgBorder, borderWidth: 2, borderRadius: 6 }}
+            ]
+        }},
+        options: barOpts
+    }});
+
+    charts.e2el = new Chart(document.getElementById('e2elChart'), {{
+        type: 'bar',
+        data: {{
+            labels: ['Mean E2EL'],
+            datasets: [
+                {{ label: 'FastDeploy', data: [d.fd.mean_e2el], backgroundColor: c.fdColor, borderColor: c.fdBorder, borderWidth: 2, borderRadius: 6 }},
+                {{ label: 'SGLang', data: [d.sg.mean_e2el], backgroundColor: c.sgColor, borderColor: c.sgBorder, borderWidth: 2, borderRadius: 6 }}
+            ]
+        }},
+        options: barOpts
+    }});
+}}
+
+function toggleTheme() {{
+    const html = document.documentElement;
+    const next = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    html.setAttribute('data-theme', next);
+    localStorage.setItem('benchmark-theme', next);
+    rebuildCharts();
+}}
+(function() {{
+    const saved = localStorage.getItem('benchmark-theme');
+    if (saved) document.documentElement.setAttribute('data-theme', saved);
+}})();
+
+function updateAll() {{
+    updateSelectors();
+    updateMetricCards();
+    updateTable();
+    updateConclusion();
+    rebuildCharts();
+}}
+
+updateAll();
+</script>
+</body>
+</html>"""
+
+    return html
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="从 benchmark 数据生成多模式 HTML 报告",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+示例:
+  # 从已有 JSON 生成
+  python3 generate_report.py --data-json all_metrics.json --output report.html
+
+  # 从日志目录扫描生成
+  python3 generate_report.py --log-dir /path/to/logs --model-name GLM-4.7-Flash --output report.html
+
+  # 指定完整配置
+  python3 generate_report.py --data-json data.json --output report.html \\
+    --model-name GLM-4.7-Flash --gpu-type H800 --tp 1 \\
+    --default-quant bf16 --default-bs 512 \\
+    --fd-attention "MLA_ATTN (FlashAttn v3)" --sg-attention flashmla \\
+    --sg-version 0.5.10.post1
+        """,
+    )
+
+    # 数据来源（二选一）
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--data-json", help="已整理好的多场景 JSON 文件路径")
+    source.add_argument("--log-dir", help="日志目录路径（自动扫描识别场景）")
+
+    # 输出
+    parser.add_argument("--output", default="benchmark_report.html", help="输出 HTML 路径")
+
+    # 模型信息
+    parser.add_argument("--model-name", default="Unknown Model", help="模型名称")
+    parser.add_argument("--model-type", default="", help="模型架构描述")
+    parser.add_argument("--model-size", default="", help="模型大小")
+    parser.add_argument("--model-experts", default="", help="Expert 信息")
+    parser.add_argument("--model-layers-hidden", default="", help="Layers / Hidden")
+
+    # 部署配置
+    parser.add_argument("--gpu-type", default="H800", help="GPU 型号")
+    parser.add_argument("--tp", type=int, default=1, help="TP 大小")
+    parser.add_argument("--dp", type=int, default=1, help="DP 大小")
+    parser.add_argument("--ep", type=int, default=0, help="EP 大小 (0=不启用)")
+    parser.add_argument("--max-model-len", type=int, default=65536, help="最大模型长度")
+    parser.add_argument("--fd-attention", default="MLA_ATTN (FlashAttn v3)", help="FD Attention Backend")
+    parser.add_argument("--sg-attention", default="flashmla", help="SG Attention Backend")
+    parser.add_argument("--sg-version", default="", help="SGLang 版本")
+    parser.add_argument("--fd-commit-date", default="", help="FD commit 日期")
+    parser.add_argument("--fd-commit-short", default="", help="FD commit 短 hash")
+    parser.add_argument("--fd-commit-full", default="", help="FD commit 完整 hash")
+
+    # 显示配置
+    parser.add_argument("--default-quant", default="bf16", help="默认量化选择")
+    parser.add_argument("--default-bs", default="512", help="默认并发选择")
+    parser.add_argument("--test-date", default="", help="测试日期")
+    parser.add_argument("--dataset-url", default="", help="数据集下载链接")
+    parser.add_argument("--dataset-desc", default="", help="数据集描述")
+
+    args = parser.parse_args()
+
+    # 加载数据
+    if args.data_json:
+        print(f"[INFO] 从 JSON 文件加载数据: {args.data_json}")
+        with open(args.data_json, "r") as f:
+            benchmark_data = json.load(f)
+    else:
+        print(f"[INFO] 扫描日志目录: {args.log_dir}")
+        benchmark_data = scan_log_dir(args.log_dir)
+
+    if not benchmark_data:
+        print("[ERROR] 未找到有效的 benchmark 数据", file=sys.stderr)
+        sys.exit(1)
+
+    # 过滤掉不完整的场景（缺少 fd 或 sg）
+    valid_data = {}
+    for key, val in benchmark_data.items():
+        if "fd" in val and "sg" in val and val["fd"] and val["sg"]:
+            valid_data[key] = val
+        else:
+            print(f"[WARN] 场景 {key} 数据不完整，跳过", file=sys.stderr)
+
+    if not valid_data:
+        print("[ERROR] 没有完整的对比场景数据", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"[INFO] 有效场景: {', '.join(sorted(valid_data.keys()))}")
+
+    # 构建配置
+    config = {
+        "model_name": args.model_name,
+        "model_type": args.model_type,
+        "model_size": args.model_size,
+        "model_experts": args.model_experts,
+        "model_layers_hidden": args.model_layers_hidden,
+        "gpu_type": args.gpu_type,
+        "tp_size": args.tp,
+        "dp_size": args.dp,
+        "ep_size": args.ep,
+        "max_model_len": args.max_model_len,
+        "fd_attention": args.fd_attention,
+        "sg_attention": args.sg_attention,
+        "sg_version": args.sg_version,
+        "fd_commit_date": args.fd_commit_date,
+        "fd_commit_short": args.fd_commit_short,
+        "fd_commit_full": args.fd_commit_full,
+        "default_quant": args.default_quant,
+        "default_bs": args.default_bs,
+        "test_date": args.test_date,
+        "dataset_url": args.dataset_url,
+        "dataset_desc": args.dataset_desc,
+    }
+
+    # 生成 HTML
+    html = generate_html(valid_data, config)
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(html)
+
+    print(f"[INFO] HTML 报告已生成: {args.output}")
+    print(f"[INFO] 包含 {len(valid_data)} 个场景: {', '.join(sorted(valid_data.keys()))}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/benchmark-compare/scripts/health_check.sh
+++ b/.claude/skills/benchmark-compare/scripts/health_check.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# health_check.sh — 服务健康检查脚本
+# 轮询 /v1/models 接口直到服务就绪或超时
+set -euo pipefail
+
+HOST="127.0.0.1"
+PORT=""
+TIMEOUT=300
+INTERVAL=30
+INITIAL_WAIT=90
+LOG_FILE=""
+
+usage() {
+    cat <<'EOF'
+用法: bash health_check.sh [OPTIONS]
+
+必需参数:
+  --port <PORT>               服务端口
+
+可选参数:
+  --host <HOST>               服务地址 (默认: 127.0.0.1)
+  --timeout <SECONDS>         超时时间 (默认: 300)
+  --interval <SECONDS>        轮询间隔 (默认: 30)
+  --initial-wait <SECONDS>    初始等待时间，让模型加载 (默认: 90)
+  --log-file <PATH>           服务日志路径，超时时打印最后几行辅助排查
+
+返回值:
+  0 = 服务就绪
+  1 = 超时未就绪
+
+示例:
+  bash health_check.sh --port 8180 --timeout 300 --log-file /tmp/fd_server.log
+EOF
+    exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)          HOST="$2"; shift 2 ;;
+        --port)          PORT="$2"; shift 2 ;;
+        --timeout)       TIMEOUT="$2"; shift 2 ;;
+        --interval)      INTERVAL="$2"; shift 2 ;;
+        --initial-wait)  INITIAL_WAIT="$2"; shift 2 ;;
+        --log-file)      LOG_FILE="$2"; shift 2 ;;
+        --help|-h)       usage 0 ;;
+        *)               echo "未知参数: $1"; usage 1 ;;
+    esac
+done
+
+if [[ -z "$PORT" ]]; then
+    echo "错误: --port 为必需参数"
+    usage 1
+fi
+
+URL="http://${HOST}:${PORT}/v1/models"
+
+echo "[INFO] 等待服务就绪: $URL"
+echo "[INFO] 初始等待 ${INITIAL_WAIT}s (模型加载时间)..."
+sleep "$INITIAL_WAIT"
+
+elapsed=$INITIAL_WAIT
+while [[ $elapsed -lt $TIMEOUT ]]; do
+    if curl -s --max-time 5 "$URL" | grep -q '"id"'; then
+        echo "[INFO] 服务已就绪! (耗时 ${elapsed}s)"
+        exit 0
+    fi
+    echo "[INFO] 服务未就绪，${INTERVAL}s 后重试... (已等待 ${elapsed}s / ${TIMEOUT}s)"
+    sleep "$INTERVAL"
+    elapsed=$((elapsed + INTERVAL))
+done
+
+echo "[ERROR] 服务启动超时 (${TIMEOUT}s)"
+
+if [[ -n "$LOG_FILE" && -f "$LOG_FILE" ]]; then
+    echo "[ERROR] 服务日志最后 30 行:"
+    echo "========================================="
+    tail -30 "$LOG_FILE"
+    echo "========================================="
+fi
+
+exit 1

--- a/.claude/skills/benchmark-compare/scripts/launch_service.sh
+++ b/.claude/skills/benchmark-compare/scripts/launch_service.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# launch_service.sh — 通用推理框架服务启动脚本
+# 支持 FastDeploy / SGLang，支持单卡/多卡 TP/DP/EP/PD 分离模式
+set -euo pipefail
+
+# ============================================================
+# 参数解析
+# ============================================================
+FRAMEWORK=""
+MODEL=""
+PORT=""
+GPUS=""
+TP=1
+DP=1
+EP=0
+CONCURRENCY=32
+MAX_MODEL_LEN=65536
+QUANTIZATION="none"
+LOG_FILE=""
+VENV=""
+GPU_MEM_UTIL="0.97"
+ATTENTION_BACKEND=""
+PD_ROLE=""
+EXTRA_ARGS=""
+
+usage() {
+    cat <<'EOF'
+用法: bash launch_service.sh [OPTIONS]
+
+必需参数:
+  --framework <fd|sg>         推理框架 (fd=FastDeploy, sg=SGLang)
+  --model <PATH>              模型权重路径
+  --port <PORT>               服务端口
+  --gpus <DEVICES>            CUDA_VISIBLE_DEVICES (如 "0" 或 "0,1,2,3,4,5,6,7")
+  --venv <PATH>               虚拟环境路径 (.venv 目录)
+
+可选参数:
+  --tp <N>                    tensor-parallel-size (默认: 1)
+  --dp <N>                    data-parallel-size (默认: 1)
+  --ep <N>                    expert-parallel-size, MoE 模型专用 (默认: 0, 不启用)
+                              FD: 映射为 --enable-expert-parallel (EP=TP×DP 隐式)
+                              SG: 映射为 --ep-size N
+  --concurrency <N>           max-num-seqs / max-running-requests (默认: 32)
+  --max-model-len <N>         最大序列长度 (默认: 65536)
+  --quantization <TYPE>       量化方式: none|block_wise_fp8|fp8|wint4|wint8 (默认: none)
+  --log-file <PATH>           日志输出路径 (默认: /tmp/<framework>_server.log)
+  --gpu-memory-utilization <F> GPU 显存利用率 (默认: 0.97)
+  --attention-backend <TYPE>  注意力后端 (FD: MLA_ATTN; SG: flashmla)
+  --pd-role <prefill|decode>  PD 分离角色, 仅 FD
+  --extra-args <ARGS>         额外传递给服务的参数
+
+示例:
+  # 单卡启动 FastDeploy
+  bash launch_service.sh --framework fd --model /path/to/model --port 8180 \
+    --gpus 0 --venv /path/to/FastDeploy/.venv
+
+  # TP=4 + DP=2 + EP=8 启动 FastDeploy (MoE, 8卡)
+  bash launch_service.sh --framework fd --model /path/to/model --port 8180 \
+    --gpus 0,1,2,3,4,5,6,7 --tp 4 --dp 2 --ep 8 --venv /path/to/FastDeploy/.venv
+
+  # TP=4 + DP=2 + EP=8 启动 SGLang (MoE, 8卡)
+  bash launch_service.sh --framework sg --model /path/to/model --port 8280 \
+    --gpus 0,1,2,3,4,5,6,7 --tp 4 --dp 2 --ep 8 --venv /path/to/sglang_env/.venv
+EOF
+    exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --framework)       FRAMEWORK="$2"; shift 2 ;;
+        --model)           MODEL="$2"; shift 2 ;;
+        --port)            PORT="$2"; shift 2 ;;
+        --gpus)            GPUS="$2"; shift 2 ;;
+        --tp)              TP="$2"; shift 2 ;;
+        --dp)              DP="$2"; shift 2 ;;
+        --ep)              EP="$2"; shift 2 ;;
+        --concurrency)     CONCURRENCY="$2"; shift 2 ;;
+        --max-model-len)   MAX_MODEL_LEN="$2"; shift 2 ;;
+        --quantization)    QUANTIZATION="$2"; shift 2 ;;
+        --log-file)        LOG_FILE="$2"; shift 2 ;;
+        --venv)            VENV="$2"; shift 2 ;;
+        --gpu-memory-utilization) GPU_MEM_UTIL="$2"; shift 2 ;;
+        --attention-backend) ATTENTION_BACKEND="$2"; shift 2 ;;
+        --pd-role)         PD_ROLE="$2"; shift 2 ;;
+        --extra-args)      EXTRA_ARGS="$2"; shift 2 ;;
+        --help|-h)         usage 0 ;;
+        *)                 echo "未知参数: $1"; usage 1 ;;
+    esac
+done
+
+# 参数校验
+if [[ -z "$FRAMEWORK" || -z "$MODEL" || -z "$PORT" || -z "$GPUS" || -z "$VENV" ]]; then
+    echo "错误: --framework, --model, --port, --gpus, --venv 均为必需参数"
+    usage 1
+fi
+
+if [[ "$FRAMEWORK" != "fd" && "$FRAMEWORK" != "sg" ]]; then
+    echo "错误: --framework 必须为 fd 或 sg"
+    exit 1
+fi
+
+# 默认日志路径
+if [[ -z "$LOG_FILE" ]]; then
+    LOG_FILE="/tmp/${FRAMEWORK}_server_${PORT}.log"
+fi
+
+# ============================================================
+# 端口清理
+# ============================================================
+if lsof -i :"$PORT" &>/dev/null; then
+    echo "[INFO] 端口 $PORT 被占用，正在清理..."
+    kill $(lsof -t -i :"$PORT") 2>/dev/null || true
+    sleep 2
+fi
+
+# ============================================================
+# 启动 FastDeploy
+# ============================================================
+launch_fastdeploy() {
+    echo "[INFO] 启动 FastDeploy 服务..."
+    echo "  模型: $MODEL"
+    echo "  端口: $PORT"
+    echo "  GPU: $GPUS (TP=$TP, DP=$DP, EP=$EP)"
+    echo "  并发: $CONCURRENCY"
+    echo "  量化: $QUANTIZATION"
+    echo "  日志: $LOG_FILE"
+
+    source "$VENV/bin/activate"
+
+    # 设置 LD_LIBRARY_PATH (NVIDIA 库)
+    export LD_LIBRARY_PATH=$(python3 -c "
+import site, os
+sp = site.getsitepackages()[0]
+nvidia_dir = os.path.join(sp, 'nvidia')
+if os.path.isdir(nvidia_dir):
+    libs = [os.path.join(nvidia_dir, d, 'lib') for d in os.listdir(nvidia_dir) if os.path.isdir(os.path.join(nvidia_dir, d, 'lib'))]
+    print(':'.join(libs))
+else:
+    print('')
+"):${LD_LIBRARY_PATH:-}
+
+    # 环境变量
+    export CUDA_VISIBLE_DEVICES="$GPUS"
+
+    # 注意力后端配置
+    if [[ -z "$ATTENTION_BACKEND" ]]; then
+        ATTENTION_BACKEND="MLA_ATTN"
+    fi
+    export FD_ATTENTION_BACKEND="$ATTENTION_BACKEND"
+    export USE_FLASH_MLA=1
+    export FLAGS_flash_attn_version=3
+    export FD_SAMPLING_CLASS=rejection
+
+    # 构建命令 (优先使用 fastdeploy CLI，如不可用则回退到 python -m)
+    local CMD
+    if command -v fastdeploy &>/dev/null; then
+        CMD="fastdeploy serve"
+    else
+        CMD="python -m fastdeploy.entrypoints.openai.api_server"
+    fi
+    CMD+=" --model $MODEL"
+    CMD+=" --port $PORT"
+    CMD+=" --tensor-parallel-size $TP"
+    CMD+=" --max-model-len $MAX_MODEL_LEN"
+    CMD+=" --max-num-seqs $CONCURRENCY"
+    CMD+=" --gpu-memory-utilization $GPU_MEM_UTIL"
+    CMD+=" --trust-remote-code"
+
+    # DP (data parallelism)
+    if [[ "$DP" -gt 1 ]]; then
+        CMD+=" --data-parallel-size $DP"
+    fi
+
+    # EP (expert parallelism) — FD 只有 flag，EP size 隐式 = TP×DP
+    if [[ "$EP" -gt 0 ]]; then
+        CMD+=" --enable-expert-parallel"
+    fi
+
+    # 量化
+    if [[ "$QUANTIZATION" != "none" ]]; then
+        CMD+=" --quantization $QUANTIZATION"
+    fi
+
+    # PD 分离
+    if [[ -n "$PD_ROLE" ]]; then
+        CMD+=" --splitwise-role $PD_ROLE"
+    fi
+
+    # 额外参数
+    if [[ -n "$EXTRA_ARGS" ]]; then
+        CMD+=" $EXTRA_ARGS"
+    fi
+
+    echo "[INFO] 执行: $CMD"
+    nohup bash -c "$CMD" > "$LOG_FILE" 2>&1 &
+    echo $! > "/tmp/fd_pid_${PORT}"
+    echo "[INFO] FastDeploy PID: $! (已写入 /tmp/fd_pid_${PORT})"
+}
+
+# ============================================================
+# 启动 SGLang
+# ============================================================
+launch_sglang() {
+    echo "[INFO] 启动 SGLang 服务..."
+    echo "  模型: $MODEL"
+    echo "  端口: $PORT"
+    echo "  GPU: $GPUS (TP=$TP, DP=$DP, EP=$EP)"
+    echo "  并发: $CONCURRENCY"
+    echo "  量化: $QUANTIZATION"
+    echo "  日志: $LOG_FILE"
+
+    source "$VENV/bin/activate"
+
+    export CUDA_VISIBLE_DEVICES="$GPUS"
+
+    # DP 模式下，设置 MASTER_PORT 避免 torch.distributed 端口冲突
+    # 默认使用 45000+ 范围，避免与系统服务（18xxx）冲突
+    if [[ "$DP" -gt 1 ]]; then
+        export MASTER_PORT=${MASTER_PORT:-45000}
+        echo "[INFO] DP=$DP, 设置 MASTER_PORT=$MASTER_PORT 避免端口冲突"
+    fi
+
+    # 注意力后端
+    if [[ -z "$ATTENTION_BACKEND" ]]; then
+        ATTENTION_BACKEND="flashmla"
+    fi
+
+    # 构建命令
+    local CMD="python3 -m sglang.launch_server"
+    CMD+=" --model-path $MODEL"
+    CMD+=" --host 0.0.0.0"
+    CMD+=" --port $PORT"
+    CMD+=" --tp $TP"
+    CMD+=" --context-length $MAX_MODEL_LEN"
+    CMD+=" --max-running-requests $CONCURRENCY"
+    CMD+=" --attention-backend $ATTENTION_BACKEND"
+    CMD+=" --trust-remote-code"
+
+    # DP (data parallelism)
+    if [[ "$DP" -gt 1 ]]; then
+        CMD+=" --dp-size $DP"
+    fi
+
+    # EP (expert parallelism) — SG 使用显式 --ep-size
+    if [[ "$EP" -gt 0 ]]; then
+        CMD+=" --ep-size $EP"
+    fi
+
+    # 量化
+    if [[ "$QUANTIZATION" != "none" ]]; then
+        local SG_QUANT="$QUANTIZATION"
+        # 映射 FD 量化名到 SG 名
+        if [[ "$SG_QUANT" == "block_wise_fp8" ]]; then
+            SG_QUANT="fp8"
+        fi
+        CMD+=" --quantization $SG_QUANT"
+    fi
+
+    # 额外参数
+    if [[ -n "$EXTRA_ARGS" ]]; then
+        CMD+=" $EXTRA_ARGS"
+    fi
+
+    echo "[INFO] 执行: $CMD"
+    nohup bash -c "$CMD" > "$LOG_FILE" 2>&1 &
+    echo $! > "/tmp/sg_pid_${PORT}"
+    echo "[INFO] SGLang PID: $! (已写入 /tmp/sg_pid_${PORT})"
+}
+
+# ============================================================
+# 主入口
+# ============================================================
+case "$FRAMEWORK" in
+    fd) launch_fastdeploy ;;
+    sg) launch_sglang ;;
+esac
+
+echo "[INFO] 服务已在后台启动，请使用 health_check.sh 等待就绪"

--- a/.claude/skills/benchmark-compare/scripts/run_benchmark.sh
+++ b/.claude/skills/benchmark-compare/scripts/run_benchmark.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# run_benchmark.sh — Benchmark 执行封装脚本
+# 调用 FastDeploy 的 benchmark_serving.py 对指定服务进行性能测试
+set -euo pipefail
+
+LABEL=""
+MODEL=""
+PORT=""
+HOST="127.0.0.1"
+DATASET=""
+HYPERPARAMS=""
+CONCURRENCY=32
+NUM_PROMPTS=1024
+OUTPUT=""
+VENV=""
+BENCHMARK_DIR=""
+IP_LIST=""
+BACKEND="openai-chat"
+ENDPOINT="/v1/chat/completions"
+EXTRA_ARGS=""
+
+usage() {
+    cat <<'EOF'
+用法: bash run_benchmark.sh [OPTIONS]
+
+必需参数:
+  --label <fd|sg>             标识 (用于输出提示)
+  --model <PATH>              模型路径
+  --port <PORT>               服务端口
+  --dataset <PATH>            数据集路径 (JSONL)
+  --hyperparams <PATH>        Hyperparameter YAML 路径
+  --output <PATH>             结果输出文件路径
+  --venv <PATH>               FastDeploy 虚拟环境路径
+  --benchmark-dir <PATH>      FastDeploy/benchmarks 目录路径
+
+可选参数:
+  --host <HOST>               服务地址 (默认: 127.0.0.1)
+  --concurrency <N>           最大并发 (默认: 32)
+  --num-prompts <N>           请求数 (默认: 1024)
+  --backend <TYPE>            后端类型 (默认: openai-chat)
+  --endpoint <PATH>           API 路径 (默认: /v1/chat/completions)
+  --ip-list <IP:PORT,...>     多实例地址列表（多机模式）
+  --extra-args <ARGS>         额外传递给 benchmark_serving.py 的参数
+
+示例:
+  bash run_benchmark.sh --label fd --model /path/to/model --port 8180 \
+    --dataset /path/to/data.jsonl --hyperparams /path/to/GLM-32k.yaml \
+    --output /tmp/result_fd.txt --venv /path/to/FastDeploy/.venv \
+    --benchmark-dir /path/to/FastDeploy/benchmarks
+EOF
+    exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --label)         LABEL="$2"; shift 2 ;;
+        --model)         MODEL="$2"; shift 2 ;;
+        --port)          PORT="$2"; shift 2 ;;
+        --host)          HOST="$2"; shift 2 ;;
+        --dataset)       DATASET="$2"; shift 2 ;;
+        --hyperparams)   HYPERPARAMS="$2"; shift 2 ;;
+        --concurrency)   CONCURRENCY="$2"; shift 2 ;;
+        --num-prompts)   NUM_PROMPTS="$2"; shift 2 ;;
+        --output)        OUTPUT="$2"; shift 2 ;;
+        --venv)          VENV="$2"; shift 2 ;;
+        --benchmark-dir) BENCHMARK_DIR="$2"; shift 2 ;;
+        --backend)       BACKEND="$2"; shift 2 ;;
+        --endpoint)      ENDPOINT="$2"; shift 2 ;;
+        --ip-list)       IP_LIST="$2"; shift 2 ;;
+        --extra-args)    EXTRA_ARGS="$2"; shift 2 ;;
+        --help|-h)       usage 0 ;;
+        *)               echo "未知参数: $1"; usage 1 ;;
+    esac
+done
+
+# 参数校验
+for param in LABEL MODEL PORT DATASET HYPERPARAMS OUTPUT VENV BENCHMARK_DIR; do
+    if [[ -z "${!param}" ]]; then
+        echo "错误: --$(echo $param | tr '[:upper:]' '[:lower:]' | tr '_' '-') 为必需参数"
+        usage 1
+    fi
+done
+
+echo "[INFO] 开始 Benchmark 测试 [$LABEL]"
+echo "  模型: $MODEL"
+echo "  端口: $HOST:$PORT"
+echo "  并发: $CONCURRENCY"
+echo "  请求数: $NUM_PROMPTS"
+echo "  输出: $OUTPUT"
+
+# 激活虚拟环境
+source "$VENV/bin/activate"
+
+# 构建命令
+CMD="python $BENCHMARK_DIR/benchmark_serving.py"
+CMD+=" --backend $BACKEND"
+CMD+=" --model $MODEL"
+CMD+=" --endpoint $ENDPOINT"
+CMD+=" --host $HOST"
+CMD+=" --port $PORT"
+CMD+=" --dataset-name EBChat"
+CMD+=" --dataset-path $DATASET"
+CMD+=" --hyperparameter-path $HYPERPARAMS"
+CMD+=" --num-prompts $NUM_PROMPTS"
+CMD+=" --max-concurrency $CONCURRENCY"
+CMD+=" --percentile-metrics ttft,tpot,itl,e2el,s_ttft,s_itl,s_e2el,s_decode,input_len,s_input_len,output_len"
+CMD+=" --metric-percentiles 80,95,99,99.9,99.95,99.99"
+CMD+=" --save-result"
+
+# 多实例模式
+if [[ -n "$IP_LIST" ]]; then
+    CMD+=" --ip-list $IP_LIST"
+fi
+
+# 额外参数
+if [[ -n "$EXTRA_ARGS" ]]; then
+    CMD+=" $EXTRA_ARGS"
+fi
+
+echo "[INFO] 执行: $CMD"
+echo "[INFO] 输出重定向到: $OUTPUT"
+
+eval "$CMD" > "$OUTPUT" 2>&1
+EXIT_CODE=$?
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+    echo "[INFO] Benchmark [$LABEL] 完成"
+else
+    echo "[ERROR] Benchmark [$LABEL] 失败 (exit code: $EXIT_CODE)"
+    echo "[ERROR] 最后 20 行输出:"
+    tail -20 "$OUTPUT" 2>/dev/null || true
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
Motivation
在日常性能评估工作中，需要频繁对比 FastDeploy 与 SGLang 两个推理框架的性能表现。手动操作涉及环境安装、服务启动、健康检查、benchmark 执行、指标提取和报告生成等多个步骤，流程繁琐且易出错。本 PR 新增一个 Agent Skill（.claude/skills/benchmark-compare/），实现全流程自动化编排，支持通过自然语言或 /benchmark 命令一键完成性能对比测试并生成可视化 HTML 报告。

Modifications
新增 .claude/skills/benchmark-compare/ 目录，包含以下文件：

SKILL.md — 主技能定义，包含完整 12 步工作流编排、参数表、决策树和两种工作模式（全自动测试 / 仅生成报告）
README.md — 使用说明文档
scripts/launch_service.sh — 通用服务启动脚本，支持 FD/SG 两个框架和 single/TP/PD 多种部署模式
scripts/health_check.sh — 服务健康检查脚本，轮询 /v1/models 接口
scripts/run_benchmark.sh — Benchmark 执行封装脚本
scripts/extract_metrics.py — 从 benchmark 结果文件中提取核心指标（吞吐、延迟、TTFT 等）输出为 JSON
scripts/generate_report.py — 生成多模式可视化 HTML 对比报告
references/html_template.md — HTML 报告模板（含 CSS/JS 和占位符）
references/model_profiles.md — 模型推荐部署参数表
支持特性：

单卡 / 多卡 TP / PD 分离等多种部署模式
BF16 / FP8 等量化方式
自动 GPU 空闲检测和分配
自动匹配 hyperparameter YAML 配置
Usage or Command
作为 Agent Skill 使用（在 Claude Code / Ducc 中）：

# 方式 1: slash command
/benchmark

# 方式 2: 自然语言
帮我跑 benchmark，模型用 /path/to/GLM-4.7-Flash，TP=2，并发 64，开启 fp8 量化

# 方式 3: 仅从已有数据生成报告
帮我根据这些日志生成 HTML 对比报告