### PR TITLE
[Benchmark] Add inner benchmark metrics component

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -40,3 +40,100 @@ python benchmark_serving.py \
   --max-concurrency 1 \
   --save-result
 ```
+
+## In-Process Benchmark Metrics Logger
+
+FastDeploy provides a built-in performance monitoring module that runs inside the inference process. It collects per-request timing data and computes rolling statistics aligned with `benchmark_serving.py`, writing results to a JSONL file for real-time monitoring and post-hoc analysis.
+
+### Enable
+
+Add `--benchmark-metrics-config` with a JSON string to the service startup command:
+
+```bash
+python -m fastdeploy.entrypoints.openai.api_server \
+       --model baidu/ERNIE-4.5-0.3B-Base-Paddle \
+       --benchmark-metrics-config '{"enable": true}'
+```
+
+### Configuration Parameters
+
+| Parameter | Type | Default | Description |
+| :-------- | :--- | :------ | :---------- |
+| `enable` | bool | `false` | Whether to enable the benchmark metrics logger. Must be set to `true` to activate. |
+| `window_size` | int | `0` | Number of recent requests to aggregate. `0` = cumulative (all requests since start). |
+| `window_mode` | str | `"sliding"` | Window aggregation mode. `"sliding"` = sliding window (keeps last N records, oldest automatically dropped). `"tumbling"` = tumbling window (clears and restarts after every N records). |
+| `percentiles` | str | `"50,90,95,99"` | Comma-separated percentile values to compute. |
+| `metrics` | str | `"all"` | Comma-separated metric names to report, or `"all"` for all metrics. |
+
+### Available Metrics
+
+Metrics are aligned with `benchmark_serving.py --percentile-metrics`:
+
+| Metric Name | Description | Unit |
+| :---------- | :---------- | :--- |
+| `ttft` | Time to First Token (client arrival → first token) | ms |
+| `s_ttft` | Server TTFT (inference start → first token) | ms |
+| `tpot` | Time per Output Token (excluding first token) | ms |
+| `s_itl` | Infer Inter-token Latency | ms |
+| `e2el` | End-to-end Latency (client arrival → last token) | ms |
+| `s_e2el` | Server E2EL (inference start → last token) | ms |
+| `s_decode` | Decode speed (excluding first token) | tok/s |
+| `input_len` | Prefix cache hit token count ("Cached Tokens") | tokens |
+| `s_input_len` | Infer input length (total prompt tokens) | tokens |
+| `output_len` | Output token length per request | tokens |
+
+In addition, the following throughput metrics are always computed (not user-selectable) when there are 2+ records:
+
+| Metric | Description | Unit |
+| :----- | :---------- | :--- |
+| `request_throughput` | Request throughput | req/s |
+| `output_throughput` | Output token throughput | tok/s |
+| `total_throughput` | Total token throughput (input + output) | tok/s |
+
+### Window Modes
+
+**Sliding Window** (`"sliding"`, default):
+
+The window keeps the most recent N records. When a new record arrives and the window is full, the oldest record is automatically dropped. Each output line reflects the statistics of the latest N requests.
+
+```bash
+--benchmark-metrics-config '{"enable": true, "window_size": 64, "window_mode": "sliding"}'
+```
+
+**Tumbling Window** (`"tumbling"`):
+
+The window accumulates records up to N, then clears and starts fresh. Each output line still reflects the current window's accumulated statistics, but the window resets at every boundary. This is useful for RL training scenarios where each step has a fixed batch size and you want per-step independent analysis.
+
+```bash
+--benchmark-metrics-config '{"enable": true, "window_size": 64, "window_mode": "tumbling"}'
+```
+
+**No Window** (`window_size: 0`):
+
+All completed requests are accumulated. Statistics reflect the entire lifetime of the service.
+
+```bash
+--benchmark-metrics-config '{"enable": true, "window_size": 0}'
+```
+
+### Output
+
+Results are written to `{FD_LOG_DIR}/benchmark_metrics.jsonl` (default: `./log/benchmark_metrics.jsonl`). Each line is a JSON object representing the window statistics at the time of a request completion.
+
+Example output line:
+
+```json
+{
+  "timestamp": "2026-05-14T10:30:05.123",
+  "window_size": 64,
+  "window_mode": "sliding",
+  "completed": 64,
+  "total_input_tokens": 8192,
+  "total_output_tokens": 16384,
+  "request_throughput": 5.2,
+  "output_throughput": 1250.0,
+  "total_throughput": 2500.0,
+  "ttft_ms": {"mean": 45.0, "median": 42.1, "p50": 42.1, "p90": 68.5, "p95": 82.3, "p99": 120.5},
+  "s_decode": {"mean": 67.3, "median": 67.5, "p50": 67.5, "p90": 70.1, "p95": 71.2, "p99": 73.0}
+}
+```

--- a/docs/zh/benchmark.md
+++ b/docs/zh/benchmark.md
@@ -40,3 +40,106 @@ python benchmark_serving.py \
   --max-concurrency 1 \
   --save-result
 ```
