### PR TITLE
[OP][Loader]decrease code && make code clean

### DIFF
--- a/fastdeploy/model_executor/layers/linear.py
+++ b/fastdeploy/model_executor/layers/linear.py
@@ -415,7 +415,9 @@ class MergedReplicatedLinear(ReplicatedLinear):
             if loaded_weight.dtype == paddle.int8 and param.dtype == paddle.float8_e4m3fn:
                 loaded_weight = loaded_weight.view(param.dtype)
             else:
-                loaded_weight = loaded_weight.cast(param.dtype)
+                assert (
+                    loaded_weight.dtype == param.dtype
+                ), f"loaded_weight.dtype: {loaded_weight.dtype}, param.dtype: {param.dtype}"
         # (bukejiyu) After this fix, the early H2D copy for non-GPU devices is no longer needed and can be safely removed.
         h2d_copy(param, loaded_weight)
 

--- a/fastdeploy/model_executor/layers/linear.py
+++ b/fastdeploy/model_executor/layers/linear.py
@@ -41,15 +41,19 @@ from fastdeploy.platforms import current_platform
 from .utils import _set_var_distributed, divide, get_tensor, modules_to_convert
 
 
-def may_be_do_cast(loaded_weight, param_dtype):
+def may_be_do_cast(loaded_weight, param):
+
+    assert param.shape == loaded_weight.shape, (
+        f" Attempted to load weight ({loaded_weight.shape}) " f"into parameter ({param.shape})"
+    )
     # Ensure loaded weight dtype matches model param dtype
-    if loaded_weight.dtype != param_dtype:
-        if loaded_weight.dtype == paddle.int8 and param_dtype == paddle.float8_e4m3fn:
-            loaded_weight = loaded_weight.view(param_dtype)
+    if loaded_weight.dtype != param.dtype:
+        if loaded_weight.dtype == paddle.int8 and param.dtype == paddle.float8_e4m3fn:
+            loaded_weight = loaded_weight.view(param.dtype)
         else:
             assert (
-                loaded_weight.dtype == param_dtype
-            ), f"loaded_weight.dtype: {loaded_weight.dtype}, param_dtype: {param_dtype}"
+                loaded_weight.dtype == param.dtype
+            ), f"loaded_weight.dtype: {loaded_weight.dtype}, param.dtype: {param.dtype}"
     return loaded_weight
 
 
@@ -419,10 +423,7 @@ class MergedReplicatedLinear(ReplicatedLinear):
                 start=param_shard_offset,
                 end=param_shard_offset + param_shard_size,
             )
-        assert param.shape == loaded_weight.shape, (
-            f" Attempted to load weight ({loaded_weight.shape}) " f"into parameter ({param.shape})"
-        )
-        loaded_weight = may_be_do_cast(loaded_weight, param.dtype)
+        loaded_weight = may_be_do_cast(loaded_weight, param)
         # (bukejiyu) After this fix, the early H2D copy for non-GPU devices is no longer needed and can be safely removed.
         h2d_copy(param, loaded_weight)
 
@@ -599,10 +600,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             if hasattr(param, "tensor_track"):
                 param.tensor_track.mark(start=param_shard_offset, end=param_shard_offset + param_shard_size)
             param = slice_fn(param, output_dim, start=param_shard_offset, end=param_shard_offset + param_shard_size)
-            assert param.shape == loaded_weight.shape, (
-                f" Attempted to load weight ({loaded_weight.shape}) " f"into parameter ({param.shape})"
-            )
-            loaded_weight = may_be_do_cast(loaded_weight, param.dtype)
+            loaded_weight = may_be_do_cast(loaded_weight, param)
             h2d_copy(param, loaded_weight)
 
     def load_state_dict(self, state_dict: dict):
@@ -754,10 +752,7 @@ class QKVParallelLinear(ColumnParallelLinear):
                 param.tensor_track.mark(start=param_shard_offset, end=param_shard_offset + param_shard_size)
 
             param = slice_fn(param, output_dim, start=param_shard_offset, end=param_shard_offset + param_shard_size)
-            assert param.shape == loaded_weight.shape, (
-                f" Attempted to load weight ({loaded_weight.shape}) " f"into parameter ({param.shape})"
-            )
-            loaded_weight = may_be_do_cast(loaded_weight, param.dtype)
+            loaded_weight = may_be_do_cast(loaded_weight, param)
             h2d_copy(param, loaded_weight)
 
     def load_weight(self, state_dict: dict):
@@ -1275,10 +1270,7 @@ class QKVGateParallelLinear(ColumnParallelLinear):
                 param.tensor_track.mark(start=param_shard_offset, end=param_shard_offset + param_shard_size)
 
             param = slice_fn(param, output_dim, start=param_shard_offset, end=param_shard_offset + param_shard_size)
