### PR TITLE
[GPU][CI] Guard SM90 pybind bindings

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -294,6 +294,16 @@ function extract_ops_from_precompiled_wheel() {
   rm -rf "${PRE_WHEEL_DIR}"
 }
 
+function is_sm8689_build() {
+  local building_arcs=${1:-""}
+  local normalized
+  normalized=$(echo "${building_arcs}" | tr -d '[][:space:]')
+  if [ "${normalized}" = "86,89" ] || [ "${normalized}" = "89,86" ]; then
+    return 0
+  fi
+  return 1
+}
+
 function build_custom_ops() {
   if [ "$FD_UNIFY_BUILD" ]; then
     mkdir -p ${OPS_SRC_DIR}/${OPS_TMP_DIR}
@@ -305,6 +315,17 @@ function build_custom_ops() {
     build_and_install_ops "[89]" "$custom_ops_dir"
 
     build_and_install_ops "[80, 90]" "${OPS_TMP_DIR}"
+    cp -r $OPS_SRC_DIR/$OPS_TMP_DIR/* ./fastdeploy/model_executor/ops/gpu
+  elif is_sm8689_build "$FD_BUILDING_ARCS"; then
+    echo -e "${BLUE}[build]${NONE} splitting SM86/SM89 custom ops to avoid oversized combined extension link"
+    mkdir -p ${OPS_SRC_DIR}/${OPS_TMP_DIR}
+
+    custom_ops_dir=${OPS_TMP_DIR}/fastdeploy_ops_86
+    build_and_install_ops "[86]" "$custom_ops_dir"
+
+    custom_ops_dir=${OPS_TMP_DIR}/fastdeploy_ops_89
+    build_and_install_ops "[89]" "$custom_ops_dir"
+
     cp -r $OPS_SRC_DIR/$OPS_TMP_DIR/* ./fastdeploy/model_executor/ops/gpu
   else
     build_and_install_ops "$FD_BUILDING_ARCS" "$OPS_TMP_DIR"

--- a/build.sh
+++ b/build.sh
@@ -294,80 +294,6 @@ function extract_ops_from_precompiled_wheel() {
   rm -rf "${PRE_WHEEL_DIR}"
 }
 
-function normalize_building_arcs() {
-  echo "${1:-}" | tr -d '[][:space:]'
-}
-
-function append_arch() {
-  local archs=${1:-}
-  local arch=${2:-}
-  if [ -z "${arch}" ]; then
-    echo "${archs}"
-  elif [ -z "${archs}" ]; then
-    echo "${arch}"
-  else
-    echo "${archs}, ${arch}"
-  fi
-}
-
-function build_split_sm86_sm89_ops() {
-  local building_arcs=${1:-}
-  local normalized
-  normalized=$(normalize_building_arcs "${building_arcs}")
-  if [ -z "${normalized}" ] || [ "${normalized}" = "86" ] || [ "${normalized}" = "89" ]; then
-    return 1
-  fi
-
-  local split_any=false
-  local remaining_archs=""
-  local built_sm86=false
-  local built_sm89=false
-  local arch
-  local -a arch_array
-  IFS=',' read -ra arch_array <<< "${normalized}"
-  for arch in "${arch_array[@]}"; do
-    case "${arch}" in
-      86|89)
-        split_any=true
-        ;;
-      *)
-        remaining_archs=$(append_arch "${remaining_archs}" "${arch}")
-        ;;
-    esac
-  done
-
-  if [ "${split_any}" != "true" ]; then
-    return 1
-  fi
-
-  echo -e "${BLUE}[build]${NONE} splitting SM86/SM89 custom ops to avoid oversized combined extension link"
-  mkdir -p ${OPS_SRC_DIR}/${OPS_TMP_DIR}
-
-  for arch in "${arch_array[@]}"; do
-    case "${arch}" in
-      86)
-        if [ "${built_sm86}" != "true" ]; then
-          build_and_install_ops "[86]" "${OPS_TMP_DIR}/fastdeploy_ops_86"
-          built_sm86=true
-        fi
-        ;;
-      89)
-        if [ "${built_sm89}" != "true" ]; then
-          build_and_install_ops "[89]" "${OPS_TMP_DIR}/fastdeploy_ops_89"
-          built_sm89=true
-        fi
-        ;;
-    esac
-  done
-
-  if [ -n "${remaining_archs}" ]; then
-    build_and_install_ops "[${remaining_archs}]" "${OPS_TMP_DIR}"
-  fi
-
-  cp -r $OPS_SRC_DIR/$OPS_TMP_DIR/* ./fastdeploy/model_executor/ops/gpu
-  return 0
-}
-
 function build_custom_ops() {
   if [ "$FD_UNIFY_BUILD" ]; then
     mkdir -p ${OPS_SRC_DIR}/${OPS_TMP_DIR}
@@ -380,8 +306,6 @@ function build_custom_ops() {
 
     build_and_install_ops "[80, 90]" "${OPS_TMP_DIR}"
     cp -r $OPS_SRC_DIR/$OPS_TMP_DIR/* ./fastdeploy/model_executor/ops/gpu
-  elif build_split_sm86_sm89_ops "$FD_BUILDING_ARCS"; then
-    return
   else
     build_and_install_ops "$FD_BUILDING_ARCS" "$OPS_TMP_DIR"
     cd $OPS_SRC_DIR

--- a/build.sh
+++ b/build.sh
@@ -294,14 +294,78 @@ function extract_ops_from_precompiled_wheel() {
   rm -rf "${PRE_WHEEL_DIR}"
 }
 
-function is_sm8689_build() {
-  local building_arcs=${1:-""}
-  local normalized
-  normalized=$(echo "${building_arcs}" | tr -d '[][:space:]')
-  if [ "${normalized}" = "86,89" ] || [ "${normalized}" = "89,86" ]; then
-    return 0
+function normalize_building_arcs() {
+  echo "${1:-}" | tr -d '[][:space:]'
+}
+
+function append_arch() {
+  local archs=${1:-}
+  local arch=${2:-}
+  if [ -z "${arch}" ]; then
+    echo "${archs}"
+  elif [ -z "${archs}" ]; then
+    echo "${arch}"
+  else
+    echo "${archs}, ${arch}"
   fi
-  return 1
+}
+
+function build_split_sm86_sm89_ops() {
+  local building_arcs=${1:-}
+  local normalized
+  normalized=$(normalize_building_arcs "${building_arcs}")
+  if [ -z "${normalized}" ] || [ "${normalized}" = "86" ] || [ "${normalized}" = "89" ]; then
+    return 1
+  fi
+
+  local split_any=false
+  local remaining_archs=""
+  local built_sm86=false
+  local built_sm89=false
+  local arch
+  local -a arch_array
+  IFS=',' read -ra arch_array <<< "${normalized}"
+  for arch in "${arch_array[@]}"; do
+    case "${arch}" in
+      86|89)
+        split_any=true
+        ;;
+      *)
+        remaining_archs=$(append_arch "${remaining_archs}" "${arch}")
+        ;;
+    esac
+  done
+
+  if [ "${split_any}" != "true" ]; then
+    return 1
+  fi
+
+  echo -e "${BLUE}[build]${NONE} splitting SM86/SM89 custom ops to avoid oversized combined extension link"
+  mkdir -p ${OPS_SRC_DIR}/${OPS_TMP_DIR}
+
+  for arch in "${arch_array[@]}"; do
+    case "${arch}" in
+      86)
+        if [ "${built_sm86}" != "true" ]; then
+          build_and_install_ops "[86]" "${OPS_TMP_DIR}/fastdeploy_ops_86"
+          built_sm86=true
+        fi
+        ;;
+      89)
+        if [ "${built_sm89}" != "true" ]; then
+          build_and_install_ops "[89]" "${OPS_TMP_DIR}/fastdeploy_ops_89"
+          built_sm89=true
+        fi
+        ;;
+    esac
+  done
+
+  if [ -n "${remaining_archs}" ]; then
+    build_and_install_ops "[${remaining_archs}]" "${OPS_TMP_DIR}"
+  fi
+
+  cp -r $OPS_SRC_DIR/$OPS_TMP_DIR/* ./fastdeploy/model_executor/ops/gpu
+  return 0
 }
 
 function build_custom_ops() {
@@ -316,17 +380,8 @@ function build_custom_ops() {
 
     build_and_install_ops "[80, 90]" "${OPS_TMP_DIR}"
     cp -r $OPS_SRC_DIR/$OPS_TMP_DIR/* ./fastdeploy/model_executor/ops/gpu
-  elif is_sm8689_build "$FD_BUILDING_ARCS"; then
-    echo -e "${BLUE}[build]${NONE} splitting SM86/SM89 custom ops to avoid oversized combined extension link"
-    mkdir -p ${OPS_SRC_DIR}/${OPS_TMP_DIR}
-
-    custom_ops_dir=${OPS_TMP_DIR}/fastdeploy_ops_86
-    build_and_install_ops "[86]" "$custom_ops_dir"
-
-    custom_ops_dir=${OPS_TMP_DIR}/fastdeploy_ops_89
-    build_and_install_ops "[89]" "$custom_ops_dir"
-
-    cp -r $OPS_SRC_DIR/$OPS_TMP_DIR/* ./fastdeploy/model_executor/ops/gpu
+  elif build_split_sm86_sm89_ops "$FD_BUILDING_ARCS"; then
+    return
   else
     build_and_install_ops "$FD_BUILDING_ARCS" "$OPS_TMP_DIR"
     cd $OPS_SRC_DIR

--- a/custom_ops/gpu_ops/cpp_extensions.cc
+++ b/custom_ops/gpu_ops/cpp_extensions.cc
@@ -189,6 +189,8 @@ std::vector<paddle::Tensor> AppendAttentionWithOutput(
     const int sliding_window,
     const int sink_size);
 
+#ifdef ENABLE_DECODE_UNIFIED_ATTENTION
+// These sources are compiled only for SM90+ CUDA 12 builds.
 std::vector<paddle::Tensor> DecoderWriteCacheWithRoPE(
     const paddle::Tensor& qkv,
     const paddle::Tensor& key_cache,
@@ -266,6 +268,7 @@ void ConfigForAttention(const paddle::Tensor& seq_lens_encoder,
                         const int group_size,
                         const int kv_num_heads,
                         const int max_tokens_per_batch);
+#endif
 
 std::vector<paddle::Tensor> GQARopeWriteCacheKernel(
     const paddle::Tensor& qkv,
@@ -2043,6 +2046,7 @@ PYBIND11_MODULE(fastdeploy_ops, m) {
         &PerTokenGroupQuantFp8,
         "per_token_group_quant_fp8");
 
+#ifdef ENABLE_DECODE_UNIFIED_ATTENTION
   /**
    * decoder_write_cache_with_rope.cu
    * decoder_write_cache_with_rope
@@ -2066,4 +2070,5 @@ PYBIND11_MODULE(fastdeploy_ops, m) {
   m.def("config_for_attention",
         &ConfigForAttention,
         "config for attention function");
+#endif
 }

--- a/custom_ops/setup_ops.py
+++ b/custom_ops/setup_ops.py
@@ -393,14 +393,6 @@ elif paddle.is_compiled_with_cuda():
 
     cc_compile_args = []
     nvcc_compile_args = get_gencode_flags(archs)
-    extra_link_args = ["-lcuda", "-lnvidia-ml"]
-    if len(sm_versions) > 1 and sys.platform.startswith("linux"):
-        # Multi-arch GPU builds pull in many CUTLASS template instantiations.
-        # Use the large code model so host objects and CUDA host stubs do not
-        # overflow x86_64 small-model PC-relative relocations at link time.
-        cc_compile_args += ["-mcmodel=large"]
-        nvcc_compile_args += ["-Xcompiler", "-mcmodel=large"]
-        extra_link_args += ["-mcmodel=large"]
     if disable_gelu_tanh:
         cc_compile_args += ["-DDISABLE_GELU_TANH_OP"]
         nvcc_compile_args += ["-DDISABLE_GELU_TANH_OP"]
@@ -597,7 +589,7 @@ elif paddle.is_compiled_with_cuda():
             sources=sources,
             extra_compile_args={"cxx": cc_compile_args, "nvcc": nvcc_compile_args},
             libraries=["cublasLt"],
-            extra_link_args=extra_link_args,
+            extra_link_args=["-lcuda", "-lnvidia-ml"],
         ),
         packages=find_packages(where="third_party/DeepGEMM"),
         package_dir={"": "third_party/DeepGEMM"},

--- a/custom_ops/setup_ops.py
+++ b/custom_ops/setup_ops.py
@@ -393,6 +393,14 @@ elif paddle.is_compiled_with_cuda():
 
     cc_compile_args = []
     nvcc_compile_args = get_gencode_flags(archs)
+    extra_link_args = ["-lcuda", "-lnvidia-ml"]
+    if len(sm_versions) > 1 and sys.platform.startswith("linux"):
+        # Multi-arch GPU builds pull in many CUTLASS template instantiations.
+        # Use the large code model so host objects and CUDA host stubs do not
+        # overflow x86_64 small-model PC-relative relocations at link time.
+        cc_compile_args += ["-mcmodel=large"]
+        nvcc_compile_args += ["-Xcompiler", "-mcmodel=large"]
+        extra_link_args += ["-mcmodel=large"]
     if disable_gelu_tanh:
         cc_compile_args += ["-DDISABLE_GELU_TANH_OP"]
         nvcc_compile_args += ["-DDISABLE_GELU_TANH_OP"]
@@ -589,7 +597,7 @@ elif paddle.is_compiled_with_cuda():
             sources=sources,
             extra_compile_args={"cxx": cc_compile_args, "nvcc": nvcc_compile_args},
             libraries=["cublasLt"],
-            extra_link_args=["-lcuda", "-lnvidia-ml"],
+            extra_link_args=extra_link_args,
         ),
         packages=find_packages(where="third_party/DeepGEMM"),
         package_dir={"": "third_party/DeepGEMM"},

--- a/custom_ops/setup_ops.py
+++ b/custom_ops/setup_ops.py
@@ -554,6 +554,8 @@ elif paddle.is_compiled_with_cuda():
         sources += find_end_files(fp8_auto_gen_directory, ".cu")
 
     if cc >= 90 and nvcc_version >= 12.0:
+        cc_compile_args += ["-DENABLE_DECODE_UNIFIED_ATTENTION"]
+        nvcc_compile_args += ["-DENABLE_DECODE_UNIFIED_ATTENTION"]
         # decode unified attention
         os.system(
             "python utils/auto_gen_template_attention.py --config gpu_ops/decode_unified_attention/template_config.json --output gpu_ops/decode_unified_attention/template_instantiation/autogen"


### PR DESCRIPTION
## Motivation

PaddlePaddle/Paddle#79121 upgraded pybind11 and changed Paddle custom op stub generation so the generated Python stub loads/registers the extension `.so` while generating/exporting APIs. This exposed a FastDeploy H20/SM86 build issue: `fastdeploy_ops.so` referenced `DecodeUnifiedAttention(...)` even when the corresponding SM90 CUDA sources were not compiled.

Original failing job: https://github.com/PaddlePaddle/FastDeploy/actions/runs/26416048432/job/77760881377

Key log:

```text
cc = 86
fastdeploy_ops.so: undefined symbol: DecodeUnifiedAttention(...)
```

## Modifications

- Add `ENABLE_DECODE_UNIFIED_ATTENTION` only in the existing `cc >= 90 and nvcc_version >= 12.0` source-list branch.
- Guard the matching declarations and pybind `m.def` entries for:
  - `decoder_write_cache_with_rope`
  - `decode_unified_attention`
  - `config_for_attention`

This keeps cc>=90 behavior unchanged and prevents cc<90 builds from referencing SM90-only implementations that are not linked into `fastdeploy_ops.so`.

Per reviewer feedback, the temporary multi-arch / oversized 86-89 `.so` workaround has been reverted; this PR now keeps only the SM90 pybind guard fix.

## Usage or Command

Local validation:

```bash
bash -n build.sh
python3 -m py_compile custom_ops/setup_ops.py
git diff --check upstream/develop...HEAD
```

Full H20/CUDA wheel build needs CI validation.

## Accuracy Tests

No model accuracy change. This PR only aligns pybind registration with existing compile conditions for SM90-only custom op sources.

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.

Unit test / accuracy note: no local H20/CUDA environment is available; this is a compile/link guard fix and should be validated by the original CI path.
