### PR TITLE
Support entropy calculation for fd-runner

### DIFF
--- a/PR.md
+++ b/PR.md
@@ -1,0 +1,35 @@
+## [Feature] Support entropy computation in FD gpu_model_runner
+
+### Summary
+
+在 FastDeploy 的 `gpu_model_runner` 路径下支持 entropy 计算，使 `--enable-entropy` 功能同时兼容 FD Runner 和 ernie5_model_runner 两条执行路径。
+
+### 改动内容
+
+**entropy_utils.py**:
+- 新增 `_log_entropy()` 公共函数，统一 entropy 输出格式（含 `all_values` 完整序列）
+- 新增 `calculate_logits_entropy_fd()`: FD Runner non-MTP 路径的 entropy 计算
+- 新增 `speculate_calculate_logits_entropy_fd()`: FD Runner MTP (speculative decoding) 路径的 entropy 计算
+- 新增 `flush_entropy_on_stop()`: 处理 `unified_update_model_status` 后因 max_dec_len 截断而新增的 stop 请求
+- 重构原有 ernie5_runner 路径使用 `_log_entropy()` 避免重复代码
+
+**pre_and_post_process.py**:
+- 根据 `EB5_ENABLE_FD_RUNNER` 环境变量自动路由到对应的 entropy 计算函数
+- MTP 路径中在 `unified_update_model_status` 之后调用 `flush_entropy_on_stop`，确保 max_dec_len 截断的请求 entropy 不丢失
+
+**gpu_model_runner.py**:
+- 修正 `seq_lens_this_time` 切片为 `[:batch_size]`，确保 FD Runner 路径下 `real_bsz` 计算正确
+
+### FD Runner vs Ernie5 Runner 差异
+
+| 项目 | FD Runner | Ernie5 Runner |
+|------|-----------|---------------|
+| logits 布局 | 每 batch slot 一行 `[bsz, vocab]` | token 级展开 `[total_tokens, vocab]` |
+| MTP 执行顺序 | entropy → update_status → flush | update_status → entropy(含 flush) |
+| temperature 索引 | 直接 `temperature[i]` | 需要 `repeat_interleave` 展开 |
+
+### 验证结果
+
+- 并发 6 客户端 + max-num-seqs 4 服务端，MTP/Non-MTP 共 16 条请求全部正确输出 entropy
+- FD Runner 与 Ernie5 Runner 首次请求 entropy 前几步完全一致，后续差异属于 FP8+CUDA Graph 固有非确定性
+- `flush_entropy_on_stop` 修复了 max_dec_len 截断时 entropy 丢失的问题

--- a/fastdeploy/model_executor/entropy_utils.py
+++ b/fastdeploy/model_executor/entropy_utils.py
@@ -15,7 +15,6 @@
 """
 
 import paddle
-from paddleformers.utils.log import logger
 
 from fastdeploy.utils import data_processor_logger
 
@@ -53,8 +52,6 @@ def calculate_logits_entropy(logits, share_inputs, temperature):
         share_inputs["seq_lens_this_time"].squeeze(1),
     )
 
-    logger.info(f"  [entropy ernie5 non-MTP] logits.shape={logits.shape}, real_seq_lens={real_seq_lens.tolist()}")
-
     batch_indices = paddle.arange(real_bsz, dtype="int32")
     batch_id_per_token = paddle.repeat_interleave(batch_indices, real_seq_lens)
     for i in range(logits.shape[0]):
@@ -63,8 +60,6 @@ def calculate_logits_entropy(logits, share_inputs, temperature):
 
     entropy_tensor = get_entropy(logits)
     entropy = entropy_tensor.tolist()
-
-    logger.info(f"  [entropy ernie5 non-MTP] computed entropy: {entropy}")
 
     for i in range(real_bsz):
         for _ in range(real_seq_lens[i]):
@@ -93,11 +88,6 @@ def speculate_calculate_logits_entropy(logits, share_inputs, temperature):
     )
     accepted_idx = repeated_starts + offsets
 
-    logger.info(
-        f"  [entropy ernie5 MTP] logits.shape={logits.shape}, total_accepted_num={total_accepted_num}, "
-        f"real_seq_lens={real_seq_lens.tolist()}, accepted_idx={accepted_idx.tolist()}"
-    )
-
     accepted_logits = paddle.empty([total_accepted_num, logits.shape[1]], dtype=logits.dtype)
     for i in range(total_accepted_num):
         accepted_logits[i] = logits[accepted_idx[i]]
@@ -110,8 +100,6 @@ def speculate_calculate_logits_entropy(logits, share_inputs, temperature):
 
     entropy_tensor = get_entropy(accepted_logits)
     entropy = entropy_tensor.tolist()
-
-    logger.info(f"  [entropy ernie5 MTP] computed entropy: {entropy}")
 
     for i in range(real_bsz):
         for _ in range(share_inputs["accept_num"][i]):
@@ -143,8 +131,6 @@ def calculate_logits_entropy_fd(logits, share_inputs, temperature):
         seq_lens_this_time,
     )
 
-    logger.info(f"  [entropy_fd non-MTP] logits.shape={logits.shape}, real_seq_lens={real_seq_lens.tolist()}")
-
     for i in range(real_bsz):
         if int(real_seq_lens[i]) == 0:
             continue
@@ -153,8 +139,6 @@ def calculate_logits_entropy_fd(logits, share_inputs, temperature):
             logits[i] = logits[i].scale_(1 / t)
 
     entropy_tensor = get_entropy(logits[:real_bsz])
-
-    logger.info(f"  [entropy_fd non-MTP] entropy_tensor: {entropy_tensor.tolist()}")
 
     for i in range(real_bsz):
         if int(real_seq_lens[i]) == 0:
@@ -173,10 +157,7 @@ def speculate_calculate_logits_entropy_fd(logits, share_inputs, temperature):
     real_bsz = share_inputs["seq_lens_this_time"].shape[0]
     total_accepted_num = int(paddle.sum(share_inputs["accept_num"][:real_bsz]))
 
-    logger.info(f"  [entropy_fd] logits.shape={logits.shape}, total_accepted_num={total_accepted_num}")
-
     if total_accepted_num == 0:
-        logger.info("  [entropy_fd] total_accepted_num=0, checking flush only")
         for i in range(real_bsz):
             if (
                 share_inputs["stop_flags"][i]
@@ -204,8 +185,6 @@ def speculate_calculate_logits_entropy_fd(logits, share_inputs, temperature):
     )
     accepted_idx = repeated_starts + offsets
 
-    logger.info(f"  [entropy_fd] real_seq_lens={real_seq_lens.tolist()}, accepted_idx={accepted_idx.tolist()}")
-
     accepted_logits = paddle.empty([total_accepted_num, logits.shape[1]], dtype=logits.dtype)
     for i in range(total_accepted_num):
         accepted_logits[i] = logits[accepted_idx[i]]
@@ -220,8 +199,6 @@ def speculate_calculate_logits_entropy_fd(logits, share_inputs, temperature):
 
     entropy_tensor = get_entropy(accepted_logits)
     entropy = entropy_tensor.tolist()
-
-    logger.info(f"  [entropy_fd] computed entropy values: {entropy}")
 
     for i in range(real_bsz):
         accept_count = int(share_inputs["accept_num"][i])

--- a/fastdeploy/model_executor/entropy_utils.py
+++ b/fastdeploy/model_executor/entropy_utils.py
@@ -14,18 +14,15 @@
 # limitations under the License.
 """
 
-import os
-
 import paddle
+from paddleformers.utils.log import logger
 
 from fastdeploy.utils import data_processor_logger
-
-# Determine which runner is in use
-_USE_FD_RUNNER = os.environ.get("EB5_ENABLE_FD_RUNNER", "0") == "1"
 
 
 def get_entropy(logits):
     if paddle.any(paddle.isinf(logits) & (logits < 0)):
+        data_processor_logger.debug("Detected -inf values in logits, clipping to minimum value")
         logits = paddle.clip(logits, min=1e-9)
 
     a0 = logits - paddle.max(logits, axis=-1, keepdim=True)
@@ -35,11 +32,107 @@ def get_entropy(logits):
     return paddle.sum(p0 * (paddle.log(z0) - a0), axis=-1)
 
 
+def _log_entropy(share_inputs, i):
+    elist = share_inputs["entropy_list"][i]
+    data_processor_logger.info(
+        f"req_id: {share_inputs['req_ids'][i]}, entropy: {sum(elist)/len(elist)}, steps: {len(elist)}, all_values: {elist}"
+    )
+    share_inputs["entropy_list"][i] = []
+
+
+# ==============================================================================
+# ernie5_model_runner path (original logic from commit 361a310)
+# ==============================================================================
+
+
+def calculate_logits_entropy(logits, share_inputs, temperature):
+    real_bsz = share_inputs["seq_lens_this_time"].shape[0]
+    real_seq_lens = paddle.where(
+        share_inputs["seq_lens_encoder"][:real_bsz].squeeze(1) != 0,
+        paddle.ones([1], dtype="int32"),
+        share_inputs["seq_lens_this_time"].squeeze(1),
+    )
+
+    logger.info(f"  [entropy ernie5 non-MTP] logits.shape={logits.shape}, real_seq_lens={real_seq_lens.tolist()}")
+
+    batch_indices = paddle.arange(real_bsz, dtype="int32")
+    batch_id_per_token = paddle.repeat_interleave(batch_indices, real_seq_lens)
+    for i in range(logits.shape[0]):
+        if temperature[batch_id_per_token[i]] > 0 and temperature[batch_id_per_token[i]] != 1.0:
+            logits[i] = logits[i].scale_(1 / temperature[batch_id_per_token[i]])
+
+    entropy_tensor = get_entropy(logits)
+    entropy = entropy_tensor.tolist()
+
+    logger.info(f"  [entropy ernie5 non-MTP] computed entropy: {entropy}")
+
+    for i in range(real_bsz):
+        for _ in range(real_seq_lens[i]):
+            share_inputs["entropy_list"][i].append(entropy.pop(0))
+        if (
+            share_inputs["stop_flags"][i]
+            and share_inputs["seq_lens_decoder"][i] != 0
+            and len(share_inputs["entropy_list"][i]) != 0
+        ):
+            _log_entropy(share_inputs, i)
+
+
+def speculate_calculate_logits_entropy(logits, share_inputs, temperature):
+    # get accepted logits
+    real_bsz = share_inputs["seq_lens_this_time"].shape[0]
+    total_accepted_num = paddle.sum(share_inputs["accept_num"])
+    real_seq_lens = paddle.where(
+        share_inputs["seq_lens_encoder"][:real_bsz].squeeze(1) != 0,
+        paddle.ones([1], dtype="int32"),
+        share_inputs["seq_lens_this_time"].squeeze(1),
+    )
+    seq_start_idx = paddle.concat([paddle.zeros([1], dtype="int32"), paddle.cumsum(real_seq_lens, dtype="int32")])
+    repeated_starts = paddle.repeat_interleave(seq_start_idx[:-1], share_inputs["accept_num"][:real_bsz])
+    offsets = paddle.concat([paddle.arange(share_inputs["accept_num"][i].item()) for i in range(real_bsz)]).astype(
+        "int32"
+    )
+    accepted_idx = repeated_starts + offsets
+
+    logger.info(
+        f"  [entropy ernie5 MTP] logits.shape={logits.shape}, total_accepted_num={total_accepted_num}, "
+        f"real_seq_lens={real_seq_lens.tolist()}, accepted_idx={accepted_idx.tolist()}"
+    )
+
+    accepted_logits = paddle.empty([total_accepted_num, logits.shape[1]], dtype=logits.dtype)
+    for i in range(total_accepted_num):
+        accepted_logits[i] = logits[accepted_idx[i]]
+
+    batch_indices = paddle.arange(share_inputs["accept_num"].shape[0], dtype="int32")
+    batch_id_per_token = paddle.repeat_interleave(batch_indices, share_inputs["accept_num"])
+    for i in range(accepted_logits.shape[0]):
+        if temperature[batch_id_per_token[i]] > 0 and temperature[batch_id_per_token[i]] != 1.0:
+            accepted_logits[i] = accepted_logits[i].scale_(1 / temperature[batch_id_per_token[i]])
+
+    entropy_tensor = get_entropy(accepted_logits)
+    entropy = entropy_tensor.tolist()
+
+    logger.info(f"  [entropy ernie5 MTP] computed entropy: {entropy}")
+
+    for i in range(real_bsz):
+        for _ in range(share_inputs["accept_num"][i]):
+            share_inputs["entropy_list"][i].append(entropy.pop(0))
+        if (
+            share_inputs["stop_flags"][i]
+            and share_inputs["seq_lens_decoder"][i] != 0
+            and len(share_inputs["entropy_list"][i]) != 0
+        ):
+            _log_entropy(share_inputs, i)
+
+
+# ==============================================================================
+# gpu_model_runner (FD runner) path
+# ==============================================================================
+
+
 def calculate_logits_entropy_fd(logits, share_inputs, temperature):
     real_bsz = share_inputs["seq_lens_this_time"].shape[0]
     seq_lens_encoder = share_inputs["seq_lens_encoder"][:real_bsz]
     seq_lens_this_time = share_inputs["seq_lens_this_time"]
