### PR TITLE
[Cherry-Pick][BugFix] fix mtp reset bugs in rl

### DIFF
--- a/fastdeploy/worker/input_batch.py
+++ b/fastdeploy/worker/input_batch.py
@@ -989,6 +989,10 @@ class ProposerInputBatch(InputBatch):
             # NOTE(fix): These tensors are dynamically resized during runtime inference.
             # Must recreate at full initial size to avoid CUDAGraph replay OOB access.
             max_num_seqs = self.scheduler_config.max_num_seqs
+            if self.enable_mm and self.model_config.mm_max_tokens_per_item is None:
+                self.max_chunk_tokens = self.model_config.max_model_len
+            else:
+                self.max_chunk_tokens = self.fd_config.get_max_chunk_tokens(self.model_config.mm_max_tokens_per_item)
             self.ids_remove_padding = paddle.full([max_num_seqs * self.max_chunk_tokens], 0, dtype="int64")
             self.batch_id_per_token = paddle.full([max_num_seqs * self.max_chunk_tokens, 1], 0, dtype="int32")
             self.cu_seqlens_q = paddle.full([max_num_seqs + 1], 0, dtype="int32")


### PR DESCRIPTION
## Motivation
在 RL 训练的 reset 流程中，`reset_model_inputs` 重建 `ids_remove_padding` 和 `batch_id_per_token` 时直接使用 `self.max_chunk_tokens`，但未在重建前重新计算该值。对于多模态模型（`enable_mm=True` 且 `mm_max_tokens_per_item is None`）场景，可能导致 tensor 尺寸与 CUDAGraph capture 时不一致，引发 replay OOB（CUDA error 700）。

## Modifications
- `fastdeploy/worker/input_batch.py`：在 `reset_model_inputs` 重建 `ids_remove_padding` / `batch_id_per_token` 前，补充与 `__init__` 一致的 `max_chunk_tokens` 计算逻辑（多模态无 `mm_max_tokens_per_item` 时取 `max_model_len`，否则调用 `fd_config.get_max_chunk_tokens`）。

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.