### PR TITLE
[Cherry-Pick][CI][BugFix] Fix rotary_embs initialization(#8012)

### DIFF
--- a/tests/layers/test_plas_attention.py
+++ b/tests/layers/test_plas_attention.py
@@ -101,7 +101,9 @@ class TestPlasAttention(unittest.TestCase):
             [self.tokens + self.attn_block_m, self.num_kv_heads, self.head_dim],
             dtype="bfloat16",
         )
-        self.rotary_embs = paddle.ones([2, self.seq_len, self.head_dim // 2], dtype="float32")
+        rotary_cos = paddle.ones([1, self.plas_max_seq_length, self.head_dim // 2], dtype="float32")
+        rotary_sin = paddle.zeros([1, self.plas_max_seq_length, self.head_dim // 2], dtype="float32")
+        self.rotary_embs = paddle.concat([rotary_cos, rotary_sin], axis=0)
 
         self.attn_gate_weight = paddle.randn(
             [self.num_kv_heads, self.plas_block_size, self.head_dim], dtype="bfloat16"


### PR DESCRIPTION
Cherry-pick of #8012 (authored by @EmmonsCurse) to `release/2.6`.

devPR:https://github.com/PaddlePaddle/FastDeploy/pull/8012 <!-- For pass CI -->

---

<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation
A CUDA kernel out-of-bounds issue was observed when running in environments with the 580 driver stack. The problem may lead to test failures, runtime instability, or unexpected kernel execution behavior under specific workloads.

This change addresses the compatibility issue to ensure stable execution in 580 driver environments.
`tests/layers/test_plas_attention.py` fails with CUDA illegal memory access errors during execution:
```text
CUDA error(700): an illegal memory access was encountered
```
Investigation using `compute-sanitizer --tool memcheck` revealed that the failures originate from out-of-bounds memory accesses inside `fused_block_mean_and_rope_kernel`.

The test initializes `rotary_embs` using:
```python
paddle.ones([2, seq_len, head_dim // 2])
```
However, the kernel computes the sin buffer offset using `plas_max_seq_length` rather than the actual test `seq_len`. As a result, the kernel accesses memory beyond the allocated buffer, causing CUDA illegal memory access and corrupting the CUDA context. Once the illegal access occurs, subsequent GPU operations also fail, which explains why `test_server` reports the same error during initialization.

In addition, the test validation expects RoPE to behave as an identity transformation, which requires:
- cos = 1
- sin = 0

The previous initialization incorrectly set both cosine and sine values to 1.

## Modifications
- Updated `rotary_embs` allocation to use `plas_max_seq_length` instead of `seq_len`.
- Initialized RoPE buffers explicitly:
- cosine values set to `1`
- sine values set to `0`
- Ensured the buffer layout matches kernel offset calculations and prevents out-of-bounds memory access.
- Restored identity RoPE behavior required by the test validation logic.
- Fixed CUDA illegal memory access failures in:
- `test_plas_attention`
- `test_server`

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
- Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
- You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