+
+## 进程内性能监控（Benchmark Metrics Logger）
+
+FastDeploy 提供了内置的进程内性能监控模块，在推理进程内部运行，复用已有的请求时间戳数据，每个请求完成时计算滚动统计并写入 JSONL 文件，可用于实时监控和事后分析。
+
+### 启用方式
+
+在服务启动命令中添加 `--benchmark-metrics-config` 参数，传入 JSON 配置字符串：
+
+```bash
+python -m fastdeploy.entrypoints.openai.api_server \
+       --model baidu/ERNIE-4.5-0.3B-Base-Paddle \
+       --benchmark-metrics-config '{"enable": true}'
+```
+
+### 配置参数
+
+| 参数 | 类型 | 默认值 | 说明 |
+| :--- | :--- | :----- | :--- |
+| `enable` | bool | `false` | 是否启用性能监控。必须设置为 `true` 才会激活。 |
+| `window_size` | int | `0` | 统计窗口大小。`0` = 累计模式（统计所有请求）；`>0` = 统计最近 N 个请求。 |
+| `window_mode` | str | `"sliding"` | 窗口聚合模式。`"sliding"` = 滑动窗口（保持最近 N 条，旧记录自动淘汰）；`"tumbling"` = 翻滚窗口（满 N 条后清空重新累积）。 |
+| `percentiles` | str | `"50,90,95,99"` | 要计算的分位值，逗号分隔。 |
+| `metrics` | str | `"all"` | 要统计的指标子集，逗号分隔，或 `"all"` 表示全部指标。 |
+
+### 可用指标
+
+指标与 `benchmark_serving.py --percentile-metrics` 对齐：
+
+| 指标名称 | 说明 | 单位 |
+| :------- | :--- | :--- |
+| `ttft` | 首 Token 时延（客户端到达 → 首 Token） | ms |
+| `s_ttft` | 服务端首 Token 时延（推理开始 → 首 Token） | ms |
+| `tpot` | 每 Token 输出时延（不含首 Token） | ms |
+| `s_itl` | 推理 Token 间时延 | ms |
+| `e2el` | 端到端时延（客户端到达 → 最后一个 Token） | ms |
+| `s_e2el` | 服务端端到端时延（推理开始 → 最后一个 Token） | ms |
+| `s_decode` | 解码速度（不含首 Token） | tok/s |
+| `input_len` | 前缀缓存命中 Token 数（"Cached Tokens"） | tokens |
+| `s_input_len` | 推理输入长度（总 prompt token 数） | tokens |
+| `output_len` | 输出 Token 长度 | tokens |
+
+此外，以下吞吐量指标在有 2 个以上请求完成时自动计算（不受 `metrics` 参数控制）：
+
+| 指标 | 说明 | 单位 |
+| :--- | :--- | :--- |
+| `request_throughput` | 请求吞吐量 | req/s |
+| `output_throughput` | 输出 Token 吞吐量 | tok/s |
+| `total_throughput` | 总 Token 吞吐量（输入 + 输出） | tok/s |
+
+### 窗口模式
+
+**滑动窗口**（`"sliding"`，默认）：
+
+窗口始终保持最近 N 条记录。当新记录到达且窗口已满时，最旧的记录自动淘汰。每行输出反映最近 N 个请求的统计值。
+
+```bash
+--benchmark-metrics-config '{"enable": true, "window_size": 64, "window_mode": "sliding"}'
+```
+
+**翻滚窗口**（`"tumbling"`）：
+
+窗口累积到 N 条后清空重新开始。每行输出反映当前窗口已累积请求的统计值，窗口在边界处重置。适用于 RL 训练场景，每个 step 有固定 batch size，需要逐 step 独立分析。
+
+```bash
+--benchmark-metrics-config '{"enable": true, "window_size": 64, "window_mode": "tumbling"}'
+```
+
+**无窗口**（`window_size: 0`）：
+
+所有已完成请求持续累积，统计值反映服务启动以来的全量数据。
+
+```bash
+--benchmark-metrics-config '{"enable": true, "window_size": 0}'
+```
+
+### 输出说明
+
+结果写入 `{FD_LOG_DIR}/benchmark_metrics.jsonl`（默认路径：`./log/benchmark_metrics.jsonl`）。每行为一个 JSON 对象，表示某个请求完成时刻窗口内的统计快照。
+
+输出示例：
+
+```json
+{
+  "timestamp": "2026-05-14T10:30:05.123",
+  "window_size": 64,
+  "window_mode": "sliding",
+  "completed": 64,
+  "total_input_tokens": 8192,
+  "total_output_tokens": 16384,
+  "request_throughput": 5.2,
+  "output_throughput": 1250.0,
+  "total_throughput": 2500.0,
+  "ttft_ms": {"mean": 45.0, "median": 42.1, "p50": 42.1, "p90": 68.5, "p95": 82.3, "p99": 120.5},
+  "s_decode": {"mean": 67.3, "median": 67.5, "p50": 67.5, "p90": 70.1, "p95": 71.2, "p99": 73.0}
+}
+```
+
+读取最后一行即可获取当前最新的性能快照：
+
+```bash
+tail -1 log/benchmark_metrics.jsonl | python -m json.tool
+```

--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -1886,6 +1886,65 @@ class RoutingReplayConfig:
         return self.to_json_string()
 
 