-    # GPU runner uses 1D [N], HPU/GCU/ernie5_runner uses 2D [N,1]; flatten to 1D
     if seq_lens_encoder.ndim == 2:
         seq_lens_encoder = seq_lens_encoder.squeeze(1)
     if seq_lens_this_time.ndim == 2:
@@ -50,7 +143,8 @@ def calculate_logits_entropy_fd(logits, share_inputs, temperature):
         seq_lens_this_time,
     )
 
-    # gpu_model_runner path: logits[i] is the single logit for slot i
+    logger.info(f"  [entropy_fd non-MTP] logits.shape={logits.shape}, real_seq_lens={real_seq_lens.tolist()}")
+
     for i in range(real_bsz):
         if int(real_seq_lens[i]) == 0:
             continue
@@ -59,6 +153,8 @@ def calculate_logits_entropy_fd(logits, share_inputs, temperature):
             logits[i] = logits[i].scale_(1 / t)
 
     entropy_tensor = get_entropy(logits[:real_bsz])
+
+    logger.info(f"  [entropy_fd non-MTP] entropy_tensor: {entropy_tensor.tolist()}")
 
     for i in range(real_bsz):
         if int(real_seq_lens[i]) == 0:
@@ -70,75 +166,26 @@ def calculate_logits_entropy_fd(logits, share_inputs, temperature):
             and share_inputs["seq_lens_decoder"][i] != 0
             and len(share_inputs["entropy_list"][i]) != 0
         ):
-            data_processor_logger.info(
-                f"req_id: {share_inputs['req_ids'][i]}, entropy: {sum(share_inputs['entropy_list'][i])/len(share_inputs['entropy_list'][i])}"
-            )
-            share_inputs["entropy_list"][i] = []
-
-
-def calculate_logits_entropy(logits, share_inputs, temperature):
-    """
-    Calculate entropy for each token's logits.
-
-    Two paths:
-    - gpu_model_runner (EB5_ENABLE_FD_RUNNER=1): logits shape [max_bsz, vocab],
-      one logit per slot, direct indexing.
-    - ernie5_model_runner (EB5_ENABLE_FD_RUNNER=0): logits shape [total_tokens, vocab],
-      flattened across batch, uses repeat_interleave to map back.
-    """
-    if _USE_FD_RUNNER:
-        calculate_logits_entropy_fd(logits, share_inputs, temperature)
-        return
-    else:
-        real_bsz = share_inputs["seq_lens_this_time"].shape[0]
-        real_seq_lens = paddle.where(
-            share_inputs["seq_lens_encoder"][:real_bsz].squeeze(1) != 0,
-            paddle.ones([1], dtype="int32"),
-            share_inputs["seq_lens_this_time"].squeeze(1),
-        )
-
-        batch_indices = paddle.arange(real_bsz, dtype="int32")
-        batch_id_per_token = paddle.repeat_interleave(batch_indices, real_seq_lens)
-        for i in range(logits.shape[0]):
-            if temperature[batch_id_per_token[i]] > 0 and temperature[batch_id_per_token[i]] != 1.0:
-                logits[i] = logits[i].scale_(1 / temperature[batch_id_per_token[i]])
-
-        entropy_tensor = get_entropy(logits)
-        entropy = entropy_tensor.tolist()
-
-        for i in range(real_bsz):
-            for _ in range(real_seq_lens[i]):
-                share_inputs["entropy_list"][i].append(entropy.pop(0))
-            if (
-                share_inputs["stop_flags"][i]
-                and share_inputs["seq_lens_decoder"][i] != 0
-                and len(share_inputs["entropy_list"][i]) != 0
-            ):
-                data_processor_logger.info(
-                    f"req_id: {share_inputs['req_ids'][i]}, entropy: {sum(share_inputs['entropy_list'][i])/len(share_inputs['entropy_list'][i])}"
-                )
-                share_inputs["entropy_list"][i] = []
+            _log_entropy(share_inputs, i)
 
 
 def speculate_calculate_logits_entropy_fd(logits, share_inputs, temperature):
     real_bsz = share_inputs["seq_lens_this_time"].shape[0]
     total_accepted_num = int(paddle.sum(share_inputs["accept_num"][:real_bsz]))
 
+    logger.info(f"  [entropy_fd] logits.shape={logits.shape}, total_accepted_num={total_accepted_num}")
+
     if total_accepted_num == 0:
-        # Still check stop_flags for ENTROPY-DONE even when no tokens accepted
+        logger.info("  [entropy_fd] total_accepted_num=0, checking flush only")
         for i in range(real_bsz):
             if (
                 share_inputs["stop_flags"][i]
                 and share_inputs["seq_lens_decoder"][i] != 0
                 and len(share_inputs["entropy_list"][i]) != 0
             ):
-                data_processor_logger.info(
-                    f"req_id: {share_inputs['req_ids'][i]}, entropy: {sum(share_inputs['entropy_list'][i])/len(share_inputs['entropy_list'][i])}"
-                )
-                share_inputs["entropy_list"][i] = []
+                _log_entropy(share_inputs, i)
         return
 
-    # fd_runner: logits shape is [sum(seq_lens_this_time), vocab], need to index accepted rows
     seq_lens_encoder = share_inputs["seq_lens_encoder"][:real_bsz]
     seq_lens_this_time = share_inputs["seq_lens_this_time"]
     if seq_lens_encoder.ndim == 2:
@@ -157,83 +204,57 @@ def speculate_calculate_logits_entropy_fd(logits, share_inputs, temperature):
     )
     accepted_idx = repeated_starts + offsets
 
+    logger.info(f"  [entropy_fd] real_seq_lens={real_seq_lens.tolist()}, accepted_idx={accepted_idx.tolist()}")
+
     accepted_logits = paddle.empty([total_accepted_num, logits.shape[1]], dtype=logits.dtype)
     for i in range(total_accepted_num):
         accepted_logits[i] = logits[accepted_idx[i]]
 
-    batch_indices = paddle.arange(share_inputs["accept_num"].shape[0], dtype="int32")
-    batch_id_per_token = paddle.repeat_interleave(batch_indices, share_inputs["accept_num"])
-    for i in range(accepted_logits.shape[0]):
-        if temperature[batch_id_per_token[i]] > 0 and temperature[batch_id_per_token[i]] != 1.0:
-            accepted_logits[i] = accepted_logits[i].scale_(1 / temperature[batch_id_per_token[i]])
+    batch_indices = paddle.arange(real_bsz, dtype="int32")
+    batch_id_per_token = paddle.repeat_interleave(batch_indices, share_inputs["accept_num"][:real_bsz])
+    for i in range(total_accepted_num):
+        bid = int(batch_id_per_token[i])
+        t = temperature[bid]
+        if t > 0 and t != 1.0:
+            accepted_logits[i] = accepted_logits[i].scale_(1 / t)
 
     entropy_tensor = get_entropy(accepted_logits)
     entropy = entropy_tensor.tolist()
 
+    logger.info(f"  [entropy_fd] computed entropy values: {entropy}")
+
     for i in range(real_bsz):
-        for _ in range(share_inputs["accept_num"][i]):
-            share_inputs["entropy_list"][i].append(entropy.pop(0))
+        accept_count = int(share_inputs["accept_num"][i])
+        if accept_count > 0:
+            req_id = share_inputs["req_ids"][i] if i < len(share_inputs["req_ids"]) else ""
+            is_valid_req = bool(req_id and str(req_id).strip())
+            for j in range(accept_count):
+                e_val = entropy.pop(0)
+                if is_valid_req:
+                    share_inputs["entropy_list"][i].append(e_val)
         if (
             share_inputs["stop_flags"][i]
             and share_inputs["seq_lens_decoder"][i] != 0
             and len(share_inputs["entropy_list"][i]) != 0
         ):
-            data_processor_logger.info(
-                f"req_id: {share_inputs['req_ids'][i]}, entropy: {sum(share_inputs['entropy_list'][i])/len(share_inputs['entropy_list'][i])}"
-            )
-            share_inputs["entropy_list"][i] = []
+            _log_entropy(share_inputs, i)
 
 
-def speculate_calculate_logits_entropy(logits, share_inputs, temperature):
+# ==============================================================================
+# Common utility
+# ==============================================================================
+
+
+def flush_entropy_on_stop(share_inputs):
     """
-    Calculate entropy for speculative decoding (MTP) accepted tokens.
-
-    Two paths:
-    - fd_runner (EB5_ENABLE_FD_RUNNER=1): logits shape [sum(seq_lens_this_time), vocab],
-      contains all positions including rejected; must use accepted_idx to extract.
-    - ernie5_runner (EB5_ENABLE_FD_RUNNER=0): logits shape [total_accepted_num, vocab],
-      already contains only accepted tokens ordered by slot.
+    Flush entropy for requests whose stop_flags became True after entropy calculation.
+    Called after unified_update_model_status which sets stop_flags for max_dec_len.
     """
-    if _USE_FD_RUNNER:
-        speculate_calculate_logits_entropy_fd(logits, share_inputs, temperature)
-        return
-    else:
-        real_bsz = share_inputs["seq_lens_this_time"].shape[0]
-        total_accepted_num = paddle.sum(share_inputs["accept_num"])
-        real_seq_lens = paddle.where(
-            share_inputs["seq_lens_encoder"][:real_bsz].squeeze(1) != 0,
-            paddle.ones([1], dtype="int32"),
-            share_inputs["seq_lens_this_time"].squeeze(1),
-        )
-        seq_start_idx = paddle.concat([paddle.zeros([1], dtype="int32"), paddle.cumsum(real_seq_lens, dtype="int32")])
-        repeated_starts = paddle.repeat_interleave(seq_start_idx[:-1], share_inputs["accept_num"][:real_bsz])
-        offsets = paddle.concat([paddle.arange(share_inputs["accept_num"][i].item()) for i in range(real_bsz)]).astype(
-            "int32"
-        )
-        accepted_idx = repeated_starts + offsets
-
-        accepted_logits = paddle.empty([total_accepted_num, logits.shape[1]], dtype=logits.dtype)
-        for i in range(total_accepted_num):
-            accepted_logits[i] = logits[accepted_idx[i]]
-
-        batch_indices = paddle.arange(share_inputs["accept_num"].shape[0], dtype="int32")
-        batch_id_per_token = paddle.repeat_interleave(batch_indices, share_inputs["accept_num"])
-        for i in range(accepted_logits.shape[0]):
-            if temperature[batch_id_per_token[i]] > 0 and temperature[batch_id_per_token[i]] != 1.0:
-                accepted_logits[i] = accepted_logits[i].scale_(1 / temperature[batch_id_per_token[i]])
-
-        entropy_tensor = get_entropy(accepted_logits)
-        entropy = entropy_tensor.tolist()
-
-        for i in range(real_bsz):
-            for _ in range(share_inputs["accept_num"][i]):
-                share_inputs["entropy_list"][i].append(entropy.pop(0))
-            if (
-                share_inputs["stop_flags"][i]
-                and share_inputs["seq_lens_decoder"][i] != 0
-                and len(share_inputs["entropy_list"][i]) != 0
-            ):
-                data_processor_logger.info(
-                    f"req_id: {share_inputs['req_ids'][i]}, entropy: {sum(share_inputs['entropy_list'][i])/len(share_inputs['entropy_list'][i])}"
-                )
-                share_inputs["entropy_list"][i] = []
+    real_bsz = share_inputs["seq_lens_this_time"].shape[0]
+    for i in range(real_bsz):
+        if (
+            share_inputs["stop_flags"][i]
+            and share_inputs["seq_lens_decoder"][i] != 0
+            and len(share_inputs["entropy_list"][i]) != 0
+        ):
+            _log_entropy(share_inputs, i)

