### PR TITLE
[Metrics] move prompt_tokens_total report to main process

### DIFF
--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -1341,7 +1341,12 @@ class EngineService:
                         main_process_metrics.inc_value("requests_number")
                         main_process_metrics.inc_value("prompt_tokens_total", request.prompt_token_ids_len)
                         main_process_metrics.obs_value("request_prompt_tokens", request.prompt_token_ids_len)
-                        main_process_metrics.obs_value("request_params_max_tokens", request.sampling_params.max_tokens)
+                        if getattr(request, "sampling_params", None) and getattr(
+                            request.sampling_params, "max_tokens", None
+                        ):
+                            main_process_metrics.obs_value(
+                                "request_params_max_tokens", request.sampling_params.max_tokens
+                            )
                         trace_carrier = data.get("trace_carrier")
                         if trace_carrier:
                             request_id = get_base_request_id(data["request_id"])

--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -1339,6 +1339,9 @@ class EngineService:
 
                         request.metrics.scheduler_recv_req_time = time.time()
                         main_process_metrics.inc_value("requests_number")
+                        main_process_metrics.inc_value("prompt_tokens_total", request.prompt_token_ids_len)
+                        main_process_metrics.obs_value("request_prompt_tokens", request.prompt_token_ids_len)
+                        main_process_metrics.obs_value("request_params_max_tokens", request.sampling_params.max_tokens)
                         trace_carrier = data.get("trace_carrier")
                         if trace_carrier:
                             request_id = get_base_request_id(data["request_id"])

--- a/fastdeploy/entrypoints/engine_client.py
+++ b/fastdeploy/entrypoints/engine_client.py
@@ -53,7 +53,6 @@ from fastdeploy.logger.request_logger import (
     log_request,
     log_request_error,
 )
-from fastdeploy.metrics.metrics import main_process_metrics
 from fastdeploy.platforms import current_platform
 from fastdeploy.trace.constants import LoggingEventName
 from fastdeploy.trace.trace_logger import print as trace_print
@@ -374,9 +373,7 @@ class EngineClient:
 
             if "messages" in task:
                 task["messages"] = None
-            main_process_metrics.obs_value("request_params_max_tokens", task["max_tokens"])
-            main_process_metrics.inc_value("prompt_tokens_total", input_ids_len)
-            main_process_metrics.obs_value("request_prompt_tokens", input_ids_len)
+
         except Exception as e:
             log_request_error(
                 message="request[{request_id}] add_requests error: {error}, {traceback}",

--- a/tests/engine/test_common_engine.py
+++ b/tests/engine/test_common_engine.py
@@ -1311,6 +1311,9 @@ class TestCommonEngineAdditionalCoverage(unittest.TestCase):
             def __init__(self):
                 self.requests_number = Mock(inc=Mock())
                 self.num_requests_waiting = Mock(inc=Mock())
+                self.prompt_tokens_total = Mock(inc=Mock())
+                self.request_prompt_tokens = Mock(observe=Mock())
+                self.request_params_max_tokens = Mock(observe=Mock())
 
             def inc_value(self, name, value=1, labelvalues=None):
                 getattr(self, name).inc(value)
@@ -2727,6 +2730,8 @@ class TestCommonEngineAdditionalCoverage(unittest.TestCase):
                 with patch("fastdeploy.engine.common_engine.Request") as MockRequest:
                     mock_request = Mock()
                     mock_request.metrics.scheduler_recv_req_time = 0
+                    mock_request.prompt_token_ids_len = 2
+                    mock_request.sampling_params = Mock(max_tokens=16)
                     MockRequest.from_dict.return_value = mock_request
 
                     with (
@@ -2756,6 +2761,8 @@ class TestCommonEngineAdditionalCoverage(unittest.TestCase):
                 with patch("fastdeploy.engine.common_engine.Request") as MockRequest:
                     mock_request = Mock()
                     mock_request.metrics.scheduler_recv_req_time = 0
+                    mock_request.prompt_token_ids_len = 2
+                    mock_request.sampling_params = Mock(max_tokens=16)
                     MockRequest.from_dict.return_value = mock_request
 
                     with (
@@ -3359,6 +3366,9 @@ class TestCommonEngineAdditionalCoverage(unittest.TestCase):
             def __init__(self):
                 self.requests_number = Mock(inc=Mock())
                 self.num_requests_waiting = Mock(inc=Mock())
+                self.prompt_tokens_total = Mock(inc=Mock())
+                self.request_prompt_tokens = Mock(observe=Mock())
+                self.request_params_max_tokens = Mock(observe=Mock())
 
             def inc_value(self, name, value=1, labelvalues=None):
                 getattr(self, name).inc(value)


### PR DESCRIPTION
## Motivation
Move prompt token related metrics reporting from the API-side EngineClient to the engine main process, so `prompt_tokens_total` is reported from the process that owns the main metrics collector.

## Modifications
- Move `prompt_tokens_total`, `request_prompt_tokens`, and `request_params_max_tokens` reporting from `fastdeploy/entrypoints/engine_client.py` to `fastdeploy/engine/common_engine.py`.
- Remove the unused `main_process_metrics` import from `fastdeploy/entrypoints/engine_client.py`.

## Usage or Command
pytest tests/engine/test_common_engine.py tests/pooling/test_Qwen3-Embedding_serving.py tests/pooling/test_Ernie4_5_reward_serving.py

## Accuracy Tests
N/A. This PR only changes metrics reporting location and does not change model output logic.

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.