### PR TITLE
[Feature] Support computing entropy with fastdeploy runner

### DIFF
--- a/fastdeploy/model_executor/entropy_utils.py
+++ b/fastdeploy/model_executor/entropy_utils.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """
 
+import os
+
 import paddle
 
 from fastdeploy.utils import data_processor_logger
@@ -45,6 +47,22 @@ def _log_entropy(share_inputs, i):
 
 
 def calculate_logits_entropy(logits, share_inputs, temperature):
+    use_fd_runner = os.environ.get("EB5_ENABLE_FD_RUNNER", "0") == "1"
+    if use_fd_runner:
+        calculate_logits_entropy_fd(logits, share_inputs, temperature)
+    else:
+        calculate_logits_entropy_ori(logits, share_inputs, temperature)
+
+
+def specifical_calculate_logits_entropy(logits, share_inputs, temperature):
+    use_fd_runner = os.environ.get("EB5_ENABLE_FD_RUNNER", "0") == "1"
+    if use_fd_runner:
+        calculate_logits_entropy_fd(logits, share_inputs, temperature)
+    else:
+        calculate_logits_entropy_ori(logits, share_inputs, temperature)
+
+
+def calculate_logits_entropy_ori(logits, share_inputs, temperature):
     real_bsz = share_inputs["seq_lens_this_time"].shape[0]
     real_seq_lens = paddle.where(
         share_inputs["seq_lens_encoder"][:real_bsz].squeeze(1) != 0,
@@ -72,7 +90,7 @@ def calculate_logits_entropy(logits, share_inputs, temperature):
             _log_entropy(share_inputs, i)
 
 
-def speculate_calculate_logits_entropy(logits, share_inputs, temperature):
+def speculate_calculate_logits_entropy_ori(logits, share_inputs, temperature):
     # get accepted logits
     real_bsz = share_inputs["seq_lens_this_time"].shape[0]
     total_accepted_num = paddle.sum(share_inputs["accept_num"])
@@ -185,30 +203,31 @@ def speculate_calculate_logits_entropy_fd(logits, share_inputs, temperature):
     )
     accepted_idx = repeated_starts + offsets
 
-    accepted_logits = paddle.empty([total_accepted_num, logits.shape[1]], dtype=logits.dtype)
-    for i in range(total_accepted_num):
-        accepted_logits[i] = logits[accepted_idx[i]]
+    accepted_logits = paddle.index_select(logits, accepted_idx, axis=0)
 
     batch_indices = paddle.arange(real_bsz, dtype="int32")
     batch_id_per_token = paddle.repeat_interleave(batch_indices, share_inputs["accept_num"][:real_bsz])
-    for i in range(total_accepted_num):
-        bid = int(batch_id_per_token[i])
-        t = temperature[bid]
-        if t > 0 and t != 1.0:
-            accepted_logits[i] = accepted_logits[i].scale_(1 / t)
+    scale = paddle.where(
+        temperature[batch_id_per_token] > 0,
+        1.0 / temperature[batch_id_per_token],
+        paddle.ones_like(temperature[batch_id_per_token]),
+    )
+    accepted_logits = accepted_logits * scale.unsqueeze(-1)
 
     entropy_tensor = get_entropy(accepted_logits)
     entropy = entropy_tensor.tolist()
 
+    idx = 0
     for i in range(real_bsz):
         accept_count = int(share_inputs["accept_num"][i])
         if accept_count > 0:
-            req_id = share_inputs["req_ids"][i] if i < len(share_inputs["req_ids"]) else ""
-            is_valid_req = bool(req_id and str(req_id).strip())
-            for j in range(accept_count):
-                e_val = entropy.pop(0)
-                if is_valid_req:
-                    share_inputs["entropy_list"][i].append(e_val)
+            # req_id = share_inputs["req_ids"][i] if i < len(share_inputs["req_ids"]) else ""
+            # is_valid_req = bool(req_id and str(req_id).strip())
+            for _ in range(accept_count):
+                e_val = entropy[idx]
+                # if is_valid_req:
+                share_inputs["entropy_list"][i].append(e_val)
+                idx += 1
         if (
             share_inputs["stop_flags"][i]
             and share_inputs["seq_lens_decoder"][i] != 0

--- a/fastdeploy/model_executor/entropy_utils.py
+++ b/fastdeploy/model_executor/entropy_utils.py
@@ -20,7 +20,6 @@ from fastdeploy.utils import data_processor_logger
 
 
 def get_entropy(logits):
-    # Check for -inf values in logits
     if paddle.any(paddle.isinf(logits) & (logits < 0)):
         data_processor_logger.debug("Detected -inf values in logits, clipping to minimum value")
         logits = paddle.clip(logits, min=1e-9)
@@ -30,6 +29,19 @@ def get_entropy(logits):
     z0 = paddle.sum(ea0, axis=-1, keepdim=True)
     p0 = ea0 / z0
     return paddle.sum(p0 * (paddle.log(z0) - a0), axis=-1)
+
+
+def _log_entropy(share_inputs, i):
+    elist = share_inputs["entropy_list"][i]
+    data_processor_logger.info(
+        f"req_id: {share_inputs['req_ids'][i]}, entropy: {sum(elist)/len(elist)}, steps: {len(elist)}, all_values: {elist}"
+    )
+    share_inputs["entropy_list"][i] = []
+
+
+# ==============================================================================
+# ernie5_model_runner path (original logic from commit 361a310)
+# ==============================================================================
 
 
 def calculate_logits_entropy(logits, share_inputs, temperature):
@@ -57,10 +69,7 @@ def calculate_logits_entropy(logits, share_inputs, temperature):
             and share_inputs["seq_lens_decoder"][i] != 0
             and len(share_inputs["entropy_list"][i]) != 0
         ):
-            data_processor_logger.info(
-                f"req_id: {share_inputs['req_ids'][i]}, entropy: {sum(share_inputs['entropy_list'][i])/len(share_inputs['entropy_list'][i])}"
-            )
-            share_inputs["entropy_list"][i] = []
+            _log_entropy(share_inputs, i)
 
 
 def speculate_calculate_logits_entropy(logits, share_inputs, temperature):
@@ -100,7 +109,129 @@ def speculate_calculate_logits_entropy(logits, share_inputs, temperature):
             and share_inputs["seq_lens_decoder"][i] != 0
             and len(share_inputs["entropy_list"][i]) != 0
         ):
-            data_processor_logger.info(
-                f"req_id: {share_inputs['req_ids'][i]}, entropy: {sum(share_inputs['entropy_list'][i])/len(share_inputs['entropy_list'][i])}"
-            )
-            share_inputs["entropy_list"][i] = []
+            _log_entropy(share_inputs, i)
+
+
+# ==============================================================================
+# gpu_model_runner (FD runner) path
+# ==============================================================================
+
+
+def calculate_logits_entropy_fd(logits, share_inputs, temperature):
+    real_bsz = share_inputs["seq_lens_this_time"].shape[0]
+    seq_lens_encoder = share_inputs["seq_lens_encoder"][:real_bsz]
+    seq_lens_this_time = share_inputs["seq_lens_this_time"]
+    if seq_lens_encoder.ndim == 2:
+        seq_lens_encoder = seq_lens_encoder.squeeze(1)
+    if seq_lens_this_time.ndim == 2:
+        seq_lens_this_time = seq_lens_this_time.squeeze(1)
+    real_seq_lens = paddle.where(
+        seq_lens_encoder != 0,
+        paddle.ones([1], dtype="int32"),
+        seq_lens_this_time,
+    )
+
+    for i in range(real_bsz):
+        if int(real_seq_lens[i]) == 0:
+            continue
+        t = temperature[i]
+        if t > 0 and t != 1.0:
+            logits[i] = logits[i].scale_(1 / t)
+
+    entropy_tensor = get_entropy(logits[:real_bsz])
+
+    for i in range(real_bsz):
+        if int(real_seq_lens[i]) == 0:
+            continue
+        entropy_val = float(entropy_tensor[i])
+        share_inputs["entropy_list"][i].append(entropy_val)
+        if (
+            share_inputs["stop_flags"][i]
+            and share_inputs["seq_lens_decoder"][i] != 0
+            and len(share_inputs["entropy_list"][i]) != 0
+        ):
+            _log_entropy(share_inputs, i)
+
+
+def speculate_calculate_logits_entropy_fd(logits, share_inputs, temperature):
+    real_bsz = share_inputs["seq_lens_this_time"].shape[0]
+    total_accepted_num = int(paddle.sum(share_inputs["accept_num"][:real_bsz]))
+
+    if total_accepted_num == 0:
+        for i in range(real_bsz):
+            if (
+                share_inputs["stop_flags"][i]
+                and share_inputs["seq_lens_decoder"][i] != 0
+                and len(share_inputs["entropy_list"][i]) != 0
+            ):
+                _log_entropy(share_inputs, i)
+        return
+
+    seq_lens_encoder = share_inputs["seq_lens_encoder"][:real_bsz]
+    seq_lens_this_time = share_inputs["seq_lens_this_time"]
+    if seq_lens_encoder.ndim == 2:
+        seq_lens_encoder = seq_lens_encoder.squeeze(1)
+    if seq_lens_this_time.ndim == 2:
+        seq_lens_this_time = seq_lens_this_time.squeeze(1)
+    real_seq_lens = paddle.where(
+        seq_lens_encoder != 0,
+        paddle.ones([1], dtype="int32"),
+        seq_lens_this_time,
+    )
+    seq_start_idx = paddle.concat([paddle.zeros([1], dtype="int32"), paddle.cumsum(real_seq_lens, dtype="int32")])
+    repeated_starts = paddle.repeat_interleave(seq_start_idx[:-1], share_inputs["accept_num"][:real_bsz])
+    offsets = paddle.concat([paddle.arange(share_inputs["accept_num"][i].item()) for i in range(real_bsz)]).astype(
+        "int32"
+    )
+    accepted_idx = repeated_starts + offsets
+
+    accepted_logits = paddle.empty([total_accepted_num, logits.shape[1]], dtype=logits.dtype)
+    for i in range(total_accepted_num):
+        accepted_logits[i] = logits[accepted_idx[i]]
+
+    batch_indices = paddle.arange(real_bsz, dtype="int32")
+    batch_id_per_token = paddle.repeat_interleave(batch_indices, share_inputs["accept_num"][:real_bsz])
+    for i in range(total_accepted_num):
+        bid = int(batch_id_per_token[i])
+        t = temperature[bid]
+        if t > 0 and t != 1.0:
+            accepted_logits[i] = accepted_logits[i].scale_(1 / t)
+
+    entropy_tensor = get_entropy(accepted_logits)
+    entropy = entropy_tensor.tolist()
+
+    for i in range(real_bsz):
+        accept_count = int(share_inputs["accept_num"][i])
+        if accept_count > 0:
+            req_id = share_inputs["req_ids"][i] if i < len(share_inputs["req_ids"]) else ""
+            is_valid_req = bool(req_id and str(req_id).strip())
+            for j in range(accept_count):
+                e_val = entropy.pop(0)
+                if is_valid_req:
+                    share_inputs["entropy_list"][i].append(e_val)
+        if (
+            share_inputs["stop_flags"][i]
+            and share_inputs["seq_lens_decoder"][i] != 0
+            and len(share_inputs["entropy_list"][i]) != 0
+        ):
+            _log_entropy(share_inputs, i)
+
+
+# ==============================================================================
+# Common utility
+# ==============================================================================
+
+
+def flush_entropy_on_stop(share_inputs):
+    """
+    Flush entropy for requests whose stop_flags became True after entropy calculation.
+    Called after unified_update_model_status which sets stop_flags for max_dec_len.
+    """
+    real_bsz = share_inputs["seq_lens_this_time"].shape[0]
+    for i in range(real_bsz):
+        if (
+            share_inputs["stop_flags"][i]
+            and share_inputs["seq_lens_decoder"][i] != 0
+            and len(share_inputs["entropy_list"][i]) != 0
+        ):
+            _log_entropy(share_inputs, i)

--- a/fastdeploy/model_executor/entropy_utils.py
+++ b/fastdeploy/model_executor/entropy_utils.py
@@ -54,12 +54,12 @@ def calculate_logits_entropy(logits, share_inputs, temperature):
         calculate_logits_entropy_ori(logits, share_inputs, temperature)
 
 
-def specifical_calculate_logits_entropy(logits, share_inputs, temperature):
+def speculate_calculate_logits_entropy(logits, share_inputs, temperature):
     use_fd_runner = os.environ.get("EB5_ENABLE_FD_RUNNER", "0") == "1"
     if use_fd_runner:
-        calculate_logits_entropy_fd(logits, share_inputs, temperature)
+        speculate_calculate_logits_entropy_fd(logits, share_inputs, temperature)
     else:
-        calculate_logits_entropy_ori(logits, share_inputs, temperature)
+        speculate_calculate_logits_entropy_ori(logits, share_inputs, temperature)
 
 
 def calculate_logits_entropy_ori(logits, share_inputs, temperature):
@@ -207,10 +207,11 @@ def speculate_calculate_logits_entropy_fd(logits, share_inputs, temperature):
 
     batch_indices = paddle.arange(real_bsz, dtype="int32")
     batch_id_per_token = paddle.repeat_interleave(batch_indices, share_inputs["accept_num"][:real_bsz])
+    temp_per_token = temperature[batch_id_per_token].flatten()
     scale = paddle.where(
-        temperature[batch_id_per_token] > 0,
-        1.0 / temperature[batch_id_per_token],
-        paddle.ones_like(temperature[batch_id_per_token]),
+        temp_per_token > 0,
+        1.0 / temp_per_token,
+        paddle.ones_like(temp_per_token),
     )
     accepted_logits = accepted_logits * scale.unsqueeze(-1)
 
@@ -221,11 +222,8 @@ def speculate_calculate_logits_entropy_fd(logits, share_inputs, temperature):
     for i in range(real_bsz):
         accept_count = int(share_inputs["accept_num"][i])
         if accept_count > 0:
-            # req_id = share_inputs["req_ids"][i] if i < len(share_inputs["req_ids"]) else ""
-            # is_valid_req = bool(req_id and str(req_id).strip())
             for _ in range(accept_count):
                 e_val = entropy[idx]
-                # if is_valid_req:
                 share_inputs["entropy_list"][i].append(e_val)
                 idx += 1
         if (

--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """
 