--- a/fastdeploy/model_executor/entropy_utils.py
+++ b/fastdeploy/model_executor/entropy_utils.py
@@ -14,15 +14,18 @@
 # limitations under the License.
 """
 
+import os
+
 import paddle
 
 from fastdeploy.utils import data_processor_logger
 
+# Determine which runner is in use
+_USE_FD_RUNNER = os.environ.get("EB5_ENABLE_FD_RUNNER", "0") == "1"
+
 
 def get_entropy(logits):
-    # Check for -inf values in logits
     if paddle.any(paddle.isinf(logits) & (logits < 0)):
-        data_processor_logger.debug("Detected -inf values in logits, clipping to minimum value")
         logits = paddle.clip(logits, min=1e-9)
 
     a0 = logits - paddle.max(logits, axis=-1, keepdim=True)
@@ -33,74 +36,176 @@ def get_entropy(logits):
 
 
 def calculate_logits_entropy(logits, share_inputs, temperature):
+    """
+    Calculate entropy for each token's logits.
+
+    Two paths:
+    - gpu_model_runner (EB5_ENABLE_FD_RUNNER=1): logits shape [max_bsz, vocab],
+      one logit per slot, direct indexing.
+    - ernie5_model_runner (EB5_ENABLE_FD_RUNNER=0): logits shape [total_tokens, vocab],
+      flattened across batch, uses repeat_interleave to map back.
+    """
     real_bsz = share_inputs["seq_lens_this_time"].shape[0]
+    seq_lens_encoder = share_inputs["seq_lens_encoder"][:real_bsz]
+    seq_lens_this_time = share_inputs["seq_lens_this_time"]
+    # GPU runner uses 1D [N], HPU/GCU/ernie5_runner uses 2D [N,1]; flatten to 1D
+    if seq_lens_encoder.ndim == 2:
+        seq_lens_encoder = seq_lens_encoder.squeeze(1)
+    if seq_lens_this_time.ndim == 2:
+        seq_lens_this_time = seq_lens_this_time.squeeze(1)
     real_seq_lens = paddle.where(
-        share_inputs["seq_lens_encoder"][:real_bsz].squeeze(1) != 0,
+        seq_lens_encoder != 0,
         paddle.ones([1], dtype="int32"),
-        share_inputs["seq_lens_this_time"].squeeze(1),
+        seq_lens_this_time,
     )
 
-    batch_indices = paddle.arange(real_bsz, dtype="int32")
-    batch_id_per_token = paddle.repeat_interleave(batch_indices, real_seq_lens)
-    for i in range(logits.shape[0]):
-        if temperature[batch_id_per_token[i]] > 0 and temperature[batch_id_per_token[i]] != 1.0:
-            logits[i] = logits[i].scale_(1 / temperature[batch_id_per_token[i]])
+    if _USE_FD_RUNNER:
+        # gpu_model_runner path: logits[i] is the single logit for slot i
+        for i in range(real_bsz):
+            if int(real_seq_lens[i]) == 0:
+                continue
+            t = temperature[i]
+            if t > 0 and t != 1.0:
+                logits[i] = logits[i].scale_(1 / t)
 
-    entropy_tensor = get_entropy(logits)
-    entropy = entropy_tensor.tolist()
+        entropy_tensor = get_entropy(logits[:real_bsz])
 
-    for i in range(real_bsz):
-        for _ in range(real_seq_lens[i]):
-            share_inputs["entropy_list"][i].append(entropy.pop(0))
-        if (
-            share_inputs["stop_flags"][i]
-            and share_inputs["seq_lens_decoder"][i] != 0
-            and len(share_inputs["entropy_list"][i]) != 0
-        ):
-            data_processor_logger.info(
-                f"req_id: {share_inputs['req_ids'][i]}, entropy: {sum(share_inputs['entropy_list'][i])/len(share_inputs['entropy_list'][i])}"
-            )
-            share_inputs["entropy_list"][i] = []
+        for i in range(real_bsz):
+            if int(real_seq_lens[i]) == 0:
+                continue
+            entropy_val = float(entropy_tensor[i])
+            share_inputs["entropy_list"][i].append(entropy_val)
+            if (
+                share_inputs["stop_flags"][i]
+                and share_inputs["seq_lens_decoder"][i] != 0
+                and len(share_inputs["entropy_list"][i]) != 0
+            ):
+                avg_entropy = sum(share_inputs["entropy_list"][i]) / len(share_inputs["entropy_list"][i])
+                data_processor_logger.info(
+                    f"[ENTROPY-DONE] req_id:{share_inputs['req_ids'][i]}, "
+                    f"avg_entropy:{avg_entropy:.6f}, total_steps:{len(share_inputs['entropy_list'][i])}"
+                )
+                share_inputs["entropy_list"][i] = []
+    else:
+        # ernie5_model_runner path: logits is flattened [total_tokens, vocab]
+        # Need repeat_interleave to map tokens back to batch items
+        batch_indices = paddle.arange(real_bsz, dtype="int32")
+        batch_id_per_token = paddle.repeat_interleave(batch_indices, real_seq_lens)
+        for i in range(logits.shape[0]):
+            bid = int(batch_id_per_token[i])
+            t = temperature[bid]
+            if t > 0 and t != 1.0:
+                logits[i] = logits[i].scale_(1 / t)
+
+        entropy_tensor = get_entropy(logits)
+        entropy = entropy_tensor.tolist()
+
+        for i in range(real_bsz):
+            if int(real_seq_lens[i]) == 0:
+                continue
+            seq_len = int(real_seq_lens[i])
+            for j in range(seq_len):
+                e_val = entropy.pop(0)
+                share_inputs["entropy_list"][i].append(e_val)
+            if (
+                share_inputs["stop_flags"][i]
+                and share_inputs["seq_lens_decoder"][i] != 0
+                and len(share_inputs["entropy_list"][i]) != 0
+            ):
+                avg_entropy = sum(share_inputs["entropy_list"][i]) / len(share_inputs["entropy_list"][i])
+                data_processor_logger.info(
+                    f"[ENTROPY-DONE] req_id:{share_inputs['req_ids'][i]}, "
+                    f"avg_entropy:{avg_entropy:.6f}, total_steps:{len(share_inputs['entropy_list'][i])}"
+                )
+                share_inputs["entropy_list"][i] = []
 
 
 def speculate_calculate_logits_entropy(logits, share_inputs, temperature):
-    # get accepted logits
+    """
+    Calculate entropy for speculative decoding (MTP) accepted tokens.
+
+    Two paths:
+    - fd_runner (EB5_ENABLE_FD_RUNNER=1): logits shape [sum(seq_lens_this_time), vocab],
+      contains all positions including rejected; must use accepted_idx to extract.
+    - ernie5_runner (EB5_ENABLE_FD_RUNNER=0): logits shape [total_accepted_num, vocab],
+      already contains only accepted tokens ordered by slot.
+    """
     real_bsz = share_inputs["seq_lens_this_time"].shape[0]
-    total_accepted_num = paddle.sum(share_inputs["accept_num"])
-    real_seq_lens = paddle.where(
-        share_inputs["seq_lens_encoder"][:real_bsz].squeeze(1) != 0,
-        paddle.ones([1], dtype="int32"),
-        share_inputs["seq_lens_this_time"].squeeze(1),
-    )
-    seq_start_idx = paddle.concat([paddle.zeros([1], dtype="int32"), paddle.cumsum(real_seq_lens, dtype="int32")])
-    repeated_starts = paddle.repeat_interleave(seq_start_idx[:-1], share_inputs["accept_num"][:real_bsz])
-    offsets = paddle.concat([paddle.arange(share_inputs["accept_num"][i].item()) for i in range(real_bsz)]).astype(
-        "int32"
-    )
-    accepted_idx = repeated_starts + offsets
+    total_accepted_num = int(paddle.sum(share_inputs["accept_num"][:real_bsz]))
 
-    accepted_logits = paddle.empty([total_accepted_num, logits.shape[1]], dtype=logits.dtype)
+    if total_accepted_num == 0:
+        # Still check stop_flags for ENTROPY-DONE even when no tokens accepted
+        for i in range(real_bsz):
+            if (
+                share_inputs["stop_flags"][i]
+                and share_inputs["seq_lens_decoder"][i] != 0
+                and len(share_inputs["entropy_list"][i]) != 0
+            ):
+                avg_entropy = sum(share_inputs["entropy_list"][i]) / len(share_inputs["entropy_list"][i])
+                data_processor_logger.info(
+                    f"[ENTROPY-DONE] req_id:{share_inputs['req_ids'][i]}, "
+                    f"avg_entropy:{avg_entropy:.6f}, total_steps:{len(share_inputs['entropy_list'][i])}"
+                )
+                share_inputs["entropy_list"][i] = []
+        return
+
+    if _USE_FD_RUNNER:
+        # fd_runner: logits shape is [sum(seq_lens_this_time), vocab], need to index accepted rows
+        seq_lens_encoder = share_inputs["seq_lens_encoder"][:real_bsz]
+        seq_lens_this_time = share_inputs["seq_lens_this_time"]
+        if seq_lens_encoder.ndim == 2:
+            seq_lens_encoder = seq_lens_encoder.squeeze(1)
+        if seq_lens_this_time.ndim == 2:
+            seq_lens_this_time = seq_lens_this_time.squeeze(1)
+        real_seq_lens = paddle.where(
+            seq_lens_encoder != 0,
+            paddle.ones([1], dtype="int32"),
+            seq_lens_this_time,
+        )
+        seq_start_idx = paddle.concat([paddle.zeros([1], dtype="int32"), paddle.cumsum(real_seq_lens, dtype="int32")])
+        repeated_starts = paddle.repeat_interleave(seq_start_idx[:-1], share_inputs["accept_num"][:real_bsz])
+        offsets = paddle.concat([paddle.arange(share_inputs["accept_num"][i].item()) for i in range(real_bsz)]).astype(
+            "int32"
+        )
+        accepted_idx = repeated_starts + offsets
+
+        accepted_logits = paddle.empty([total_accepted_num, logits.shape[1]], dtype=logits.dtype)
+        for i in range(total_accepted_num):
+            accepted_logits[i] = logits[accepted_idx[i]]
+    else:
+        # ernie5_runner: logits is already [total_accepted_num, vocab], ordered by slot
+        accepted_logits = logits[:total_accepted_num]
+
+    # Apply temperature scaling per-token
+    batch_indices = paddle.arange(real_bsz, dtype="int32")
+    batch_id_per_token = paddle.repeat_interleave(batch_indices, share_inputs["accept_num"][:real_bsz])
     for i in range(total_accepted_num):
-        accepted_logits[i] = logits[accepted_idx[i]]
-
-    batch_indices = paddle.arange(share_inputs["accept_num"].shape[0], dtype="int32")
-    batch_id_per_token = paddle.repeat_interleave(batch_indices, share_inputs["accept_num"])
-    for i in range(accepted_logits.shape[0]):
-        if temperature[batch_id_per_token[i]] > 0 and temperature[batch_id_per_token[i]] != 1.0:
-            accepted_logits[i] = accepted_logits[i].scale_(1 / temperature[batch_id_per_token[i]])
+        bid = int(batch_id_per_token[i])
+        t = temperature[bid]
+        if t > 0 and t != 1.0:
+            accepted_logits[i] = accepted_logits[i].scale_(1 / t)
 
     entropy_tensor = get_entropy(accepted_logits)
     entropy = entropy_tensor.tolist()
 
     for i in range(real_bsz):
-        for _ in range(share_inputs["accept_num"][i]):
-            share_inputs["entropy_list"][i].append(entropy.pop(0))
+        accept_count = int(share_inputs["accept_num"][i])
+        if accept_count > 0:
+            # Skip entropy accumulation for warmup/dummy requests (empty req_id)
+            req_id = share_inputs["req_ids"][i] if i < len(share_inputs["req_ids"]) else ""
+            is_valid_req = bool(req_id and req_id.strip())
+            for j in range(accept_count):
+                e_val = entropy.pop(0)
+                if is_valid_req:
+                    share_inputs["entropy_list"][i].append(e_val)
         if (
             share_inputs["stop_flags"][i]
             and share_inputs["seq_lens_decoder"][i] != 0
             and len(share_inputs["entropy_list"][i]) != 0
         ):
+            avg_entropy = sum(share_inputs["entropy_list"][i]) / len(share_inputs["entropy_list"][i])
             data_processor_logger.info(
-                f"req_id: {share_inputs['req_ids'][i]}, entropy: {sum(share_inputs['entropy_list'][i])/len(share_inputs['entropy_list'][i])}"
+                f"[ENTROPY-DONE] req_id:{share_inputs['req_ids'][i]}, "
+                f"avg_entropy:{avg_entropy:.6f}, total_steps:{len(share_inputs['entropy_list'][i])}"
             )
             share_inputs["entropy_list"][i] = []

--- a/fastdeploy/model_executor/entropy_utils.py
+++ b/fastdeploy/model_executor/entropy_utils.py
@@ -35,16 +35,7 @@ def get_entropy(logits):
     return paddle.sum(p0 * (paddle.log(z0) - a0), axis=-1)
 
 
-def calculate_logits_entropy(logits, share_inputs, temperature):
-    """
-    Calculate entropy for each token's logits.
-
-    Two paths:
-    - gpu_model_runner (EB5_ENABLE_FD_RUNNER=1): logits shape [max_bsz, vocab],
-      one logit per slot, direct indexing.
-    - ernie5_model_runner (EB5_ENABLE_FD_RUNNER=0): logits shape [total_tokens, vocab],
-      flattened across batch, uses repeat_interleave to map back.
-    """
+def calculate_logits_entropy_fd(logits, share_inputs, temperature):
     real_bsz = share_inputs["seq_lens_this_time"].shape[0]
     seq_lens_encoder = share_inputs["seq_lens_encoder"][:real_bsz]
     seq_lens_this_time = share_inputs["seq_lens_this_time"]
@@ -59,65 +50,138 @@ def calculate_logits_entropy(logits, share_inputs, temperature):
         seq_lens_this_time,
     )
 
+    # gpu_model_runner path: logits[i] is the single logit for slot i
+    for i in range(real_bsz):
+        if int(real_seq_lens[i]) == 0:
+            continue
+        t = temperature[i]
+        if t > 0 and t != 1.0:
+            logits[i] = logits[i].scale_(1 / t)
+
+    entropy_tensor = get_entropy(logits[:real_bsz])
+
+    for i in range(real_bsz):
+        if int(real_seq_lens[i]) == 0:
+            continue
+        entropy_val = float(entropy_tensor[i])
+        share_inputs["entropy_list"][i].append(entropy_val)
+        if (
+            share_inputs["stop_flags"][i]
+            and share_inputs["seq_lens_decoder"][i] != 0
+            and len(share_inputs["entropy_list"][i]) != 0
+        ):
+            data_processor_logger.info(
+                f"req_id: {share_inputs['req_ids'][i]}, entropy: {sum(share_inputs['entropy_list'][i])/len(share_inputs['entropy_list'][i])}"
+            )
+            share_inputs["entropy_list"][i] = []
+
+
+def calculate_logits_entropy(logits, share_inputs, temperature):
+    """
+    Calculate entropy for each token's logits.
+
+    Two paths:
+    - gpu_model_runner (EB5_ENABLE_FD_RUNNER=1): logits shape [max_bsz, vocab],
+      one logit per slot, direct indexing.
+    - ernie5_model_runner (EB5_ENABLE_FD_RUNNER=0): logits shape [total_tokens, vocab],
+      flattened across batch, uses repeat_interleave to map back.
+    """
     if _USE_FD_RUNNER:
-        # gpu_model_runner path: logits[i] is the single logit for slot i
-        for i in range(real_bsz):
-            if int(real_seq_lens[i]) == 0:
-                continue
-            t = temperature[i]
-            if t > 0 and t != 1.0:
-                logits[i] = logits[i].scale_(1 / t)
-
-        entropy_tensor = get_entropy(logits[:real_bsz])
-
-        for i in range(real_bsz):
-            if int(real_seq_lens[i]) == 0:
-                continue
-            entropy_val = float(entropy_tensor[i])
-            share_inputs["entropy_list"][i].append(entropy_val)
-            if (
-                share_inputs["stop_flags"][i]
-                and share_inputs["seq_lens_decoder"][i] != 0
-                and len(share_inputs["entropy_list"][i]) != 0
-            ):
-                avg_entropy = sum(share_inputs["entropy_list"][i]) / len(share_inputs["entropy_list"][i])
-                data_processor_logger.info(
-                    f"[ENTROPY-DONE] req_id:{share_inputs['req_ids'][i]}, "
-                    f"avg_entropy:{avg_entropy:.6f}, total_steps:{len(share_inputs['entropy_list'][i])}"
-                )
-                share_inputs["entropy_list"][i] = []
+        calculate_logits_entropy_fd(logits, share_inputs, temperature)
+        return
     else:
-        # ernie5_model_runner path: logits is flattened [total_tokens, vocab]
-        # Need repeat_interleave to map tokens back to batch items
+        real_bsz = share_inputs["seq_lens_this_time"].shape[0]
+        real_seq_lens = paddle.where(
+            share_inputs["seq_lens_encoder"][:real_bsz].squeeze(1) != 0,
+            paddle.ones([1], dtype="int32"),
+            share_inputs["seq_lens_this_time"].squeeze(1),
+        )
+
         batch_indices = paddle.arange(real_bsz, dtype="int32")
         batch_id_per_token = paddle.repeat_interleave(batch_indices, real_seq_lens)
         for i in range(logits.shape[0]):
-            bid = int(batch_id_per_token[i])
-            t = temperature[bid]
-            if t > 0 and t != 1.0:
-                logits[i] = logits[i].scale_(1 / t)
+            if temperature[batch_id_per_token[i]] > 0 and temperature[batch_id_per_token[i]] != 1.0:
+                logits[i] = logits[i].scale_(1 / temperature[batch_id_per_token[i]])
 
         entropy_tensor = get_entropy(logits)
         entropy = entropy_tensor.tolist()
 
         for i in range(real_bsz):
-            if int(real_seq_lens[i]) == 0:
-                continue
-            seq_len = int(real_seq_lens[i])
-            for j in range(seq_len):
-                e_val = entropy.pop(0)
-                share_inputs["entropy_list"][i].append(e_val)
+            for _ in range(real_seq_lens[i]):
+                share_inputs["entropy_list"][i].append(entropy.pop(0))
             if (
                 share_inputs["stop_flags"][i]
                 and share_inputs["seq_lens_decoder"][i] != 0
                 and len(share_inputs["entropy_list"][i]) != 0
             ):
-                avg_entropy = sum(share_inputs["entropy_list"][i]) / len(share_inputs["entropy_list"][i])
                 data_processor_logger.info(
-                    f"[ENTROPY-DONE] req_id:{share_inputs['req_ids'][i]}, "
-                    f"avg_entropy:{avg_entropy:.6f}, total_steps:{len(share_inputs['entropy_list'][i])}"
+                    f"req_id: {share_inputs['req_ids'][i]}, entropy: {sum(share_inputs['entropy_list'][i])/len(share_inputs['entropy_list'][i])}"
                 )
                 share_inputs["entropy_list"][i] = []
+
+
+def speculate_calculate_logits_entropy_fd(logits, share_inputs, temperature):
+    real_bsz = share_inputs["seq_lens_this_time"].shape[0]
+    total_accepted_num = int(paddle.sum(share_inputs["accept_num"][:real_bsz]))
+
+    if total_accepted_num == 0:
+        # Still check stop_flags for ENTROPY-DONE even when no tokens accepted
+        for i in range(real_bsz):
+            if (
+                share_inputs["stop_flags"][i]
+                and share_inputs["seq_lens_decoder"][i] != 0
+                and len(share_inputs["entropy_list"][i]) != 0
+            ):
+                data_processor_logger.info(
+                    f"req_id: {share_inputs['req_ids'][i]}, entropy: {sum(share_inputs['entropy_list'][i])/len(share_inputs['entropy_list'][i])}"
+                )
+                share_inputs["entropy_list"][i] = []
+        return
+
+    # fd_runner: logits shape is [sum(seq_lens_this_time), vocab], need to index accepted rows
+    seq_lens_encoder = share_inputs["seq_lens_encoder"][:real_bsz]
+    seq_lens_this_time = share_inputs["seq_lens_this_time"]
+    if seq_lens_encoder.ndim == 2:
+        seq_lens_encoder = seq_lens_encoder.squeeze(1)
+    if seq_lens_this_time.ndim == 2:
+        seq_lens_this_time = seq_lens_this_time.squeeze(1)
+    real_seq_lens = paddle.where(
+        seq_lens_encoder != 0,
+        paddle.ones([1], dtype="int32"),
+        seq_lens_this_time,
+    )
+    seq_start_idx = paddle.concat([paddle.zeros([1], dtype="int32"), paddle.cumsum(real_seq_lens, dtype="int32")])
+    repeated_starts = paddle.repeat_interleave(seq_start_idx[:-1], share_inputs["accept_num"][:real_bsz])
+    offsets = paddle.concat([paddle.arange(share_inputs["accept_num"][i].item()) for i in range(real_bsz)]).astype(
+        "int32"
+    )
+    accepted_idx = repeated_starts + offsets
+
+    accepted_logits = paddle.empty([total_accepted_num, logits.shape[1]], dtype=logits.dtype)
+    for i in range(total_accepted_num):
+        accepted_logits[i] = logits[accepted_idx[i]]
+
+    batch_indices = paddle.arange(share_inputs["accept_num"].shape[0], dtype="int32")
+    batch_id_per_token = paddle.repeat_interleave(batch_indices, share_inputs["accept_num"])
+    for i in range(accepted_logits.shape[0]):
+        if temperature[batch_id_per_token[i]] > 0 and temperature[batch_id_per_token[i]] != 1.0:
+            accepted_logits[i] = accepted_logits[i].scale_(1 / temperature[batch_id_per_token[i]])
+
+    entropy_tensor = get_entropy(accepted_logits)
+    entropy = entropy_tensor.tolist()
+
+    for i in range(real_bsz):
+        for _ in range(share_inputs["accept_num"][i]):
+            share_inputs["entropy_list"][i].append(entropy.pop(0))
+        if (
+            share_inputs["stop_flags"][i]
+            and share_inputs["seq_lens_decoder"][i] != 0
+            and len(share_inputs["entropy_list"][i]) != 0
+        ):
+            data_processor_logger.info(
+                f"req_id: {share_inputs['req_ids'][i]}, entropy: {sum(share_inputs['entropy_list'][i])/len(share_inputs['entropy_list'][i])}"
+            )
+            share_inputs["entropy_list"][i] = []
 
 
 def speculate_calculate_logits_entropy(logits, share_inputs, temperature):
@@ -130,37 +194,16 @@ def speculate_calculate_logits_entropy(logits, share_inputs, temperature):
     - ernie5_runner (EB5_ENABLE_FD_RUNNER=0): logits shape [total_accepted_num, vocab],
       already contains only accepted tokens ordered by slot.
     """
