### PR TITLE
[Cherry-Pick][BugFix][Metax] Fix TypeError calling post_process with unexpected kwarg line_break_id (#6521)

### DIFF
--- a/fastdeploy/worker/metax_model_runner.py
+++ b/fastdeploy/worker/metax_model_runner.py
@@ -1705,7 +1705,7 @@ class MetaxModelRunner(ModelRunnerBase):
             skip_save_output=True,
             async_output_queue=self.async_output_queue,
             think_end_id=self.model_config.think_end_id,
-            line_break_id=self.model_config.line_break_id,
+            splitwise_role_is_decode=self.scheduler_config.splitwise_role == "decode",
         )
         self.exist_prefill_flag = False
         return pooler_output
@@ -1810,7 +1810,7 @@ class MetaxModelRunner(ModelRunnerBase):
             skip_save_output=True,
             async_output_queue=self.async_output_queue,
             think_end_id=self.model_config.think_end_id,
-            line_break_id=self.model_config.line_break_id,
+            splitwise_role_is_decode=self.scheduler_config.splitwise_role == "decode",
             enable_entropy=self.enable_entropy and self.parallel_config.tensor_parallel_rank == 0,
         )
         self.exist_prefill_flag = False
@@ -2457,7 +2457,7 @@ class MetaxModelRunner(ModelRunnerBase):
                 skip_save_output=skip_save_output,
                 async_output_queue=self.async_output_queue,
                 think_end_id=self.model_config.think_end_id,
-                line_break_id=self.model_config.line_break_id,
+                splitwise_role_is_decode=self.scheduler_config.splitwise_role == "decode",
                 enable_entropy=self.enable_entropy and self.parallel_config.tensor_parallel_rank == 0,
             )
 


### PR DESCRIPTION
## Motivation

Closes #7940.

`metax_model_runner.py` on `release/2.5` calls
`post_process(line_break_id=self.model_config.line_break_id, ...)` at
three call sites, but `pre_and_post_process.post_process` on the same
branch does **not** accept that kwarg. Any inference path hitting these
sites raises:

TypeError: post_process() got an unexpected keyword argument 'line_break_id'

**Reproducer**: launch FastDeploy OpenAI server on MetaX with
PaddleOCR-VL-1.5, the worker subprocess dies during
`graph_optimize_and_warm_up_model`. The sibling `gpu_model_runner.py`
on the **same `release/2.5`** already uses `splitwise_role_is_decode=...`
correctly — this was apparently missed when `post_process`'s signature
changed.

I also audited the other hardware runners on `release/2.5`:
- `gpu_model_runner.py`, `dcu_model_runner.py`, `gcu_model_runner.py`,
  `hpu_model_runner.py`, `iluvatar_model_runner.py` — already use
  `splitwise_role_is_decode=...`, no fix needed.
- `xpu_model_runner.py` does pass `line_break_id=...`, but it calls
  `xpu_post_process_normal` (in `xpu_pre_and_post_process.py`) whose
  signature **does** accept that kwarg, so XPU is fine.
- Only `metax_model_runner.py` is affected — fixed by this PR.

## Modifications

3-site cherry-pick from #6521 (commit c369f7139 on `develop`): replace
`line_break_id=self.model_config.line_break_id,` with
`splitwise_role_is_decode=self.scheduler_config.splitwise_role == "decode",`
in `fastdeploy/worker/metax_model_runner.py`.

Net diff: 3 lines added, 3 lines removed.

## Usage or Command

```bash
python -m fastdeploy.entrypoints.openai.api_server \
    --model /path/to/PaddleOCR-VL-1.5 \
    --max-model-len 2048 --max-num-seqs 4 \
    --quantization wint8 --enable-mm
```

After this patch the server starts cleanly and /health returns 200;
end-to-end OCR verified on a 1100×690 image — paddleocr doc_parser
returns the expected HTML table.

Accuracy Tests

No model-output changes — pure call-site fix to align the kwarg name
with the function signature. Verified locally on MetaX C500 64 GiB +
MACA 3.3.0.15 + paddle 3.4.0.dev20260127 + paddle-metax-gpu
3.3.0.dev20260128 that PaddleOCR-VL-1.5 produces the same OCR text as
the develop branch.

Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [[FDConfig],[APIServer],[Engine], [Scheduler], [PD Disaggregation], [Executor], [Graph Optimization], [Speculative Decoding], [RL], [Models], [Quantization],
[Loader], [OP], [KVCache], [DataProcessor], [BugFix], [Docs], [CI], [Optimization], [Feature], [Benchmark], [Others], [XPU], [HPU], [GCU], [DCU], [Iluvatar], [Metax]]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run pre-commit before commit.
- [ ] Add unit tests. (N/A: this is a 3-line cherry-pick that fixes a TypeError raised before any inference runs; the reproducer in the description is the test. No unit test
 in the original PR #6521 either.)
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the release branch, make sure the PR has been submitted to the develop branch, then cherry-pick it to the release branch with the
[Cherry-Pick] PR tag. (Original PR #6521 already merged to develop.)