-import os
 import queue
 from typing import Dict, List, Optional, Union
 
@@ -108,14 +107,9 @@ else:
 
 from fastdeploy.model_executor.entropy_utils import (
     calculate_logits_entropy,
-    calculate_logits_entropy_fd,
     flush_entropy_on_stop,
     speculate_calculate_logits_entropy,
-    speculate_calculate_logits_entropy_fd,
 )
-
-_USE_FD_RUNNER = os.environ.get("EB5_ENABLE_FD_RUNNER", "0") == "1"
-
 from fastdeploy.model_executor.layers.moe.routing_indices_cache import (
     RoutingReplayManager,
 )
@@ -328,10 +322,7 @@ def post_process_normal(
         )
 
     if enable_entropy:
-        if _USE_FD_RUNNER:
-            calculate_logits_entropy_fd(sampler_output.logits, share_inputs, sampling_metadata.temperature)
-        else:
-            calculate_logits_entropy(sampler_output.logits, share_inputs, sampling_metadata.temperature)
+        calculate_logits_entropy(sampler_output.logits, share_inputs, sampling_metadata.temperature)
 
     # Routing replay
     if routing_replay_manager is not None:
@@ -481,10 +472,7 @@ def post_process_speculate(
     )
 
     if enable_entropy:
-        if _USE_FD_RUNNER:
-            speculate_calculate_logits_entropy_fd(sampler_output.logits, share_inputs, sampling_metadata.temperature)
-        else:
-            speculate_calculate_logits_entropy(sampler_output.logits, share_inputs, sampling_metadata.temperature)
+        speculate_calculate_logits_entropy(sampler_output.logits, share_inputs, sampling_metadata.temperature)
 
     # Routing replay
     if routing_replay_manager is not None:

--- a/fastdeploy/model_executor/pre_and_post_process.py
+++ b/fastdeploy/model_executor/pre_and_post_process.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """
 
+import os
 import queue
 from typing import Dict, List, Optional, Union
 
@@ -107,8 +108,14 @@ else:
 
 from fastdeploy.model_executor.entropy_utils import (
     calculate_logits_entropy,
+    calculate_logits_entropy_fd,
+    flush_entropy_on_stop,
     speculate_calculate_logits_entropy,
+    speculate_calculate_logits_entropy_fd,
 )
+
+_USE_FD_RUNNER = os.environ.get("EB5_ENABLE_FD_RUNNER", "0") == "1"
+
 from fastdeploy.model_executor.layers.moe.routing_indices_cache import (
     RoutingReplayManager,
 )
@@ -321,7 +328,10 @@ def post_process_normal(
         )
 
     if enable_entropy:
-        calculate_logits_entropy(sampler_output.logits, share_inputs, sampling_metadata.temperature)
+        if _USE_FD_RUNNER:
+            calculate_logits_entropy_fd(sampler_output.logits, share_inputs, sampling_metadata.temperature)
+        else:
+            calculate_logits_entropy(sampler_output.logits, share_inputs, sampling_metadata.temperature)
 
     # Routing replay
     if routing_replay_manager is not None:
@@ -471,7 +481,10 @@ def post_process_speculate(
     )
 
     if enable_entropy:
-        speculate_calculate_logits_entropy(sampler_output.logits, share_inputs, sampling_metadata.temperature)
+        if _USE_FD_RUNNER:
+            speculate_calculate_logits_entropy_fd(sampler_output.logits, share_inputs, sampling_metadata.temperature)
+        else:
+            speculate_calculate_logits_entropy(sampler_output.logits, share_inputs, sampling_metadata.temperature)
 
     # Routing replay
     if routing_replay_manager is not None:
@@ -519,6 +532,9 @@ def post_process_speculate(
         model_output.eos_token_id,  # end_tokens
         model_output.max_dec_len,  # max_dec_len
     )
+
+    if enable_entropy:
+        flush_entropy_on_stop(share_inputs)
 
 
 def save_output_speculate(

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1254,7 +1254,7 @@ class GPUModelRunner(ModelRunnerBase):
             self.share_inputs["block_tables"][idx : idx + 1, :block_num] = np.arange(
                 idx * block_num, (idx + 1) * block_num, 1
             )
-        self.share_inputs["seq_lens_this_time"] = self.share_inputs["seq_lens_this_time_buffer"]
+        self.share_inputs["seq_lens_this_time"] = self.share_inputs["seq_lens_this_time_buffer"][:batch_size]
 
     def _prepare_inputs(self, cached_token_num=-1, cached_real_bsz=-1, is_dummy_or_profile_run=False) -> None:
         """Prepare the model inputs"""
@@ -2415,6 +2415,7 @@ class GPUModelRunner(ModelRunnerBase):
         model_inputs, p_done_idxs, token_num_event = self._preprocess(
             model_forward_batch, num_running_requests, self._cached_launch_token_num, self._cached_real_bsz
         )
+
         model_output = self._execute(model_inputs)
         # save output (last batch)
         if self._cached_model_output_data is not None:

--- a/tests/model_executor/test_entropy_utils_fd_runner_mtp.py
+++ b/tests/model_executor/test_entropy_utils_fd_runner_mtp.py
@@ -13,600 +13,198 @@
 # limitations under the License.
 
 """
-Unit tests for entropy_utils under FD runner (EB5_ENABLE_FD_RUNNER=1) + MTP scenario.
+Unit tests for entropy_utils FD runner path.
 
