### PR TITLE
[BugFix] fix mtp block allocation threshold

### DIFF
--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -1004,7 +1004,7 @@ class ResourceManagerV1(ResourceManager):
                     num_new_block = self.get_new_block_nums(request, num_new_tokens)
                     if self.config.scheduler_config.splitwise_role == "prefill":
                         # for prefill instance, do not set threshold for running requests
-                        can_schedule_block_num_threshold = 0
+                        can_schedule_block_num_threshold = num_new_block
                     else:
                         can_schedule_block_num_threshold = self._get_can_schedule_prefill_threshold_block(
                             num_new_block


### PR DESCRIPTION
## Motivation
Prefill 实例（splitwise_role == "prefill"）在处理 running 队列中的 chunked prefill 请求时，`can_schedule_block_num_threshold` 被错误地设为 0，导致 `can_allocate_gpu_blocks(0)` 始终返回 True，调度器在显存不足时仍尝试分配块，可能引发块分配失败或显存耗尽。

## Modifications
- `fastdeploy/engine/sched/resource_manager_v1.py`：将 Prefill 实例 running 队列 chunked prefill 路径的 `can_schedule_block_num_threshold` 从 `0` 修改为 `num_new_block`，确保预检查与实际分配量一致。

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests. (单行逻辑修复，无需新增单测)
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.