-            assert param.shape == loaded_weight.shape, (
-                f" Attempted to load weight ({loaded_weight.shape}) " f"into parameter ({param.shape})"
-            )
-            loaded_weight = may_be_do_cast(loaded_weight, param.dtype)
+            loaded_weight = may_be_do_cast(loaded_weight, param)
             h2d_copy(param, loaded_weight)
 
     def gate_weight_loader(self, param, loaded_weight):
@@ -1310,10 +1302,7 @@ class QKVGateParallelLinear(ColumnParallelLinear):
             param.tensor_track.mark(start=param_shard_offset, end=param_shard_offset + param_shard_size)
 
         param = slice_fn(param, output_dim, start=param_shard_offset, end=param_shard_offset + param_shard_size)
-        assert param.shape == loaded_weight.shape, (
-            f"Attempted to load weight ({loaded_weight.shape}) " f"into parameter ({param.shape})"
-        )
-        loaded_weight = may_be_do_cast(loaded_weight, param.dtype)
+        loaded_weight = may_be_do_cast(loaded_weight, param)
         h2d_copy(param, loaded_weight)
 
     def load_weight(self, state_dict: dict):

--- a/fastdeploy/model_executor/layers/linear.py
+++ b/fastdeploy/model_executor/layers/linear.py
@@ -602,7 +602,9 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                 if loaded_weight.dtype == paddle.int8 and param.dtype == paddle.float8_e4m3fn:
                     loaded_weight = loaded_weight.view(param.dtype)
                 else:
-                    loaded_weight = loaded_weight.cast(param.dtype)
+                    assert (
+                        loaded_weight.dtype == param.dtype
+                    ), f"loaded_weight.dtype: {loaded_weight.dtype}, param.dtype: {param.dtype}"
 
             h2d_copy(param, loaded_weight)
 
@@ -763,7 +765,9 @@ class QKVParallelLinear(ColumnParallelLinear):
                 if loaded_weight.dtype == paddle.int8 and param.dtype == paddle.float8_e4m3fn:
                     loaded_weight = loaded_weight.view(param.dtype)
                 else:
-                    loaded_weight = loaded_weight.cast(param.dtype)
+                    assert (
+                        loaded_weight.dtype == param.dtype
+                    ), f"loaded_weight.dtype: {loaded_weight.dtype}, param.dtype: {param.dtype}"
             h2d_copy(param, loaded_weight)
 
     def load_weight(self, state_dict: dict):
@@ -1289,7 +1293,9 @@ class QKVGateParallelLinear(ColumnParallelLinear):
                 if loaded_weight.dtype == paddle.int8 and param.dtype == paddle.float8_e4m3fn:
                     loaded_weight = loaded_weight.view(param.dtype)
                 else:
-                    loaded_weight = loaded_weight.cast(param.dtype)
+                    assert (
+                        loaded_weight.dtype == param.dtype
+                    ), f"loaded_weight.dtype: {loaded_weight.dtype}, param.dtype: {param.dtype}"
             h2d_copy(param, loaded_weight)
 
     def gate_weight_loader(self, param, loaded_weight):
@@ -1329,7 +1335,9 @@ class QKVGateParallelLinear(ColumnParallelLinear):
             if loaded_weight.dtype == paddle.int8 and param.dtype == paddle.float8_e4m3fn:
                 loaded_weight = loaded_weight.view(param.dtype)
             else:
-                loaded_weight = loaded_weight.cast(param.dtype)
+                assert (
+                    loaded_weight.dtype == param.dtype
+                ), f"loaded_weight.dtype: {loaded_weight.dtype}, param.dtype: {param.dtype}"
         h2d_copy(param, loaded_weight)
 
     def load_weight(self, state_dict: dict):

--- a/fastdeploy/model_executor/layers/linear.py
+++ b/fastdeploy/model_executor/layers/linear.py
@@ -41,6 +41,18 @@ from fastdeploy.platforms import current_platform
 from .utils import _set_var_distributed, divide, get_tensor, modules_to_convert
 
 
+def may_be_do_cast(loaded_weight, param_dtype):
+    # Ensure loaded weight dtype matches model param dtype
+    if loaded_weight.dtype != param_dtype:
+        if loaded_weight.dtype == paddle.int8 and param_dtype == paddle.float8_e4m3fn:
+            loaded_weight = loaded_weight.view(param_dtype)
+        else:
+            assert (
+                loaded_weight.dtype == param_dtype
+            ), f"loaded_weight.dtype: {loaded_weight.dtype}, param_dtype: {param_dtype}"
+    return loaded_weight
+
+
 class UnquantizedLinearMethod(QuantMethodBase):
     """Linear method without quantization."""
 