+class BenchmarkMetricsConfig:
+    """Configuration for in-process benchmark metrics logger.
+
+    Args (passed as JSON dict via --benchmark-metrics-config):
+        enable: Whether to enable the benchmark metrics logger. Default: False.
+        window_size: Number of recent requests to aggregate. 0 = all requests (cumulative).
+        window_mode: Window aggregation mode. Default: "sliding".
+            "sliding" = sliding window (keep last N records),
+            "tumbling" = tumbling window (clear and restart after every N records).
+        percentiles: Comma-separated percentile values to compute, e.g. "50,90,95,99".
+        metrics: Comma-separated metric names to report, or "all".
+            Available metrics (aligned with benchmark_serving.py --percentile-metrics):
+                ttft          - Time to First Token (client arrival → first token)
+                s_ttft        - Server TTFT (inference start → first token)
+                tpot          - Time per Output Token (excluding first token)
+                s_itl         - Infer Inter-token Latency
+                e2el          - End-to-end Latency (client arrival → last token)
+                s_e2el        - Server E2EL (inference start → last token)
+                s_decode      - Decode speed (tokens/s, excluding first token)
+                input_len     - Prefix cache hit token count ("Cached Tokens" in benchmark_serving)
+                s_input_len   - Infer input length (total prompt tokens on inference side)
+                output_len    - Output token length per request
+    """
+
+    _DEFAULTS = {
+        "enable": False,
+        "window_size": 0,
+        "window_mode": "sliding",
+        "percentiles": "50,90,95,99",
+        "metrics": "all",
+    }
+
+    _ALL_METRICS = [
+        "ttft",  # Time to First Token
+        "s_ttft",  # Server TTFT
+        "tpot",  # Time per Output Token
+        "s_itl",  # Infer Inter-token Latency
+        "e2el",  # End-to-end Latency
+        "s_e2el",  # Server E2EL
+        "s_decode",  # Decode speed (tok/s)
+        "input_len",  # Prefix cache hit tokens (= "Cached Tokens" in benchmark_serving)
+        "s_input_len",  # Infer input length (total prompt tokens)
+        "output_len",  # Output token length
+    ]
+
+    def __init__(self, args: Optional[dict] = None):
+        for key, value in self._DEFAULTS.items():
+            setattr(self, key, value)
+        if args:
+            for key, value in args.items():
+                if key in self._DEFAULTS:
+                    setattr(self, key, value)
+        self.percentile_values = [float(p.strip()) for p in self.percentiles.split(",") if p.strip()]
+        if self.metrics == "all":
+            self.selected_metrics = set(self._ALL_METRICS)
+        else:
+            self.selected_metrics = {m.strip() for m in self.metrics.split(",") if m.strip()}
+
+
 class FDConfig:
     """
     The configuration class which contains all fastdeploy-related configuration. This
@@ -1920,6 +1979,7 @@ class FDConfig:
         tool_parser: str = None,
         test_mode=False,
         routing_replay_config: Optional[RoutingReplayConfig] = None,
+        benchmark_metrics_config=None,
         deploy_modality: DeployModality = DeployModality.MIXED,
     ):
         self.model_config: ModelConfig = model_config  # type: ignore
@@ -1937,6 +1997,7 @@ class FDConfig:
         self.structured_outputs_config: StructuredOutputsConfig = structured_outputs_config
         self.router_config: RouterConfig = router_config
         self.routing_replay_config = routing_replay_config
+        self.benchmark_metrics_config = benchmark_metrics_config
         self.deploy_modality: DeployModality = deploy_modality
         # Initialize cuda graph capture list
         max_capture_shape = self.scheduler_config.max_num_seqs
@@ -2412,6 +2473,33 @@ class FDConfig:
                 raise ImportError(
                     "cuda-python not installed. Install the version matching your CUDA toolkit:\n"
                     "  CUDA 12.x → pip install cuda-python==12.*\n"
+                )
+
+        if self.benchmark_metrics_config is not None:
+            cfg = self.benchmark_metrics_config
+            assert isinstance(
+                cfg.enable, bool
+            ), f"BenchmarkMetricsConfig: 'enable' must be a bool, got {type(cfg.enable).__name__}"
+            assert (
+                isinstance(cfg.window_size, int) and cfg.window_size >= 0
+            ), f"BenchmarkMetricsConfig: 'window_size' must be a non-negative integer, got {cfg.window_size!r}"
+            assert cfg.window_mode in (
+                "sliding",
+                "tumbling",
+            ), f"BenchmarkMetricsConfig: 'window_mode' must be 'sliding' or 'tumbling', got {cfg.window_mode!r}"
+            assert (
+                isinstance(cfg.percentiles, str) and cfg.percentiles.strip()
+            ), f"BenchmarkMetricsConfig: 'percentiles' must be a non-empty string, got {cfg.percentiles!r}"
+            for p in cfg.percentile_values:
+                assert 0 <= p <= 100, f"BenchmarkMetricsConfig: percentile value {p} out of range [0, 100]"
+            assert (
+                isinstance(cfg.metrics, str) and cfg.metrics.strip()
+            ), f"BenchmarkMetricsConfig: 'metrics' must be a non-empty string, got {cfg.metrics!r}"
+            if cfg.metrics != "all":
+                invalid = cfg.selected_metrics - set(BenchmarkMetricsConfig._ALL_METRICS)
+                assert not invalid, (
+                    f"BenchmarkMetricsConfig: unknown metric(s): {invalid}. "
+                    f"Valid metrics: {BenchmarkMetricsConfig._ALL_METRICS}"
                 )
 
     def print(self):

--- a/fastdeploy/engine/args_utils.py
+++ b/fastdeploy/engine/args_utils.py
@@ -188,6 +188,10 @@ class EngineArgs:
     """
     Configuration for speculative execution.
     """
+    benchmark_metrics_config: Optional[Dict[str, Any]] = None
+    """
+    Configuration for in-process benchmark metrics logger.
+    """
     dynamic_load_weight: bool = False
     """
     dynamic load weight
