### PR TITLE
[Optimization][APIServer] FD_REQUEST_WAIT_TIMEOUT control req timeout

### DIFF
--- a/fastdeploy/entrypoints/openai/serving_engine.py
+++ b/fastdeploy/entrypoints/openai/serving_engine.py
@@ -306,7 +306,9 @@ class ZmqOpenAIServing(OpenAIServing):
                 for pr in ctx.preprocess_requests:
                     dealer.write([b"", pr["request_id"].encode("utf-8")])
             while num_choices > 0:
-                request_output_dicts = await asyncio.wait_for(request_output_queue.get(), timeout=60)
+                request_output_dicts = await asyncio.wait_for(
+                    request_output_queue.get(), timeout=envs.FD_REQUEST_WAIT_TIMEOUT
+                )
                 for request_output_dict in request_output_dicts:
                     log_request(
                         level=RequestLogLevel.FULL,

--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -305,6 +305,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # When set to a valid JSON dict, metric labels are automatically enabled.
     # Example: '{"model_id":"my_model"}' adds model_id label to all metrics.
     "FD_DEFAULT_METRIC_LABEL_VALUES": lambda: os.getenv("FD_DEFAULT_METRIC_LABEL_VALUES", "{}"),
+    # Timeout for request output queue get operation in seconds
+    "FD_REQUEST_WAIT_TIMEOUT": lambda: int(os.getenv("FD_REQUEST_WAIT_TIMEOUT", "60")),
 }
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
在请求pooling模型(2机16卡部署)的reward接口时，60s超时时间太少，需要增加参数调整。
<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

## Modifications

修改前：超时时间固定60s
修改后：增加环境变量`FD_REQUEST_WAIT_TIMEOUT`控制请求超时时间，默认为60s。
<!-- Detail the changes made in this pull request. -->

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
