### PR TITLE
[CI] Use prebuilt wheels and remove CI_METAX from release branches

### DIFF
--- a/.github/workflows/ci_metax.yml
+++ b/.github/workflows/ci_metax.yml
@@ -7,7 +7,6 @@ on:
       - synchronize
     branches:
       - develop
-      - release/**
 
 permissions:
   contents: read

--- a/scripts/run_pre_ce.sh
+++ b/scripts/run_pre_ce.sh
@@ -8,11 +8,10 @@ python -m pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/p
 python -m pip install -r requirements.txt
 python -m pip install jsonschema aistudio_sdk==0.3.5
 # Use prebuilt wheel files to install xgrammar==0.1.19 and torch==2.8.0 specifically for the CI environment
-python -m pip install xgrammar==0.1.19 torch==2.8.0
-# python -m pip install  \
-#   https://paddle-qa.bj.bcebos.com/FastDeploy/torch-2.6.0-cp310-cp310-manylinux1_x86_64.whl \
-#   https://paddle-qa.bj.bcebos.com/FastDeploy/triton-3.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl \
-#   https://paddle-qa.bj.bcebos.com/FastDeploy/xgrammar-0.1.19-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+ python -m pip install  \
+   https://paddle-qa.bj.bcebos.com/FastDeploy/torch-2.8.0-cp310-cp310-manylinux_2_28_x86_64.whl \
+   https://paddle-qa.bj.bcebos.com/FastDeploy/triton-3.4.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl \
+   https://paddle-qa.bj.bcebos.com/FastDeploy/xgrammar-0.1.19-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 
 failed_files=()
 run_path="$DIR/../tests/ci_use/"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

Installing `xgrammar==0.1.19` `triton==3.4.0` and `torch==2.8.0` directly from upstream sources in CI may introduce unnecessary installation overhead and instability.

Using prebuilt wheel packages improves installation efficiency and environment consistency for CI workflows.

In addition, the `CI_METAX` job is no longer required for `release/*` branches and should be removed to reduce unnecessary CI resource consumption.

## Modifications

- Switched CI installation of:
  - `xgrammar==0.1.19`
  - `torch==2.8.0`
  -  `triton==3.4.0`
  to use prebuilt wheel files.
- Improved dependency installation stability and efficiency in CI environments.
- Removed `CI_METAX` job from `release/*` branches.
- Reduced unnecessary CI workload for release branch validation.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
