### PR TITLE
[Cherry-Pick][CI] Set --workers=1 to avoid intermittent timeout failures(#7846)

### DIFF
--- a/.github/workflows/_base_test.yml
+++ b/.github/workflows/_base_test.yml
@@ -272,7 +272,7 @@ jobs:
 
           curl -X POST http://0.0.0.0:${FLASK_PORT}/switch \
             -H "Content-Type: application/json" \
-            -d "{ \"--model\": \"/MODELDATA/ERNIE-4.5-0.3B-Paddle\", \"--max-concurrency\": 5000, \"--max-waiting-time\": 1 }"
+            -d "{ \"--model\": \"/MODELDATA/ERNIE-4.5-0.3B-Paddle\", \"--workers\": 1, \"--max-concurrency\": 5000, \"--max-waiting-time\": 1 }"
           check_service 90
           python -m pytest -sv test_max_waiting_time.py || TEST_EXIT_CODE=1
 


### PR DESCRIPTION
Cherry-pick of #7846 (authored by @EmmonsCurse) to `release/2.6`.

devPR:https://github.com/PaddlePaddle/FastDeploy/pull/7846 <!-- For pass CI -->

---

<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
Under the configuration:
- `--max-concurrency 5000`
- `--max-waiting-time 1`

the test intermittently fails due to insufficient successful responses:
- concurrent requests: 1333
- expected successful responses: `>= 1024`
- actual successful responses: around `1011`
- timeout failures (500): around `322`

The issue is related to worker-level semaphore allocation:

```python
self.semaphore = StatefulSemaphore((FD_SUPPORT_MAX_CONNECTIONS + workers - 1) // workers)
```
Since `FD_SUPPORT_MAX_CONNECTIONS` defaults to `1024`:

* `workers = 1 → semaphore size = 1024`
* `workers = 4 → semaphore size = 256 per worker`

Although the total theoretical capacity remains unchanged, requests are not evenly distributed across Gunicorn workers in practice.

With `workers = 4`, some workers may receive significantly more requests than others, causing local semaphore exhaustion and triggering timeout failures before requests can enter inference execution.

This issue is intermittent because it depends on:
* OS-level socket accept scheduling
* runtime request distribution across workers
* inference latency fluctuations under GPU load
* boundary-state concurrency conditions

To preserve existing test behavior and avoid introducing unintended variability, it is necessary to explicitly set `--workers=1` in test configurations.

## Modifications
- Explicitly set `--workers=1` in the related test configuration.
- Avoided worker-level semaphore fragmentation caused by multi-worker request imbalance.
- Improved concurrency stability and reduced intermittent timeout-related assertion failures.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
- Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
- You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.