### PR TITLE
[CI] Explicitly require mooncake-transfer-engine>=0.3.7,<0.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,6 @@ einops
 setproctitle
 aistudio_sdk
 p2pstore
-mooncake-transfer-engine>=0.3.7,<0.4.0
 py-cpuinfo
 flashinfer-python-paddle @ https://xly-devops.bj.bcebos.com/flashinfer/flashinfer_python_paddle-0.4.1.2-py3-none-any.whl
 transformers>=4.55.1,<5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ einops
 setproctitle
 aistudio_sdk
 p2pstore
-mooncake-transfer-engine>=0.3.10
+mooncake-transfer-engine>=0.3.7,<0.4.0
 py-cpuinfo
 flashinfer-python-paddle @ https://xly-devops.bj.bcebos.com/flashinfer/flashinfer_python_paddle-0.4.1.2-py3-none-any.whl
 transformers>=4.55.1,<5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ einops
 setproctitle
 aistudio_sdk
 p2pstore
+mooncake-transfer-engine>=0.3.10
 py-cpuinfo
 flashinfer-python-paddle @ https://xly-devops.bj.bcebos.com/flashinfer/flashinfer_python_paddle-0.4.1.2-py3-none-any.whl
 transformers>=4.55.1,<5.0.0

--- a/scripts/unittest_requirement.txt
+++ b/scripts/unittest_requirement.txt
@@ -10,3 +10,4 @@ aistudio_sdk==0.3.5
 pandas
 use_triton_in_paddle
 arctic_inference @ https://paddle-qa.bj.bcebos.com/ernie/arctic_inference-0.1.3-cp310-cp310-linux_x86_64.whl
+mooncake-transfer-engine>=0.3.7,<0.4.0


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

`mooncake-transfer-engine` was previously installed through transitive dependencies from `p2pstore`, which itself is an indirect dependency of `fast_dataindex`.

Dependency chain:

```text
requirements.txt
  └─ fast_dataindex
       └─ p2pstore
            └─ (0.1.15)       mooncake-transfer-engine>=0.3.7,<0.4.0
            └─ (0.1.15.post1) dependency removed
```

After upgrading to `p2pstore==0.1.15.post1`, the implicit dependency on `mooncake-transfer-engine` was removed, causing `mooncake_master` related components to no longer be installed automatically.

Recent upstream dependency changes may cause `mooncake-transfer-engine` installation behavior to become unstable or inconsistent.

In addition, starting from `mooncake-transfer-engine 0.3.9`, released x86_64 wheels are built with:

```text id="f1cz7q"
manylinux_2_35_x86_64
```

while current FastDeploy CI environments still include:

- `manylinux_2_28_x86_64`
- `manylinux_2_17_x86_64`

According to pip compatibility rules, wheels requiring newer glibc versions cannot be installed in older environments.

This may cause installation failures in CI environments using older glibc baselines.

The purpose of this change is mainly to avoid compatibility risks introduced by newer `manylinux_2_35_x86_64` wheels and preserve stable dependency installation behavior across existing CI environments.

## Modifications

- Explicitly added:
  - `mooncake-transfer-engine<0.4.0,>=0.3.7`
  to `unittest_requirement.txt`
- Avoided relying on transitive dependency propagation from `p2pstore`.
- Preserved compatibility with existing CI environments based on:
  - `manylinux_2_28_x86_64`
  - `manylinux_2_17_x86_64`
- Reduced installation risks caused by newer incompatible wheel packaging formats.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