@@ -854,6 +858,16 @@ class EngineArgs:
             help="Configuration for speculative execution.",
         )
         model_group.add_argument(
+            "--benchmark-metrics-config",
+            type=json.loads,
+            default=EngineArgs.benchmark_metrics_config,
+            help="Configuration for in-process benchmark metrics logger. "
+            "Pass '{}' for defaults or a JSON with keys: "
+            "window_size (int, 0=all requests), "
+            "percentiles (str, e.g. '50,90,95,99'), "
+            "metrics (str, 'all' or comma-separated subset).",
+        )
+        model_group.add_argument(
             "--dynamic-load-weight",
             action="store_true",
             default=EngineArgs.dynamic_load_weight,
@@ -1440,6 +1454,14 @@ class EngineArgs:
 
         return SpeculativeConfig(speculative_args)
 
+    def create_benchmark_metrics_config(self):
+        """Create BenchmarkMetricsConfig if --benchmark-metrics-config is provided."""
+        if self.benchmark_metrics_config is None:
+            return None
+        from fastdeploy.config import BenchmarkMetricsConfig
+
+        return BenchmarkMetricsConfig(self.benchmark_metrics_config)
+
     def create_scheduler_config(self) -> SchedulerConfig:
         """
         Create and return a SchedulerConfig object based on the current settings.
@@ -1519,6 +1541,7 @@ class EngineArgs:
             self.tensor_parallel_size = model_cfg.tensor_parallel_size
 
         speculative_cfg = self.create_speculative_config()
+        benchmark_metrics_cfg = self.create_benchmark_metrics_config()
         if not self.enable_chunked_prefill:
             if (current_platform.is_cuda() or current_platform.is_maca()) and self.splitwise_role == "mixed":
                 # default enable chunked prefill
@@ -1583,5 +1606,6 @@ class EngineArgs:
             plas_attention_config=plas_attention_config,
             early_stop_config=early_stop_cfg,
             routing_replay_config=routing_replay_config,
+            benchmark_metrics_config=benchmark_metrics_cfg,
             deploy_modality=DeployModality.from_str(self.deploy_modality),
         )

--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -212,6 +212,18 @@ class EngineService:
         self.resource_manager.scheduler_metrics_logger = self.scheduler_metrics_logger
         self.token_processor.set_scheduler_metrics_logger(self.scheduler_metrics_logger)
 
+        if self.cfg.benchmark_metrics_config is not None and self.cfg.benchmark_metrics_config.enable:
+            from fastdeploy.metrics.benchmark_metrics_logger import (
+                BenchmarkMetricsLogger,
+            )
+
+            self.benchmark_metrics_logger = BenchmarkMetricsLogger(
+                config=self.cfg.benchmark_metrics_config,
+                log_dir=envs.FD_LOG_DIR,
+                dp_rank=self.cfg.parallel_config.local_data_parallel_id,
+            )
+            self.token_processor.set_benchmark_logger(self.benchmark_metrics_logger)
+
         self.partial_chunked_tokens = [0] * (self.cfg.max_num_partial_prefills + 1)
         for idx in range(1, self.cfg.max_num_partial_prefills + 1):
             self.partial_chunked_tokens[idx] = (

--- a/fastdeploy/metrics/benchmark_metrics_logger.py
+++ b/fastdeploy/metrics/benchmark_metrics_logger.py
@@ -1,0 +1,222 @@
+"""
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
+import json
+import os
+import threading
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+import numpy as np
+
+from fastdeploy.config import BenchmarkMetricsConfig
+
+
+@dataclass(slots=True)
+class CompletedRequestRecord:
+    """Raw timing data collected when a request completes."""
+
+    request_id: str
+    completion_time: float
+    arrival_time: float
+    inference_start_time: float
+    first_token_time: float
+    last_token_time: float
+    input_len: int
+    output_len: int
+    num_cached_tokens: int = 0
+    itl_samples: list = field(default_factory=list)
+
+
+class BenchmarkMetricsLogger:
+    """
+    In-process performance monitoring that produces metrics aligned with
+    benchmark_serving.py. Uses a lock-free deque for data collection and
+    a background daemon thread for stats computation and file I/O.
+    """
+
+    def __init__(self, config: BenchmarkMetricsConfig, log_dir: str, dp_rank: int = 0):
+        self.config = config
+        self.enabled = config.enable
+        self.dp_rank = dp_rank
+
+        if config.window_mode == "sliding" and config.window_size > 0:
+            self._window: deque = deque(maxlen=config.window_size)
+        else:
+            self._window: deque = deque()
+
+        self._pending: deque = deque()
+        self._condition = threading.Condition()
+        self._stop_event = threading.Event()
+
+        os.makedirs(log_dir, exist_ok=True)
+        self._file_path = os.path.join(log_dir, "benchmark_metrics.jsonl")
+        self._file = open(self._file_path, "a", encoding="utf-8")
+
+        self._thread = threading.Thread(
+            target=self._writer_loop,
+            daemon=True,
+            name=f"BenchmarkMetricsLogger-dp{dp_rank}",
+        )
+        self._thread.start()
+
+    def on_request_completed(self, record: CompletedRequestRecord) -> None:
+        """Called from token processor on request completion. Lock-free append."""
+        self._pending.append(record)
+        with self._condition:
+            self._condition.notify()
+
+    def _writer_loop(self) -> None:
+        """Background thread: wait for new records, compute stats, write JSONL."""
+        while not self._stop_event.is_set():
+            with self._condition:
+                self._condition.wait(timeout=1.0)
+            self._process_pending()
+
+    def _process_pending(self) -> None:
+        """Process all pending records, write one JSONL line per record."""
+        while True:
+            try:
+                record = self._pending.popleft()
+            except IndexError:
+                break
+            self._window.append(record)
+            stats = self._compute_rolling_stats()
+            line = json.dumps(stats, ensure_ascii=False)
+            self._file.write(line + "\n")
+            # Tumbling window: clear after reaching window_size
+            if (
+                self.config.window_mode == "tumbling"
+                and self.config.window_size > 0
+                and len(self._window) >= self.config.window_size
+            ):
+                self._window.clear()
+        self._file.flush()
+
+    def _compute_rolling_stats(self) -> dict:
+        """Compute aggregate statistics over the current window."""
+        records = list(self._window)
+        n = len(records)
+        if n == 0:
+            return {"timestamp": datetime.now().isoformat(), "completed": 0}
+
+        selected = self.config.selected_metrics
+        percentile_values = self.config.percentile_values
+
+        ttfts = []
+        s_ttfts = []
+        tpots = []
+        all_itls = []
+        e2els = []
+        s_e2els = []
+        decode_speeds = []
+        input_lens = []
+        s_input_lens = []
+        output_lens = []
+
+        for r in records:
+            if r.first_token_time and r.arrival_time:
+                ttfts.append((r.first_token_time - r.arrival_time) * 1000)
+            if r.first_token_time and r.inference_start_time:
+                s_ttfts.append((r.first_token_time - r.inference_start_time) * 1000)
+            if r.output_len > 1 and r.first_token_time and r.arrival_time:
+                e2el_s = r.last_token_time - r.arrival_time
+                ttft_s = r.first_token_time - r.arrival_time
+                tpots.append(((e2el_s - ttft_s) / (r.output_len - 1)) * 1000)
+            if r.itl_samples:
+                all_itls.extend([x * 1000 for x in r.itl_samples])
+            if r.last_token_time and r.arrival_time:
+                e2els.append((r.last_token_time - r.arrival_time) * 1000)
+            if r.last_token_time and r.inference_start_time:
+                s_e2els.append((r.last_token_time - r.inference_start_time) * 1000)
+            if r.output_len > 1 and r.first_token_time and r.last_token_time:
+                decode_time = r.last_token_time - r.first_token_time
+                if decode_time > 0:
+                    decode_speeds.append((r.output_len - 1) / decode_time)
+            input_lens.append(r.num_cached_tokens)
+            s_input_lens.append(r.input_len)
+            output_lens.append(r.output_len)
+
+        # Throughput: based on window time span
+        total_input = sum(s_input_lens)
+        total_output = sum(output_lens)
+        if n >= 2:
+            duration = records[-1].completion_time - records[0].arrival_time
+        else:
+            duration = 0.0
+
+        result: dict[str, Any] = {
+            "timestamp": datetime.now().isoformat(),
+            "window_size": self.config.window_size,
+            "window_mode": self.config.window_mode,
+            "completed": n,
+            "total_input_tokens": total_input,
+            "total_output_tokens": total_output,
+        }
+
+        if duration > 0:
+            result["request_throughput"] = round(n / duration, 2)
+            result["output_throughput"] = round(total_output / duration, 2)
+            result["total_throughput"] = round((total_input + total_output) / duration, 2)
+
+        if "ttft" in selected:
+            result["ttft_ms"] = self._stats(ttfts, percentile_values)
+        if "s_ttft" in selected:
+            result["s_ttft_ms"] = self._stats(s_ttfts, percentile_values)
+        if "tpot" in selected:
+            result["tpot_ms"] = self._stats(tpots, percentile_values)
+        if "s_itl" in selected:
+            result["s_itl_ms"] = self._stats(all_itls, percentile_values)
+        if "e2el" in selected:
+            result["e2el_ms"] = self._stats(e2els, percentile_values)
+        if "s_e2el" in selected:
+            result["s_e2el_ms"] = self._stats(s_e2els, percentile_values)
+        if "s_decode" in selected:
+            result["s_decode"] = self._stats(decode_speeds, percentile_values)
+        if "input_len" in selected:
+            result["input_len"] = self._stats(input_lens, percentile_values)
+        if "s_input_len" in selected:
+            result["s_input_len"] = self._stats(s_input_lens, percentile_values)
+        if "output_len" in selected:
+            result["output_len"] = self._stats(output_lens, percentile_values)
+
+        return result
+
+    @staticmethod
+    def _stats(values: list, percentiles: list[float]) -> dict:
+        """Compute mean/median/percentiles for a list of values."""
+        if not values:
+            return {}
+        arr = np.array(values)
+        result = {
+            "mean": round(float(np.mean(arr)), 2),
+            "median": round(float(np.median(arr)), 2),
+        }
+        for p in percentiles:
+            key = f"p{int(p)}" if int(p) == p else f"p{p}"
+            result[key] = round(float(np.percentile(arr, p)), 2)
+        return result
+
+    def shutdown(self) -> None:
+        """Stop the writer thread and close the file."""
+        self._stop_event.set()
+        with self._condition:
+            self._condition.notify()
+        self._thread.join(timeout=5)
+        self._process_pending()
+        self._file.close()

--- a/fastdeploy/output/token_processor.py
+++ b/fastdeploy/output/token_processor.py
@@ -74,6 +74,7 @@ class TokenProcessor:
         self.cached_generated_tokens = cached_generated_tokens
         self.resource_manager = None
         self.scheduler_metrics_logger = None
+        self._benchmark_logger = None
         self.engine_worker_queue = engine_worker_queue
         self.tokens_counter = Counter()
         self.split_connector = split_connector
@@ -173,6 +174,9 @@ class TokenProcessor:
 
     def set_scheduler_metrics_logger(self, scheduler_metrics_logger):
         self.scheduler_metrics_logger = scheduler_metrics_logger
+
+    def set_benchmark_logger(self, benchmark_logger):
+        self._benchmark_logger = benchmark_logger
 
     def _is_decode_stage(self, task):
         if task is None:
@@ -1097,6 +1101,10 @@ class TokenProcessor:
         if hasattr(task, "last_token_time") and task.last_token_time is not None:
             token_gen_time = current_time - task.last_token_time
             main_process_metrics.time_per_output_token.observe(token_gen_time)
+            if self._benchmark_logger:
+                if not hasattr(task, "_itl_samples"):
+                    task._itl_samples = []
+                task._itl_samples.append(token_gen_time)
         task.last_token_time = current_time
 
         # Record generation metrics
@@ -1131,6 +1139,25 @@ class TokenProcessor:
         main_process_metrics.request_success_total.inc()
         main_process_metrics.request_inference_time.observe(current_time - metrics.inference_start_time)
         main_process_metrics.request_generation_tokens.observe(self.tokens_counter[task.request_id])
+
+        if self._benchmark_logger:
+            from fastdeploy.metrics.benchmark_metrics_logger import (
+                CompletedRequestRecord,
+            )
+
+            record = CompletedRequestRecord(
+                request_id=task.request_id,
+                completion_time=current_time,
+                arrival_time=metrics.arrival_time or 0.0,
+                inference_start_time=metrics.inference_start_time or 0.0,
+                first_token_time=metrics.engine_recv_first_token_time or 0.0,
+                last_token_time=metrics.engine_recv_latest_token_time or current_time,
+                input_len=getattr(task, "prompt_token_ids_len", 0) or 0,
+                output_len=self.tokens_counter[task.request_id],
+                num_cached_tokens=getattr(task, "num_cached_tokens", 0) or 0,
+                itl_samples=getattr(task, "_itl_samples", []),
+            )
+            self._benchmark_logger.on_request_completed(record)
 
     def _record_speculative_decoding_metrics(self, accept_num):
         """Record metrics of speculative decoding"""

--- a/tests/metrics/test_benchmark_metrics_logger.py
+++ b/tests/metrics/test_benchmark_metrics_logger.py
@@ -366,3 +366,134 @@ def test_invalid_metrics_unknown(mock_envs):
     fd_cfg = _make_fd_config_with_benchmark(benchmark_cfg)
     with pytest.raises(AssertionError, match="unknown metric"):
         fd_cfg.check()
+
+
+# ============================================================
+# Direct method tests (bypass daemon thread for coverage)
+# ============================================================
+
+
+def test_process_pending_direct(tmp_path):
+    """Directly call _process_pending to cover lines 98-109."""
+    config = BenchmarkMetricsConfig({"enable": True, "window_size": 0, "metrics": "all", "percentiles": "50,99"})
+    logger = BenchmarkMetricsLogger(config=config, log_dir=str(tmp_path), dp_rank=0)
+
+    now = time.time()
+    # Add records directly to _pending without relying on background thread
+    for i in range(3):
+        logger._pending.append(_make_record(f"req-{i}", now, i * 0.5))
+
+    # Call _process_pending directly from main thread (coverage-tracked)
+    logger._process_pending()
+
+    assert len(logger._window) == 3
+    logger.shutdown()
+
+    jsonl_path = os.path.join(str(tmp_path), "benchmark_metrics.jsonl")
+    with open(jsonl_path) as f:
+        lines = f.readlines()
+    assert len(lines) == 3
+    rec = json.loads(lines[-1])
+    assert rec["completed"] == 3
+    assert "ttft_ms" in rec
+    assert "tpot_ms" in rec
+    assert "e2el_ms" in rec
+    assert "s_ttft_ms" in rec
+    assert "s_e2el_ms" in rec
+    assert "s_decode" in rec
+    assert "input_len" in rec
+    assert "s_input_len" in rec
+    assert "output_len" in rec
+    assert "request_throughput" in rec
+    assert "output_throughput" in rec
+    assert "total_throughput" in rec
+
+
+def test_process_pending_tumbling_clear(tmp_path):
+    """Tumbling window clears after reaching window_size via direct call."""
+    config = BenchmarkMetricsConfig(
+        {"enable": True, "window_size": 2, "window_mode": "tumbling", "metrics": "ttft", "percentiles": "50"}
+    )
+    logger = BenchmarkMetricsLogger(config=config, log_dir=str(tmp_path), dp_rank=0)
+
+    now = time.time()
+    for i in range(3):
+        logger._pending.append(_make_record(f"req-{i}", now, i * 0.5))
+
+    logger._process_pending()
+
+    # After 3 records with window_size=2: first 2 fill window then clear, 3rd starts fresh
+    assert len(logger._window) == 1
+    logger.shutdown()
+
+
+def test_compute_rolling_stats_empty_window(tmp_path):
+    """_compute_rolling_stats with empty window returns minimal result."""
+    config = BenchmarkMetricsConfig({"enable": True, "window_size": 0, "metrics": "all", "percentiles": "50"})
+    logger = BenchmarkMetricsLogger(config=config, log_dir=str(tmp_path), dp_rank=0)
+
+    result = logger._compute_rolling_stats()
+    assert result["completed"] == 0
+    logger.shutdown()
+
+
+def test_compute_rolling_stats_single_record(tmp_path):
+    """Single record: no throughput, no tpot (needs output_len > 1 check)."""
+    config = BenchmarkMetricsConfig({"enable": True, "window_size": 0, "metrics": "all", "percentiles": "50,99"})
+    logger = BenchmarkMetricsLogger(config=config, log_dir=str(tmp_path), dp_rank=0)
+
+    now = time.time()
+    # output_len=1 means tpot and decode_speed won't be computed
+    logger._window.append(
+        CompletedRequestRecord(
+            request_id="r1",
+            completion_time=now,
+            arrival_time=now - 0.05,
+            inference_start_time=now - 0.04,
+            first_token_time=now - 0.02,
+            last_token_time=now,
+            input_len=100,
+            output_len=1,
+            itl_samples=[],
+        )
+    )
+
+    result = logger._compute_rolling_stats()
+    assert result["completed"] == 1
+    assert "request_throughput" not in result  # duration=0 for single record
+    assert result["ttft_ms"]["mean"] > 0
+    assert result["tpot_ms"] == {}  # no tpot with output_len=1
+    assert result["s_itl_ms"] == {}  # no itl samples
+    logger.shutdown()
+
+
+def test_compute_rolling_stats_multiple_records(tmp_path):
+    """Multiple records: throughput and all metrics computed."""
+    config = BenchmarkMetricsConfig({"enable": True, "window_size": 0, "metrics": "all", "percentiles": "50,95"})
+    logger = BenchmarkMetricsLogger(config=config, log_dir=str(tmp_path), dp_rank=0)
+
+    now = time.time()
+    for i in range(3):
+        logger._window.append(_make_record(f"req-{i}", now, i * 0.5))
+
+    result = logger._compute_rolling_stats()
+    assert result["completed"] == 3
+    assert result["request_throughput"] > 0
+    assert result["output_throughput"] > 0
+    assert result["total_throughput"] > 0
+    assert result["ttft_ms"]["mean"] > 0
+    assert result["s_ttft_ms"]["mean"] > 0
+    assert result["tpot_ms"]["mean"] > 0
+    assert result["s_itl_ms"]["mean"] > 0
+    assert result["e2el_ms"]["mean"] > 0
+    assert result["s_e2el_ms"]["mean"] > 0
+    assert result["s_decode"]["mean"] > 0
+    assert "p50" in result["ttft_ms"]
+    assert "p95" in result["ttft_ms"]
+    logger.shutdown()
+
+
+def test_stats_with_float_percentile():
+    """Percentile key uses float format when not integer."""
+    stats = BenchmarkMetricsLogger._stats([1.0, 2.0, 3.0], [99.9])
+    assert "p99.9" in stats

--- a/tests/metrics/test_benchmark_metrics_logger.py
+++ b/tests/metrics/test_benchmark_metrics_logger.py
@@ -1,0 +1,368 @@
+"""
+Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+import os
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fastdeploy.config import BenchmarkMetricsConfig, FDConfig
+from fastdeploy.metrics.benchmark_metrics_logger import (
+    BenchmarkMetricsLogger,
+    CompletedRequestRecord,
+)
+
+
+def _make_record(request_id, now, offset, input_len=100, output_len=50):
+    return CompletedRequestRecord(
+        request_id=request_id,
+        completion_time=now + offset,
+        arrival_time=now + offset - 0.05,
+        inference_start_time=now + offset - 0.04,
+        first_token_time=now + offset - 0.02,
+        last_token_time=now + offset,
+        input_len=input_len,
+        output_len=output_len,
+        itl_samples=[0.02, 0.021, 0.019],
+    )
+
+
+def test_config_defaults():
+    config = BenchmarkMetricsConfig(None)
+    assert config.enable is False
+    assert config.window_size == 0
+    assert config.window_mode == "sliding"
+    assert config.percentile_values == [50.0, 90.0, 95.0, 99.0]
+    assert config.selected_metrics == set(BenchmarkMetricsConfig._ALL_METRICS)
+
+
+def test_config_custom():
+    config = BenchmarkMetricsConfig(
+        {"enable": True, "window_size": 200, "window_mode": "tumbling", "percentiles": "50,99", "metrics": "ttft,e2el"}
+    )
+    assert config.enable is True
+    assert config.window_size == 200
+    assert config.window_mode == "tumbling"
+    assert config.percentile_values == [50.0, 99.0]
+    assert config.selected_metrics == {"ttft", "e2el"}
+
+
+def test_config_empty_dict():
+    config = BenchmarkMetricsConfig({})
+    assert config.enable is False
+    assert config.window_size == 0
+    assert config.window_mode == "sliding"
+    assert config.percentile_values == [50.0, 90.0, 95.0, 99.0]
+
+
+def test_config_enable_only():
+    config = BenchmarkMetricsConfig({"enable": True})
+    assert config.enable is True
+    assert config.window_mode == "sliding"
+
+
+def test_logger_writes_jsonl(tmp_path):
+    config = BenchmarkMetricsConfig({"enable": True, "window_size": 0, "percentiles": "50,99", "metrics": "ttft,e2el"})
+    log_dir = str(tmp_path)
+    logger = BenchmarkMetricsLogger(config=config, log_dir=log_dir, dp_rank=0)
+
+    now = time.time()
+    for i in range(5):
+        logger.on_request_completed(_make_record(f"req-{i}", now, i * 0.1))
+
+    time.sleep(0.5)
+    logger.shutdown()
+
+    jsonl_path = os.path.join(log_dir, "benchmark_metrics.jsonl")
+    assert os.path.exists(jsonl_path)
+
+    with open(jsonl_path) as f:
+        lines = f.readlines()
+
+    assert len(lines) == 5
+
+    last_record = json.loads(lines[-1])
+    assert last_record["completed"] == 5
+    assert "ttft_ms" in last_record
+    assert "e2el_ms" in last_record
+    assert "tpot_ms" not in last_record
+    assert last_record["ttft_ms"]["mean"] > 0
+
+
+def test_logger_sliding_window(tmp_path):
+    """Sliding window: keeps the last N records, never clears."""
+    config = BenchmarkMetricsConfig(
+        {"enable": True, "window_size": 3, "window_mode": "sliding", "percentiles": "50", "metrics": "all"}
+    )
+    log_dir = str(tmp_path)
+    logger = BenchmarkMetricsLogger(config=config, log_dir=log_dir, dp_rank=0)
+
+    now = time.time()
+    for i in range(5):
+        logger.on_request_completed(_make_record(f"req-{i}", now, i))
+
+    time.sleep(0.5)
+    logger.shutdown()
+
+    jsonl_path = os.path.join(log_dir, "benchmark_metrics.jsonl")
+    with open(jsonl_path) as f:
+        lines = f.readlines()
+
+    assert len(lines) == 5
+
+    # After 5 records with window_size=3, the window always has at most 3
+    rec3 = json.loads(lines[2])  # 3rd record: window full (3 records)
+    assert rec3["completed"] == 3
+
+    rec4 = json.loads(lines[3])  # 4th record: still 3 (oldest dropped)
+    assert rec4["completed"] == 3
+
+    last_record = json.loads(lines[-1])
+    assert last_record["completed"] == 3
+    assert last_record["window_size"] == 3
+    assert last_record["window_mode"] == "sliding"
+
+
+def test_logger_tumbling_window(tmp_path):
+    """Tumbling window: clears after reaching window_size, then restarts."""
+    config = BenchmarkMetricsConfig(
+        {"enable": True, "window_size": 3, "window_mode": "tumbling", "percentiles": "50", "metrics": "all"}
+    )
+    log_dir = str(tmp_path)
+    logger = BenchmarkMetricsLogger(config=config, log_dir=log_dir, dp_rank=0)
+
+    now = time.time()
+    for i in range(5):
+        logger.on_request_completed(_make_record(f"req-{i}", now, i))
+
+    time.sleep(0.5)
+    logger.shutdown()
+
+    jsonl_path = os.path.join(log_dir, "benchmark_metrics.jsonl")
+    with open(jsonl_path) as f:
+        lines = f.readlines()
+
+    assert len(lines) == 5
+
+    # Records 1,2,3 accumulate then clear; records 4,5 start fresh
+    rec1 = json.loads(lines[0])
+    assert rec1["completed"] == 1
+
+    rec3 = json.loads(lines[2])  # 3rd record: window full (3 records), then clears
+    assert rec3["completed"] == 3
+
+    rec4 = json.loads(lines[3])  # 4th record: window restarted, 1 record
+    assert rec4["completed"] == 1
+
+    rec5 = json.loads(lines[4])  # 5th record: 2 records in new window
+    assert rec5["completed"] == 2
+    assert rec5["window_mode"] == "tumbling"
+
+
+def test_logger_no_output_when_no_requests(tmp_path):
+    config = BenchmarkMetricsConfig({"enable": True})
+    log_dir = str(tmp_path)
+    logger = BenchmarkMetricsLogger(config=config, log_dir=log_dir, dp_rank=0)
+
+    time.sleep(0.3)
+    logger.shutdown()
+
+    jsonl_path = os.path.join(log_dir, "benchmark_metrics.jsonl")
+    assert os.path.exists(jsonl_path)
+    with open(jsonl_path) as f:
+        content = f.read()
+    assert content == ""
+
+
+def test_logger_enabled_flag(tmp_path):
+    """Logger with enable=False should have enabled=False."""
+    config = BenchmarkMetricsConfig({"enable": False})
+    log_dir = str(tmp_path)
+    logger = BenchmarkMetricsLogger(config=config, log_dir=log_dir, dp_rank=0)
+    assert logger.enabled is False
+    logger.shutdown()
+
+
+def test_logger_enabled_true(tmp_path):
+    """Logger with enable=True should have enabled=True."""
+    config = BenchmarkMetricsConfig({"enable": True})
+    log_dir = str(tmp_path)
+    logger = BenchmarkMetricsLogger(config=config, log_dir=log_dir, dp_rank=0)
+    assert logger.enabled is True
+    logger.shutdown()
+
+
+def test_stats_computation():
+    stats = BenchmarkMetricsLogger._stats([10.0, 20.0, 30.0, 40.0, 50.0], [50.0, 99.0])
+    assert stats["mean"] == 30.0
+    assert stats["median"] == 30.0
+    assert "p50" in stats
+    assert "p99" in stats
+    assert stats["p50"] == 30.0
+
+
+def test_stats_empty_list():
+    stats = BenchmarkMetricsLogger._stats([], [50.0])
+    assert stats == {}
+
+
+def test_throughput_in_output(tmp_path):
+    """Throughput fields should appear when there are 2+ records."""
+    config = BenchmarkMetricsConfig({"enable": True, "window_size": 0, "percentiles": "50", "metrics": "ttft"})
+    log_dir = str(tmp_path)
+    logger = BenchmarkMetricsLogger(config=config, log_dir=log_dir, dp_rank=0)
+
+    now = time.time()
+    for i in range(3):
+        logger.on_request_completed(_make_record(f"req-{i}", now, i * 0.5))
+
+    time.sleep(0.5)
+    logger.shutdown()
+
+    jsonl_path = os.path.join(log_dir, "benchmark_metrics.jsonl")
+    with open(jsonl_path) as f:
+        lines = f.readlines()
+
+    # First record has no throughput (only 1 sample, duration=0)
+    rec1 = json.loads(lines[0])
+    assert "request_throughput" not in rec1
+
+    # Last record should have throughput
+    last = json.loads(lines[-1])
+    assert "request_throughput" in last
+    assert "output_throughput" in last
+    assert "total_throughput" in last
+    assert last["request_throughput"] > 0
+
+
+# ============================================================
+# Validation tests (via FDConfig.check())
+# ============================================================
+
+
+def _make_fd_config_with_benchmark(benchmark_cfg):
+    """Create a mock FDConfig with valid base attributes, only benchmark_metrics_config is real."""
+    cfg = object.__new__(FDConfig)
+    # Mock all attributes accessed by check() before benchmark validation
+    cfg.scheduler_config = MagicMock()
+    cfg.scheduler_config.max_num_seqs = 128
+    cfg.scheduler_config.max_num_batched_tokens = 8192
+    cfg.scheduler_config.splitwise_role = "mixed"
+    cfg.scheduler_config.check = MagicMock()
+    cfg.model_config = MagicMock()
+    cfg.model_config.max_model_len = 8192
+    cfg.cache_config = MagicMock()
+    cfg.cache_config.enable_chunked_prefill = True
+    cfg.cache_config.block_size = 64
+    cfg.speculative_config = None
+    cfg.eplb_config = None
+    cfg.structured_outputs_config = None
+    cfg.graph_opt_config = MagicMock()
+    cfg.graph_opt_config.graph_opt_level = 0
+    cfg.nnode = 1
+    cfg.max_num_partial_prefills = 1
+    cfg.max_long_partial_prefills = 1
+    cfg.long_prefill_token_threshold = 0
+    cfg.benchmark_metrics_config = benchmark_cfg
+    return cfg
+
+
+@patch("fastdeploy.config.envs")
+def test_valid_config_passes_check(mock_envs):
+    """Valid configs should pass FDConfig.check() without errors."""
+    mock_envs.ENABLE_V1_KVCACHE_SCHEDULER = 0
+    configs = [
+        {"enable": True},
+        {"enable": True, "window_size": 64, "window_mode": "tumbling"},
+        {"enable": False, "window_size": 0, "window_mode": "sliding"},
+        {"enable": True, "percentiles": "50,90,99", "metrics": "ttft,e2el,s_decode"},
+    ]
+    for args in configs:
+        benchmark_cfg = BenchmarkMetricsConfig(args)
+        fd_cfg = _make_fd_config_with_benchmark(benchmark_cfg)
+        fd_cfg.check()  # Should not raise
+
+
+@patch("fastdeploy.config.envs")
+def test_invalid_enable(mock_envs):
+    """enable must be a bool."""
+    mock_envs.ENABLE_V1_KVCACHE_SCHEDULER = 0
+    benchmark_cfg = BenchmarkMetricsConfig({"enable": "true"})
+    fd_cfg = _make_fd_config_with_benchmark(benchmark_cfg)
+    with pytest.raises(AssertionError, match="'enable' must be a bool"):
+        fd_cfg.check()
+
+
+@patch("fastdeploy.config.envs")
+def test_invalid_window_size_negative(mock_envs):
+    """window_size must be non-negative."""
+    mock_envs.ENABLE_V1_KVCACHE_SCHEDULER = 0
+    benchmark_cfg = BenchmarkMetricsConfig({"enable": True, "window_size": -1})
+    fd_cfg = _make_fd_config_with_benchmark(benchmark_cfg)
+    with pytest.raises(AssertionError, match="'window_size' must be a non-negative integer"):
+        fd_cfg.check()
+
+
+@patch("fastdeploy.config.envs")
+def test_invalid_window_size_type(mock_envs):
+    """window_size must be an integer."""
+    mock_envs.ENABLE_V1_KVCACHE_SCHEDULER = 0
+    benchmark_cfg = BenchmarkMetricsConfig({"enable": True, "window_size": 3.5})
+    fd_cfg = _make_fd_config_with_benchmark(benchmark_cfg)
+    with pytest.raises(AssertionError, match="'window_size' must be a non-negative integer"):
+        fd_cfg.check()
+
+
+@patch("fastdeploy.config.envs")
+def test_invalid_window_mode(mock_envs):
+    """window_mode must be 'sliding' or 'tumbling'."""
+    mock_envs.ENABLE_V1_KVCACHE_SCHEDULER = 0
+    benchmark_cfg = BenchmarkMetricsConfig({"enable": True, "window_mode": "fixed"})
+    fd_cfg = _make_fd_config_with_benchmark(benchmark_cfg)
+    with pytest.raises(AssertionError, match="'window_mode' must be 'sliding' or 'tumbling'"):
+        fd_cfg.check()
+
+
+@patch("fastdeploy.config.envs")
+def test_invalid_percentile_out_of_range(mock_envs):
+    """Percentile values must be in [0, 100]."""
+    mock_envs.ENABLE_V1_KVCACHE_SCHEDULER = 0
+    benchmark_cfg = BenchmarkMetricsConfig({"enable": True, "percentiles": "50,101"})
+    fd_cfg = _make_fd_config_with_benchmark(benchmark_cfg)
+    with pytest.raises(AssertionError, match="percentile value .* out of range"):
+        fd_cfg.check()
+
+
+@patch("fastdeploy.config.envs")
+def test_invalid_percentile_negative(mock_envs):
+    """Percentile values must be >= 0."""
+    mock_envs.ENABLE_V1_KVCACHE_SCHEDULER = 0
+    benchmark_cfg = BenchmarkMetricsConfig({"enable": True, "percentiles": "-1,50"})
+    fd_cfg = _make_fd_config_with_benchmark(benchmark_cfg)
+    with pytest.raises(AssertionError, match="percentile value .* out of range"):
+        fd_cfg.check()
+
+
+@patch("fastdeploy.config.envs")
+def test_invalid_metrics_unknown(mock_envs):
+    """Unknown metric names should fail validation."""
+    mock_envs.ENABLE_V1_KVCACHE_SCHEDULER = 0
+    benchmark_cfg = BenchmarkMetricsConfig({"enable": True, "metrics": "ttft,unknown_metric"})
+    fd_cfg = _make_fd_config_with_benchmark(benchmark_cfg)
+    with pytest.raises(AssertionError, match="unknown metric"):
+        fd_cfg.check()

--- a/tests/output/test_process_batch_output.py
+++ b/tests/output/test_process_batch_output.py
@@ -168,6 +168,7 @@ class TestTokenProcessorProcessBatchOutput(unittest.TestCase):
         processor.total_step_per_request = {}
         processor.accept_token_num_per_head_per_request = {}
         processor.accept_token_num_per_head = [0] * MAX_DRAFT_TOKENS
+        processor._benchmark_logger = None
 
         # processor._recycle_resources = Mock()
 


### PR DESCRIPTION
## Motivation
为 FastDeploy 添加进程内性能监控模块（Benchmark Metrics Logger），在推理进程内部实时采集每请求延迟数据，以滑动窗口或翻滚窗口模式计算聚合统计指标（TTFT、TPOT、E2EL、吞吐量等），写入 JSONL 文件供实时监控与事后分析，无需依赖外部 benchmark 工具。

## Modifications
- `fastdeploy/config.py`：新增 `BenchmarkMetricsConfig` 配置类；在 `FDConfig` 中添加 `benchmark_metrics_config` 字段，并在 `FDConfig.check()` 中补充参数合法性校验
- `fastdeploy/engine/args_utils.py`：新增 `--benchmark-metrics-config` CLI 参数及 `create_benchmark_metrics_config()` 方法
- `fastdeploy/engine/common_engine.py`：引擎初始化时按配置实例化 `BenchmarkMetricsLogger` 并注入 `token_processor`
- `fastdeploy/metrics/benchmark_metrics_logger.py`：新增 `BenchmarkMetricsLogger`，后台 daemon 线程 + deque 窗口，支持滑动/翻滚两种模式
- `fastdeploy/output/token_processor.py`：在 `_record_metrics` 中收集 ITL 样本，在 `_record_completion_metrics` 中组装 `CompletedRequestRecord` 并回调 logger
- `docs/benchmark.md` / `docs/zh/benchmark.md`：新增进程内监控模块中英文文档

## Usage or Command
python -m fastdeploy.entrypoints.openai.api_server \
       --model baidu/ERNIE-4.5-0.3B-Base-Paddle \
       --benchmark-metrics-config '{"enable": true, "window_size": 64, "window_mode": "sliding"}'

查看最新统计快照：tail -1 log/benchmark_metrics.jsonl | python -m json.tool

## Accuracy Tests
N/A（本 PR 为性能监控功能，不涉及模型前向推理逻辑变更，不影响模型输出精度）

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.