### PR TITLE
[Feature] Support partial rotary embedding (rotary_percent) for fleet-gqa-latent

### DIFF
--- a/fastdeploy/worker/input_batch.py
+++ b/fastdeploy/worker/input_batch.py
@@ -108,10 +108,6 @@ class InputBatch:
         else:
             self.max_chunk_tokens = self.fd_config.get_max_chunk_tokens(self.model_config.mm_max_tokens_per_item)
 
-        # NOTE (changwenbin):Supports neox_rotary_style.
-        rotary_percent = getattr(self.model_config, "rotary_percent", 1)
-        self.rotary_dim = int(rotary_percent * self.model_config.head_dim)
-
     def init_share_inputs(self):
         max_num_seqs = self.scheduler_config.max_num_seqs
 
@@ -240,8 +236,10 @@ class InputBatch:
 
         # Initialize rotary position embedding
         if not self.enable_mm:
+            rotary_percent = getattr(self.model_config, "rotary_percent", 1.0)
+            self.rotary_dim = int(self.model_config.head_dim * rotary_percent)
             self.rope_emb = get_rope(
-                rotary_dim=self.rotary_dim,
+                rotary_dim=self.rotary_dim if rotary_percent < 1.0 else self.model_config.head_dim,
                 position_ids=paddle.arange(self.model_config.max_model_len).reshape((1, -1)),
                 base=self.model_config.rope_theta,
                 model_config=self.model_config,
@@ -720,8 +718,10 @@ class InputBatch:
                 fill_paddle_tensor(self, "attn_mask_offsets_full", -1)
             else:
                 # Reset non-multimodal rope_emb
+                rotary_percent = getattr(self.model_config, "rotary_percent", 1.0)
+                self.rotary_dim = int(self.model_config.head_dim * rotary_percent)
                 self.rope_emb = get_rope(
-                    rotary_dim=self.rotary_dim,
+                    rotary_dim=self.rotary_dim if rotary_percent < 1.0 else self.model_config.head_dim,
                     position_ids=paddle.arange(self.model_config.max_model_len).reshape((1, -1)),
                     base=self.model_config.rope_theta,
                     model_config=self.model_config,
@@ -764,10 +764,6 @@ class ProposerInputBatch(InputBatch):
         self.cache_config: CacheConfig = fd_config.cache_config
         self.speculative_config: SpeculativeConfig = fd_config.speculative_config
         self.enable_pd_reorder: bool = False
-
-        # NOTE (changwenbin):Supports neox_rotary_style.
-        rotary_percent = getattr(self.model_config, "rotary_percent", 1)
-        self.rotary_dim = int(rotary_percent * self.model_config.head_dim)
 
     def init_share_inputs(self):
         # share with targe model
@@ -824,8 +820,10 @@ class ProposerInputBatch(InputBatch):
 
         tmp_position_ids = paddle.arange(self.model_config.max_model_len).reshape((1, -1))
 
+        rotary_percent = getattr(self.model_config, "rotary_percent", 1.0)
+        self.rotary_dim = int(self.model_config.head_dim * rotary_percent)
         self.rope_emb = get_rope(
-            rotary_dim=self.rotary_dim,
+            rotary_dim=self.rotary_dim if rotary_percent < 1.0 else self.model_config.head_dim,
             position_ids=tmp_position_ids,
             base=self.model_config.rope_theta,
             model_config=self.model_config,
@@ -1048,8 +1046,10 @@ class ProposerInputBatch(InputBatch):
 
             # Reset rope embedding by recreating with default position_ids
             tmp_position_ids = paddle.arange(self.model_config.max_model_len).reshape((1, -1))
+            rotary_percent = getattr(self.model_config, "rotary_percent", 1.0)
+            self.rotary_dim = int(self.model_config.head_dim * rotary_percent)
             self.rope_emb = get_rope(
-                rotary_dim=self.rotary_dim,
+                rotary_dim=self.rotary_dim if rotary_percent < 1.0 else self.model_config.head_dim,
                 position_ids=tmp_position_ids,
                 base=self.model_config.rope_theta,
                 model_config=self.model_config,

--- a/fastdeploy/worker/input_batch.py
+++ b/fastdeploy/worker/input_batch.py
@@ -108,6 +108,10 @@ class InputBatch:
         else:
             self.max_chunk_tokens = self.fd_config.get_max_chunk_tokens(self.model_config.mm_max_tokens_per_item)
 
+        # NOTE (changwenbin):Supports neox_rotary_style.
+        rotary_percent = getattr(self.model_config, "rotary_percent", 1)
+        self.rotary_dim = int(rotary_percent * self.model_config.head_dim)
+
     def init_share_inputs(self):
         max_num_seqs = self.scheduler_config.max_num_seqs
 
@@ -237,7 +241,7 @@ class InputBatch:
         # Initialize rotary position embedding
         if not self.enable_mm:
             self.rope_emb = get_rope(
-                rotary_dim=self.model_config.head_dim,
+                rotary_dim=self.rotary_dim,
                 position_ids=paddle.arange(self.model_config.max_model_len).reshape((1, -1)),
                 base=self.model_config.rope_theta,
                 model_config=self.model_config,
@@ -717,7 +721,7 @@ class InputBatch:
             else:
                 # Reset non-multimodal rope_emb
                 self.rope_emb = get_rope(
-                    rotary_dim=self.model_config.head_dim,
+                    rotary_dim=self.rotary_dim,
                     position_ids=paddle.arange(self.model_config.max_model_len).reshape((1, -1)),
                     base=self.model_config.rope_theta,
                     model_config=self.model_config,
@@ -760,6 +764,10 @@ class ProposerInputBatch(InputBatch):
         self.cache_config: CacheConfig = fd_config.cache_config
         self.speculative_config: SpeculativeConfig = fd_config.speculative_config
         self.enable_pd_reorder: bool = False
+
+        # NOTE (changwenbin):Supports neox_rotary_style.
+        rotary_percent = getattr(self.model_config, "rotary_percent", 1)
+        self.rotary_dim = int(rotary_percent * self.model_config.head_dim)
 
     def init_share_inputs(self):
         # share with targe model
@@ -817,7 +825,7 @@ class ProposerInputBatch(InputBatch):
         tmp_position_ids = paddle.arange(self.model_config.max_model_len).reshape((1, -1))
 
         self.rope_emb = get_rope(
-            rotary_dim=self.model_config.head_dim,
+            rotary_dim=self.rotary_dim,
             position_ids=tmp_position_ids,
             base=self.model_config.rope_theta,
             model_config=self.model_config,
@@ -1041,7 +1049,7 @@ class ProposerInputBatch(InputBatch):
             # Reset rope embedding by recreating with default position_ids
             tmp_position_ids = paddle.arange(self.model_config.max_model_len).reshape((1, -1))
             self.rope_emb = get_rope(
-                rotary_dim=self.model_config.head_dim,
+                rotary_dim=self.rotary_dim,
                 position_ids=tmp_position_ids,
                 base=self.model_config.rope_theta,
                 model_config=self.model_config,


### PR DESCRIPTION
## Motivation
为支持 fleet-gqa-latent 模型（GPT-NeoX 系列等使用 `rotary_percent < 1` 的模型），`InputBatch` 和 `ProposerInputBatch` 中 `get_rope()` 调用原先硬编码 `rotary_dim=model_config.head_dim`，导致 partial rotary embedding 模型的 rope 维度计算错误。

## Modifications
- `fastdeploy/worker/input_batch.py`：在 `InputBatch.init_share_inputs`、`InputBatch.reset_share_inputs`、`ProposerInputBatch.init_share_inputs`、`ProposerInputBatch.reset_model_inputs` 中新增 `rotary_dim` 计算（`int(rotary_percent * head_dim)`，默认 `rotary_percent=1.0` 保持向后兼容），将 `get_rope()` 调用改为使用 `self.rotary_dim`。

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.