### PR TITLE
[CI] Refine prebuilt wheel installation for xgrammar and torch in CI

### DIFF
--- a/scripts/run_pre_ce.sh
+++ b/scripts/run_pre_ce.sh
@@ -7,11 +7,15 @@ python -m pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/p
 
 python -m pip install -r requirements.txt
 python -m pip install jsonschema aistudio_sdk==0.3.5
-# Use prebuilt wheel files to install xgrammar==0.1.19 and torch==2.8.0 specifically for the CI environment
- python -m pip install  \
-   https://paddle-qa.bj.bcebos.com/FastDeploy/torch-2.8.0-cp310-cp310-manylinux_2_28_x86_64.whl \
-   https://paddle-qa.bj.bcebos.com/FastDeploy/triton-3.4.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl \
-   https://paddle-qa.bj.bcebos.com/FastDeploy/xgrammar-0.1.19-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+# Use prebuilt wheel files to install xgrammar==0.1.19 triton==3.4.0 nvidia_nccl_cu12==2.27.3 and torch==2.8.0 specifically for the CI environment
+python -m pip install --no-deps \
+    https://paddle-qa.bj.bcebos.com/FastDeploy/torch-2.8.0-cp310-cp310-manylinux_2_28_x86_64.whl \
+    https://paddle-qa.bj.bcebos.com/FastDeploy/nvidia_nccl_cu12-2.27.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl \
+    https://paddle-qa.bj.bcebos.com/FastDeploy/triton-3.4.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl \
+    https://paddle-qa.bj.bcebos.com/FastDeploy/xgrammar-0.1.19-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+
+# install runtime dependencies for torch and xgrammar
+python -m pip install pydantic sentencepiece tiktoken ninja filelock sympy jinja2 fsspec
 
 failed_files=()
 run_path="$DIR/../tests/ci_use/"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

The previous installation method still relied on automatic dependency resolution during package installation, which increased CI setup time and introduced unnecessary dependency resolution overhead.

To reduce CI dependency installation time and improve environment setup efficiency, the installation flow should use fully controlled prebuilt wheel installation with explicit dependency handling.

## Modifications

- Updated prebuilt wheel installation to use:
  - `python -m pip install --no-deps`
- Explicitly installed prebuilt wheel packages for:
  - `torch==2.8.0`
  - `nvidia_nccl_cu12==2.27.3`
  - `triton==3.4.0`
  - `xgrammar==0.1.19`
- Moved required `xgrammar` runtime dependencies to a separate installation step:
  - `pydantic`
  - `sentencepiece`
  - `tiktoken`
  - `ninja`
  - `filelock`
  - `sympy`
  - `jinja2`
  - `fsspec`
- Reduced dependency resolution overhead and improved CI installation efficiency.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
