### PR TITLE
[Scheduler] Defer block recycling to accelerate LRU node freeing

### DIFF
--- a/fastdeploy/cache_manager/prefix_cache_manager.py
+++ b/fastdeploy/cache_manager/prefix_cache_manager.py
@@ -1338,20 +1338,23 @@ class PrefixCacheManager:
                     logger.error(f"free_nodes_directly: error: {type(e)} {e}, {traceback.format_exc()}")
                     raise e
 
-    def _handle_free_gpu_node_without_cpu(self, node):
+    def _handle_free_gpu_node_without_cpu(self, node, defer_recycle=False):
         """
         GPU node eviction
         """
-        node.cache_status = CacheStatus.CPU
-
         self.node_id_pool.append(node.node_id)
         if node.node_id in self.node_map:
             del self.node_map[node.node_id]
-        logger.info(f"free_block_ids_async: free node {node}")
+        logger.info(f"_handle_free_gpu_node_without_cpu: free node {node.node_id}")
 
-        self.recycle_gpu_blocks(node.reverved_dec_block_ids)
-        node.reverved_dec_block_ids = []
-        self.recycle_gpu_blocks(node.block_id)
+        blocks_to_recycle = list(node.reverved_dec_block_ids) + [node.block_id]
+        if not defer_recycle:
+            self.recycle_gpu_blocks(blocks_to_recycle)
+            logger.info(f"_handle_free_gpu_node_without_cpu: recycle blocks for node {node.node_id}, {blocks_to_recycle}")
+            return []
+        else:
+            return blocks_to_recycle
+
 
     def _handle_free_gpu_node_with_cpu(
         self,
@@ -1447,6 +1450,9 @@ class PrefixCacheManager:
                 hash_value_flush_info = {}  # {input_hash_value: (token_ids, min_depth)}
                 total_gpu_free_count = 0
 
+                # Defer block recycling to avoid busy heap operations in loop
+                blocks_deferred_to_recycle = []
+
                 while True:
                     if len(self.gpu_lru_leaf_heap) == 0:
                         logger.info("free_block_ids_async: no more gpu leaf node available.")
@@ -1461,24 +1467,28 @@ class PrefixCacheManager:
                                 key = node.input_hash_value
                                 if key not in hash_value_flush_info or node.depth < hash_value_flush_info[key][1]:
                                     hash_value_flush_info[key] = (node.input_ids, node.depth)
-                            self._handle_free_gpu_node_without_cpu(node)
+                            blocks_deferred_to_recycle.extend(self._handle_free_gpu_node_without_cpu(node, defer_recycle=True))
                             total_gpu_free_count += 1
-                            cur_node = node
-                            node = node.parent
-                            if cur_node.hash_value in node.children:
-                                del node.children[cur_node.hash_value]
-                            if not node.children:
-                                if node in self.gpu_lru_leaf_set:
+
+                            # Disconnect node from its parent node
+                            parent = node.parent
+                            if node.hash_value in parent.children:
+                                del parent.children[node.hash_value]
+                            
+                            if not parent.children:
+                                if parent in self.gpu_lru_leaf_set:
+                                    logger.warning(f"Node {parent.node_id} is already in gpu lru leaf heap, duplicated node free may occured!")
                                     continue
                                 if (
-                                    node != self.radix_tree_root
-                                    and node.shared_count == 0
-                                    and node.is_gpu_leaf_node
-                                    and node.is_persistent is False
+                                    parent != self.radix_tree_root
+                                    and parent.shared_count == 0
+                                    and parent.is_gpu_leaf_node
+                                    and parent.is_persistent is False
                                 ):
-                                    heapq.heappush(self.gpu_lru_leaf_heap, node)
-                                    self.gpu_lru_leaf_set.add(node)
+                                    heapq.heappush(self.gpu_lru_leaf_heap, parent)
+                                    self.gpu_lru_leaf_set.add(parent)
                         else:
+                            logger.warning(f"Node {node.node_id} popped out of gpu lru leaf heap, but its shared count is not zero.")
                             continue
                     else:
                         if node.shared_count == 0 and node.is_gpu_leaf_node:
@@ -1509,6 +1519,10 @@ class PrefixCacheManager:
                 logger.info(
                     f"free_block_ids_async: need_block_num {need_block_num}, free_block_num {total_gpu_free_count}."
                 )
+
+                if blocks_deferred_to_recycle:
+                    self.recycle_gpu_blocks(blocks_deferred_to_recycle)
+                    logger.info(f"free_block_ids_async: deferred recycling {len(blocks_deferred_to_recycle)} blocks, {blocks_deferred_to_recycle}")
 
                 if (
                     envs.FD_AS_ONLY_FLUSH

--- a/fastdeploy/cache_manager/prefix_cache_manager.py
+++ b/fastdeploy/cache_manager/prefix_cache_manager.py
@@ -1350,11 +1350,12 @@ class PrefixCacheManager:
         blocks_to_recycle = list(node.reverved_dec_block_ids) + [node.block_id]
         if not defer_recycle:
             self.recycle_gpu_blocks(blocks_to_recycle)
-            logger.info(f"_handle_free_gpu_node_without_cpu: recycle blocks for node {node.node_id}, {blocks_to_recycle}")
+            logger.info(
+                f"_handle_free_gpu_node_without_cpu: recycle blocks for node {node.node_id}, {blocks_to_recycle}"
+            )
             return []
         else:
             return blocks_to_recycle
-
 
     def _handle_free_gpu_node_with_cpu(
         self,
@@ -1467,17 +1468,21 @@ class PrefixCacheManager:
                                 key = node.input_hash_value
                                 if key not in hash_value_flush_info or node.depth < hash_value_flush_info[key][1]:
                                     hash_value_flush_info[key] = (node.input_ids, node.depth)
-                            blocks_deferred_to_recycle.extend(self._handle_free_gpu_node_without_cpu(node, defer_recycle=True))
+                            blocks_deferred_to_recycle.extend(
+                                self._handle_free_gpu_node_without_cpu(node, defer_recycle=True)
+                            )
                             total_gpu_free_count += 1
 
                             # Disconnect node from its parent node
                             parent = node.parent
                             if node.hash_value in parent.children:
                                 del parent.children[node.hash_value]
-                            
+
                             if not parent.children:
                                 if parent in self.gpu_lru_leaf_set:
-                                    logger.warning(f"Node {parent.node_id} is already in gpu lru leaf heap, duplicated node free may occured!")
+                                    logger.warning(
+                                        f"Node {parent.node_id} is already in gpu lru leaf heap, duplicated node free may occured!"
+                                    )
                                     continue
                                 if (
                                     parent != self.radix_tree_root
@@ -1488,7 +1493,9 @@ class PrefixCacheManager:
                                     heapq.heappush(self.gpu_lru_leaf_heap, parent)
                                     self.gpu_lru_leaf_set.add(parent)
                         else:
-                            logger.warning(f"Node {node.node_id} popped out of gpu lru leaf heap, but its shared count is not zero.")
+                            logger.warning(
+                                f"Node {node.node_id} popped out of gpu lru leaf heap, but its shared count is not zero."
+                            )
                             continue
                     else:
                         if node.shared_count == 0 and node.is_gpu_leaf_node:
@@ -1522,7 +1529,9 @@ class PrefixCacheManager:
 
                 if blocks_deferred_to_recycle:
                     self.recycle_gpu_blocks(blocks_deferred_to_recycle)
-                    logger.info(f"free_block_ids_async: deferred recycling {len(blocks_deferred_to_recycle)} blocks, {blocks_deferred_to_recycle}")
+                    logger.info(
+                        f"free_block_ids_async: deferred recycling {len(blocks_deferred_to_recycle)} blocks, {blocks_deferred_to_recycle}"
+                    )
 
                 if (
                     envs.FD_AS_ONLY_FLUSH

--- a/fastdeploy/cache_manager/prefix_cache_manager.py
+++ b/fastdeploy/cache_manager/prefix_cache_manager.py
@@ -1342,12 +1342,15 @@ class PrefixCacheManager:
         """
         GPU node eviction
         """
+        node.cache_status = CacheStatus.CPU
+
         self.node_id_pool.append(node.node_id)
         if node.node_id in self.node_map:
             del self.node_map[node.node_id]
         logger.info(f"_handle_free_gpu_node_without_cpu: free node {node.node_id}")
 
         blocks_to_recycle = list(node.reverved_dec_block_ids) + [node.block_id]
+        node.reverved_dec_block_ids = []
         if not defer_recycle:
             self.recycle_gpu_blocks(blocks_to_recycle)
             logger.info(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

In the LRU eviction loop of `free_block_ids_async`, each iteration calls `recycle_gpu_blocks` individually, which causes frequent heap operations and slows down the overall freeing process. This PR defers block recycling to a single batch call after the loop completes.

## Modifications

<!-- Detail the changes made in this pull request. -->

- **Defer block recycling in LRU loop**: Introduce `blocks_deferred_to_recycle` list in `free_block_ids_async`. Instead of calling `recycle_gpu_blocks` per node inside the while-loop, blocks are appended to this list and recycled in a single batch call after the loop exits, reducing the overhead of repeated heap operations.
- **Add `defer_recycle` parameter to `_handle_free_gpu_node_without_cpu`**: When `defer_recycle=True`, the method returns the list of block IDs to recycle (`reverved_dec_block_ids + [block_id]`) without calling `recycle_gpu_blocks` itself, allowing the caller to batch the recycling. When `defer_recycle=False`, behavior is unchanged (immediate recycling).
- **Fix: clear `node.reverved_dec_block_ids` in defer path**: When `defer_recycle=True`, the node's `reverved_dec_block_ids` is now cleared after copying to the return list, preventing double recycling if the node object is accessed again before GC.
- **Fix: restore `node.cache_status = CacheStatus.CPU`**: This line was accidentally removed during the refactor. Restored to keep consistency with `_handle_free_gpu_node_with_cpu`.
- **Refactor parent disconnection logic**: Extract parent disconnection into a separate `parent` variable for clarity, and add a dedup check with warning log when the parent is already in `gpu_lru_leaf_set`.
- **Add warning log for inconsistent LRU state**: When a node popped from the LRU heap has `shared_count != 0`, log a warning to aid diagnosis.

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

No additional configuration required. The optimization takes effect automatically.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Only affects KV Cache block recycling timing, no impact on model output accuracy.

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.