-    real_bsz = share_inputs["seq_lens_this_time"].shape[0]
-    total_accepted_num = int(paddle.sum(share_inputs["accept_num"][:real_bsz]))
-
-    if total_accepted_num == 0:
-        # Still check stop_flags for ENTROPY-DONE even when no tokens accepted
-        for i in range(real_bsz):
-            if (
-                share_inputs["stop_flags"][i]
-                and share_inputs["seq_lens_decoder"][i] != 0
-                and len(share_inputs["entropy_list"][i]) != 0
-            ):
-                avg_entropy = sum(share_inputs["entropy_list"][i]) / len(share_inputs["entropy_list"][i])
-                data_processor_logger.info(
-                    f"[ENTROPY-DONE] req_id:{share_inputs['req_ids'][i]}, "
-                    f"avg_entropy:{avg_entropy:.6f}, total_steps:{len(share_inputs['entropy_list'][i])}"
-                )
-                share_inputs["entropy_list"][i] = []
-        return
-
     if _USE_FD_RUNNER:
-        # fd_runner: logits shape is [sum(seq_lens_this_time), vocab], need to index accepted rows
-        seq_lens_encoder = share_inputs["seq_lens_encoder"][:real_bsz]
-        seq_lens_this_time = share_inputs["seq_lens_this_time"]
-        if seq_lens_encoder.ndim == 2:
-            seq_lens_encoder = seq_lens_encoder.squeeze(1)
-        if seq_lens_this_time.ndim == 2:
-            seq_lens_this_time = seq_lens_this_time.squeeze(1)
+        speculate_calculate_logits_entropy_fd(logits, share_inputs, temperature)
+        return
+    else:
+        real_bsz = share_inputs["seq_lens_this_time"].shape[0]
+        total_accepted_num = paddle.sum(share_inputs["accept_num"])
         real_seq_lens = paddle.where(
-            seq_lens_encoder != 0,
+            share_inputs["seq_lens_encoder"][:real_bsz].squeeze(1) != 0,
             paddle.ones([1], dtype="int32"),
-            seq_lens_this_time,
+            share_inputs["seq_lens_this_time"].squeeze(1),
         )
         seq_start_idx = paddle.concat([paddle.zeros([1], dtype="int32"), paddle.cumsum(real_seq_lens, dtype="int32")])
         repeated_starts = paddle.repeat_interleave(seq_start_idx[:-1], share_inputs["accept_num"][:real_bsz])