-This test can be run standalone:
-    EB5_ENABLE_FD_RUNNER=1 python tests/model_executor/test_entropy_utils_fd_runner_mtp.py
-
-Key differences from ernie5_runner path:
-- speculate_calculate_logits_entropy receives logits of shape [sum(seq_lens_this_time), vocab]
-  which includes ALL positions (accepted + rejected). The code must use accepted_idx to
-  extract the correct rows.
-- calculate_logits_entropy receives logits of shape [max_bsz, vocab], one row per slot.
+Run:  python tests/model_executor/test_entropy_utils_fd_runner_mtp.py
 """
 
 import importlib
 import logging
+import math
 import os
 import sys
 import types
 import unittest
 
-# Force FD runner path before importing the module
 os.environ["EB5_ENABLE_FD_RUNNER"] = "1"
 
 import paddle
 
-# Mock fastdeploy.utils to avoid importing the full fastdeploy package
-_mock_fastdeploy = types.ModuleType("fastdeploy")
-_mock_fastdeploy.__path__ = []
+# Mock fastdeploy.utils
+_mock_fd = types.ModuleType("fastdeploy")
+_mock_fd.__path__ = []
 _mock_utils = types.ModuleType("fastdeploy.utils")
-_mock_utils.data_processor_logger = logging.getLogger("test_entropy_fd_runner")
-_mock_fastdeploy.utils = _mock_utils
-
-sys.modules["fastdeploy"] = _mock_fastdeploy
+_mock_utils.data_processor_logger = logging.getLogger("test_entropy")
+_mock_fd.utils = _mock_utils
+sys.modules["fastdeploy"] = _mock_fd
 sys.modules["fastdeploy.utils"] = _mock_utils
 
-# Now import the module under test via importlib to ensure it picks up our mocks
-_entropy_spec = importlib.util.spec_from_file_location(
+# Import module under test
+_spec = importlib.util.spec_from_file_location(
     "fastdeploy.model_executor.entropy_utils",
     os.path.join(os.path.dirname(__file__), "../../fastdeploy/model_executor/entropy_utils.py"),
 )
-_entropy_module = importlib.util.module_from_spec(_entropy_spec)
+_mod = importlib.util.module_from_spec(_spec)
 sys.modules["fastdeploy.model_executor"] = types.ModuleType("fastdeploy.model_executor")
-sys.modules["fastdeploy.model_executor.entropy_utils"] = _entropy_module
-_entropy_spec.loader.exec_module(_entropy_module)
+sys.modules["fastdeploy.model_executor.entropy_utils"] = _mod
+_spec.loader.exec_module(_mod)
 
-_USE_FD_RUNNER = _entropy_module._USE_FD_RUNNER
-get_entropy = _entropy_module.get_entropy
-calculate_logits_entropy = _entropy_module.calculate_logits_entropy
-speculate_calculate_logits_entropy = _entropy_module.speculate_calculate_logits_entropy
+get_entropy = _mod.get_entropy
+calculate_logits_entropy_fd = _mod.calculate_logits_entropy_fd
+speculate_calculate_logits_entropy_fd = _mod.speculate_calculate_logits_entropy_fd
+flush_entropy_on_stop = _mod.flush_entropy_on_stop
 
 
-class TestFdRunnerFlag(unittest.TestCase):
-    """Verify the module loaded with FD runner enabled."""
-
-    def test_fd_runner_enabled(self):
-        self.assertTrue(_USE_FD_RUNNER)
+def _make_share_inputs(
+    bsz, seq_lens_this_time, seq_lens_encoder, seq_lens_decoder, stop_flags, req_ids, accept_num=None
+):
+    d = {
+        "seq_lens_this_time": paddle.to_tensor(seq_lens_this_time, dtype="int32"),
+        "seq_lens_encoder": paddle.to_tensor(seq_lens_encoder, dtype="int32"),
+        "seq_lens_decoder": paddle.to_tensor(seq_lens_decoder, dtype="int32"),
+        "entropy_list": [[] for _ in range(bsz)],
+        "stop_flags": paddle.to_tensor(stop_flags, dtype="bool"),
+        "req_ids": req_ids,
+    }
+    if accept_num is not None:
+        d["accept_num"] = paddle.to_tensor(accept_num, dtype="int32")
+    return d
 
 
 class TestGetEntropy(unittest.TestCase):
-    """Test the core entropy calculation function."""
-
-    def test_uniform_distribution(self):
-        # Uniform logits => max entropy = ln(vocab_size)
+    def test_uniform_and_deterministic(self):
         logits = paddle.zeros([1, 4], dtype="float32")
-        entropy = get_entropy(logits)
-        import math
+        self.assertAlmostEqual(float(get_entropy(logits)[0]), math.log(4), places=5)
 
-        self.assertAlmostEqual(float(entropy[0]), math.log(4), places=5)
-
-    def test_deterministic_distribution(self):
-        # One logit dominates => entropy near 0
         logits = paddle.to_tensor([[100.0, 0.0, 0.0, 0.0]], dtype="float32")
-        entropy = get_entropy(logits)
-        self.assertAlmostEqual(float(entropy[0]), 0.0, places=5)
+        self.assertAlmostEqual(float(get_entropy(logits)[0]), 0.0, places=5)
 
-    def test_negative_inf_handling(self):
+    def test_negative_inf(self):
         logits = paddle.to_tensor([[10.0, -float("inf"), -float("inf")]], dtype="float32")
-        entropy = get_entropy(logits)
-        # After clipping -inf, effectively one dominant logit
-        self.assertGreaterEqual(float(entropy[0]), 0.0)
+        self.assertGreaterEqual(float(get_entropy(logits)[0]), 0.0)
 
 
-class TestCalculateLogitsEntropyFdRunner(unittest.TestCase):
-    """Test calculate_logits_entropy under FD runner (1D shape, direct indexing)."""
+class TestNonMTP(unittest.TestCase):
+    def test_accumulation_and_skip_zero(self):
+        si = _make_share_inputs(3, [1, 1, 0], [0, 0, 0], [10, 10, 0], [False, False, False], ["a", "b", "c"])
+        logits = paddle.to_tensor([[10.0, 1.0, 1.0], [1.0, 1.0, 10.0], [5.0, 5.0, 5.0]], dtype="float32")
+        calculate_logits_entropy_fd(logits, si, paddle.ones([3], dtype="float32"))
 
-    def _make_share_inputs(self, bsz, seq_lens_this_time, seq_lens_encoder, seq_lens_decoder, stop_flags, req_ids):
-        return {
-            "seq_lens_this_time": paddle.to_tensor(seq_lens_this_time, dtype="int32"),
-            "seq_lens_encoder": paddle.to_tensor(seq_lens_encoder, dtype="int32"),
-            "seq_lens_decoder": paddle.to_tensor(seq_lens_decoder, dtype="int32"),
-            "entropy_list": [[] for _ in range(bsz)],
-            "stop_flags": paddle.to_tensor(stop_flags, dtype="bool"),
-            "req_ids": req_ids,
-        }
+        self.assertEqual(len(si["entropy_list"][0]), 1)
+        self.assertEqual(len(si["entropy_list"][1]), 1)
+        self.assertEqual(len(si["entropy_list"][2]), 0)
+        # [10,1,1] and [1,1,10] symmetric => same entropy
+        self.assertAlmostEqual(si["entropy_list"][0][0], si["entropy_list"][1][0], places=6)
 
-    def test_basic_accumulation(self):
-        # FD runner: logits shape [max_bsz, vocab], 1D seq_lens
-        share_inputs = self._make_share_inputs(
-            bsz=3,
-            seq_lens_this_time=[1, 1, 0],
-            seq_lens_encoder=[0, 0, 0],
-            seq_lens_decoder=[10, 10, 0],
-            stop_flags=[False, False, False],
-            req_ids=["req_a", "req_b", "req_c"],
-        )
-        logits = paddle.to_tensor(
-            [
-                [10.0, 1.0, 1.0],  # slot 0
-                [1.0, 1.0, 10.0],  # slot 1
-                [5.0, 5.0, 5.0],  # slot 2 (seq_lens_this_time=0, skipped)
-            ],
-            dtype="float32",
-        )
-        temperature = paddle.ones([3], dtype="float32")
+    def test_stop_flags_and_temperature(self):
+        # stop_flags clears entropy
+        si = _make_share_inputs(2, [1, 1], [0, 0], [10, 10], [True, False], ["a", "b"])
+        logits = paddle.to_tensor([[10.0, 1.0, 1.0], [10.0, 1.0, 1.0]], dtype="float32")
+        calculate_logits_entropy_fd(logits, si, paddle.ones([2], dtype="float32"))
+        self.assertEqual(si["entropy_list"][0], [])
+        self.assertEqual(len(si["entropy_list"][1]), 1)
 
-        calculate_logits_entropy(logits, share_inputs, temperature)
+        # temperature scaling: lower temp => lower entropy
+        si = _make_share_inputs(2, [1, 1], [0, 0], [10, 10], [False, False], ["a", "b"])
+        logits = paddle.to_tensor([[10.0, 1.0, 1.0], [10.0, 1.0, 1.0]], dtype="float32")
+        calculate_logits_entropy_fd(logits, si, paddle.to_tensor([1.0, 0.5], dtype="float32"))
+        self.assertGreater(si["entropy_list"][0][0], si["entropy_list"][1][0])
 
-        self.assertEqual(len(share_inputs["entropy_list"][0]), 1)
-        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
-        self.assertEqual(len(share_inputs["entropy_list"][2]), 0)
-        # Same logits pattern => same entropy
-        self.assertAlmostEqual(
-            share_inputs["entropy_list"][0][0],
-            share_inputs["entropy_list"][1][0],
-            places=6,
-        )
 
-    def test_stop_flags_clear(self):
-        share_inputs = self._make_share_inputs(
-            bsz=2,
-            seq_lens_this_time=[1, 1],
-            seq_lens_encoder=[0, 0],
-            seq_lens_decoder=[10, 10],
-            stop_flags=[True, False],
-            req_ids=["req_a", "req_b"],
+class TestMTP(unittest.TestCase):
+    def test_accepted_idx_and_partial(self):
+        """accept_num=[2, 0, 1, 2], verifies correct row extraction and per-slot counts."""
+        si = _make_share_inputs(
+            4,
+            [2, 2, 2, 2],
+            [0, 0, 0, 0],
+            [10, 10, 10, 10],
+            [False, False, False, False],
+            ["a", "b", "c", "d"],
+            [2, 0, 1, 2],
         )
         logits = paddle.to_tensor(
             [
                 [10.0, 1.0, 1.0],
-                [1.0, 10.0, 1.0],
+                [1.0, 10.0, 1.0],  # slot 0 (both accepted)
+                [5.0, 5.0, 5.0],
+                [5.0, 5.0, 5.0],  # slot 1 (none accepted)
+                [1.0, 1.0, 10.0],
+                [5.0, 5.0, 5.0],  # slot 2 (first accepted)
+                [10.0, 10.0, 1.0],
+                [1.0, 10.0, 10.0],  # slot 3 (both accepted)
             ],
             dtype="float32",
         )
-        temperature = paddle.ones([2], dtype="float32")
+        speculate_calculate_logits_entropy_fd(logits, si, paddle.ones([4], dtype="float32"))
 
-        calculate_logits_entropy(logits, share_inputs, temperature)
+        self.assertEqual(len(si["entropy_list"][0]), 2)
+        self.assertEqual(len(si["entropy_list"][1]), 0)
+        self.assertEqual(len(si["entropy_list"][2]), 1)
+        self.assertEqual(len(si["entropy_list"][3]), 2)
+        # [10,1,1] [1,10,1] [1,1,10] all symmetric => same entropy
+        self.assertAlmostEqual(si["entropy_list"][0][0], si["entropy_list"][0][1], places=6)
+        self.assertAlmostEqual(si["entropy_list"][0][0], si["entropy_list"][2][0], places=6)
 
-        # slot 0: stop_flags=True + seq_lens_decoder!=0 => cleared
-        self.assertEqual(len(share_inputs["entropy_list"][0]), 0)
-        # slot 1: stop_flags=False => kept
-        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
-
-    def test_temperature_scaling(self):
-        share_inputs = self._make_share_inputs(
-            bsz=2,
-            seq_lens_this_time=[1, 1],
-            seq_lens_encoder=[0, 0],
-            seq_lens_decoder=[10, 10],
-            stop_flags=[False, False],
-            req_ids=["req_a", "req_b"],
+    def test_zero_accepted_flushes_stop(self):
+        si = _make_share_inputs(2, [1, 1], [0, 0], [10, 10], [True, False], ["a", "b"], [0, 0])
+        si["entropy_list"][0] = [1.0, 2.0, 3.0]
+        si["entropy_list"][1] = [4.0, 5.0]
+        speculate_calculate_logits_entropy_fd(
+            paddle.zeros([2, 3], dtype="float32"), si, paddle.ones([2], dtype="float32")
         )
-        logits = paddle.to_tensor(
-            [
-                [10.0, 1.0, 1.0],
-                [10.0, 1.0, 1.0],
-            ],
-            dtype="float32",
-        )
-        # slot 0: temp=1.0 (no scaling), slot 1: temp=0.5 (sharper distribution)
-        temperature = paddle.to_tensor([1.0, 0.5], dtype="float32")
-
-        calculate_logits_entropy(logits, share_inputs, temperature)
-
-        # Lower temperature => lower entropy (more peaked)
-        self.assertGreater(
-            share_inputs["entropy_list"][0][0],
-            share_inputs["entropy_list"][1][0],
-        )
-
-
-class TestSpeculateCalculateLogitsEntropyFdRunner(unittest.TestCase):
-    """
-    Test speculate_calculate_logits_entropy under FD runner + MTP.
-
-    Key: logits shape is [sum(seq_lens_this_time), vocab], containing all positions
-    (accepted + rejected). The function must use accepted_idx to extract correct rows.
-    """
-
-    def _make_share_inputs(
-        self, bsz, seq_lens_this_time, seq_lens_encoder, seq_lens_decoder, stop_flags, req_ids, accept_num
-    ):
-        return {
-            "seq_lens_this_time": paddle.to_tensor(seq_lens_this_time, dtype="int32"),
-            "seq_lens_encoder": paddle.to_tensor(seq_lens_encoder, dtype="int32"),
-            "seq_lens_decoder": paddle.to_tensor(seq_lens_decoder, dtype="int32"),
-            "entropy_list": [[] for _ in range(bsz)],
-            "stop_flags": paddle.to_tensor(stop_flags, dtype="bool"),
-            "req_ids": req_ids,
-            "accept_num": paddle.to_tensor(accept_num, dtype="int32"),
-        }
-
-    def test_accepted_idx_extraction(self):
-        """
-        Scenario: 3 slots, seq_lens_this_time=[2, 3, 1], accept_num=[1, 2, 1]
-        logits shape: [2+3+1=6, vocab]
-        - slot 0: positions [0,1], accepted=1 => take row 0
-        - slot 1: positions [2,3,4], accepted=2 => take rows 2,3
-        - slot 2: positions [5], accepted=1 => take row 5
-        """
-        share_inputs = self._make_share_inputs(
-            bsz=3,
-            seq_lens_this_time=[2, 3, 1],
-            seq_lens_encoder=[0, 0, 0],
-            seq_lens_decoder=[10, 10, 10],
-            stop_flags=[False, False, False],
-            req_ids=["req_a", "req_b", "req_c"],
-            accept_num=[1, 2, 1],
-        )
-        # 6 rows total, each with distinct logits so we can verify correct extraction
-        logits = paddle.to_tensor(
-            [
-                [10.0, 1.0, 1.0],  # row 0: slot 0, position 0 (accepted)
-                [1.0, 1.0, 1.0],  # row 1: slot 0, position 1 (rejected)
-                [1.0, 10.0, 1.0],  # row 2: slot 1, position 0 (accepted)
-                [1.0, 1.0, 10.0],  # row 3: slot 1, position 1 (accepted)
-                [5.0, 5.0, 5.0],  # row 4: slot 1, position 2 (rejected)
-                [10.0, 10.0, 1.0],  # row 5: slot 2, position 0 (accepted)
-            ],
-            dtype="float32",
-        )
-        temperature = paddle.ones([3], dtype="float32")
-
-        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
-
-        # slot 0: 1 accepted token
-        self.assertEqual(len(share_inputs["entropy_list"][0]), 1)
-        # slot 1: 2 accepted tokens
-        self.assertEqual(len(share_inputs["entropy_list"][1]), 2)
-        # slot 2: 1 accepted token
-        self.assertEqual(len(share_inputs["entropy_list"][2]), 1)
-
-        # Verify the extracted logits produce correct entropy values
-        # row 0: [10, 1, 1] => same as row 2: [1, 10, 1] (symmetric)
-        self.assertAlmostEqual(
-            share_inputs["entropy_list"][0][0],
-            share_inputs["entropy_list"][1][0],
-            places=6,
-        )
-        # row 3: [1, 1, 10] => same entropy as [10, 1, 1]
-        self.assertAlmostEqual(
-            share_inputs["entropy_list"][1][1],
-            share_inputs["entropy_list"][0][0],
-            places=6,
-        )
-        # row 5: [10, 10, 1] => different entropy (more uniform among top-2)
-        self.assertGreater(
-            share_inputs["entropy_list"][2][0],
-            share_inputs["entropy_list"][0][0],
-        )
-
-    def test_zero_accepted_with_stop_flags(self):
-        """
-        When total_accepted_num=0 but stop_flags is set, ENTROPY-DONE should trigger
-        and clear the entropy_list.
-        """
-        share_inputs = self._make_share_inputs(
-            bsz=2,
-            seq_lens_this_time=[1, 1],
-            seq_lens_encoder=[0, 0],
-            seq_lens_decoder=[10, 10],
-            stop_flags=[True, False],
-            req_ids=["req_a", "req_b"],
-            accept_num=[0, 0],
-        )
-        # Pre-fill some entropy values to verify clearing
-        share_inputs["entropy_list"][0] = [1.0, 2.0, 3.0]
-        share_inputs["entropy_list"][1] = [4.0, 5.0]
-
-        logits = paddle.zeros([2, 3], dtype="float32")  # irrelevant, won't be used
-
-        speculate_calculate_logits_entropy(logits, share_inputs, paddle.ones([2], dtype="float32"))
-
-        # slot 0: stop_flags=True => cleared
-        self.assertEqual(share_inputs["entropy_list"][0], [])
-        # slot 1: stop_flags=False => unchanged
-        self.assertEqual(share_inputs["entropy_list"][1], [4.0, 5.0])
+        self.assertEqual(si["entropy_list"][0], [])
+        self.assertEqual(si["entropy_list"][1], [4.0, 5.0])
 
     def test_warmup_skip(self):
-        """
-        Warmup/dummy requests with empty req_id should not accumulate entropy.
-        """
-        share_inputs = self._make_share_inputs(
-            bsz=3,
-            seq_lens_this_time=[2, 2, 2],
-            seq_lens_encoder=[0, 0, 0],
-            seq_lens_decoder=[10, 10, 10],
-            stop_flags=[False, False, False],
-            req_ids=["", "req_real", "  "],  # slot 0 and 2 are warmup
-            accept_num=[1, 1, 1],
+        si = _make_share_inputs(
+            3, [2, 2, 2], [0, 0, 0], [10, 10, 10], [False, False, False], ["", "real", "  "], [1, 1, 1]
         )
         logits = paddle.to_tensor(
-            [
-                [10.0, 1.0, 1.0],  # slot 0, pos 0 (accepted) - warmup
-                [5.0, 5.0, 5.0],  # slot 0, pos 1 (rejected)
-                [1.0, 10.0, 1.0],  # slot 1, pos 0 (accepted) - real
-                [5.0, 5.0, 5.0],  # slot 1, pos 1 (rejected)
-                [1.0, 1.0, 10.0],  # slot 2, pos 0 (accepted) - warmup (whitespace)
-                [5.0, 5.0, 5.0],  # slot 2, pos 1 (rejected)
-            ],
-            dtype="float32",
-        )
-        temperature = paddle.ones([3], dtype="float32")
-
-        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
-
-        # slot 0: warmup, skipped
-        self.assertEqual(len(share_inputs["entropy_list"][0]), 0)
-        # slot 1: real request, accumulated
-        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
-        # slot 2: whitespace req_id, skipped
-        self.assertEqual(len(share_inputs["entropy_list"][2]), 0)
-
-    def test_partial_accept(self):
-        """
-        Mixed accept counts: some slots accept 2, some accept 0.
-        Verifies correct indexing when accept_num varies per slot.
-        """
-        share_inputs = self._make_share_inputs(
-            bsz=4,
-            seq_lens_this_time=[2, 2, 2, 2],
-            seq_lens_encoder=[0, 0, 0, 0],
-            seq_lens_decoder=[10, 10, 10, 10],
-            stop_flags=[False, False, False, False],
-            req_ids=["req_a", "req_b", "req_c", "req_d"],
-            accept_num=[2, 0, 1, 2],
-        )
-        # total rows = sum(seq_lens_this_time) = 8
-        logits = paddle.to_tensor(
-            [
-                [10.0, 1.0, 1.0],  # row 0: slot 0, pos 0 (accepted)
-                [1.0, 10.0, 1.0],  # row 1: slot 0, pos 1 (accepted)
-                [5.0, 5.0, 5.0],  # row 2: slot 1, pos 0 (not accepted)
-                [5.0, 5.0, 5.0],  # row 3: slot 1, pos 1 (not accepted)
-                [1.0, 1.0, 10.0],  # row 4: slot 2, pos 0 (accepted)
-                [5.0, 5.0, 5.0],  # row 5: slot 2, pos 1 (rejected)
-                [10.0, 10.0, 1.0],  # row 6: slot 3, pos 0 (accepted)
-                [1.0, 10.0, 10.0],  # row 7: slot 3, pos 1 (accepted)
-            ],
-            dtype="float32",
-        )
-        temperature = paddle.ones([4], dtype="float32")
-
-        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
-
-        self.assertEqual(len(share_inputs["entropy_list"][0]), 2)
-        self.assertEqual(len(share_inputs["entropy_list"][1]), 0)
-        self.assertEqual(len(share_inputs["entropy_list"][2]), 1)
-        self.assertEqual(len(share_inputs["entropy_list"][3]), 2)
-
-        # Verify values: row 0 [10,1,1] and row 1 [1,10,1] have same entropy
-        self.assertAlmostEqual(
-            share_inputs["entropy_list"][0][0],
-            share_inputs["entropy_list"][0][1],
-            places=6,
-        )
-        # row 4 [1,1,10] same entropy as row 0
-        self.assertAlmostEqual(
-            share_inputs["entropy_list"][2][0],
-            share_inputs["entropy_list"][0][0],
-            places=6,
-        )
-        # row 6 [10,10,1] and row 7 [1,10,10] same entropy (symmetric)
-        self.assertAlmostEqual(
-            share_inputs["entropy_list"][3][0],
-            share_inputs["entropy_list"][3][1],
-            places=6,
-        )
-
-    def test_stop_flags_after_accept(self):
-        """
-        Slot finishes (stop_flags=True) after accepting tokens in same step.
-        Entropy should be accumulated then immediately cleared.
-        """
-        share_inputs = self._make_share_inputs(
-            bsz=2,
-            seq_lens_this_time=[2, 2],
-            seq_lens_encoder=[0, 0],
-            seq_lens_decoder=[10, 10],
-            stop_flags=[True, False],
-            req_ids=["req_a", "req_b"],
-            accept_num=[2, 1],
-        )
-        logits = paddle.to_tensor(
-            [
-                [10.0, 1.0, 1.0],  # slot 0, pos 0 (accepted)
-                [1.0, 10.0, 1.0],  # slot 0, pos 1 (accepted)
-                [1.0, 1.0, 10.0],  # slot 1, pos 0 (accepted)
-                [5.0, 5.0, 5.0],  # slot 1, pos 1 (rejected)
-            ],
-            dtype="float32",
-        )
-        temperature = paddle.ones([2], dtype="float32")
-
-        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
-
-        # slot 0: accepted 2, then stop_flags=True => cleared
-        self.assertEqual(share_inputs["entropy_list"][0], [])
-        # slot 1: accepted 1, stop_flags=False => kept
-        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
-
-    def test_temperature_scaling_mtp(self):
-        """Verify temperature scaling is applied per-slot in MTP path."""
-        share_inputs = self._make_share_inputs(
-            bsz=2,
-            seq_lens_this_time=[2, 2],
-            seq_lens_encoder=[0, 0],
-            seq_lens_decoder=[10, 10],
-            stop_flags=[False, False],
-            req_ids=["req_a", "req_b"],
-            accept_num=[1, 1],
-        )
-        # Same logits for both slots
-        logits = paddle.to_tensor(
-            [
-                [10.0, 1.0, 1.0],  # slot 0, pos 0 (accepted)
-                [5.0, 5.0, 5.0],  # slot 0, pos 1 (rejected)
-                [10.0, 1.0, 1.0],  # slot 1, pos 0 (accepted)
-                [5.0, 5.0, 5.0],  # slot 1, pos 1 (rejected)
-            ],
-            dtype="float32",
-        )
-        # slot 0: temp=1.0, slot 1: temp=0.5
-        temperature = paddle.to_tensor([1.0, 0.5], dtype="float32")
-
-        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
-
-        # Lower temperature => lower entropy
-        self.assertGreater(
-            share_inputs["entropy_list"][0][0],
-            share_inputs["entropy_list"][1][0],
-        )
-
-    def test_encoder_prefill_slot(self):
-        """
-        When seq_lens_encoder != 0, real_seq_lens is forced to 1 regardless of
-        seq_lens_this_time. Verify accepted_idx handles this correctly.
-        """
-        share_inputs = self._make_share_inputs(
-            bsz=3,
-            seq_lens_this_time=[2, 100, 2],  # slot 1 is prefill (large seq_lens_this_time)
-            seq_lens_encoder=[0, 100, 0],  # slot 1 is encoder (prefill)
-            seq_lens_decoder=[10, 0, 10],
-            stop_flags=[False, False, False],
-            req_ids=["req_a", "req_b", "req_c"],
-            accept_num=[1, 1, 1],
-        )
-        # real_seq_lens = [2, 1, 2] (slot 1 forced to 1 because encoder != 0)
-        # total rows = sum(real_seq_lens) = 2 + 1 + 2 = 5
-        logits = paddle.to_tensor(
-            [
-                [10.0, 1.0, 1.0],  # row 0: slot 0, pos 0 (accepted)
-                [5.0, 5.0, 5.0],  # row 1: slot 0, pos 1
-                [1.0, 10.0, 1.0],  # row 2: slot 1, pos 0 (accepted, prefill)
-                [1.0, 1.0, 10.0],  # row 3: slot 2, pos 0 (accepted)
-                [5.0, 5.0, 5.0],  # row 4: slot 2, pos 1
-            ],
-            dtype="float32",
-        )
-        temperature = paddle.ones([3], dtype="float32")
-
-        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
-
-        self.assertEqual(len(share_inputs["entropy_list"][0]), 1)
-        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
-        self.assertEqual(len(share_inputs["entropy_list"][2]), 1)
-
-        # All accepted logits are [10,1,1]-symmetric => same entropy
-        self.assertAlmostEqual(
-            share_inputs["entropy_list"][0][0],
-            share_inputs["entropy_list"][1][0],
-            places=6,
-        )
-        self.assertAlmostEqual(
-            share_inputs["entropy_list"][1][0],
-            share_inputs["entropy_list"][2][0],
-            places=6,
-        )
-
-    def test_multi_step_accumulation(self):
-        """
-        Simulate multiple MTP steps and verify entropy accumulates correctly
-        across steps until stop_flags triggers ENTROPY-DONE.
-        """
-        share_inputs = {
-            "seq_lens_this_time": paddle.to_tensor([2, 2], dtype="int32"),
-            "seq_lens_encoder": paddle.to_tensor([0, 0], dtype="int32"),
-            "seq_lens_decoder": paddle.to_tensor([10, 10], dtype="int32"),
-            "entropy_list": [[], []],
-            "stop_flags": paddle.to_tensor([False, False], dtype="bool"),
-            "req_ids": ["req_a", "req_b"],
-            "accept_num": paddle.to_tensor([2, 1], dtype="int32"),
-        }
-
-        logits_step1 = paddle.to_tensor(
             [
                 [10.0, 1.0, 1.0],
+                [5.0, 5.0, 5.0],
                 [1.0, 10.0, 1.0],
+                [5.0, 5.0, 5.0],
                 [1.0, 1.0, 10.0],
                 [5.0, 5.0, 5.0],
             ],
             dtype="float32",
         )
-        temperature = paddle.ones([2], dtype="float32")
+        speculate_calculate_logits_entropy_fd(logits, si, paddle.ones([3], dtype="float32"))
+        self.assertEqual(len(si["entropy_list"][0]), 0)
+        self.assertEqual(len(si["entropy_list"][1]), 1)
+        self.assertEqual(len(si["entropy_list"][2]), 0)
 
-        # Step 1
-        speculate_calculate_logits_entropy(logits_step1, share_inputs, temperature)
-        self.assertEqual(len(share_inputs["entropy_list"][0]), 2)
-        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
-
-        # Step 2: same structure, slot 1 finishes
-        share_inputs["accept_num"] = paddle.to_tensor([1, 1], dtype="int32")
-        share_inputs["stop_flags"] = paddle.to_tensor([False, True], dtype="bool")
-        logits_step2 = paddle.to_tensor(
-            [
-                [10.0, 1.0, 1.0],
-                [5.0, 5.0, 5.0],
-                [10.0, 1.0, 1.0],
-                [5.0, 5.0, 5.0],
-            ],
-            dtype="float32",
+    def test_multi_step_and_stop(self):
+        si = _make_share_inputs(2, [2, 2], [0, 0], [10, 10], [False, False], ["a", "b"], [2, 1])
+        logits = paddle.to_tensor(
+            [[10.0, 1.0, 1.0], [1.0, 10.0, 1.0], [1.0, 1.0, 10.0], [5.0, 5.0, 5.0]], dtype="float32"
         )
+        speculate_calculate_logits_entropy_fd(logits, si, paddle.ones([2], dtype="float32"))
+        self.assertEqual(len(si["entropy_list"][0]), 2)
+        self.assertEqual(len(si["entropy_list"][1]), 1)
 
-        speculate_calculate_logits_entropy(logits_step2, share_inputs, temperature)
-
-        # slot 0: 2 + 1 = 3 accumulated
-        self.assertEqual(len(share_inputs["entropy_list"][0]), 3)
-        # slot 1: had 1 from step1, got 1 more, then cleared by stop_flags
-        self.assertEqual(share_inputs["entropy_list"][1], [])
-
-
-class TestCrossRunnerConsistency(unittest.TestCase):
-    """
-    Verify FD runner and ernie5_runner paths produce the same entropy values
-    when given equivalent inputs (accepted-only logits).
-    """
-
-    def test_same_entropy_both_paths(self):
-        """
-        Construct inputs such that the accepted logits are identical for both paths,
-        then compare the entropy values.
-        """
-        # The accepted logits we want both paths to process
-        accepted_logits_data = [
-            [10.0, 1.0, 1.0],
-            [1.0, 10.0, 1.0],
-            [1.0, 1.0, 10.0],
-        ]
-
-        # --- FD runner path (current module) ---
-        # logits = [sum(seq_lens_this_time), vocab] with extra rejected rows
-        share_inputs_fd = {
-            "seq_lens_this_time": paddle.to_tensor([2, 2, 2], dtype="int32"),
-            "seq_lens_encoder": paddle.to_tensor([0, 0, 0], dtype="int32"),
-            "seq_lens_decoder": paddle.to_tensor([10, 10, 10], dtype="int32"),
-            "entropy_list": [[], [], []],
-            "stop_flags": paddle.to_tensor([False, False, False], dtype="bool"),
-            "req_ids": ["req_a", "req_b", "req_c"],
-            "accept_num": paddle.to_tensor([1, 1, 1], dtype="int32"),
-        }
-        logits_fd = paddle.to_tensor(
-            [
-                [10.0, 1.0, 1.0],  # slot 0, pos 0 (accepted)
-                [99.0, 99.0, 99.0],  # slot 0, pos 1 (rejected - should be ignored)
-                [1.0, 10.0, 1.0],  # slot 1, pos 0 (accepted)
-                [99.0, 99.0, 99.0],  # slot 1, pos 1 (rejected)
-                [1.0, 1.0, 10.0],  # slot 2, pos 0 (accepted)
-                [99.0, 99.0, 99.0],  # slot 2, pos 1 (rejected)
-            ],
-            dtype="float32",
+        # Step 2: slot 1 stops
+        si["accept_num"] = paddle.to_tensor([1, 1], dtype="int32")
+        si["stop_flags"] = paddle.to_tensor([False, True], dtype="bool")
+        logits2 = paddle.to_tensor(
+            [[10.0, 1.0, 1.0], [5.0, 5.0, 5.0], [10.0, 1.0, 1.0], [5.0, 5.0, 5.0]], dtype="float32"
         )
-        temperature = paddle.ones([3], dtype="float32")
+        speculate_calculate_logits_entropy_fd(logits2, si, paddle.ones([2], dtype="float32"))
+        self.assertEqual(len(si["entropy_list"][0]), 3)
+        self.assertEqual(si["entropy_list"][1], [])
 
-        speculate_calculate_logits_entropy(logits_fd, share_inputs_fd, temperature)
 
-        # --- Direct entropy calculation on accepted logits ---
-        direct_entropy = get_entropy(paddle.to_tensor(accepted_logits_data, dtype="float32")).tolist()
-
-        # Compare
-        for i in range(3):
-            self.assertAlmostEqual(
-                share_inputs_fd["entropy_list"][i][0],
-                direct_entropy[i],
-                places=6,
-                msg=f"Mismatch at slot {i}",
-            )
+class TestFlushEntropyOnStop(unittest.TestCase):
+    def test_flush(self):
+        si = _make_share_inputs(3, [1, 1, 1], [0, 0, 0], [10, 10, 10], [True, False, True], ["a", "b", "c"])
+        si["entropy_list"][0] = [1.0, 2.0]
+        si["entropy_list"][2] = [3.0]
+        flush_entropy_on_stop(si)
+        self.assertEqual(si["entropy_list"][0], [])
+        self.assertEqual(si["entropy_list"][1], [])
+        self.assertEqual(si["entropy_list"][2], [])
 
 
 if __name__ == "__main__":

--- a/tests/model_executor/test_entropy_utils_fd_runner_mtp.py
+++ b/tests/model_executor/test_entropy_utils_fd_runner_mtp.py
@@ -1,0 +1,613 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for entropy_utils under FD runner (EB5_ENABLE_FD_RUNNER=1) + MTP scenario.
+
+This test can be run standalone:
+    EB5_ENABLE_FD_RUNNER=1 python tests/model_executor/test_entropy_utils_fd_runner_mtp.py
+
+Key differences from ernie5_runner path:
+- speculate_calculate_logits_entropy receives logits of shape [sum(seq_lens_this_time), vocab]
+  which includes ALL positions (accepted + rejected). The code must use accepted_idx to
+  extract the correct rows.
+- calculate_logits_entropy receives logits of shape [max_bsz, vocab], one row per slot.
+"""
+
+import importlib
+import logging
+import os
+import sys
+import types
+import unittest
+
+# Force FD runner path before importing the module
+os.environ["EB5_ENABLE_FD_RUNNER"] = "1"
+
+import paddle
+
+# Mock fastdeploy.utils to avoid importing the full fastdeploy package
+_mock_fastdeploy = types.ModuleType("fastdeploy")
+_mock_fastdeploy.__path__ = []
+_mock_utils = types.ModuleType("fastdeploy.utils")
+_mock_utils.data_processor_logger = logging.getLogger("test_entropy_fd_runner")
+_mock_fastdeploy.utils = _mock_utils
+
+sys.modules["fastdeploy"] = _mock_fastdeploy
+sys.modules["fastdeploy.utils"] = _mock_utils
+
+# Now import the module under test via importlib to ensure it picks up our mocks
+_entropy_spec = importlib.util.spec_from_file_location(
+    "fastdeploy.model_executor.entropy_utils",
+    os.path.join(os.path.dirname(__file__), "../../fastdeploy/model_executor/entropy_utils.py"),
+)
+_entropy_module = importlib.util.module_from_spec(_entropy_spec)
+sys.modules["fastdeploy.model_executor"] = types.ModuleType("fastdeploy.model_executor")
+sys.modules["fastdeploy.model_executor.entropy_utils"] = _entropy_module
+_entropy_spec.loader.exec_module(_entropy_module)
+
+_USE_FD_RUNNER = _entropy_module._USE_FD_RUNNER
+get_entropy = _entropy_module.get_entropy
+calculate_logits_entropy = _entropy_module.calculate_logits_entropy
+speculate_calculate_logits_entropy = _entropy_module.speculate_calculate_logits_entropy
+
+
+class TestFdRunnerFlag(unittest.TestCase):
+    """Verify the module loaded with FD runner enabled."""
+
+    def test_fd_runner_enabled(self):
+        self.assertTrue(_USE_FD_RUNNER)
+
+
+class TestGetEntropy(unittest.TestCase):
+    """Test the core entropy calculation function."""
+
+    def test_uniform_distribution(self):
+        # Uniform logits => max entropy = ln(vocab_size)
+        logits = paddle.zeros([1, 4], dtype="float32")
+        entropy = get_entropy(logits)
+        import math
+
+        self.assertAlmostEqual(float(entropy[0]), math.log(4), places=5)
+
+    def test_deterministic_distribution(self):
+        # One logit dominates => entropy near 0
+        logits = paddle.to_tensor([[100.0, 0.0, 0.0, 0.0]], dtype="float32")
+        entropy = get_entropy(logits)
+        self.assertAlmostEqual(float(entropy[0]), 0.0, places=5)
+
+    def test_negative_inf_handling(self):
+        logits = paddle.to_tensor([[10.0, -float("inf"), -float("inf")]], dtype="float32")
+        entropy = get_entropy(logits)
+        # After clipping -inf, effectively one dominant logit
+        self.assertGreaterEqual(float(entropy[0]), 0.0)
+
+
+class TestCalculateLogitsEntropyFdRunner(unittest.TestCase):
+    """Test calculate_logits_entropy under FD runner (1D shape, direct indexing)."""
+
+    def _make_share_inputs(self, bsz, seq_lens_this_time, seq_lens_encoder, seq_lens_decoder, stop_flags, req_ids):
+        return {
+            "seq_lens_this_time": paddle.to_tensor(seq_lens_this_time, dtype="int32"),
+            "seq_lens_encoder": paddle.to_tensor(seq_lens_encoder, dtype="int32"),
+            "seq_lens_decoder": paddle.to_tensor(seq_lens_decoder, dtype="int32"),
+            "entropy_list": [[] for _ in range(bsz)],
+            "stop_flags": paddle.to_tensor(stop_flags, dtype="bool"),
+            "req_ids": req_ids,
+        }
+
+    def test_basic_accumulation(self):
+        # FD runner: logits shape [max_bsz, vocab], 1D seq_lens
+        share_inputs = self._make_share_inputs(
+            bsz=3,
+            seq_lens_this_time=[1, 1, 0],
+            seq_lens_encoder=[0, 0, 0],
+            seq_lens_decoder=[10, 10, 0],
+            stop_flags=[False, False, False],
+            req_ids=["req_a", "req_b", "req_c"],
+        )
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],  # slot 0
+                [1.0, 1.0, 10.0],  # slot 1
+                [5.0, 5.0, 5.0],  # slot 2 (seq_lens_this_time=0, skipped)
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([3], dtype="float32")
+
+        calculate_logits_entropy(logits, share_inputs, temperature)
+
+        self.assertEqual(len(share_inputs["entropy_list"][0]), 1)
+        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
+        self.assertEqual(len(share_inputs["entropy_list"][2]), 0)
+        # Same logits pattern => same entropy
+        self.assertAlmostEqual(
+            share_inputs["entropy_list"][0][0],
+            share_inputs["entropy_list"][1][0],
+            places=6,
+        )
+
+    def test_stop_flags_clear(self):
+        share_inputs = self._make_share_inputs(
+            bsz=2,
+            seq_lens_this_time=[1, 1],
+            seq_lens_encoder=[0, 0],
+            seq_lens_decoder=[10, 10],
+            stop_flags=[True, False],
+            req_ids=["req_a", "req_b"],
+        )
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],
+                [1.0, 10.0, 1.0],
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([2], dtype="float32")
+
+        calculate_logits_entropy(logits, share_inputs, temperature)
+
+        # slot 0: stop_flags=True + seq_lens_decoder!=0 => cleared
+        self.assertEqual(len(share_inputs["entropy_list"][0]), 0)
+        # slot 1: stop_flags=False => kept
+        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
+
+    def test_temperature_scaling(self):
+        share_inputs = self._make_share_inputs(
+            bsz=2,
+            seq_lens_this_time=[1, 1],
+            seq_lens_encoder=[0, 0],
+            seq_lens_decoder=[10, 10],
+            stop_flags=[False, False],
+            req_ids=["req_a", "req_b"],
+        )
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],
+                [10.0, 1.0, 1.0],
+            ],
+            dtype="float32",
+        )
+        # slot 0: temp=1.0 (no scaling), slot 1: temp=0.5 (sharper distribution)
+        temperature = paddle.to_tensor([1.0, 0.5], dtype="float32")
+
+        calculate_logits_entropy(logits, share_inputs, temperature)
+
+        # Lower temperature => lower entropy (more peaked)
+        self.assertGreater(
+            share_inputs["entropy_list"][0][0],
+            share_inputs["entropy_list"][1][0],
+        )
+
+
+class TestSpeculateCalculateLogitsEntropyFdRunner(unittest.TestCase):
+    """
+    Test speculate_calculate_logits_entropy under FD runner + MTP.
+
+    Key: logits shape is [sum(seq_lens_this_time), vocab], containing all positions
+    (accepted + rejected). The function must use accepted_idx to extract correct rows.
+    """
+
+    def _make_share_inputs(
+        self, bsz, seq_lens_this_time, seq_lens_encoder, seq_lens_decoder, stop_flags, req_ids, accept_num
+    ):
+        return {
+            "seq_lens_this_time": paddle.to_tensor(seq_lens_this_time, dtype="int32"),
+            "seq_lens_encoder": paddle.to_tensor(seq_lens_encoder, dtype="int32"),
+            "seq_lens_decoder": paddle.to_tensor(seq_lens_decoder, dtype="int32"),
+            "entropy_list": [[] for _ in range(bsz)],
+            "stop_flags": paddle.to_tensor(stop_flags, dtype="bool"),
+            "req_ids": req_ids,
+            "accept_num": paddle.to_tensor(accept_num, dtype="int32"),
+        }
+
+    def test_accepted_idx_extraction(self):
+        """
+        Scenario: 3 slots, seq_lens_this_time=[2, 3, 1], accept_num=[1, 2, 1]
+        logits shape: [2+3+1=6, vocab]
+        - slot 0: positions [0,1], accepted=1 => take row 0
+        - slot 1: positions [2,3,4], accepted=2 => take rows 2,3
+        - slot 2: positions [5], accepted=1 => take row 5
+        """
+        share_inputs = self._make_share_inputs(
+            bsz=3,
+            seq_lens_this_time=[2, 3, 1],
+            seq_lens_encoder=[0, 0, 0],
+            seq_lens_decoder=[10, 10, 10],
+            stop_flags=[False, False, False],
+            req_ids=["req_a", "req_b", "req_c"],
+            accept_num=[1, 2, 1],
+        )
+        # 6 rows total, each with distinct logits so we can verify correct extraction
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],  # row 0: slot 0, position 0 (accepted)
+                [1.0, 1.0, 1.0],  # row 1: slot 0, position 1 (rejected)
+                [1.0, 10.0, 1.0],  # row 2: slot 1, position 0 (accepted)
+                [1.0, 1.0, 10.0],  # row 3: slot 1, position 1 (accepted)
+                [5.0, 5.0, 5.0],  # row 4: slot 1, position 2 (rejected)
+                [10.0, 10.0, 1.0],  # row 5: slot 2, position 0 (accepted)
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([3], dtype="float32")
+
+        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
+
+        # slot 0: 1 accepted token
+        self.assertEqual(len(share_inputs["entropy_list"][0]), 1)
+        # slot 1: 2 accepted tokens
+        self.assertEqual(len(share_inputs["entropy_list"][1]), 2)
+        # slot 2: 1 accepted token
+        self.assertEqual(len(share_inputs["entropy_list"][2]), 1)
+
+        # Verify the extracted logits produce correct entropy values
+        # row 0: [10, 1, 1] => same as row 2: [1, 10, 1] (symmetric)
+        self.assertAlmostEqual(
+            share_inputs["entropy_list"][0][0],
+            share_inputs["entropy_list"][1][0],
+            places=6,
+        )
+        # row 3: [1, 1, 10] => same entropy as [10, 1, 1]
+        self.assertAlmostEqual(
+            share_inputs["entropy_list"][1][1],
+            share_inputs["entropy_list"][0][0],
+            places=6,
+        )
+        # row 5: [10, 10, 1] => different entropy (more uniform among top-2)
+        self.assertGreater(
+            share_inputs["entropy_list"][2][0],
+            share_inputs["entropy_list"][0][0],
+        )
+
+    def test_zero_accepted_with_stop_flags(self):
+        """
+        When total_accepted_num=0 but stop_flags is set, ENTROPY-DONE should trigger
+        and clear the entropy_list.
+        """
+        share_inputs = self._make_share_inputs(
+            bsz=2,
+            seq_lens_this_time=[1, 1],
+            seq_lens_encoder=[0, 0],
+            seq_lens_decoder=[10, 10],
+            stop_flags=[True, False],
+            req_ids=["req_a", "req_b"],
+            accept_num=[0, 0],
+        )
+        # Pre-fill some entropy values to verify clearing
+        share_inputs["entropy_list"][0] = [1.0, 2.0, 3.0]
+        share_inputs["entropy_list"][1] = [4.0, 5.0]
+
+        logits = paddle.zeros([2, 3], dtype="float32")  # irrelevant, won't be used
+
+        speculate_calculate_logits_entropy(logits, share_inputs, paddle.ones([2], dtype="float32"))
+
+        # slot 0: stop_flags=True => cleared
+        self.assertEqual(share_inputs["entropy_list"][0], [])
+        # slot 1: stop_flags=False => unchanged
+        self.assertEqual(share_inputs["entropy_list"][1], [4.0, 5.0])
+
+    def test_warmup_skip(self):
+        """
+        Warmup/dummy requests with empty req_id should not accumulate entropy.
+        """
+        share_inputs = self._make_share_inputs(
+            bsz=3,
+            seq_lens_this_time=[2, 2, 2],
+            seq_lens_encoder=[0, 0, 0],
+            seq_lens_decoder=[10, 10, 10],
+            stop_flags=[False, False, False],
+            req_ids=["", "req_real", "  "],  # slot 0 and 2 are warmup
+            accept_num=[1, 1, 1],
+        )
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],  # slot 0, pos 0 (accepted) - warmup
+                [5.0, 5.0, 5.0],  # slot 0, pos 1 (rejected)
+                [1.0, 10.0, 1.0],  # slot 1, pos 0 (accepted) - real
+                [5.0, 5.0, 5.0],  # slot 1, pos 1 (rejected)
+                [1.0, 1.0, 10.0],  # slot 2, pos 0 (accepted) - warmup (whitespace)
+                [5.0, 5.0, 5.0],  # slot 2, pos 1 (rejected)
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([3], dtype="float32")
+
+        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
+
+        # slot 0: warmup, skipped
+        self.assertEqual(len(share_inputs["entropy_list"][0]), 0)
+        # slot 1: real request, accumulated
+        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
+        # slot 2: whitespace req_id, skipped
+        self.assertEqual(len(share_inputs["entropy_list"][2]), 0)
+
+    def test_partial_accept(self):
+        """
+        Mixed accept counts: some slots accept 2, some accept 0.
+        Verifies correct indexing when accept_num varies per slot.
+        """
+        share_inputs = self._make_share_inputs(
+            bsz=4,
+            seq_lens_this_time=[2, 2, 2, 2],
+            seq_lens_encoder=[0, 0, 0, 0],
+            seq_lens_decoder=[10, 10, 10, 10],
+            stop_flags=[False, False, False, False],
+            req_ids=["req_a", "req_b", "req_c", "req_d"],
+            accept_num=[2, 0, 1, 2],
+        )
+        # total rows = sum(seq_lens_this_time) = 8
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],  # row 0: slot 0, pos 0 (accepted)
+                [1.0, 10.0, 1.0],  # row 1: slot 0, pos 1 (accepted)
+                [5.0, 5.0, 5.0],  # row 2: slot 1, pos 0 (not accepted)
+                [5.0, 5.0, 5.0],  # row 3: slot 1, pos 1 (not accepted)
+                [1.0, 1.0, 10.0],  # row 4: slot 2, pos 0 (accepted)
+                [5.0, 5.0, 5.0],  # row 5: slot 2, pos 1 (rejected)
+                [10.0, 10.0, 1.0],  # row 6: slot 3, pos 0 (accepted)
+                [1.0, 10.0, 10.0],  # row 7: slot 3, pos 1 (accepted)
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([4], dtype="float32")
+
+        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
+
+        self.assertEqual(len(share_inputs["entropy_list"][0]), 2)
+        self.assertEqual(len(share_inputs["entropy_list"][1]), 0)
+        self.assertEqual(len(share_inputs["entropy_list"][2]), 1)
+        self.assertEqual(len(share_inputs["entropy_list"][3]), 2)
+
+        # Verify values: row 0 [10,1,1] and row 1 [1,10,1] have same entropy
+        self.assertAlmostEqual(
+            share_inputs["entropy_list"][0][0],
+            share_inputs["entropy_list"][0][1],
+            places=6,
+        )
+        # row 4 [1,1,10] same entropy as row 0
+        self.assertAlmostEqual(
+            share_inputs["entropy_list"][2][0],
+            share_inputs["entropy_list"][0][0],
+            places=6,
+        )
+        # row 6 [10,10,1] and row 7 [1,10,10] same entropy (symmetric)
+        self.assertAlmostEqual(
+            share_inputs["entropy_list"][3][0],
+            share_inputs["entropy_list"][3][1],
+            places=6,
+        )
+
+    def test_stop_flags_after_accept(self):
+        """
+        Slot finishes (stop_flags=True) after accepting tokens in same step.
+        Entropy should be accumulated then immediately cleared.
+        """
+        share_inputs = self._make_share_inputs(
+            bsz=2,
+            seq_lens_this_time=[2, 2],
+            seq_lens_encoder=[0, 0],
+            seq_lens_decoder=[10, 10],
+            stop_flags=[True, False],
+            req_ids=["req_a", "req_b"],
+            accept_num=[2, 1],
+        )
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],  # slot 0, pos 0 (accepted)
+                [1.0, 10.0, 1.0],  # slot 0, pos 1 (accepted)
+                [1.0, 1.0, 10.0],  # slot 1, pos 0 (accepted)
+                [5.0, 5.0, 5.0],  # slot 1, pos 1 (rejected)
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([2], dtype="float32")
+
+        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
+
+        # slot 0: accepted 2, then stop_flags=True => cleared
+        self.assertEqual(share_inputs["entropy_list"][0], [])
+        # slot 1: accepted 1, stop_flags=False => kept
+        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
+
+    def test_temperature_scaling_mtp(self):
+        """Verify temperature scaling is applied per-slot in MTP path."""
+        share_inputs = self._make_share_inputs(
+            bsz=2,
+            seq_lens_this_time=[2, 2],
+            seq_lens_encoder=[0, 0],
+            seq_lens_decoder=[10, 10],
+            stop_flags=[False, False],
+            req_ids=["req_a", "req_b"],
+            accept_num=[1, 1],
+        )
+        # Same logits for both slots
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],  # slot 0, pos 0 (accepted)
+                [5.0, 5.0, 5.0],  # slot 0, pos 1 (rejected)
+                [10.0, 1.0, 1.0],  # slot 1, pos 0 (accepted)
+                [5.0, 5.0, 5.0],  # slot 1, pos 1 (rejected)
+            ],
+            dtype="float32",
+        )
+        # slot 0: temp=1.0, slot 1: temp=0.5
+        temperature = paddle.to_tensor([1.0, 0.5], dtype="float32")
+
+        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
+
+        # Lower temperature => lower entropy
+        self.assertGreater(
+            share_inputs["entropy_list"][0][0],
+            share_inputs["entropy_list"][1][0],
+        )
+
+    def test_encoder_prefill_slot(self):
+        """
+        When seq_lens_encoder != 0, real_seq_lens is forced to 1 regardless of
+        seq_lens_this_time. Verify accepted_idx handles this correctly.
+        """
+        share_inputs = self._make_share_inputs(
+            bsz=3,
+            seq_lens_this_time=[2, 100, 2],  # slot 1 is prefill (large seq_lens_this_time)
+            seq_lens_encoder=[0, 100, 0],  # slot 1 is encoder (prefill)
+            seq_lens_decoder=[10, 0, 10],
+            stop_flags=[False, False, False],
+            req_ids=["req_a", "req_b", "req_c"],
+            accept_num=[1, 1, 1],
+        )
+        # real_seq_lens = [2, 1, 2] (slot 1 forced to 1 because encoder != 0)
+        # total rows = sum(real_seq_lens) = 2 + 1 + 2 = 5
+        logits = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],  # row 0: slot 0, pos 0 (accepted)
+                [5.0, 5.0, 5.0],  # row 1: slot 0, pos 1
+                [1.0, 10.0, 1.0],  # row 2: slot 1, pos 0 (accepted, prefill)
+                [1.0, 1.0, 10.0],  # row 3: slot 2, pos 0 (accepted)
+                [5.0, 5.0, 5.0],  # row 4: slot 2, pos 1
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([3], dtype="float32")
+
+        speculate_calculate_logits_entropy(logits, share_inputs, temperature)
+
+        self.assertEqual(len(share_inputs["entropy_list"][0]), 1)
+        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
+        self.assertEqual(len(share_inputs["entropy_list"][2]), 1)
+
+        # All accepted logits are [10,1,1]-symmetric => same entropy
+        self.assertAlmostEqual(
+            share_inputs["entropy_list"][0][0],
+            share_inputs["entropy_list"][1][0],
+            places=6,
+        )
+        self.assertAlmostEqual(
+            share_inputs["entropy_list"][1][0],
+            share_inputs["entropy_list"][2][0],
+            places=6,
+        )
+
+    def test_multi_step_accumulation(self):
+        """
+        Simulate multiple MTP steps and verify entropy accumulates correctly
+        across steps until stop_flags triggers ENTROPY-DONE.
+        """
+        share_inputs = {
+            "seq_lens_this_time": paddle.to_tensor([2, 2], dtype="int32"),
+            "seq_lens_encoder": paddle.to_tensor([0, 0], dtype="int32"),
+            "seq_lens_decoder": paddle.to_tensor([10, 10], dtype="int32"),
+            "entropy_list": [[], []],
+            "stop_flags": paddle.to_tensor([False, False], dtype="bool"),
+            "req_ids": ["req_a", "req_b"],
+            "accept_num": paddle.to_tensor([2, 1], dtype="int32"),
+        }
+
+        logits_step1 = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],
+                [1.0, 10.0, 1.0],
+                [1.0, 1.0, 10.0],
+                [5.0, 5.0, 5.0],
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([2], dtype="float32")
+
+        # Step 1
+        speculate_calculate_logits_entropy(logits_step1, share_inputs, temperature)
+        self.assertEqual(len(share_inputs["entropy_list"][0]), 2)
+        self.assertEqual(len(share_inputs["entropy_list"][1]), 1)
+
+        # Step 2: same structure, slot 1 finishes
+        share_inputs["accept_num"] = paddle.to_tensor([1, 1], dtype="int32")
+        share_inputs["stop_flags"] = paddle.to_tensor([False, True], dtype="bool")
+        logits_step2 = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],
+                [5.0, 5.0, 5.0],
+                [10.0, 1.0, 1.0],
+                [5.0, 5.0, 5.0],
+            ],
+            dtype="float32",
+        )
+
+        speculate_calculate_logits_entropy(logits_step2, share_inputs, temperature)
+
+        # slot 0: 2 + 1 = 3 accumulated
+        self.assertEqual(len(share_inputs["entropy_list"][0]), 3)
+        # slot 1: had 1 from step1, got 1 more, then cleared by stop_flags
+        self.assertEqual(share_inputs["entropy_list"][1], [])
+
+
+class TestCrossRunnerConsistency(unittest.TestCase):
+    """
+    Verify FD runner and ernie5_runner paths produce the same entropy values
+    when given equivalent inputs (accepted-only logits).
+    """
+
+    def test_same_entropy_both_paths(self):
+        """
+        Construct inputs such that the accepted logits are identical for both paths,
+        then compare the entropy values.
+        """
+        # The accepted logits we want both paths to process
+        accepted_logits_data = [
+            [10.0, 1.0, 1.0],
+            [1.0, 10.0, 1.0],
+            [1.0, 1.0, 10.0],
+        ]
+
+        # --- FD runner path (current module) ---
+        # logits = [sum(seq_lens_this_time), vocab] with extra rejected rows
+        share_inputs_fd = {
+            "seq_lens_this_time": paddle.to_tensor([2, 2, 2], dtype="int32"),
+            "seq_lens_encoder": paddle.to_tensor([0, 0, 0], dtype="int32"),
+            "seq_lens_decoder": paddle.to_tensor([10, 10, 10], dtype="int32"),
+            "entropy_list": [[], [], []],
+            "stop_flags": paddle.to_tensor([False, False, False], dtype="bool"),
+            "req_ids": ["req_a", "req_b", "req_c"],
+            "accept_num": paddle.to_tensor([1, 1, 1], dtype="int32"),
+        }
+        logits_fd = paddle.to_tensor(
+            [
+                [10.0, 1.0, 1.0],  # slot 0, pos 0 (accepted)
+                [99.0, 99.0, 99.0],  # slot 0, pos 1 (rejected - should be ignored)
+                [1.0, 10.0, 1.0],  # slot 1, pos 0 (accepted)
+                [99.0, 99.0, 99.0],  # slot 1, pos 1 (rejected)
+                [1.0, 1.0, 10.0],  # slot 2, pos 0 (accepted)
+                [99.0, 99.0, 99.0],  # slot 2, pos 1 (rejected)
+            ],
+            dtype="float32",
+        )
+        temperature = paddle.ones([3], dtype="float32")
+
+        speculate_calculate_logits_entropy(logits_fd, share_inputs_fd, temperature)
+
+        # --- Direct entropy calculation on accepted logits ---
+        direct_entropy = get_entropy(paddle.to_tensor(accepted_logits_data, dtype="float32")).tolist()
+
+        # Compare
+        for i in range(3):
+            self.assertAlmostEqual(
+                share_inputs_fd["entropy_list"][i][0],
+                direct_entropy[i],
+                places=6,
+                msg=f"Mismatch at slot {i}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/model_executor/test_entropy_utils_fd_runner_mtp.py
+++ b/tests/model_executor/test_entropy_utils_fd_runner_mtp.py
@@ -18,41 +18,17 @@ Unit tests for entropy_utils FD runner path.
 Run:  python tests/model_executor/test_entropy_utils_fd_runner_mtp.py
 """
 
-import importlib
-import logging
 import math
-import os
-import sys
-import types
 import unittest
-
-os.environ["EB5_ENABLE_FD_RUNNER"] = "1"
 
 import paddle
 
-# Mock fastdeploy.utils
-_mock_fd = types.ModuleType("fastdeploy")
-_mock_fd.__path__ = []
-_mock_utils = types.ModuleType("fastdeploy.utils")
-_mock_utils.data_processor_logger = logging.getLogger("test_entropy")
-_mock_fd.utils = _mock_utils
-sys.modules["fastdeploy"] = _mock_fd
-sys.modules["fastdeploy.utils"] = _mock_utils
-
-# Import module under test
-_spec = importlib.util.spec_from_file_location(
-    "fastdeploy.model_executor.entropy_utils",
-    os.path.join(os.path.dirname(__file__), "../../fastdeploy/model_executor/entropy_utils.py"),
+from fastdeploy.model_executor.entropy_utils import (
+    calculate_logits_entropy_fd,
+    flush_entropy_on_stop,
+    get_entropy,
+    speculate_calculate_logits_entropy_fd,
 )
-_mod = importlib.util.module_from_spec(_spec)
-sys.modules["fastdeploy.model_executor"] = types.ModuleType("fastdeploy.model_executor")
-sys.modules["fastdeploy.model_executor.entropy_utils"] = _mod
-_spec.loader.exec_module(_mod)
-
-get_entropy = _mod.get_entropy
-calculate_logits_entropy_fd = _mod.calculate_logits_entropy_fd
-speculate_calculate_logits_entropy_fd = _mod.speculate_calculate_logits_entropy_fd
-flush_entropy_on_stop = _mod.flush_entropy_on_stop
 
 
 def _make_share_inputs(

--- a/tests/model_executor/test_entropy_utils_fd_runner_mtp.py
+++ b/tests/model_executor/test_entropy_utils_fd_runner_mtp.py
@@ -132,26 +132,6 @@ class TestMTP(unittest.TestCase):
         self.assertEqual(si["entropy_list"][0], [])
         self.assertEqual(si["entropy_list"][1], [4.0, 5.0])
 
-    def test_warmup_skip(self):
-        si = _make_share_inputs(
-            3, [2, 2, 2], [0, 0, 0], [10, 10, 10], [False, False, False], ["", "real", "  "], [1, 1, 1]
-        )
-        logits = paddle.to_tensor(
-            [
-                [10.0, 1.0, 1.0],
-                [5.0, 5.0, 5.0],
-                [1.0, 10.0, 1.0],
-                [5.0, 5.0, 5.0],
-                [1.0, 1.0, 10.0],
-                [5.0, 5.0, 5.0],
-            ],
-            dtype="float32",
-        )
-        speculate_calculate_logits_entropy_fd(logits, si, paddle.ones([3], dtype="float32"))
-        self.assertEqual(len(si["entropy_list"][0]), 0)
-        self.assertEqual(len(si["entropy_list"][1]), 1)
-        self.assertEqual(len(si["entropy_list"][2]), 0)
-
     def test_multi_step_and_stop(self):
         si = _make_share_inputs(2, [2, 2], [0, 0], [10, 10], [False, False], ["a", "b"], [2, 1])
         logits = paddle.to_tensor(


### PR DESCRIPTION
## Motivation

Support entropy calculation for fastdeploy runner. The previous implementation had three bugs in the fd-runner + MTP scenario:

1. **ENTROPY-DONE never triggered**: When `accept_num=0` for a finishing slot, the code skipped the `stop_flags` check entirely, so entropy was never summarized or cleared.
2. **Incorrect logits indexing**: fd-runner's logits shape is `[sum(seq_lens_this_time), vocab]` (all positions including rejected), but the code treated it as `[total_accepted_num, vocab]` (accepted-only, which is the ernie5_runner layout).
3. **Warmup pollution**: CUDA Graph warmup sends dummy requests with empty `req_id`. Their entropy values accumulated in `entropy_list` and were never cleared, contaminating subsequent real requests.

## Modifications

**`fastdeploy/model_executor/entropy_utils.py`**:

- Add dual-path logic in `speculate_calculate_logits_entropy`: fd-runner uses `accepted_idx` to extract correct rows from full logits; ernie5_runner uses pre-filtered logits directly.
- Move `stop_flags` check outside the `if accept_count > 0` block so ENTROPY-DONE fires even when no tokens are accepted in the final step.
- Add `is_valid_req` guard: skip entropy accumulation for warmup requests (empty/whitespace `req_id`).
- Remove verbose per-step debug logging; only emit `[ENTROPY-DONE]` at request completion.
- Remove unused `import time` and `_mtp_step_counter`.


## Accuracy Tests

测试配置：ERNIE5 TP1, block_wise_fp8, fd_runner, no-prefix-cache, temperature=0

fd_runner Overlap 开启 vs 关闭 (水的化学式是什么？, max_tokens=10)

| 配置 | all_values | avg_entropy |
|------|-----------|-------------|
| overlap 开启 | `[0.0, 0.001631, 0.20335, 0.058157, 0.293438, 0.00377, 0.498297, 1.209875, 0.765423, 0.605906]` | 0.363945 |
| overlap 关闭 | `[0.0, 0.001631, 0.20335, 0.058157, 0.293438, 0.00377, 0.498297, 1.209875, 0.765423, 0.605906]` | 0.363945 |
| **对比** | **10步完全一致** | **完全一致** |

## Checklist

- [x] Add at least a tag in the PR title: `[BugFix]`, `[Feature]`
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests.
- [x] Provide accuracy results.
