### PR TITLE
[Scheduler] Simplify scheduler for prefill instances

### DIFF
--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -1097,6 +1097,7 @@ class EngineService:
                 if self.engine_worker_queue.exist_tasks():
                     time.sleep(0.001)
                     continue
+
                 if self.cfg.scheduler_config.splitwise_role != "mixed":
                     if not is_fetching:
                         is_fetching = True
@@ -1118,7 +1119,10 @@ class EngineService:
                 if hasattr(self.resource_manager, "scheduler_unhandled_request_num"):
                     self.resource_manager.scheduler_unhandled_request_num = self._get_scheduler_unhandled_request_num()
                 # 2. Schedule requests
-                batch_request, error_tasks = self.resource_manager.schedule()
+                if self.cfg.scheduler_config.splitwise_role == "prefill":
+                    batch_request, error_tasks = self.resource_manager.prefill_schedule()
+                else:
+                    batch_request, error_tasks = self.resource_manager.schedule()
 
                 # 3. Send to engine
                 if len(batch_request) > 0:

--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -1248,6 +1248,32 @@ class ResourceManagerV1(ResourceManager):
 
             return batch_request, error_reqs
 
+    def prefill_schedule(self):
+        with self.lock:
+            # P instance has no decode — full budget for prefill
+            batch_request = BatchRequest()
+            token_budget = self.config.scheduler_config.max_num_batched_tokens
+
+            assert len(self.waiting) == 0, "Prefill scheduler should not have waiting requests"
+
+            # Prepare prefill tasks for all running requests
+            for request in list(self.running):
+                if self._is_decoding(request):
+                    continue
+
+                num_new_tokens = self._get_num_new_tokens(request, token_budget)
+                if num_new_tokens == 0:
+                    continue
+
+                # Add requests into scheduled batch as blocks were preallocated
+                llm_logger.debug(f"schedule prefill tasks {request.request_id} with {num_new_tokens} tokens")
+                batch_request.add_request(self._prepare_prefill_task(request, num_new_tokens))
+                token_budget -= num_new_tokens
+                request.num_computed_tokens += num_new_tokens
+
+            self.update_metrics()
+            return batch_request, []
+
     def waiting_async_process(self, request: Request) -> None:
         """
         Check if async preprocessing is complete for a request.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

Prefill instances shared the same `schedule()` with Decode instances, introducing unnecessary waiting-queue and block-allocation overhead. This PR adds a dedicated `prefill_schedule()` to simplify the Prefill scheduling path.

## Modifications

<!-- Detail the changes made in this pull request. -->

- Add `prefill_schedule()` that skips the waiting queue and directly schedules from running requests with full token budget.
- Dispatch to `prefill_schedule()` when `splitwise_role == "prefill"`.
- Fix layer0 signal race in `cache_messager.py` via `pending_layer0_signals` buffering.
- Support NaiveProposer; fix CUDAGraph replay OOB access (CUDA error 700); fix `top_p_list` sync and buffer sizing.

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

No configuration change needed. Prefill instances automatically use the new path.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

No model computation changed. Accuracy unaffected.

## Performance

GLM-4.5-Air, TP8, 1P3D, 39 concurrency, 78 multi-round chat sessions:

| Metric | Before | After | Δ |
|--------|--------|-------|---|
| Total time | 7912s | 6778s | **-14.3%** |
| Avg TTFT | 29.4s | 23.6s | **-19.8%** |
| P90 TTFT | 121.3s | 91.7s | **-24.4%** |

End-to-end throughput **+16.7%**.

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.