### PR TITLE
[PD Disaggregation] Limit prefill fetch num with FD_MAX_INFLIGHT_PREFILL

### DIFF
--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -912,10 +912,23 @@ class EngineService:
                 with self._pause_cond:
                     self._pause_cond.wait_for(lambda: not self.is_paused)
                 nonlocal is_fetching
-                num_prefill_batch = min(
-                    int(self.resource_manager.available_batch()),
-                    self.cfg.max_prefill_batch,
-                )
+                if self.cfg.scheduler_config.splitwise_role == "prefill":
+                    max_inflight_prefill = envs.FD_MAX_INFLIGHT_PREFILL
+                    inflight_prefill = len(self.resource_manager.running)
+                    if inflight_prefill >= max_inflight_prefill:
+                        is_fetching = False
+                        return
+                    available_for_new = max_inflight_prefill - inflight_prefill
+                    num_prefill_batch = min(
+                        int(self.resource_manager.available_batch()),
+                        self.cfg.max_prefill_batch,
+                        available_for_new,
+                    )
+                else:
+                    num_prefill_batch = min(
+                        int(self.resource_manager.available_batch()),
+                        self.cfg.max_prefill_batch,
+                    )
 
                 if self.cfg.scheduler_config.splitwise_role != "mixed":
                     max_num_batched_tokens = self.cfg.scheduler_config.max_num_batched_tokens

--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -190,6 +190,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # "Enable FP8 calibration on HPU"
     "FD_HPU_MEASUREMENT_MODE": lambda: os.getenv("FD_HPU_MEASUREMENT_MODE", "0"),
     "FD_PREFILL_WAIT_DECODE_RESOURCE_SECONDS": lambda: int(os.getenv("FD_PREFILL_WAIT_DECODE_RESOURCE_SECONDS", "30")),
+    "FD_MAX_INFLIGHT_PREFILL": lambda: int(os.getenv("FD_MAX_INFLIGHT_PREFILL", "20")),
     "FD_ENABLE_REQUEST_DISCONNECT_STOP_INFERENCE": lambda: int(
         os.getenv("FD_ENABLE_REQUEST_DISCONNECT_STOP_INFERENCE", "1")
     ),

--- a/tests/engine/test_common_engine.py
+++ b/tests/engine/test_common_engine.py
@@ -333,7 +333,7 @@ class TestCommonEngineAdditionalCoverage(unittest.TestCase):
         return DummyRM()
 
     @staticmethod
-    def _make_v1_prefill_continuous_rm(eng, waiting_async_result=False):
+    def _make_v1_prefill_continuous_rm(eng, waiting_async_result=False, available_batch=1):
         class DummyRM:
             def __init__(self):
                 self.abort_req_ids_set = set()
@@ -344,7 +344,7 @@ class TestCommonEngineAdditionalCoverage(unittest.TestCase):
                 self.pre_recycle_resource = Mock()
 
             def available_batch(self):
-                return 1
+                return available_batch
 
             def apply_async_preprocess(self, _task):
                 return None
@@ -1496,6 +1496,133 @@ class TestCommonEngineAdditionalCoverage(unittest.TestCase):
 
         eng.scheduler.put_results.assert_called_once()
         eng.resource_manager.add_request_in_p.assert_not_called()