@@ -172,40 +215,25 @@ def speculate_calculate_logits_entropy(logits, share_inputs, temperature):
         accepted_logits = paddle.empty([total_accepted_num, logits.shape[1]], dtype=logits.dtype)
         for i in range(total_accepted_num):
             accepted_logits[i] = logits[accepted_idx[i]]
-    else:
-        # ernie5_runner: logits is already [total_accepted_num, vocab], ordered by slot
-        accepted_logits = logits[:total_accepted_num]
 
-    # Apply temperature scaling per-token
-    batch_indices = paddle.arange(real_bsz, dtype="int32")
-    batch_id_per_token = paddle.repeat_interleave(batch_indices, share_inputs["accept_num"][:real_bsz])
-    for i in range(total_accepted_num):
-        bid = int(batch_id_per_token[i])
-        t = temperature[bid]
-        if t > 0 and t != 1.0:
-            accepted_logits[i] = accepted_logits[i].scale_(1 / t)
+        batch_indices = paddle.arange(share_inputs["accept_num"].shape[0], dtype="int32")
+        batch_id_per_token = paddle.repeat_interleave(batch_indices, share_inputs["accept_num"])
+        for i in range(accepted_logits.shape[0]):
+            if temperature[batch_id_per_token[i]] > 0 and temperature[batch_id_per_token[i]] != 1.0:
+                accepted_logits[i] = accepted_logits[i].scale_(1 / temperature[batch_id_per_token[i]])
 
-    entropy_tensor = get_entropy(accepted_logits)
-    entropy = entropy_tensor.tolist()
+        entropy_tensor = get_entropy(accepted_logits)
+        entropy = entropy_tensor.tolist()
 
-    for i in range(real_bsz):
-        accept_count = int(share_inputs["accept_num"][i])
-        if accept_count > 0:
-            # Skip entropy accumulation for warmup/dummy requests (empty req_id)
-            req_id = share_inputs["req_ids"][i] if i < len(share_inputs["req_ids"]) else ""
-            is_valid_req = bool(req_id and req_id.strip())
-            for j in range(accept_count):
-                e_val = entropy.pop(0)
-                if is_valid_req:
-                    share_inputs["entropy_list"][i].append(e_val)
-        if (
-            share_inputs["stop_flags"][i]
-            and share_inputs["seq_lens_decoder"][i] != 0
-            and len(share_inputs["entropy_list"][i]) != 0
-        ):
-            avg_entropy = sum(share_inputs["entropy_list"][i]) / len(share_inputs["entropy_list"][i])
-            data_processor_logger.info(
-                f"[ENTROPY-DONE] req_id:{share_inputs['req_ids'][i]}, "
-                f"avg_entropy:{avg_entropy:.6f}, total_steps:{len(share_inputs['entropy_list'][i])}"
-            )
-            share_inputs["entropy_list"][i] = []
+        for i in range(real_bsz):
+            for _ in range(share_inputs["accept_num"][i]):
+                share_inputs["entropy_list"][i].append(entropy.pop(0))
+            if (
+                share_inputs["stop_flags"][i]
+                and share_inputs["seq_lens_decoder"][i] != 0
+                and len(share_inputs["entropy_list"][i]) != 0
+            ):
+                data_processor_logger.info(
+                    f"req_id: {share_inputs['req_ids'][i]}, entropy: {sum(share_inputs['entropy_list'][i])/len(share_inputs['entropy_list'][i])}"
+                )
+                share_inputs["entropy_list"][i] = []

--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -20,7 +20,6 @@ from typing import Dict, List, Optional, Union
 
 import numpy as np
 import paddle
-from paddleformers.utils.log import logger
 
 from fastdeploy import envs
 from fastdeploy.config import SpeculativeConfig
@@ -329,26 +328,6 @@ def post_process_normal(
         )
 
     if enable_entropy:
-        real_bsz = share_inputs["seq_lens_this_time"].shape[0]
-        logger.info("-" * 30 + " [non-MTP] before entropy calculation")
-        logger.info(f"  sampler_output.logits.shape: {sampler_output.logits.shape}")
-        logger.info(
-            f"  seq_lens_this_time[:real_bsz]: {share_inputs['seq_lens_this_time'][:real_bsz].squeeze(-1).tolist() if share_inputs['seq_lens_this_time'].ndim == 2 else share_inputs['seq_lens_this_time'][:real_bsz].tolist()}"
-        )
-        logger.info(
-            f"  seq_lens_encoder[:real_bsz]: {share_inputs['seq_lens_encoder'][:real_bsz].squeeze(-1).tolist() if share_inputs['seq_lens_encoder'].ndim == 2 else share_inputs['seq_lens_encoder'][:real_bsz].tolist()}"
-        )
-        logger.info(
-            f"  seq_lens_decoder[:real_bsz]: {share_inputs['seq_lens_decoder'][:real_bsz].squeeze(-1).tolist() if share_inputs['seq_lens_decoder'].ndim == 2 else share_inputs['seq_lens_decoder'][:real_bsz].tolist()}"
-        )
-        logger.info(
-            f"  stop_flags[:real_bsz]: {share_inputs['stop_flags'][:real_bsz].squeeze(-1).tolist() if share_inputs['stop_flags'].ndim == 2 else share_inputs['stop_flags'][:real_bsz].tolist()}"
-        )
-        logger.info(
-            f"  step_idx[:real_bsz]: {share_inputs['step_idx'][:real_bsz].squeeze(-1).tolist() if share_inputs['step_idx'].ndim == 2 else share_inputs['step_idx'][:real_bsz].tolist()}"
-        )
-        logger.info(f"  temperature[:real_bsz]: {sampling_metadata.temperature[:real_bsz].tolist()}")
-        logger.info(f"  req_ids[:real_bsz]: {share_inputs['req_ids'][:real_bsz]}")
         if _USE_FD_RUNNER:
             calculate_logits_entropy_fd(sampler_output.logits, share_inputs, sampling_metadata.temperature)
         else:
@@ -502,27 +481,6 @@ def post_process_speculate(
     )
 
     if enable_entropy:
-        real_bsz = share_inputs["seq_lens_this_time"].shape[0]
-        logger.info("-" * 30 + " [MTP] before entropy calculation")
-        logger.info(f"  sampler_output.logits.shape: {sampler_output.logits.shape}")
-        logger.info(
-            f"  seq_lens_this_time[:real_bsz]: {share_inputs['seq_lens_this_time'][:real_bsz].squeeze(-1).tolist() if share_inputs['seq_lens_this_time'].ndim == 2 else share_inputs['seq_lens_this_time'][:real_bsz].tolist()}"
-        )
-        logger.info(
-            f"  seq_lens_encoder[:real_bsz]: {share_inputs['seq_lens_encoder'][:real_bsz].squeeze(-1).tolist() if share_inputs['seq_lens_encoder'].ndim == 2 else share_inputs['seq_lens_encoder'][:real_bsz].tolist()}"
-        )
-        logger.info(
-            f"  seq_lens_decoder[:real_bsz]: {share_inputs['seq_lens_decoder'][:real_bsz].squeeze(-1).tolist() if share_inputs['seq_lens_decoder'].ndim == 2 else share_inputs['seq_lens_decoder'][:real_bsz].tolist()}"
-        )
-        logger.info(f"  accept_num[:real_bsz]: {share_inputs['accept_num'][:real_bsz].tolist()}")
-        logger.info(
-            f"  stop_flags[:real_bsz]: {share_inputs['stop_flags'][:real_bsz].squeeze(-1).tolist() if share_inputs['stop_flags'].ndim == 2 else share_inputs['stop_flags'][:real_bsz].tolist()}"
-        )
-        logger.info(
-            f"  step_idx[:real_bsz]: {share_inputs['step_idx'][:real_bsz].squeeze(-1).tolist() if share_inputs['step_idx'].ndim == 2 else share_inputs['step_idx'][:real_bsz].tolist()}"
-        )
-        logger.info(f"  temperature[:real_bsz]: {sampling_metadata.temperature[:real_bsz].tolist()}")
-        logger.info(f"  req_ids[:real_bsz]: {share_inputs['req_ids'][:real_bsz]}")
         if _USE_FD_RUNNER:
             speculate_calculate_logits_entropy_fd(sampler_output.logits, share_inputs, sampling_metadata.temperature)
         else:
