### PR TITLE
[KVCache] Add free_cpu_block_num gauge metric

### DIFF
--- a/docs/online_serving/metrics.md
+++ b/docs/online_serving/metrics.md
@@ -38,6 +38,7 @@ After FastDeploy is launched, it supports continuous monitoring of the FastDeplo
 | KV Cache | `fastdeploy:free_gpu_block_num` | Gauge | Number of free GPU blocks in cache | count |
 | KV Cache | `fastdeploy:max_gpu_block_num` | Gauge | Total number of GPU blocks initialized at startup | count |
 | KV Cache | `fastdeploy:max_cpu_block_num` | Gauge | Total number of CPU blocks initialized at startup | count |
+| KV Cache | `fastdeploy:free_cpu_block_num` | Gauge | Number of free CPU blocks in cache | count |
 | KV Cache | `fastdeploy:available_gpu_resource` | Gauge | Ratio of available GPU blocks to total GPU blocks | % |
 | KV Cache | `fastdeploy:gpu_cache_usage_perc` | Gauge | GPU KV cache utilization | % |
 | KV Cache | `fastdeploy:send_cache_failed_num` | Counter | Total number of cache send failures | count |

--- a/docs/zh/online_serving/metrics.md
+++ b/docs/zh/online_serving/metrics.md
@@ -38,6 +38,7 @@
 | KV缓存 | `fastdeploy:free_gpu_block_num`           | Gauge     | 缓存中的可用块数             | 个   |
 | KV缓存 | `fastdeploy:max_gpu_block_num`            | Gauge     | 服务启动时确定的 GPU 总块数        | 个   |
 | KV缓存 | `fastdeploy:max_cpu_block_num`            | Gauge     | 服务启动时确定的 CPU 总块数        | 个   |
+| KV缓存 | `fastdeploy:free_cpu_block_num`           | Gauge     | 缓存中的可用 CPU 块数            | 个   |
 | KV缓存 | `fastdeploy:available_gpu_resource`       | Gauge     | 可用块占比，即可用 GPU 块数量 / 最大GPU块数量| 百分比   |
 | KV缓存 | `fastdeploy:gpu_cache_usage_perc`         | Gauge     | GPU 上的 KV 缓存使用率          | 百分比    |
 | KV缓存 | `fastdeploy:send_cache_failed_num`        | Counter   | 发送缓存失败的总次数          | 个   |

--- a/fastdeploy/cache_manager/prefix_cache_manager.py
+++ b/fastdeploy/cache_manager/prefix_cache_manager.py
@@ -132,6 +132,7 @@ class PrefixCacheManager:
         main_process_metrics.max_cpu_block_num.set(self.num_cpu_blocks)
         main_process_metrics.available_gpu_block_num.set(self.num_gpu_blocks)
         main_process_metrics.free_gpu_block_num.set(self.num_gpu_blocks)
+        main_process_metrics.free_cpu_block_num.set(self.num_cpu_blocks)
         main_process_metrics.available_gpu_resource.set(1.0)
 
     def _get_kv_cache_shape(self, max_block_num):
@@ -461,6 +462,7 @@ class PrefixCacheManager:
         main_process_metrics.max_cpu_block_num.set(self.num_cpu_blocks)
         main_process_metrics.available_gpu_block_num.set(self.num_gpu_blocks)
         main_process_metrics.free_gpu_block_num.set(self.num_gpu_blocks)
+        main_process_metrics.free_cpu_block_num.set(self.num_cpu_blocks)
         main_process_metrics.available_gpu_resource.set(1.0)
 
     def can_allocate_gpu_blocks(self, num_blocks: int):
@@ -520,6 +522,7 @@ class PrefixCacheManager:
         logger.info(
             f"allocate_cpu_blocks: {allocated_block_ids}, len(self.cpu_free_block_list) {len(self.cpu_free_block_list)}"
         )
+        main_process_metrics.free_cpu_block_num.set(len(self.cpu_free_block_list))
         return allocated_block_ids
 
     def recycle_cpu_blocks(self, cpu_block_ids):
@@ -534,6 +537,7 @@ class PrefixCacheManager:
                 heapq.heappush(self.cpu_free_block_list, cpu_block_id)
         else:
             heapq.heappush(self.cpu_free_block_list, cpu_block_ids)
+        main_process_metrics.free_cpu_block_num.set(len(self.cpu_free_block_list))
 
     def issue_swap_task(
         self,
@@ -1439,6 +1443,7 @@ class PrefixCacheManager:
         logger.info(
             "free_cpu_block_ids: after free, " + f"len(self.cpu_free_block_list) {len(self.cpu_free_block_list)}"
         )
+        main_process_metrics.free_cpu_block_num.set(len(self.cpu_free_block_list))
         return total_cpu_free_count
 
     def get_block_hash_extra_keys(self, request, start_idx, end_idx, mm_idx):
@@ -2127,6 +2132,7 @@ class PrefixCacheManager:
         # reset metrics
         self.metrics.reset_metrics()
         main_process_metrics.free_gpu_block_num.set(len(self.gpu_free_block_list))
+        main_process_metrics.free_cpu_block_num.set(len(self.cpu_free_block_list))
         main_process_metrics.available_gpu_block_num.set(len(self.gpu_free_block_list))
         main_process_metrics.available_gpu_resource.set(self.available_gpu_resource)
 

--- a/fastdeploy/metrics/metrics.py
+++ b/fastdeploy/metrics/metrics.py
@@ -159,6 +159,7 @@ class MetricsManager:
     free_gpu_block_num: "Gauge"
     max_gpu_block_num: "Gauge"
     max_cpu_block_num: "Gauge"
+    free_cpu_block_num: "Gauge"
     available_gpu_resource: "Gauge"
     requests_number: "Counter"
     send_cache_failed_num: "Counter"
@@ -243,6 +244,12 @@ class MetricsManager:
             "type": Gauge,
             "name": "fastdeploy:max_cpu_block_num",
             "description": "Number of total CPU blocks determined when service started",
+            "kwargs": {},
+        },
+        "free_cpu_block_num": {
+            "type": Gauge,
+            "name": "fastdeploy:free_cpu_block_num",
+            "description": "Number of free CPU blocks in cache",
             "kwargs": {},
         },
         "available_gpu_resource": {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

当前已有 `free_gpu_block_num` 指标用于监控 GPU 可用 block 数量，但缺少对应的 CPU 侧指标 `free_cpu_block_num`。在开启 swap/prefix caching 场景下，需要监控 CPU block 的使用情况以便及时发现瓶颈。

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications

1. **fastdeploy/metrics/metrics.py**: 新增 `free_cpu_block_num` Gauge 指标定义和注册
2. **fastdeploy/cache_manager/prefix_cache_manager.py**: 在以下位置设置 `free_cpu_block_num`：
   - `__init__` 初始化时设置为 `num_cpu_blocks`
   - `_setup_for_worker` 初始化时设置为 `num_cpu_blocks`
   - `allocate_cpu_blocks` 分配后更新
   - `recycle_cpu_blocks` 回收后更新
   - `free_cpu_block_ids` 淘汰后更新
   - `reset` 方法中更新
3. **docs/online_serving/metrics.md**: 补充英文文档
4. **docs/zh/online_serving/metrics.md**: 补充中文文档

## Usage or Command

访问 `/metrics` 端点即可查看 `fastdeploy:free_cpu_block_num` 指标。

## Accuracy Tests

此 PR 不涉及模型输出变更，无需精度测试。

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.