@@ -410,14 +422,7 @@ class MergedReplicatedLinear(ReplicatedLinear):
         assert param.shape == loaded_weight.shape, (
             f" Attempted to load weight ({loaded_weight.shape}) " f"into parameter ({param.shape})"
         )
-        # Ensure loaded weight dtype matches model param dtype
-        if loaded_weight.dtype != param.dtype:
-            if loaded_weight.dtype == paddle.int8 and param.dtype == paddle.float8_e4m3fn:
-                loaded_weight = loaded_weight.view(param.dtype)
-            else:
-                assert (
-                    loaded_weight.dtype == param.dtype
-                ), f"loaded_weight.dtype: {loaded_weight.dtype}, param.dtype: {param.dtype}"
+        loaded_weight = may_be_do_cast(loaded_weight, param.dtype)
         # (bukejiyu) After this fix, the early H2D copy for non-GPU devices is no longer needed and can be safely removed.
         h2d_copy(param, loaded_weight)
 
@@ -597,15 +602,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             assert param.shape == loaded_weight.shape, (
                 f" Attempted to load weight ({loaded_weight.shape}) " f"into parameter ({param.shape})"
             )
-            # Ensure loaded weight dtype matches model param dtype
-            if loaded_weight.dtype != param.dtype:
-                if loaded_weight.dtype == paddle.int8 and param.dtype == paddle.float8_e4m3fn:
-                    loaded_weight = loaded_weight.view(param.dtype)
-                else:
-                    assert (
-                        loaded_weight.dtype == param.dtype
-                    ), f"loaded_weight.dtype: {loaded_weight.dtype}, param.dtype: {param.dtype}"
-
+            loaded_weight = may_be_do_cast(loaded_weight, param.dtype)
             h2d_copy(param, loaded_weight)
 
     def load_state_dict(self, state_dict: dict):
@@ -760,14 +757,7 @@ class QKVParallelLinear(ColumnParallelLinear):
             assert param.shape == loaded_weight.shape, (
                 f" Attempted to load weight ({loaded_weight.shape}) " f"into parameter ({param.shape})"
             )
-            # Ensure loaded weight dtype matches model param dtype
-            if loaded_weight.dtype != param.dtype:
-                if loaded_weight.dtype == paddle.int8 and param.dtype == paddle.float8_e4m3fn:
-                    loaded_weight = loaded_weight.view(param.dtype)
-                else:
-                    assert (
-                        loaded_weight.dtype == param.dtype
-                    ), f"loaded_weight.dtype: {loaded_weight.dtype}, param.dtype: {param.dtype}"
+            loaded_weight = may_be_do_cast(loaded_weight, param.dtype)
             h2d_copy(param, loaded_weight)
 
     def load_weight(self, state_dict: dict):
@@ -1288,14 +1278,7 @@ class QKVGateParallelLinear(ColumnParallelLinear):
             assert param.shape == loaded_weight.shape, (
                 f" Attempted to load weight ({loaded_weight.shape}) " f"into parameter ({param.shape})"
             )
-            # Ensure loaded weight dtype matches model param dtype
-            if loaded_weight.dtype != param.dtype:
-                if loaded_weight.dtype == paddle.int8 and param.dtype == paddle.float8_e4m3fn:
-                    loaded_weight = loaded_weight.view(param.dtype)
-                else:
-                    assert (
-                        loaded_weight.dtype == param.dtype
-                    ), f"loaded_weight.dtype: {loaded_weight.dtype}, param.dtype: {param.dtype}"
+            loaded_weight = may_be_do_cast(loaded_weight, param.dtype)
             h2d_copy(param, loaded_weight)
 
     def gate_weight_loader(self, param, loaded_weight):
@@ -1330,14 +1313,7 @@ class QKVGateParallelLinear(ColumnParallelLinear):
         assert param.shape == loaded_weight.shape, (
             f"Attempted to load weight ({loaded_weight.shape}) " f"into parameter ({param.shape})"
         )
-        # Ensure loaded weight dtype matches model param dtype
-        if loaded_weight.dtype != param.dtype:
-            if loaded_weight.dtype == paddle.int8 and param.dtype == paddle.float8_e4m3fn:
-                loaded_weight = loaded_weight.view(param.dtype)
-            else:
-                assert (
-                    loaded_weight.dtype == param.dtype
-                ), f"loaded_weight.dtype: {loaded_weight.dtype}, param.dtype: {param.dtype}"
+        loaded_weight = may_be_do_cast(loaded_weight, param.dtype)
         h2d_copy(param, loaded_weight)
 
     def load_weight(self, state_dict: dict):

