### PR TITLE
[CI] Restore self-hosted runners for GitHub workflows

### DIFF
--- a/.github/workflows/CheckPRTemplate.yml
+++ b/.github/workflows/CheckPRTemplate.yml
@@ -10,7 +10,8 @@ jobs:
   check:
     name: Check PR Template
     if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     env:
       PR_ID: ${{ github.event.pull_request.number }}
       BASE_BRANCH: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -10,7 +10,8 @@ jobs:
   pre-commit:
     name: Pre Commit
     if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     env:
       PR_ID: ${{ github.event.pull_request.number }}
       BRANCH: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/_unit_test_coverage.yml
+++ b/.github/workflows/_unit_test_coverage.yml
@@ -416,11 +416,15 @@ jobs:
   diff_coverage_report:
     needs: run_tests_with_coverage
     if: always()
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     timeout-minutes: 15
     env:
       all_cov_file_url: ${{ needs.run_tests_with_coverage.outputs.all_cov_file_url }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Clone FastDeploy
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/_xpu_coverage_report.yml
+++ b/.github/workflows/_xpu_coverage_report.yml
@@ -265,11 +265,15 @@ jobs:
   xpu_codecov_upload:
     needs: xpu_coverage_combine
     if: always()
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     timeout-minutes: 15
     env:
       xpu_cov_xml_url: ${{ needs.xpu_coverage_combine.outputs.xpu_cov_xml_url }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Clone FastDeploy
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -13,11 +13,15 @@ jobs:
   Approval:
     name: Approval
     if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     env:
       PR_ID: ${{ github.event.pull_request.number }}
       BRANCH: ${{ github.event.pull_request.base.ref }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout base repo
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/cancel_ci_iluvatar.yml
+++ b/.github/workflows/cancel_ci_iluvatar.yml
@@ -13,8 +13,12 @@ concurrency:
 jobs:
   cancel:
     name: Cancel ILUVATAR-CI for ${{ github.event.pull_request.number }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Cancel ILUVATAR-CI
         run: |
           exit 0

--- a/.github/workflows/cancel_ci_xpu.yml
+++ b/.github/workflows/cancel_ci_xpu.yml
@@ -13,8 +13,12 @@ concurrency:
 jobs:
   cancel:
     name: Cancel CI_XPU for ${{ github.event.pull_request.number }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Cancel CI_XPU
         run: |
           exit 0

--- a/.github/workflows/cancel_pr_build_and_test.yml
+++ b/.github/workflows/cancel_pr_build_and_test.yml
@@ -12,8 +12,12 @@ concurrency:
 jobs:
   cancel:
     name: Cancel PR Build and Test for ${{ github.event.pull_request.number }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Cancel PR Build and Test
         run: |
           exit 0

--- a/.github/workflows/ce_job.yml
+++ b/.github/workflows/ce_job.yml
@@ -14,7 +14,8 @@ concurrency:
 
 jobs:
   ce_job_pre_check:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     env:
       COMPILE_BRANCH: ${{ vars.COMPILE_BRANCH }}
       CE_COMPILE_SELECTION: ${{ vars.CE_COMPILE_SELECTION }}
@@ -26,6 +27,9 @@ jobs:
       sm8090_match: ${{ steps.set_output.outputs.sm8090_match }}
 
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Set Version
         id: set_output
         env:
@@ -78,9 +82,13 @@ jobs:
           done
 
   print_ce_job_pre_check_outputs:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     needs: ce_job_pre_check
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Print outputs as JSON
         run: |
           echo '${{ toJSON(needs.ce_job_pre_check.outputs) }}'
@@ -89,12 +97,16 @@ jobs:
   clone:
     environment: CodeSync
     name: FD-Clone-Linux
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     needs: ce_job_pre_check
     if: ${{ needs.ce_job_pre_check.outputs.branch_match == 'true' }}
     outputs:
       repo_archive_url: ${{ steps.set_output.outputs.repo_archive_url }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Clone FastDeploy
         uses: actions/checkout@v6
         with:
@@ -154,8 +166,12 @@ jobs:
   resultshow:
     name: Show Code Archive Output
     needs: clone
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Print repo_archive_url path
         run: |
           echo "The code archive is located at: ${{ needs.clone.outputs.repo_archive_url }}"
@@ -219,13 +235,17 @@ jobs:
     environment: CodeSync
     name: CE_UPLOAD
     needs: build_sm8090
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     env:
       AK: ${{ secrets.BOS_AK }}
       SK: ${{ secrets.BOS_SK }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8090.outputs.wheel_path }}
       COMPILE_ARCH: "80,90"
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
@@ -269,13 +289,17 @@ jobs:
     environment: CodeSync
     name: CE_UPLOAD_RL
     needs: build_sm8090_rl
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     env:
       AK: ${{ secrets.BOS_AK }}
       SK: ${{ secrets.BOS_SK }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8090_rl.outputs.wheel_path_rl }}
       COMPILE_ARCH: "80,90"
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
@@ -315,13 +339,17 @@ jobs:
     environment: CodeSync
     name: CE_UPLOAD_90RL
     needs: build_sm90_rl
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     env:
       AK: ${{ secrets.BOS_AK }}
       SK: ${{ secrets.BOS_SK }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm90_rl.outputs.wheel_path_rl }}
       COMPILE_ARCH: "90,100"
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
@@ -361,13 +389,17 @@ jobs:
     environment: CodeSync
     name: CE_UPLOAD
     needs: build_sm8689
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     env:
       AK: ${{ secrets.BOS_AK }}
       SK: ${{ secrets.BOS_SK }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_sm8689.outputs.wheel_path }}
       COMPILE_ARCH: "86,89"
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'

--- a/.github/workflows/check-bypass.yml
+++ b/.github/workflows/check-bypass.yml
@@ -18,7 +18,8 @@ on:
 jobs:
   check-bypass:
     name: Check bypass
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     permissions:
       contents: read
     env:

--- a/.github/workflows/check-bypass.yml
+++ b/.github/workflows/check-bypass.yml
@@ -65,7 +65,9 @@ jobs:
             exit 0
           fi
 
-          files=$(gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json files --jq '.files[].path')
+          files=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100" \
+            | jq -r '.[].filename')
           echo "$files"
 
           can_skip_docs=true

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -22,8 +22,12 @@ jobs:
         github.event.action == 'labeled' ||
         contains(join(github.event.pull_request.labels.*.name, ' '), 'cherry-pick')
       )
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci_image_update.yml
+++ b/.github/workflows/ci_image_update.yml
@@ -16,10 +16,14 @@ jobs:
   clone:
     environment: CodeSync
     name: FD-Clone-Linux
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     outputs:
       repo_archive_url: ${{ steps.set_output.outputs.repo_archive_url }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Clone FastDeploy
         uses: actions/checkout@v6
         with:
@@ -64,8 +68,12 @@ jobs:
   resultshow:
     name: Show Code Archive Output
     needs: clone
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Print wheel path
         run: |
           echo "The code archive is located at: ${{ needs.clone.outputs.repo_archive_url }}"

--- a/.github/workflows/ci_metax.yml
+++ b/.github/workflows/ci_metax.yml
@@ -19,10 +19,14 @@ concurrency:
 jobs:
   trigger-jenkins:
     name: Trigger Jenkins for PR
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     environment: Metax_ci
 
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Trigger Jenkins job
         timeout-minutes: 60
         uses: MetaX-MACA/simple-jenkins-githubaction@v1.1

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,8 +9,12 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -32,8 +32,12 @@ jobs:
   resultshow:
     name: Use Build Output
     needs: build
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Print wheel path
         run: |
           echo "The built wheel is located at: ${{ needs.build.outputs.wheel_path }}"

--- a/.github/workflows/publish_job.yml
+++ b/.github/workflows/publish_job.yml
@@ -19,7 +19,8 @@ concurrency:
 
 jobs:
   publish_pre_check:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     if: |
       github.event.repository.fork == false &&
       (
@@ -40,6 +41,9 @@ jobs:
       compile_use_paddle_whl_url: ${{ steps.set_output.outputs.compile_use_paddle_whl_url }}
 
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Get tag version
         if: github.ref_type == 'tag'
         run: |
@@ -108,9 +112,13 @@ jobs:
           echo "with_nightly_build=${with_nightly_build:-OFF}" >> $GITHUB_OUTPUT
 
   print_publish_pre_check_outputs:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     needs: publish_pre_check
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Print outputs as JSON
         run: |
           echo '${{ toJSON(needs.publish_pre_check.outputs) }}'
@@ -118,12 +126,16 @@ jobs:
   clone:
     environment: CodeSync
     name: FD-Clone-Linux
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     needs: publish_pre_check
     if: ${{ needs.publish_pre_check.outputs.compile_continue == 'true' }}
     outputs:
       repo_archive_url: ${{ steps.set_output.outputs.repo_archive_url }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Clone FastDeploy
         uses: actions/checkout@v6
         with:
@@ -168,8 +180,12 @@ jobs:
   resultshow:
     name: Show Code Archive Output
     needs: clone
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Print wheel path
         run: |
           echo "The code archive is located at: ${{ needs.clone.outputs.repo_archive_url }}"
@@ -235,12 +251,16 @@ jobs:
     environment: CodeSync
     name: CE_UPLOAD_FD_ROUTER
     needs: build_fd_router
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     env:
       AK: ${{ secrets.BOS_AK }}
       SK: ${{ secrets.BOS_SK }}
       FD_ROUTER_URL: ${{ needs.build_fd_router.outputs.fd_router_path }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
@@ -291,12 +311,16 @@ jobs:
     environment: PaddleSourceUpload
     name: PADDLE_PYPI_UPLOAD_cu126
     needs: build_cu126
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     env:
       AK: ${{ secrets.BOS_AK }}
       SK: ${{ secrets.BOS_SK }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_cu126.outputs.wheel_path }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
@@ -323,12 +347,16 @@ jobs:
     environment: PaddleSourceUpload
     name: PADDLE_PYPI_UPLOAD_cu129
     needs: build_cu129
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     env:
       AK: ${{ secrets.BOS_AK }}
       SK: ${{ secrets.BOS_SK }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_cu129.outputs.wheel_path_cu129 }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
@@ -355,12 +383,16 @@ jobs:
     environment: PaddleSourceUpload
     name: PADDLE_PYPI_UPLOAD_cu130
     needs: build_cu130
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     env:
       AK: ${{ secrets.BOS_AK }}
       SK: ${{ secrets.BOS_SK }}
       FASTDEPLOY_WHEEL_URL: ${{ needs.build_cu130.outputs.wheel_path_cu130 }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'

--- a/.github/workflows/remove-skip-ci-labels.yml
+++ b/.github/workflows/remove-skip-ci-labels.yml
@@ -10,8 +10,12 @@ permissions:
 jobs:
   remove-skip-ci-labels:
     name: Remove skip-ci labels on new commits
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Get PR labels
         id: get-labels
         uses: actions/github-script@v8

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   re-run:
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/re-run') && github.event.comment.user.login == github.event.issue.user.login }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
       - name: Cleanup
         run: |


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

Recent updates introduced by https://github.com/PaddlePaddle/Paddle/pull/79123 require corresponding CI-side adaptations in FastDeploy to keep workflow behavior.

Without synchronization, existing CI logic may become incompatible with the updated Paddle workflow implementation and introduce validation inconsistencies or execution issues.

## Modifications

- Switched 33 lightweight workflow jobs under `.github/workflows` back to the common Paddle self-hosted runner configuration:

```
runs-on:
  group: APPROVAL
```

- Added workspace cleanup logic:

```
rm -rf * .[^.]*
```

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