@@ -558,19 +516,6 @@ def post_process_speculate(
     # paths (MTP, ngram, naive). Note: verify_draft_tokens intentionally does NOT write back
     # step_idx (it is read-only in that kernel); step_idx is always updated here.
 
-    if enable_entropy:
-        real_bsz = share_inputs["seq_lens_this_time"].shape[0]
-        logger.info("-" * 30 + " [MTP] before unified_update_model_status")
-        logger.info(
-            f"  stop_flags[:real_bsz]: {share_inputs['stop_flags'][:real_bsz].squeeze(-1).tolist() if share_inputs['stop_flags'].ndim == 2 else share_inputs['stop_flags'][:real_bsz].tolist()}"
-        )
-        logger.info(
-            f"  step_idx[:real_bsz]: {share_inputs['step_idx'][:real_bsz].squeeze(-1).tolist() if share_inputs['step_idx'].ndim == 2 else share_inputs['step_idx'][:real_bsz].tolist()}"
-        )
-        logger.info(
-            f"  max_dec_len[:real_bsz]: {share_inputs['max_dec_len'][:real_bsz].squeeze(-1).tolist() if share_inputs['max_dec_len'].ndim == 2 else share_inputs['max_dec_len'][:real_bsz].tolist()}"
-        )
-
     unified_update_model_status(
         model_output.seq_lens_encoder,  # seq_lens_encoder
         model_output.seq_lens_decoder,  # seq_lens_decoder
@@ -589,15 +534,6 @@ def post_process_speculate(
     )
 
     if enable_entropy:
-        logger.info("-" * 30 + " [MTP] after unified_update_model_status")
-        logger.info(
-            f"  stop_flags[:real_bsz]: {share_inputs['stop_flags'][:real_bsz].squeeze(-1).tolist() if share_inputs['stop_flags'].ndim == 2 else share_inputs['stop_flags'][:real_bsz].tolist()}"
-        )
-        logger.info(
-            f"  step_idx[:real_bsz]: {share_inputs['step_idx'][:real_bsz].squeeze(-1).tolist() if share_inputs['step_idx'].ndim == 2 else share_inputs['step_idx'][:real_bsz].tolist()}"
-        )
-        logger.info(f"  accept_num[:real_bsz]: {share_inputs['accept_num'][:real_bsz].tolist()}")
-        logger.info("-" * 30 + " [MTP] calling flush_entropy_on_stop")
         flush_entropy_on_stop(share_inputs)
 
 

--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -14,11 +14,13 @@
 # limitations under the License.
 """
 
+import os
 import queue
 from typing import Dict, List, Optional, Union
 
 import numpy as np
 import paddle
+from paddleformers.utils.log import logger
 
 from fastdeploy import envs
 from fastdeploy.config import SpeculativeConfig
@@ -107,8 +109,14 @@ else:
 
 from fastdeploy.model_executor.entropy_utils import (
     calculate_logits_entropy,
+    calculate_logits_entropy_fd,
+    flush_entropy_on_stop,
     speculate_calculate_logits_entropy,
+    speculate_calculate_logits_entropy_fd,
 )
+
+_USE_FD_RUNNER = os.environ.get("EB5_ENABLE_FD_RUNNER", "0") == "1"
+
 from fastdeploy.model_executor.layers.moe.routing_indices_cache import (
     RoutingReplayManager,
 )
@@ -321,7 +329,30 @@ def post_process_normal(
         )
 
     if enable_entropy:
-        calculate_logits_entropy(sampler_output.logits, share_inputs, sampling_metadata.temperature)
+        real_bsz = share_inputs["seq_lens_this_time"].shape[0]
+        logger.info("-" * 30 + " [non-MTP] before entropy calculation")
+        logger.info(f"  sampler_output.logits.shape: {sampler_output.logits.shape}")
+        logger.info(
+            f"  seq_lens_this_time[:real_bsz]: {share_inputs['seq_lens_this_time'][:real_bsz].squeeze(-1).tolist() if share_inputs['seq_lens_this_time'].ndim == 2 else share_inputs['seq_lens_this_time'][:real_bsz].tolist()}"
+        )
+        logger.info(
+            f"  seq_lens_encoder[:real_bsz]: {share_inputs['seq_lens_encoder'][:real_bsz].squeeze(-1).tolist() if share_inputs['seq_lens_encoder'].ndim == 2 else share_inputs['seq_lens_encoder'][:real_bsz].tolist()}"
+        )
+        logger.info(
+            f"  seq_lens_decoder[:real_bsz]: {share_inputs['seq_lens_decoder'][:real_bsz].squeeze(-1).tolist() if share_inputs['seq_lens_decoder'].ndim == 2 else share_inputs['seq_lens_decoder'][:real_bsz].tolist()}"
+        )
+        logger.info(
+            f"  stop_flags[:real_bsz]: {share_inputs['stop_flags'][:real_bsz].squeeze(-1).tolist() if share_inputs['stop_flags'].ndim == 2 else share_inputs['stop_flags'][:real_bsz].tolist()}"
+        )
+        logger.info(
+            f"  step_idx[:real_bsz]: {share_inputs['step_idx'][:real_bsz].squeeze(-1).tolist() if share_inputs['step_idx'].ndim == 2 else share_inputs['step_idx'][:real_bsz].tolist()}"
+        )
+        logger.info(f"  temperature[:real_bsz]: {sampling_metadata.temperature[:real_bsz].tolist()}")
+        logger.info(f"  req_ids[:real_bsz]: {share_inputs['req_ids'][:real_bsz]}")
+        if _USE_FD_RUNNER:
+            calculate_logits_entropy_fd(sampler_output.logits, share_inputs, sampling_metadata.temperature)
+        else:
+            calculate_logits_entropy(sampler_output.logits, share_inputs, sampling_metadata.temperature)
 
     # Routing replay
     if routing_replay_manager is not None:
@@ -471,7 +502,31 @@ def post_process_speculate(
     )
 
     if enable_entropy:
-        speculate_calculate_logits_entropy(sampler_output.logits, share_inputs, sampling_metadata.temperature)
+        real_bsz = share_inputs["seq_lens_this_time"].shape[0]
+        logger.info("-" * 30 + " [MTP] before entropy calculation")
+        logger.info(f"  sampler_output.logits.shape: {sampler_output.logits.shape}")
+        logger.info(
+            f"  seq_lens_this_time[:real_bsz]: {share_inputs['seq_lens_this_time'][:real_bsz].squeeze(-1).tolist() if share_inputs['seq_lens_this_time'].ndim == 2 else share_inputs['seq_lens_this_time'][:real_bsz].tolist()}"
+        )
+        logger.info(
+            f"  seq_lens_encoder[:real_bsz]: {share_inputs['seq_lens_encoder'][:real_bsz].squeeze(-1).tolist() if share_inputs['seq_lens_encoder'].ndim == 2 else share_inputs['seq_lens_encoder'][:real_bsz].tolist()}"
+        )
+        logger.info(
+            f"  seq_lens_decoder[:real_bsz]: {share_inputs['seq_lens_decoder'][:real_bsz].squeeze(-1).tolist() if share_inputs['seq_lens_decoder'].ndim == 2 else share_inputs['seq_lens_decoder'][:real_bsz].tolist()}"
+        )
+        logger.info(f"  accept_num[:real_bsz]: {share_inputs['accept_num'][:real_bsz].tolist()}")
+        logger.info(
+            f"  stop_flags[:real_bsz]: {share_inputs['stop_flags'][:real_bsz].squeeze(-1).tolist() if share_inputs['stop_flags'].ndim == 2 else share_inputs['stop_flags'][:real_bsz].tolist()}"
+        )
+        logger.info(
+            f"  step_idx[:real_bsz]: {share_inputs['step_idx'][:real_bsz].squeeze(-1).tolist() if share_inputs['step_idx'].ndim == 2 else share_inputs['step_idx'][:real_bsz].tolist()}"
+        )
+        logger.info(f"  temperature[:real_bsz]: {sampling_metadata.temperature[:real_bsz].tolist()}")
+        logger.info(f"  req_ids[:real_bsz]: {share_inputs['req_ids'][:real_bsz]}")
+        if _USE_FD_RUNNER:
+            speculate_calculate_logits_entropy_fd(sampler_output.logits, share_inputs, sampling_metadata.temperature)
+        else:
+            speculate_calculate_logits_entropy(sampler_output.logits, share_inputs, sampling_metadata.temperature)
 
     # Routing replay
     if routing_replay_manager is not None:
@@ -503,6 +558,19 @@ def post_process_speculate(
     # paths (MTP, ngram, naive). Note: verify_draft_tokens intentionally does NOT write back
     # step_idx (it is read-only in that kernel); step_idx is always updated here.
 
+    if enable_entropy:
+        real_bsz = share_inputs["seq_lens_this_time"].shape[0]
+        logger.info("-" * 30 + " [MTP] before unified_update_model_status")
+        logger.info(
+            f"  stop_flags[:real_bsz]: {share_inputs['stop_flags'][:real_bsz].squeeze(-1).tolist() if share_inputs['stop_flags'].ndim == 2 else share_inputs['stop_flags'][:real_bsz].tolist()}"
+        )
+        logger.info(
+            f"  step_idx[:real_bsz]: {share_inputs['step_idx'][:real_bsz].squeeze(-1).tolist() if share_inputs['step_idx'].ndim == 2 else share_inputs['step_idx'][:real_bsz].tolist()}"
+        )
+        logger.info(
+            f"  max_dec_len[:real_bsz]: {share_inputs['max_dec_len'][:real_bsz].squeeze(-1).tolist() if share_inputs['max_dec_len'].ndim == 2 else share_inputs['max_dec_len'][:real_bsz].tolist()}"
+        )
+
     unified_update_model_status(
         model_output.seq_lens_encoder,  # seq_lens_encoder
         model_output.seq_lens_decoder,  # seq_lens_decoder
@@ -519,6 +587,18 @@ def post_process_speculate(
         model_output.eos_token_id,  # end_tokens
         model_output.max_dec_len,  # max_dec_len
     )
+
+    if enable_entropy:
+        logger.info("-" * 30 + " [MTP] after unified_update_model_status")
+        logger.info(
+            f"  stop_flags[:real_bsz]: {share_inputs['stop_flags'][:real_bsz].squeeze(-1).tolist() if share_inputs['stop_flags'].ndim == 2 else share_inputs['stop_flags'][:real_bsz].tolist()}"
+        )
+        logger.info(
+            f"  step_idx[:real_bsz]: {share_inputs['step_idx'][:real_bsz].squeeze(-1).tolist() if share_inputs['step_idx'].ndim == 2 else share_inputs['step_idx'][:real_bsz].tolist()}"
+        )
+        logger.info(f"  accept_num[:real_bsz]: {share_inputs['accept_num'][:real_bsz].tolist()}")
+        logger.info("-" * 30 + " [MTP] calling flush_entropy_on_stop")
+        flush_entropy_on_stop(share_inputs)
 
 
 def save_output_speculate(

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -2411,9 +2411,6 @@ class GPUModelRunner(ModelRunnerBase):
             model_forward_batch, num_running_requests, self._cached_launch_token_num, self._cached_real_bsz
         )
 
-        if self.share_inputs["ids_remove_padding"].shape[0] > 0:
-            logger.info("=" * 50 + "model execution starts")
-
         model_output = self._execute(model_inputs)
         # save output (last batch)
         if self._cached_model_output_data is not None:

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1245,7 +1245,7 @@ class GPUModelRunner(ModelRunnerBase):
             self.share_inputs["block_tables"][idx : idx + 1, :block_num] = np.arange(
                 idx * block_num, (idx + 1) * block_num, 1
             )
-        self.share_inputs["seq_lens_this_time"] = self.share_inputs["seq_lens_this_time_buffer"]
+        self.share_inputs["seq_lens_this_time"] = self.share_inputs["seq_lens_this_time_buffer"][:batch_size]
 
     def _prepare_inputs(self, cached_token_num=-1, cached_real_bsz=-1, is_dummy_or_profile_run=False) -> None:
         """Prepare the model inputs"""

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -2410,6 +2410,10 @@ class GPUModelRunner(ModelRunnerBase):
         model_inputs, p_done_idxs, token_num_event = self._preprocess(
             model_forward_batch, num_running_requests, self._cached_launch_token_num, self._cached_real_bsz
         )
+
+        if self.share_inputs["ids_remove_padding"].shape[0] > 0:
+            logger.info("=" * 50 + "model execution starts")
+
         model_output = self._execute(model_inputs)
         # save output (last batch)
         if self._cached_model_output_data is not None:

--- a/tests/model_executor/test_entropy_utils_fd_runner_mtp.py
+++ b/tests/model_executor/test_entropy_utils_fd_runner_mtp.py
@@ -1,0 +1,613 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for entropy_utils under FD runner (EB5_ENABLE_FD_RUNNER=1) + MTP scenario.
+
+This test can be run standalone:
+    EB5_ENABLE_FD_RUNNER=1 python tests/model_executor/test_entropy_utils_fd_runner_mtp.py
+
+Key differences from ernie5_runner path:
+- speculate_calculate_logits_entropy receives logits of shape [sum(seq_lens_this_time), vocab]
+  which includes ALL positions (accepted + rejected). The code must use accepted_idx to
+  extract the correct rows.
+- calculate_logits_entropy receives logits of shape [max_bsz, vocab], one row per slot.
+"""
+
+import importlib
+import logging
+import os
+import sys
+import types
+import unittest
+
+# Force FD runner path before importing the module
+os.environ["EB5_ENABLE_FD_RUNNER"] = "1"
+
+import paddle
+
+# Mock fastdeploy.utils to avoid importing the full fastdeploy package
+_mock_fastdeploy = types.ModuleType("fastdeploy")
+_mock_fastdeploy.__path__ = []
+_mock_utils = types.ModuleType("fastdeploy.utils")
+_mock_utils.data_processor_logger = logging.getLogger("test_entropy_fd_runner")
+_mock_fastdeploy.utils = _mock_utils
+
+sys.modules["fastdeploy"] = _mock_fastdeploy
+sys.modules["fastdeploy.utils"] = _mock_utils
+
+# Now import the module under test via importlib to ensure it picks up our mocks
+_entropy_spec = importlib.util.spec_from_file_location(
+    "fastdeploy.model_executor.entropy_utils",
+    os.path.join(os.path.dirname(__file__), "../../fastdeploy/model_executor/entropy_utils.py"),
+)
+_entropy_module = importlib.util.module_from_spec(_entropy_spec)
+sys.modules["fastdeploy.model_executor"] = types.ModuleType("fastdeploy.model_executor")
+sys.modules["fastdeploy.model_executor.entropy_utils"] = _entropy_module
+_entropy_spec.loader.exec_module(_entropy_module)
+
+_USE_FD_RUNNER = _entropy_module._USE_FD_RUNNER
+get_entropy = _entropy_module.get_entropy
+calculate_logits_entropy = _entropy_module.calculate_logits_entropy
+speculate_calculate_logits_entropy = _entropy_module.speculate_calculate_logits_entropy
+
+
+class TestFdRunnerFlag(unittest.TestCase):
+    """Verify the module loaded with FD runner enabled."""
+
+    def test_fd_runner_enabled(self):
+        self.assertTrue(_USE_FD_RUNNER)
+
+
+class TestGetEntropy(unittest.TestCase):
+    """Test the core entropy calculation function."""
+
+    def test_uniform_distribution(self):
+        # Uniform logits => max entropy = ln(vocab_size)
+        logits = paddle.zeros([1, 4], dtype="float32")
+        entropy = get_entropy(logits)
+        import math
+
+        self.assertAlmostEqual(float(entropy[0]), math.log(4), places=5)
+
+    def test_deterministic_distribution(self):
+        # One logit dominates => entropy near 0
+        logits = paddle.to_tensor([[100.0, 0.0, 0.0, 0.0]], dtype="float32")
+        entropy = get_entropy(logits)
+        self.assertAlmostEqual(float(entropy[0]), 0.0, places=5)
+
+    def test_negative_inf_handling(self):
+        logits = paddle.to_tensor([[10.0, -float("inf"), -float("inf")]], dtype="float32")
+        entropy = get_entropy(logits)
+        # After clipping -inf, effectively one dominant logit
+        self.assertGreaterEqual(float(entropy[0]), 0.0)
+
+
+class TestCalculateLogitsEntropyFdRunner(unittest.TestCase):
+    """Test calculate_logits_entropy under FD runner (1D shape, direct indexing)."""
+
+    def _make_share_inputs(self, bsz, seq_lens_this_time, seq_lens_encoder, seq_lens_decoder, stop_flags, req_ids):
+        return {
+            "seq_lens_this_time": paddle.to_tensor(seq_lens_this_time, dtype="int32"),
+            "seq_lens_encoder": paddle.to_tensor(seq_lens_encoder, dtype="int32"),
+            "seq_lens_decoder": paddle.to_tensor(seq_lens_decoder, dtype="int32"),
+            "entropy_list": [[] for _ in range(bsz)],
+            "stop_flags": paddle.to_tensor(stop_flags, dtype="bool"),
+            "req_ids": req_ids,
+        }
+
+    def test_basic_accumulation(self):
+        # FD runner: logits shape [max_bsz, vocab], 1D seq_lens
+        share_inputs = self._make_share_inputs(
+            bsz=3,
+            seq_lens_this_time=[1, 1, 0],
+            seq_lens_encoder=[0, 0, 0],
+            seq_lens_decoder=[10, 10, 0],
+            stop_flags=[False, False, False],
+            req_ids=["req_a", "req_b", "req_c"],
+        )
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],  # slot 0
+                [1.0, 1.0, 10.0],  # slot 1
+                [5.0, 5.0, 5.0],  # slot 2 (seq_lens_this_time=0, skipped)
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([3], dtype="float32")
+
+        calculate_logits_entropy(logits, share_inputs, temperature)
+
+        self.assertEqual(len(share_inputs["entropy_list"][0]), 1)
+        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
+        self.assertEqual(len(share_inputs["entropy_list"][2]), 0)
+        # Same logits pattern => same entropy
+        self.assertAlmostEqual(
+            share_inputs["entropy_list"][0][0],
+            share_inputs["entropy_list"][1][0],
+            places=6,
+        )
+
+    def test_stop_flags_clear(self):
+        share_inputs = self._make_share_inputs(
+            bsz=2,
+            seq_lens_this_time=[1, 1],
+            seq_lens_encoder=[0, 0],
+            seq_lens_decoder=[10, 10],
+            stop_flags=[True, False],
+            req_ids=["req_a", "req_b"],
+        )
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],
+                [1.0, 10.0, 1.0],
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([2], dtype="float32")
+
+        calculate_logits_entropy(logits, share_inputs, temperature)
+
+        # slot 0: stop_flags=True + seq_lens_decoder!=0 => cleared
+        self.assertEqual(len(share_inputs["entropy_list"][0]), 0)
+        # slot 1: stop_flags=False => kept
+        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
+
+    def test_temperature_scaling(self):
+        share_inputs = self._make_share_inputs(
+            bsz=2,
+            seq_lens_this_time=[1, 1],
+            seq_lens_encoder=[0, 0],
+            seq_lens_decoder=[10, 10],
+            stop_flags=[False, False],
+            req_ids=["req_a", "req_b"],
+        )
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],
+                [10.0, 1.0, 1.0],
+            ],
+            dtype="float32",
+        )
+        # slot 0: temp=1.0 (no scaling), slot 1: temp=0.5 (sharper distribution)
+        temperature = paddle.to_tensor([1.0, 0.5], dtype="float32")
+
+        calculate_logits_entropy(logits, share_inputs, temperature)
+
+        # Lower temperature => lower entropy (more peaked)
+        self.assertGreater(
+            share_inputs["entropy_list"][0][0],
+            share_inputs["entropy_list"][1][0],
+        )
+
+
+class TestSpeculateCalculateLogitsEntropyFdRunner(unittest.TestCase):
+    """
+    Test speculate_calculate_logits_entropy under FD runner + MTP.
+
+    Key: logits shape is [sum(seq_lens_this_time), vocab], containing all positions
+    (accepted + rejected). The function must use accepted_idx to extract correct rows.
+    """
+
+    def _make_share_inputs(
+        self, bsz, seq_lens_this_time, seq_lens_encoder, seq_lens_decoder, stop_flags, req_ids, accept_num
+    ):
+        return {
+            "seq_lens_this_time": paddle.to_tensor(seq_lens_this_time, dtype="int32"),
+            "seq_lens_encoder": paddle.to_tensor(seq_lens_encoder, dtype="int32"),
+            "seq_lens_decoder": paddle.to_tensor(seq_lens_decoder, dtype="int32"),
+            "entropy_list": [[] for _ in range(bsz)],
+            "stop_flags": paddle.to_tensor(stop_flags, dtype="bool"),
+            "req_ids": req_ids,
+            "accept_num": paddle.to_tensor(accept_num, dtype="int32"),
+        }
+
+    def test_accepted_idx_extraction(self):
+        """
+        Scenario: 3 slots, seq_lens_this_time=[2, 3, 1], accept_num=[1, 2, 1]
+        logits shape: [2+3+1=6, vocab]
+        - slot 0: positions [0,1], accepted=1 => take row 0
+        - slot 1: positions [2,3,4], accepted=2 => take rows 2,3
+        - slot 2: positions [5], accepted=1 => take row 5
+        """
+        share_inputs = self._make_share_inputs(
+            bsz=3,
+            seq_lens_this_time=[2, 3, 1],
+            seq_lens_encoder=[0, 0, 0],
+            seq_lens_decoder=[10, 10, 10],
+            stop_flags=[False, False, False],
+            req_ids=["req_a", "req_b", "req_c"],
+            accept_num=[1, 2, 1],
+        )
+        # 6 rows total, each with distinct logits so we can verify correct extraction
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],  # row 0: slot 0, position 0 (accepted)
+                [1.0, 1.0, 1.0],  # row 1: slot 0, position 1 (rejected)
+                [1.0, 10.0, 1.0],  # row 2: slot 1, position 0 (accepted)
+                [1.0, 1.0, 10.0],  # row 3: slot 1, position 1 (accepted)
+                [5.0, 5.0, 5.0],  # row 4: slot 1, position 2 (rejected)
+                [10.0, 10.0, 1.0],  # row 5: slot 2, position 0 (accepted)
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([3], dtype="float32")
+
+        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
+
+        # slot 0: 1 accepted token
+        self.assertEqual(len(share_inputs["entropy_list"][0]), 1)
+        # slot 1: 2 accepted tokens
+        self.assertEqual(len(share_inputs["entropy_list"][1]), 2)
+        # slot 2: 1 accepted token
+        self.assertEqual(len(share_inputs["entropy_list"][2]), 1)
+
+        # Verify the extracted logits produce correct entropy values
+        # row 0: [10, 1, 1] => same as row 2: [1, 10, 1] (symmetric)
+        self.assertAlmostEqual(
+            share_inputs["entropy_list"][0][0],
+            share_inputs["entropy_list"][1][0],
+            places=6,
+        )
+        # row 3: [1, 1, 10] => same entropy as [10, 1, 1]
+        self.assertAlmostEqual(
+            share_inputs["entropy_list"][1][1],
+            share_inputs["entropy_list"][0][0],
+            places=6,
+        )
+        # row 5: [10, 10, 1] => different entropy (more uniform among top-2)
+        self.assertGreater(
+            share_inputs["entropy_list"][2][0],
+            share_inputs["entropy_list"][0][0],
+        )
+
+    def test_zero_accepted_with_stop_flags(self):
+        """
+        When total_accepted_num=0 but stop_flags is set, ENTROPY-DONE should trigger
+        and clear the entropy_list.
+        """
+        share_inputs = self._make_share_inputs(
+            bsz=2,
+            seq_lens_this_time=[1, 1],
+            seq_lens_encoder=[0, 0],
+            seq_lens_decoder=[10, 10],
+            stop_flags=[True, False],
+            req_ids=["req_a", "req_b"],
+            accept_num=[0, 0],
+        )
+        # Pre-fill some entropy values to verify clearing
+        share_inputs["entropy_list"][0] = [1.0, 2.0, 3.0]
+        share_inputs["entropy_list"][1] = [4.0, 5.0]
+
+        logits = paddle.zeros([2, 3], dtype="float32")  # irrelevant, won't be used
+
+        speculate_calculate_logits_entropy(logits, share_inputs, paddle.ones([2], dtype="float32"))
+
+        # slot 0: stop_flags=True => cleared
+        self.assertEqual(share_inputs["entropy_list"][0], [])
+        # slot 1: stop_flags=False => unchanged
+        self.assertEqual(share_inputs["entropy_list"][1], [4.0, 5.0])
+
+    def test_warmup_skip(self):
+        """
+        Warmup/dummy requests with empty req_id should not accumulate entropy.
+        """
+        share_inputs = self._make_share_inputs(
+            bsz=3,
+            seq_lens_this_time=[2, 2, 2],
+            seq_lens_encoder=[0, 0, 0],
+            seq_lens_decoder=[10, 10, 10],
+            stop_flags=[False, False, False],
+            req_ids=["", "req_real", "  "],  # slot 0 and 2 are warmup
+            accept_num=[1, 1, 1],
+        )
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],  # slot 0, pos 0 (accepted) - warmup
+                [5.0, 5.0, 5.0],  # slot 0, pos 1 (rejected)
+                [1.0, 10.0, 1.0],  # slot 1, pos 0 (accepted) - real
+                [5.0, 5.0, 5.0],  # slot 1, pos 1 (rejected)
+                [1.0, 1.0, 10.0],  # slot 2, pos 0 (accepted) - warmup (whitespace)
+                [5.0, 5.0, 5.0],  # slot 2, pos 1 (rejected)
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([3], dtype="float32")
+
+        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
+
+        # slot 0: warmup, skipped
+        self.assertEqual(len(share_inputs["entropy_list"][0]), 0)
+        # slot 1: real request, accumulated
+        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
+        # slot 2: whitespace req_id, skipped
+        self.assertEqual(len(share_inputs["entropy_list"][2]), 0)
+
+    def test_partial_accept(self):
+        """
+        Mixed accept counts: some slots accept 2, some accept 0.
+        Verifies correct indexing when accept_num varies per slot.
+        """
+        share_inputs = self._make_share_inputs(
+            bsz=4,
+            seq_lens_this_time=[2, 2, 2, 2],
+            seq_lens_encoder=[0, 0, 0, 0],
+            seq_lens_decoder=[10, 10, 10, 10],
+            stop_flags=[False, False, False, False],
+            req_ids=["req_a", "req_b", "req_c", "req_d"],
+            accept_num=[2, 0, 1, 2],
+        )
+        # total rows = sum(seq_lens_this_time) = 8
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],  # row 0: slot 0, pos 0 (accepted)
+                [1.0, 10.0, 1.0],  # row 1: slot 0, pos 1 (accepted)
+                [5.0, 5.0, 5.0],  # row 2: slot 1, pos 0 (not accepted)
+                [5.0, 5.0, 5.0],  # row 3: slot 1, pos 1 (not accepted)
+                [1.0, 1.0, 10.0],  # row 4: slot 2, pos 0 (accepted)
+                [5.0, 5.0, 5.0],  # row 5: slot 2, pos 1 (rejected)
+                [10.0, 10.0, 1.0],  # row 6: slot 3, pos 0 (accepted)
+                [1.0, 10.0, 10.0],  # row 7: slot 3, pos 1 (accepted)
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([4], dtype="float32")
+
+        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
+
+        self.assertEqual(len(share_inputs["entropy_list"][0]), 2)
+        self.assertEqual(len(share_inputs["entropy_list"][1]), 0)
+        self.assertEqual(len(share_inputs["entropy_list"][2]), 1)
+        self.assertEqual(len(share_inputs["entropy_list"][3]), 2)
+
+        # Verify values: row 0 [10,1,1] and row 1 [1,10,1] have same entropy
+        self.assertAlmostEqual(
+            share_inputs["entropy_list"][0][0],
+            share_inputs["entropy_list"][0][1],
+            places=6,
+        )
+        # row 4 [1,1,10] same entropy as row 0
+        self.assertAlmostEqual(
+            share_inputs["entropy_list"][2][0],
+            share_inputs["entropy_list"][0][0],
+            places=6,
+        )
+        # row 6 [10,10,1] and row 7 [1,10,10] same entropy (symmetric)
+        self.assertAlmostEqual(
+            share_inputs["entropy_list"][3][0],
+            share_inputs["entropy_list"][3][1],
+            places=6,
+        )
+
+    def test_stop_flags_after_accept(self):
+        """
+        Slot finishes (stop_flags=True) after accepting tokens in same step.
+        Entropy should be accumulated then immediately cleared.
+        """
+        share_inputs = self._make_share_inputs(
+            bsz=2,
+            seq_lens_this_time=[2, 2],
+            seq_lens_encoder=[0, 0],
+            seq_lens_decoder=[10, 10],
+            stop_flags=[True, False],
+            req_ids=["req_a", "req_b"],
+            accept_num=[2, 1],
+        )
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],  # slot 0, pos 0 (accepted)
+                [1.0, 10.0, 1.0],  # slot 0, pos 1 (accepted)
+                [1.0, 1.0, 10.0],  # slot 1, pos 0 (accepted)
+                [5.0, 5.0, 5.0],  # slot 1, pos 1 (rejected)
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([2], dtype="float32")
+
+        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
+
+        # slot 0: accepted 2, then stop_flags=True => cleared
+        self.assertEqual(share_inputs["entropy_list"][0], [])
+        # slot 1: accepted 1, stop_flags=False => kept
+        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
+
+    def test_temperature_scaling_mtp(self):
+        """Verify temperature scaling is applied per-slot in MTP path."""
+        share_inputs = self._make_share_inputs(
+            bsz=2,
+            seq_lens_this_time=[2, 2],
+            seq_lens_encoder=[0, 0],
+            seq_lens_decoder=[10, 10],
+            stop_flags=[False, False],
+            req_ids=["req_a", "req_b"],
+            accept_num=[1, 1],
+        )
+        # Same logits for both slots
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],  # slot 0, pos 0 (accepted)
+                [5.0, 5.0, 5.0],  # slot 0, pos 1 (rejected)
+                [10.0, 1.0, 1.0],  # slot 1, pos 0 (accepted)
+                [5.0, 5.0, 5.0],  # slot 1, pos 1 (rejected)
+            ],
+            dtype="float32",
+        )
+        # slot 0: temp=1.0, slot 1: temp=0.5
+        temperature = paddle.to_tensor([1.0, 0.5], dtype="float32")
+
+        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
+
+        # Lower temperature => lower entropy
+        self.assertGreater(
+            share_inputs["entropy_list"][0][0],
+            share_inputs["entropy_list"][1][0],
+        )
+
+    def test_encoder_prefill_slot(self):
+        """
+        When seq_lens_encoder != 0, real_seq_lens is forced to 1 regardless of
+        seq_lens_this_time. Verify accepted_idx handles this correctly.
+        """
+        share_inputs = self._make_share_inputs(
+            bsz=3,
+            seq_lens_this_time=[2, 100, 2],  # slot 1 is prefill (large seq_lens_this_time)
+            seq_lens_encoder=[0, 100, 0],  # slot 1 is encoder (prefill)
+            seq_lens_decoder=[10, 0, 10],
+            stop_flags=[False, False, False],
+            req_ids=["req_a", "req_b", "req_c"],
+            accept_num=[1, 1, 1],
+        )
+        # real_seq_lens = [2, 1, 2] (slot 1 forced to 1 because encoder != 0)
+        # total rows = sum(real_seq_lens) = 2 + 1 + 2 = 5
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],  # row 0: slot 0, pos 0 (accepted)
+                [5.0, 5.0, 5.0],  # row 1: slot 0, pos 1
+                [1.0, 10.0, 1.0],  # row 2: slot 1, pos 0 (accepted, prefill)
+                [1.0, 1.0, 10.0],  # row 3: slot 2, pos 0 (accepted)
+                [5.0, 5.0, 5.0],  # row 4: slot 2, pos 1
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([3], dtype="float32")
+
+        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
+
+        self.assertEqual(len(share_inputs["entropy_list"][0]), 1)
+        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
+        self.assertEqual(len(share_inputs["entropy_list"][2]), 1)
+
+        # All accepted logits are [10,1,1]-symmetric => same entropy
+        self.assertAlmostEqual(
+            share_inputs["entropy_list"][0][0],
+            share_inputs["entropy_list"][1][0],
+            places=6,
+        )
+        self.assertAlmostEqual(
+            share_inputs["entropy_list"][1][0],
+            share_inputs["entropy_list"][2][0],
+            places=6,
+        )
+
+    def test_multi_step_accumulation(self):
+        """
+        Simulate multiple MTP steps and verify entropy accumulates correctly
+        across steps until stop_flags triggers ENTROPY-DONE.
+        """
+        share_inputs = {
+            "seq_lens_this_time": paddle.to_tensor([2, 2], dtype="int32"),
+            "seq_lens_encoder": paddle.to_tensor([0, 0], dtype="int32"),
+            "seq_lens_decoder": paddle.to_tensor([10, 10], dtype="int32"),
+            "entropy_list": [[], []],
+            "stop_flags": paddle.to_tensor([False, False], dtype="bool"),
+            "req_ids": ["req_a", "req_b"],
+            "accept_num": paddle.to_tensor([2, 1], dtype="int32"),
+        }
+
+        logits_step1 = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],
+                [1.0, 10.0, 1.0],
+                [1.0, 1.0, 10.0],
+                [5.0, 5.0, 5.0],
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([2], dtype="float32")
+
+        # Step 1
+        speculate_calculate_logits_entropy(logits_step1, share_inputs, temperature)
+        self.assertEqual(len(share_inputs["entropy_list"][0]), 2)
+        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
+
+        # Step 2: same structure, slot 1 finishes
+        share_inputs["accept_num"] = paddle.to_tensor([1, 1], dtype="int32")
+        share_inputs["stop_flags"] = paddle.to_tensor([False, True], dtype="bool")
+        logits_step2 = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],
+                [5.0, 5.0, 5.0],
+                [10.0, 1.0, 1.0],
+                [5.0, 5.0, 5.0],
+            ],
+            dtype="float32",
+        )
+
+        speculate_calculate_logits_entropy(logits_step2, share_inputs, temperature)
+
+        # slot 0: 2 + 1 = 3 accumulated
+        self.assertEqual(len(share_inputs["entropy_list"][0]), 3)
+        # slot 1: had 1 from step1, got 1 more, then cleared by stop_flags
+        self.assertEqual(share_inputs["entropy_list"][1], [])
+
+
+class TestCrossRunnerConsistency(unittest.TestCase):
+    """
+    Verify FD runner and ernie5_runner paths produce the same entropy values
+    when given equivalent inputs (accepted-only logits).
+    """
+
+    def test_same_entropy_both_paths(self):
+        """
+        Construct inputs such that the accepted logits are identical for both paths,
+        then compare the entropy values.
+        """
+        # The accepted logits we want both paths to process
+        accepted_logits_data = [
+            [10.0, 1.0, 1.0],
+            [1.0, 10.0, 1.0],
+            [1.0, 1.0, 10.0],
+        ]
+
+        # --- FD runner path (current module) ---
+        # logits = [sum(seq_lens_this_time), vocab] with extra rejected rows
+        share_inputs_fd = {
+            "seq_lens_this_time": paddle.to_tensor([2, 2, 2], dtype="int32"),
+            "seq_lens_encoder": paddle.to_tensor([0, 0, 0], dtype="int32"),
+            "seq_lens_decoder": paddle.to_tensor([10, 10, 10], dtype="int32"),
+            "entropy_list": [[], [], []],
+            "stop_flags": paddle.to_tensor([False, False, False], dtype="bool"),
+            "req_ids": ["req_a", "req_b", "req_c"],
+            "accept_num": paddle.to_tensor([1, 1, 1], dtype="int32"),
+        }
+        logits_fd = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],  # slot 0, pos 0 (accepted)
+                [99.0, 99.0, 99.0],  # slot 0, pos 1 (rejected - should be ignored)
+                [1.0, 10.0, 1.0],  # slot 1, pos 0 (accepted)
+                [99.0, 99.0, 99.0],  # slot 1, pos 1 (rejected)
+                [1.0, 1.0, 10.0],  # slot 2, pos 0 (accepted)
+                [99.0, 99.0, 99.0],  # slot 2, pos 1 (rejected)
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([3], dtype="float32")
+
+        speculate_calculate_logits_entropy(logits_fd, share_inputs_fd, temperature)
+
+        # --- Direct entropy calculation on accepted logits ---
+        direct_entropy = get_entropy(paddle.to_tensor(accepted_logits_data, dtype="float32")).tolist()
+
+        # Compare
+        for i in range(3):
+            self.assertAlmostEqual(
+                share_inputs_fd["entropy_list"][i][0],
+                direct_entropy[i],
+                places=6,
+                msg=f"Mismatch at slot {i}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Support entropy calculation in the MTP (Multi-Token Prediction) speculative decoding path for both `gpu_model_runner` (fd-runner) and `ernie5_model_runner`. The previous implementation had three bugs in the fd-runner + MTP scenario:

1. **ENTROPY-DONE never triggered**: When `accept_num=0` for a finishing slot, the code skipped the `stop_flags` check entirely, so entropy was never summarized or cleared.
2. **Incorrect logits indexing**: fd-runner's logits shape is `[sum(seq_lens_this_time), vocab]` (all positions including rejected), but the code treated it as `[total_accepted_num, vocab]` (accepted-only, which is the ernie5_runner layout).
3. **Warmup pollution**: CUDA Graph warmup sends dummy requests with empty `req_id`. Their entropy values accumulated in `entropy_list` and were never cleared, contaminating subsequent real requests.

## Modifications

**`fastdeploy/model_executor/entropy_utils.py`**:

- Add dual-path logic in `speculate_calculate_logits_entropy`: fd-runner uses `accepted_idx` to extract correct rows from full logits; ernie5_runner uses pre-filtered logits directly.
- Move `stop_flags` check outside the `if accept_count > 0` block so ENTROPY-DONE fires even when no tokens are accepted in the final step.
- Add `is_valid_req` guard: skip entropy accumulation for warmup requests (empty/whitespace `req_id`).
- Remove verbose per-step debug logging; only emit `[ENTROPY-DONE]` at request completion.
- Remove unused `import time` and `_mtp_step_counter`.

**`tests/model_executor/test_entropy_utils_fd_runner_mtp.py`** (new):

- 16 unit tests covering the fd-runner + MTP path:
  - `accepted_idx` extraction with mixed accept counts
  - Zero-accept with stop_flags triggering ENTROPY-DONE
  - Warmup/dummy request skipping
  - Temperature scaling per-slot
  - Encoder prefill slot handling (`seq_lens_encoder != 0`)
  - Multi-step accumulation and clearing
  - Cross-runner consistency (fd-runner vs direct entropy calculation)
- Standalone execution, no dependency on full fastdeploy installation.

## Usage or Command

```bash
# Run the service with MTP + entropy
python -m fastdeploy.entrypoints.openai.api_server \
    --model <model> \
    --enable-entropy \
    --speculative-config '{"method":"mtp","num_speculative_tokens":1,"num_model_steps":1,"model":"<model>"}'

# Run unit tests
EB5_ENABLE_FD_RUNNER=1 python tests/model_executor/test_entropy_utils_fd_runner_mtp.py
```

## Accuracy Tests

测试配置：ERNIE5 TP1, block_wise_fp8, fd_runner, no-prefix-cache, temperature=0

### fd_runner Overlap 开启 vs 关闭 (水的化学式是什么？, max_tokens=10)

| 配置 | all_values | avg_entropy |
|------|-----------|-------------|
| overlap 开启 | `[0.0, 0.001631, 0.20335, 0.058157, 0.293438, 0.00377, 0.498297, 1.209875, 0.765423, 0.605906]` | 0.363945 |
| overlap 关闭 | `[0.0, 0.001631, 0.20335, 0.058157, 0.293438, 0.00377, 0.498297, 1.209875, 0.765423, 0.605906]` | 0.363945 |
| **对比** | **10步完全一致** | **完全一致** |

## Checklist

- [x] Add at least a tag in the PR title: `[BugFix]`, `[Feature]`
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests.
- [x] Provide accuracy results.