+        self._detach_finalizer(eng)
+
+    def test_schedule_request_to_worker_v1_prefill_max_inflight_skip_fetch(self):
+        """When len(running) >= FD_MAX_INFLIGHT_PREFILL, fetch should be skipped."""
+        cfg = self._make_cfg(
+            splitwise_role="prefill",
+            num_gpu_blocks_override=4,
+            router="0.0.0.0:30000",
+            kv_cache_ratio=1,
+        )
+        eng = self._make_engine(cfg)
+        self._setup_v1_engine(eng)
+
+        eng.scheduler = Mock(get_requests=Mock(return_value=[]), put_results=Mock())
+        eng.engine_worker_queue = Mock(
+            exist_tasks=Mock(return_value=False),
+            get_finished_add_cache_task_req=Mock(return_value=[]),
+        )
+
+        rm = self._make_v1_prefill_continuous_rm(eng, waiting_async_result=False)
+        rm.running = [Mock() for _ in range(20)]  # running == FD_MAX_INFLIGHT_PREFILL default
+        eng.resource_manager = rm
+        eng.split_connector = Mock(
+            send_splitwise_tasks=Mock(),
+            check_decode_allocated=Mock(return_value=(True, "")),
+            send_cache_info_to_messager=Mock(),
+        )
+
+        try:
+            with (
+                patch("fastdeploy.engine.common_engine.envs.FD_MAX_INFLIGHT_PREFILL", 20),
+                patch("fastdeploy.engine.common_engine.envs.PREFILL_CONTINUOUS_REQUEST_DECODE_RESOURCES", False),
+                patch("fastdeploy.engine.common_engine.ThreadPoolExecutor", self._make_dummy_executor(eng)),
+                patch("fastdeploy.engine.common_engine.time.sleep", lambda *_: None),
+            ):
+                eng._schedule_request_to_worker_v1()
+        finally:
+            eng.running = False
+
+        # get_requests should NOT be called because fetch was skipped
+        eng.scheduler.get_requests.assert_not_called()
+        self._detach_finalizer(eng)
+
+    def test_schedule_request_to_worker_v1_prefill_inflight_constrains_batch(self):
+        """When 0 < len(running) < FD_MAX_INFLIGHT_PREFILL, num_prefill_batch is constrained by available_for_new."""
+        cfg = self._make_cfg(
+            splitwise_role="prefill",
+            num_gpu_blocks_override=4,
+            router="0.0.0.0:30000",
+            kv_cache_ratio=1,
+        )
+        eng = self._make_engine(cfg)
+        self._setup_v1_engine(eng)
+
+        eng.scheduler = Mock(get_requests=Mock(return_value=[]), put_results=Mock())
+        eng.engine_worker_queue = Mock(
+            exist_tasks=Mock(return_value=False),
+            get_finished_add_cache_task_req=Mock(return_value=[]),
+        )
+
+        rm = self._make_v1_prefill_continuous_rm(eng, waiting_async_result=False, available_batch=10)
+        rm.running = [Mock() for _ in range(18)]  # 18 in-flight, max=20, so available_for_new=2
+        eng.resource_manager = rm
+        eng.split_connector = Mock(
+            send_splitwise_tasks=Mock(),
+            check_decode_allocated=Mock(return_value=(True, "")),
+            send_cache_info_to_messager=Mock(),
+        )
+
+        try:
+            with (
+                patch("fastdeploy.engine.common_engine.envs.FD_MAX_INFLIGHT_PREFILL", 20),
+                patch("fastdeploy.engine.common_engine.envs.PREFILL_CONTINUOUS_REQUEST_DECODE_RESOURCES", False),
+                patch("fastdeploy.engine.common_engine.ThreadPoolExecutor", self._make_dummy_executor(eng)),
+                patch("fastdeploy.engine.common_engine.time.sleep", lambda *_: None),
+            ):
+                eng._schedule_request_to_worker_v1()
+        finally:
+            eng.running = False
+
+        # get_requests should be called with batch=2 (available_for_new=20-18)
+        eng.scheduler.get_requests.assert_called_once()
+        call_kwargs = eng.scheduler.get_requests.call_args
+        self.assertEqual(call_kwargs.kwargs.get("batch", call_kwargs[1].get("batch")), 2)
+        self._detach_finalizer(eng)
+
+    def test_schedule_request_to_worker_v1_prefill_inflight_boundary_last_slot(self):
+        """When len(running) == max_inflight_prefill - 1, only 1 slot remains (boundary)."""
+        cfg = self._make_cfg(
+            splitwise_role="prefill",
+            num_gpu_blocks_override=4,
+            router="0.0.0.0:30000",
+            kv_cache_ratio=1,
+        )
+        eng = self._make_engine(cfg)
+        self._setup_v1_engine(eng)
+
+        eng.scheduler = Mock(get_requests=Mock(return_value=[]), put_results=Mock())
+        eng.engine_worker_queue = Mock(
+            exist_tasks=Mock(return_value=False),
+            get_finished_add_cache_task_req=Mock(return_value=[]),
+        )
+
+        rm = self._make_v1_prefill_continuous_rm(eng, waiting_async_result=False, available_batch=10)
+        rm.running = [Mock() for _ in range(19)]  # 19 in-flight, max=20, so available_for_new=1
+        eng.resource_manager = rm
+        eng.split_connector = Mock(
+            send_splitwise_tasks=Mock(),
+            check_decode_allocated=Mock(return_value=(True, "")),
+            send_cache_info_to_messager=Mock(),
+        )
+
+        try:
+            with (
+                patch("fastdeploy.engine.common_engine.envs.FD_MAX_INFLIGHT_PREFILL", 20),
+                patch("fastdeploy.engine.common_engine.envs.PREFILL_CONTINUOUS_REQUEST_DECODE_RESOURCES", False),
+                patch("fastdeploy.engine.common_engine.ThreadPoolExecutor", self._make_dummy_executor(eng)),
+                patch("fastdeploy.engine.common_engine.time.sleep", lambda *_: None),
+            ):
+                eng._schedule_request_to_worker_v1()
+        finally:
+            eng.running = False
+
+        # get_requests should be called with batch=1 (available_for_new=20-19)
+        eng.scheduler.get_requests.assert_called_once()
+        call_kwargs = eng.scheduler.get_requests.call_args
+        self.assertEqual(call_kwargs.kwargs.get("batch", call_kwargs[1].get("batch")), 1)
         self._detach_finalizer(eng)
 
     def test_schedule_request_to_worker_v1_decode_preempted_and_errors(self):

--- a/tests/engine/test_common_engine.py
+++ b/tests/engine/test_common_engine.py
@@ -338,6 +338,7 @@ class TestCommonEngineAdditionalCoverage(unittest.TestCase):
             def __init__(self):
                 self.abort_req_ids_set = set()
                 self.waiting = []
+                self.running = []
                 self.real_bsz = 1
                 self.add_request_in_p = Mock()
                 self.pre_recycle_resource = Mock()


### PR DESCRIPTION
## Motivation

在 PD 分离（splitwise）部署场景中，prefill 实例可能一次性从等待队列中获取过多请求，导致 inflight prefill 数量过大、资源压力增加。需要对 prefill 实例的并发请求获取数做上限控制。

## Modifications

- `fastdeploy/engine/common_engine.py`：在 `_fetch_request` 中，当 `splitwise_role == "prefill"` 时，通过 `FD_MAX_INFLIGHT_PREFILL` 环境变量限制 inflight prefill 数量，超过上限则跳过本轮获取；未超上限时，将可用余量纳入 `num_prefill_batch` 的 min 计算。
- `fastdeploy/envs.py`：新增环境变量 `FD_MAX_INFLIGHT_PREFILL`，默认值 20。

## Usage or Command

通过环境变量控制 prefill 实例最大 inflight 数：
```bash
export FD_MAX_INFLIGHT_PREFILL=20
```

## Accuracy Tests

N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.