--- a/tests/model_executor/test_linear.py
+++ b/tests/model_executor/test_linear.py
@@ -189,12 +189,12 @@ def test_merged_and_column_weight_paths():
     layer_merge = MergedReplicatedLinear.__new__(MergedReplicatedLinear)
     layer_merge.__dict__.update(fd_config=make_fd_config(model_format="paddle"), output_sizes=[2, 2])
     param = TinyParam(paddle.zeros([2, 4], dtype="float32"), initialized=False, with_track=True)
-    loaded_weight = paddle.ones([2, 4], dtype="float16")
+    loaded_weight = paddle.ones([2, 4], dtype="float32")
     layer_merge.weight_loader(param, loaded_weight, loaded_shard_id=None)
     assert param.tensor_track.calls == [(0, loaded_weight.shape[-1])]
     np.testing.assert_allclose(param._tensor.numpy(), np.ones((2, 4), dtype="float32"))
     param_shard = TinyParam(paddle.zeros([2, 4], dtype="float32"), initialized=False)
-    layer_merge.weight_loader(param_shard, paddle.ones([2, 2], dtype="int8"), loaded_shard_id="gate")
+    layer_merge.weight_loader(param_shard, paddle.ones([2, 2], dtype="float32"), loaded_shard_id="gate")
     assert param_shard._is_initialized() is True
     assert not np.allclose(param_shard._tensor.numpy()[..., :2], 0)
     assert np.allclose(param_shard._tensor.numpy()[..., 2:], 0)
@@ -213,7 +213,7 @@ def test_merged_and_column_weight_paths():
     param_gate = TinyParam(paddle.zeros([2, 4], dtype="float32"), initialized=True)
     param_gate.output_dim = True
     param_gate.weight_need_transpose = True
-    layer_mc.weight_loader(param_gate, paddle.ones([4, 2], dtype="int8"), loaded_shard_id="gate")
+    layer_mc.weight_loader(param_gate, paddle.ones([4, 2], dtype="float32"), loaded_shard_id="gate")
     assert not np.allclose(param_gate._tensor.numpy()[..., :2], 0)
     assert np.allclose(param_gate._tensor.numpy()[..., 2:], 0)
     layer_mc.local_rank = 1


### PR DESCRIPTION
> 🤖 Paddle-CI-Agent | pr_review | `2026-05-21 15:15:06`

## 📋 Review 摘要

**PR 概述**：将 `linear.py` 中多处重复的 weight dtype 处理逻辑提取为公共函数 `may_be_do_cast()`，同时将原 `else` 分支的 `.cast()` 静默转换改为 `assert` 报错
**变更范围**：`fastdeploy/model_executor/layers/linear.py`
**影响面 Tag**：`[OP]` `[Loader]`

### 问题

| 级别 | 文件 | 概述 |
|------|------|------|
| 🔴 Bug | `fastdeploy/model_executor/layers/linear.py:50` | `assert` 用于运行时 dtype 校验，在 Python `-O` 模式下会被跳过，导致错误静默 |
| 🔴 兼容性 | `fastdeploy/model_executor/layers/linear.py:44` | 语义变更：原代码 `else` 分支做 `.cast()` 允许隐式转换，新代码改为 assert 失败，属 Breaking Change |

### 📝 PR 规范检查

PR 标题缺少官方 Tag（当前为 `add assert`），PR 描述各必填 section（Motivation / Modifications / Usage or Command / Accuracy Tests）均为空。

**标题建议**（可直接复制）：
- `[OP] Replace implicit dtype cast with assert in linear weight_loader`

**PR 描述建议**（可直接复制，必须复刻 checklist §D2 模板的完整结构）：

```markdown
## Motivation
将 `linear.py` 中 5 处重复的 weight dtype 兼容处理逻辑抽取为公共函数 `may_be_do_cast()`，消除代码重复，同时将 `else` 分支由静默 `.cast()` 改为 assert 报错，以便在 dtype 不匹配时尽早暴露问题。

## Modifications
- 新增 `may_be_do_cast(loaded_weight, param_dtype)` 公共函数，封装 int8→float8_e4m3fn 的 `.view()` 转换及其余 dtype 不匹配时的 assert 检查
- 替换 `ColumnParallelLinear`、`RowParallelLinear`、`QKVParallelLinear`、`MergedColumnParallelLinear`、`gate_weight_loader` 等处的重复 dtype 处理逻辑

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
```

### 总体评价

PR 将 5 处重复的 dtype 处理逻辑成功抽取为公共函数，有利于维护；但存在两个需要修复的问题：① `assert` 不应用于运行时校验（应改为 `raise ValueError`）；② 原 `else` 分支的静默 `.cast()` 被删除属 Breaking Change，需在 PR 描述中说明意图并确认不影响已有模型加载流程。
