### PR TITLE
[OP] Remove unused parameters in produce_kv_blockwise

### DIFF
--- a/custom_ops/gpu_ops/append_attn/append_attention_func.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_func.cuh
@@ -274,9 +274,6 @@ __device__ __forceinline__ void produce_kv_blockwise(
     smem_t smem,
     uint32_t* smem_offset,
     T** gptr,  // [max_block_num, num_heads, block_size, head_dim]
-    const uint32_t kv_head_idx,
-    const uint32_t kv_n_stride,
-    const uint32_t kv_h_stride,
     const uint32_t kv_b_stride,
     const uint32_t kv_idx_base,
     const uint32_t kv_len) {

--- a/custom_ops/gpu_ops/append_attn/append_attention_func.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_func.cuh
@@ -2276,11 +2276,9 @@ __global__ void merge_multi_chunks_decoder_kernel(
     const float quant_max_bound,
     const float quant_min_bound,
     const float in_scale,
-    const int max_seq_len,
     const int num_chunks,
     const int num_heads,
-    const int chunk_size,
-    const int head_dim) {
+    const int chunk_size) {
   const int vid = threadIdx.x, ty = threadIdx.y;
   const int bid = blockIdx.x, hid = blockIdx.y;
   __shared__ T smem[bdy * HEAD_DIM];
@@ -2336,7 +2334,7 @@ __global__ void merge_multi_chunks_decoder_kernel(
     const float m_now = multi_m[offset];
     const float d_now = multi_d[offset];
     m = max(m_prev, m_now);
-    offset = offset * head_dim + vid * vec_size;
+    offset = offset * HEAD_DIM + vid * vec_size;
     Load<T, vec_size>(&multi_out[offset], &load_vec);
     const float scale1 = __expf(m_prev - m), scale2 = __expf(m_now - m);
     const T scale1_T = static_cast<T>(scale1),
@@ -2348,7 +2346,7 @@ __global__ void merge_multi_chunks_decoder_kernel(
     }
   }
   // store ty res
-  Store<T, vec_size>(res_vec, &smem[ty * head_dim + vid * vec_size]);
+  Store<T, vec_size>(res_vec, &smem[ty * HEAD_DIM + vid * vec_size]);
   md_smem[2 * ty] = m;
   md_smem[2 * ty + 1] = d;
   __syncthreads();
@@ -2358,7 +2356,7 @@ __global__ void merge_multi_chunks_decoder_kernel(
     st.init();
 #pragma unroll
     for (int i = 0; i < bdy; i++) {
-      Load<T, vec_size>(&smem[i * head_dim + vid * vec_size], &load_vec);
+      Load<T, vec_size>(&smem[i * HEAD_DIM + vid * vec_size], &load_vec);
       const float m_tmp = md_smem[2 * i], d_tmp = md_smem[2 * i + 1];
       st.merge(load_vec, m_tmp, d_tmp);
     }
@@ -2369,7 +2367,7 @@ __global__ void merge_multi_chunks_decoder_kernel(
       st.normalize();
     }
 
-    const uint32_t shift_smooth_offset = hid * head_dim + vid * vec_size;
+    const uint32_t shift_smooth_offset = hid * HEAD_DIM + vid * vec_size;
     AlignedVector<T, vec_size> shift_bias_vec;
     AlignedVector<T, vec_size> smooth_weight_vec;
     AlignedVector<OutT, vec_size> out_vec;
@@ -2391,7 +2389,7 @@ __global__ void merge_multi_chunks_decoder_kernel(
     }
     Store<OutT, vec_size>(
         out_vec,
-        &out[(start_token_idx * num_heads + hid) * head_dim + vid * vec_size]);
+        &out[(start_token_idx * num_heads + hid) * HEAD_DIM + vid * vec_size]);
   }
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaTriggerProgrammaticLaunchCompletion();
@@ -2422,7 +2420,6 @@ __global__ void merge_multi_chunks_v2_kernel(
     const float quant_max_bound,
     const float quant_min_bound,
     const float in_scale,
-    const int max_seq_len,
     const int num_chunks,
     const int num_heads,
     const int chunk_size,

--- a/custom_ops/gpu_ops/append_attn/append_attention_func.cuh
+++ b/custom_ops/gpu_ops/append_attn/append_attention_func.cuh
@@ -270,7 +270,7 @@ template <SharedMemFillMode fill_mode,
           uint32_t num_frags_z,
           uint32_t NUM_WARP_Q,
           typename T>
-__device__ __forceinline__ void produce_kv_blockwise(
+__device__ __forceinline__ void produce_kv_blockwise_c16(
     smem_t smem,
     uint32_t* smem_offset,
     T** gptr,  // [max_block_num, num_heads, block_size, head_dim]

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c16_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c16_impl.cuh
@@ -213,29 +213,29 @@ __global__ void multi_query_append_attention_kernel(
   const T *cache_k_now = cache_k + block_id * kv_n_stride + const_offset;
   const T *cache_v_now = cache_v + block_id * kv_n_stride + const_offset;
 
-  produce_kv_blockwise<SharedMemFillMode::kNoFill,
-                       NUM_WARPS,
-                       BLOCK_SIZE,
-                       num_frags_y,
-                       num_frags_z,
-                       NUM_WARP_Q>(k_smem,
-                                   &kv_smem_offset_w,
-                                   &cache_k_now,
-                                   kv_b_stride,
-                                   kv_idx_base,
-                                   chunk_end);
+  produce_kv_blockwise_c16<SharedMemFillMode::kNoFill,
+                           NUM_WARPS,
+                           BLOCK_SIZE,
+                           num_frags_y,
+                           num_frags_z,
+                           NUM_WARP_Q>(k_smem,
+                                       &kv_smem_offset_w,
+                                       &cache_k_now,
+                                       kv_b_stride,
+                                       kv_idx_base,
+                                       chunk_end);
   commit_group();
-  produce_kv_blockwise<SharedMemFillMode::kFillZero,
-                       NUM_WARPS,
-                       BLOCK_SIZE,
-                       num_frags_y,
-                       num_frags_z,
-                       NUM_WARP_Q>(v_smem,
-                                   &kv_smem_offset_w,
-                                   &cache_v_now,
-                                   kv_b_stride,
-                                   kv_idx_base,
-                                   chunk_end);
+  produce_kv_blockwise_c16<SharedMemFillMode::kFillZero,
+                           NUM_WARPS,
+                           BLOCK_SIZE,
+                           num_frags_y,
+                           num_frags_z,
+                           NUM_WARP_Q>(v_smem,
+                                       &kv_smem_offset_w,
+                                       &cache_v_now,
+                                       kv_b_stride,
+                                       kv_idx_base,
+                                       chunk_end);
   commit_group();
 #pragma unroll 1
   for (uint32_t iter = 0; iter < num_iterations; ++iter) {
@@ -272,17 +272,17 @@ __global__ void multi_query_append_attention_kernel(
       block_id = 0;
     }
     cache_k_now = cache_k + block_id * kv_n_stride + const_offset;
-    produce_kv_blockwise<SharedMemFillMode::kNoFill,
-                         NUM_WARPS,
-                         BLOCK_SIZE,
-                         num_frags_y,
-                         num_frags_z,
-                         NUM_WARP_Q>(k_smem,
-                                     &kv_smem_offset_w,
-                                     &cache_k_now,
-                                     kv_b_stride,
-                                     kv_idx_base,
-                                     chunk_end);
+    produce_kv_blockwise_c16<SharedMemFillMode::kNoFill,
+                             NUM_WARPS,
+                             BLOCK_SIZE,
+                             num_frags_y,
+                             num_frags_z,
+                             NUM_WARP_Q>(k_smem,
+                                         &kv_smem_offset_w,
+                                         &cache_k_now,
+                                         kv_b_stride,
+                                         kv_idx_base,
+                                         chunk_end);
     commit_group();
     wait_group<1>();
     __syncthreads();
@@ -293,17 +293,17 @@ __global__ void multi_query_append_attention_kernel(
 
     __syncthreads();
     cache_v_now = cache_v + block_id * kv_n_stride + const_offset;
-    produce_kv_blockwise<SharedMemFillMode::kFillZero,
-                         NUM_WARPS,
-                         BLOCK_SIZE,
-                         num_frags_y,
-                         num_frags_z,
-                         NUM_WARP_Q>(v_smem,
-                                     &kv_smem_offset_w,
-                                     &cache_v_now,
-                                     kv_b_stride,
-                                     kv_idx_base,
-                                     chunk_end);
+    produce_kv_blockwise_c16<SharedMemFillMode::kFillZero,
+                             NUM_WARPS,
+                             BLOCK_SIZE,
+                             num_frags_y,
+                             num_frags_z,
+                             NUM_WARP_Q>(v_smem,
+                                         &kv_smem_offset_w,
+                                         &cache_v_now,
+                                         kv_b_stride,
+                                         kv_idx_base,
+                                         chunk_end);
     commit_group();
   }
   wait_group<0>();
@@ -577,30 +577,30 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
   T *cache_k_now = cache_k + block_id * kv_n_stride + const_offset;
   T *cache_v_now = cache_v + block_id * kv_n_stride + const_offset;
 
-  produce_kv_blockwise<SharedMemFillMode::kNoFill,
-                       NUM_WARPS,
-                       BLOCK_SIZE,
-                       num_frags_y,
-                       num_frags_z,
-                       NUM_WARP_Q>(k_smem,
-                                   &kv_smem_offset_w,
-                                   &cache_k_now,
-                                   kv_b_stride,
-                                   kv_idx_base,
-                                   chunk_end);
+  produce_kv_blockwise_c16<SharedMemFillMode::kNoFill,
+                           NUM_WARPS,
+                           BLOCK_SIZE,
+                           num_frags_y,
+                           num_frags_z,
+                           NUM_WARP_Q>(k_smem,
+                                       &kv_smem_offset_w,
+                                       &cache_k_now,
+                                       kv_b_stride,
+                                       kv_idx_base,
+                                       chunk_end);
   commit_group();
 
-  produce_kv_blockwise<SharedMemFillMode::kFillZero,
-                       NUM_WARPS,
-                       BLOCK_SIZE,
-                       num_frags_y,
-                       num_frags_z,
-                       NUM_WARP_Q>(v_smem,
-                                   &kv_smem_offset_w,
-                                   &cache_v_now,
-                                   kv_b_stride,
-                                   kv_idx_base,
-                                   chunk_end);
+  produce_kv_blockwise_c16<SharedMemFillMode::kFillZero,
+                           NUM_WARPS,
+                           BLOCK_SIZE,
+                           num_frags_y,
+                           num_frags_z,
+                           NUM_WARP_Q>(v_smem,
+                                       &kv_smem_offset_w,
+                                       &cache_v_now,
+                                       kv_b_stride,
+                                       kv_idx_base,
+                                       chunk_end);
   commit_group();
 
 #pragma unroll 1
@@ -639,17 +639,17 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
       block_id = 0;
     }
     cache_k_now = cache_k + block_id * kv_n_stride + const_offset;
-    produce_kv_blockwise<SharedMemFillMode::kNoFill,
-                         NUM_WARPS,
-                         BLOCK_SIZE,
-                         num_frags_y,
-                         num_frags_z,
-                         NUM_WARP_Q>(k_smem,
-                                     &kv_smem_offset_w,
-                                     &cache_k_now,
-                                     kv_b_stride,
-                                     kv_idx_base,
-                                     chunk_end);
+    produce_kv_blockwise_c16<SharedMemFillMode::kNoFill,
+                             NUM_WARPS,
+                             BLOCK_SIZE,
+                             num_frags_y,
+                             num_frags_z,
+                             NUM_WARP_Q>(k_smem,
+                                         &kv_smem_offset_w,
+                                         &cache_k_now,
+                                         kv_b_stride,
+                                         kv_idx_base,
+                                         chunk_end);
     commit_group();
     wait_group<1>();
     __syncthreads();
@@ -660,17 +660,17 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
     __syncthreads();
 
     cache_v_now = cache_v + block_id * kv_n_stride + const_offset;
-    produce_kv_blockwise<SharedMemFillMode::kFillZero,
-                         NUM_WARPS,
-                         BLOCK_SIZE,
-                         num_frags_y,
-                         num_frags_z,
-                         NUM_WARP_Q>(v_smem,
-                                     &kv_smem_offset_w,
-                                     &cache_v_now,
-                                     kv_b_stride,
-                                     kv_idx_base,
-                                     chunk_end);
+    produce_kv_blockwise_c16<SharedMemFillMode::kFillZero,
+                             NUM_WARPS,
+                             BLOCK_SIZE,
+                             num_frags_y,
+                             num_frags_z,
+                             NUM_WARP_Q>(v_smem,
+                                         &kv_smem_offset_w,
+                                         &cache_v_now,
+                                         kv_b_stride,
+                                         kv_idx_base,
+                                         chunk_end);
     commit_group();
   }
   wait_group<0>();

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c16_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c16_impl.cuh
@@ -221,9 +221,6 @@ __global__ void multi_query_append_attention_kernel(
                        NUM_WARP_Q>(k_smem,
                                    &kv_smem_offset_w,
                                    &cache_k_now,
-                                   kv_head_idx,
-                                   kv_n_stride,
-                                   kv_h_stride,
                                    kv_b_stride,
                                    kv_idx_base,
                                    chunk_end);
@@ -236,9 +233,6 @@ __global__ void multi_query_append_attention_kernel(
                        NUM_WARP_Q>(v_smem,
                                    &kv_smem_offset_w,
                                    &cache_v_now,
-                                   kv_head_idx,
-                                   kv_n_stride,
-                                   kv_h_stride,
                                    kv_b_stride,
                                    kv_idx_base,
                                    chunk_end);
@@ -286,9 +280,6 @@ __global__ void multi_query_append_attention_kernel(
                          NUM_WARP_Q>(k_smem,
                                      &kv_smem_offset_w,
                                      &cache_k_now,
-                                     kv_head_idx,
-                                     kv_n_stride,
-                                     kv_h_stride,
                                      kv_b_stride,
                                      kv_idx_base,
                                      chunk_end);
@@ -310,9 +301,6 @@ __global__ void multi_query_append_attention_kernel(
                          NUM_WARP_Q>(v_smem,
                                      &kv_smem_offset_w,
                                      &cache_v_now,
-                                     kv_head_idx,
-                                     kv_n_stride,
-                                     kv_h_stride,
                                      kv_b_stride,
                                      kv_idx_base,
                                      chunk_end);
@@ -597,9 +585,6 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
                        NUM_WARP_Q>(k_smem,
                                    &kv_smem_offset_w,
                                    &cache_k_now,
-                                   kv_head_idx,
-                                   kv_n_stride,
-                                   kv_h_stride,
                                    kv_b_stride,
                                    kv_idx_base,
                                    chunk_end);
@@ -613,9 +598,6 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
                        NUM_WARP_Q>(v_smem,
                                    &kv_smem_offset_w,
                                    &cache_v_now,
-                                   kv_head_idx,
-                                   kv_n_stride,
-                                   kv_h_stride,
                                    kv_b_stride,
                                    kv_idx_base,
                                    chunk_end);
@@ -665,9 +647,6 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
                          NUM_WARP_Q>(k_smem,
                                      &kv_smem_offset_w,
                                      &cache_k_now,
-                                     kv_head_idx,
-                                     kv_n_stride,
-                                     kv_h_stride,
                                      kv_b_stride,
                                      kv_idx_base,
                                      chunk_end);
@@ -689,9 +668,6 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
                          NUM_WARP_Q>(v_smem,
                                      &kv_smem_offset_w,
                                      &cache_v_now,
-                                     kv_head_idx,
-                                     kv_n_stride,
-                                     kv_h_stride,
                                      kv_b_stride,
                                      kv_idx_base,
                                      chunk_end);

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c16_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c16_impl.cuh
@@ -45,7 +45,6 @@ __global__ void multi_query_append_attention_kernel(
     const int *__restrict__ cu_seqlens_q,
     const int *__restrict__ block_table,  // [bsz, block_num_per_seq]
     const int *__restrict__ mask_offset,
-    const int max_seq_len,
     const int max_block_num_per_seq,
     const float scale,
     const float quant_max_bound,
@@ -430,7 +429,6 @@ __global__ void multi_query_append_attention_warp1_4_kernel(
     const int *__restrict__ block_table,  // [bsz, block_num_per_seq]
     const int *__restrict__ mask_offset,
     const bool *__restrict__ attn_mask,  // [bsz, max_q, max_q] for tree-mask
-    const int max_seq_len,
     const int max_block_num_per_seq,
     const float scale,
     const float quant_max_bound,
@@ -923,7 +921,6 @@ void MultiQueryAppendAttention(
           cu_seqlens_q.data<int>(),
           block_table.data<int>(),
           meta_data.mask_offset,
-          max_seq_len,
           max_block_num_per_seq,
           scale,
           quant_max_bound,
@@ -991,7 +988,6 @@ void MultiQueryAppendAttention(
           cu_seqlens_q.data<int>(),
           block_table.data<int>(),
           meta_data.mask_offset,
-          max_seq_len,
           max_block_num_per_seq,
           scale,
           quant_max_bound,
@@ -1047,7 +1043,6 @@ void MultiQueryAppendAttention(
           quant_max_bound,
           quant_min_bound,
           in_scale,
-          max_seq_len,
           num_chunks,
           num_heads,
           chunk_size,
@@ -1152,7 +1147,6 @@ void MultiQueryAppendAttention(
           meta_data.mask_offset,
           attn_mask ? const_cast<bool *>(attn_mask.get().data<bool>())
                     : nullptr,
-          max_seq_len,
           max_block_num_per_seq,
           scale,
           quant_max_bound,
@@ -1210,7 +1204,6 @@ void MultiQueryAppendAttention(
           meta_data.mask_offset,
           attn_mask ? const_cast<bool *>(attn_mask.get().data<bool>())
                     : nullptr,
-          max_seq_len,
           max_block_num_per_seq,
           scale,
           quant_max_bound,
@@ -1266,11 +1259,9 @@ void MultiQueryAppendAttention(
             quant_max_bound,
             quant_min_bound,
             in_scale,
-            max_seq_len,
             num_chunks,
             num_heads,
-            chunk_size,
-            HEAD_DIM);
+            chunk_size);
       } else {
         constexpr int blockx = HEAD_DIM / vec_size;
         constexpr int blocky = (128 + blockx - 1) / blockx;
@@ -1310,7 +1301,6 @@ void MultiQueryAppendAttention(
             quant_max_bound,
             quant_min_bound,
             in_scale,
-            max_seq_len,
             num_chunks,
             num_heads,
             chunk_size,

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c4_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c4_impl.cuh
@@ -1298,7 +1298,6 @@ void MultiQueryAppendC4Attention(
           quant_max_bound,
           quant_min_bound,
           in_scale,
-          max_seq_len,
           num_chunks,
           num_heads,
           chunk_size,
@@ -1563,11 +1562,9 @@ void MultiQueryAppendC4Attention(
             quant_max_bound,
             quant_min_bound,
             in_scale,
-            max_seq_len,
             num_chunks,
             num_heads,
-            chunk_size,
-            HEAD_DIM);
+            chunk_size);
       } else {
         constexpr int blockx = HEAD_DIM / vec_size;
         constexpr int blocky = (128 + blockx - 1) / blockx;
@@ -1606,7 +1603,6 @@ void MultiQueryAppendC4Attention(
             quant_max_bound,
             quant_min_bound,
             in_scale,
-            max_seq_len,
             num_chunks,
             num_heads,
             chunk_size,

--- a/custom_ops/gpu_ops/append_attn/multiquery_attention_c8_impl.cuh
+++ b/custom_ops/gpu_ops/append_attn/multiquery_attention_c8_impl.cuh
@@ -52,7 +52,6 @@ __global__ void multi_query_append_attention_c8_kernel(
     const int *__restrict__ cu_seqlens_q,
     const int *__restrict__ block_table,  // [bsz, block_num_per_seq]
     const int *__restrict__ mask_offset,
-    const int max_seq_len,
     const int max_dec_len,
     const int max_block_num_per_seq,
     const float scale,
@@ -587,7 +586,6 @@ __global__ void multi_query_append_attention_c8_warp1_4_kernel(
     const int *__restrict__ block_table,  // [bsz, block_num_per_seq]
     const int *__restrict__ mask_offset,
     const bool *__restrict__ attn_mask,  // [bsz, max_q, max_q] for tree-mask
-    const int max_seq_len,
     const int max_dec_len,
     const int max_block_num_per_seq,
     const float scale,
@@ -1294,7 +1292,6 @@ void MultiQueryAppendC8Attention(
           cu_seqlens_q.data<int>(),
           block_table.data<int>(),
           meta_data.mask_offset,
-          max_seq_len,
           max_dec_len,
           max_block_num_per_seq,
           scale,
@@ -1363,7 +1360,6 @@ void MultiQueryAppendC8Attention(
           cu_seqlens_q.data<int>(),
           block_table.data<int>(),
           meta_data.mask_offset,
-          max_seq_len,
           max_dec_len,
           max_block_num_per_seq,
           scale,
@@ -1418,7 +1414,6 @@ void MultiQueryAppendC8Attention(
           quant_max_bound,
           quant_min_bound,
           in_scale,
-          max_seq_len,
           num_chunks,
           num_heads,
           chunk_size,
@@ -1568,7 +1563,6 @@ void MultiQueryAppendC8Attention(
           meta_data.mask_offset,
           attn_mask ? const_cast<bool *>(attn_mask.get().data<bool>())
                     : nullptr,
-          max_seq_len,
           max_dec_len,
           max_block_num_per_seq,
           scale,
@@ -1654,7 +1648,7 @@ void MultiQueryAppendC8Attention(
           meta_data.mask_offset,
           attn_mask ? const_cast<bool *>(attn_mask.get().data<bool>())
                     : nullptr,
-          max_seq_len,
+
           max_dec_len,
           max_block_num_per_seq,
           scale,
@@ -1710,11 +1704,9 @@ void MultiQueryAppendC8Attention(
             quant_max_bound,
             quant_min_bound,
             in_scale,
-            max_seq_len,
             num_chunks,
             num_heads,
-            chunk_size,
-            HEAD_DIM);
+            chunk_size);
       } else {
         constexpr int blockx = HEAD_DIM / vec_size;
         constexpr int blocky = (128 + blockx - 1) / blockx;
@@ -1753,7 +1745,6 @@ void MultiQueryAppendC8Attention(
             quant_max_bound,
             quant_min_bound,
             in_scale,
-            max_seq_len,
             num_chunks,
             num_heads,
             chunk_size,


### PR DESCRIPTION
> 🤖 Paddle-CI-Agent | pr_review | `2026-06-02 17:27:00`

## 📋 Review 摘要

**PR 概述**：移除 `produce_kv_blockwise` 及 `merge_multi_chunks_decoder_kernel` 中未使用的冗余参数，提升代码可读性
**变更范围**：custom_ops/gpu_ops/append_attn/
**影响面 Tag**：`[OP]`

### 问题

未发现阻塞性问题。

### 历史 Findings 修复情况

| Finding | 问题 | 状态 |
|---------|------|------|
| PR 规范 | 标题拼写错误（"unsed" → "unused"）且缺少官方 Tag；描述为空 | ✅ 已修复（标题已修正为 `[OP] Remove unused parameters in produce_kv_blockwise`） |

### 📝 PR 规范检查

标题已符合规范。PR 描述各段落内容仍为空（Motivation / Modifications / Usage or Command / Accuracy Tests 均未填写）。

<details>
<summary><b>PR 描述建议</b>（点击展开，可直接复制）</summary>

```markdown
## Motivation

移除 `produce_kv_blockwise` 和 `merge_multi_chunks_decoder_kernel` 函数签名中未被函数体使用的冗余参数（`kv_head_idx`、`kv_n_stride`、`kv_h_stride`、`max_seq_len`、`head_dim`），简化接口，提升代码可读性。

## Modifications

- `append_attention_func.cuh`：将 `produce_kv_blockwise` 重命名为 `produce_kv_blockwise_c16`，移除 3 个未使用参数；`merge_multi_chunks_decoder_kernel` 移除 `max_seq_len` 和 `head_dim` 参数，改用模板参数 `HEAD_DIM`
- `multiquery_attention_c16_impl.cuh`：同步更新所有调用点（kernel launch + 函数调用），移除对应实参
- `multiquery_attention_c4_impl.cuh`：同步移除 merge kernel 调用中的 `max_seq_len` / `head_dim` 实参
- `multiquery_attention_c8_impl.cuh`：同步移除 kernel 声明及调用中的 `max_seq_len` 参数

## Usage or Command

N/A

## Accuracy Tests

N/A（纯代码清理，不影响计算逻辑）

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
```

</details>

### 总体评价

变更安全、正确。`produce_kv_blockwise` 中被移除的三个参数在函数体中确实未使用；`merge_multi_chunks_decoder_kernel` 中 `head_dim` 被替换为编译期模板常量 `HEAD_DIM`，语义等价且性能更优。所有调用点已同步更新。
