### PR TITLE
[Benchmark] support input_ids for benchmark dataset

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -356,14 +356,16 @@ async def async_request_eb_openai_chat_completions(
     if request_func_input.response_format:
         payload["response_format"] = request_func_input.response_format
 
-    # 随机输入开关
+    # Random-length input/output knob.
     if request_func_input.random_flag:
         payload["max_tokens"] = request_func_input.output_len
         payload["min_tokens"] = request_func_input.output_len
-        # 随机token_ids场景
-        if isinstance(request_func_input.prompt, list):
-            request_func_input.prompt_token_ids = request_func_input.prompt
-            request_func_input.prompt = ""
+
+    # When the prompt is a list of token ids, route through prompt_token_ids
+    # regardless of random_flag.
+    if isinstance(request_func_input.prompt, list):
+        request_func_input.prompt_token_ids = request_func_input.prompt
+        request_func_input.prompt = ""
 
     # 支持传入prompt_token_ids
     if request_func_input.prompt_token_ids:

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -300,19 +300,30 @@ class EBChatDataset(BenchmarkDataset):
             if len(samples) >= num_requests:
                 break
             json_data = entry
-            prompt = entry["messages"][-1].get("content", "")
-            history_QA = entry.get("messages", [])
             response_format = entry.get("response_format")
             new_output_len = int(entry.get("max_tokens", output_len if output_len else 12288))
 
-            if enable_multimodal_chat:
-                prompt = self.apply_multimodal_chat_transformation(prompt, None)
+            # If the sample already carries pre-tokenized input_ids, send them
+            # directly via prompt_token_ids and skip the server-side
+            # chat_template + tokenizer step.
+            input_ids = entry.get("input_ids")
+            if input_ids is not None:
+                prompt = [int(x) for x in input_ids]
+                history_QA = []
+                prompt_len = len(prompt)
+            else:
+                prompt = entry["messages"][-1].get("content", "")
+                history_QA = entry.get("messages", [])
+                prompt_len = 0
+                if enable_multimodal_chat:
+                    prompt = self.apply_multimodal_chat_transformation(prompt, None)
+
             samples.append(
                 SampleRequest(
                     no=cnt,
                     json_data=json_data,
                     prompt=prompt,
-                    prompt_len=0,
+                    prompt_len=prompt_len,
                     history_QA=history_QA,
                     expected_output_len=new_output_len,
                     response_format=response_format,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
当数据集已包含预 tokenize 的 `input_ids` 字段时，支持直接将其作为 `prompt_token_ids` 传给服务端，跳过服务端 chat_template + tokenizer 步骤，满足固定 token ids 压测场景需求。

## Modifications
- `benchmarks/benchmark_dataset.py`：`EBChatDataset.sample()` 新增 `input_ids` 字段检测，若存在则将其转为 `list[int]` 作为 prompt，并设置正确的 `prompt_len`。
- `benchmarks/backend_request_func.py`：将 `prompt` 为 `list` 时路由至 `prompt_token_ids` 的逻辑从 `random_flag` 条件块中解耦，使其在非随机输入场景同样生效。

## Usage or Command
数据集 jsonl 中新增 `input_ids` 字段示例：
```json
{"input_ids": [1, 2, 3, 100], "max_tokens": 128}
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
