### PR TITLE
[BugFix][PD Disaggregation] remove redundant block allocation of prefill tasks in decode instance

### DIFF
--- a/fastdeploy/engine/sched/resource_manager_v1.py
+++ b/fastdeploy/engine/sched/resource_manager_v1.py
@@ -259,12 +259,11 @@ class ResourceManagerV1(ResourceManager):
         block_num = (
             request.num_computed_tokens + num_new_tokens + self.config.cache_config.block_size - 1
         ) // self.config.cache_config.block_size - len(request.block_tables)
-
         if self.config.speculative_config.method is not None:
             block_num = min(block_num + 1, self.config.cache_config.max_block_num_per_seq)
         else:
             block_num = min(block_num, self.config.cache_config.max_block_num_per_seq)
-
+        block_num = max(block_num, 0)
         return block_num
 
     def _is_decoding(self, request) -> bool:
@@ -519,6 +518,9 @@ class ResourceManagerV1(ResourceManager):
 
     def _get_can_schedule_prefill_threshold_block(self, num_chunk_new_block):
         """Compute the minimum free blocks required to admit a new prefill request."""
+        if self.config.scheduler_config.splitwise_role != "mixed":
+            return num_chunk_new_block
+
         if self.use_new_token_ratio_reserve:
             reserve_blocks = sum(self._get_running_request_reserve_blocks(req) for req in self.running)
             can_schedule_block_num_threshold = num_chunk_new_block + reserve_blocks


### PR DESCRIPTION
## Motivation      
In the disaggregated prefill-decode serving mode (splitwise_role != "mixed"), the decode instance incorrectly applied the mixed-role block reservation logic when determining whether to admit a new prefill request. This caused the scheduler to over-provision KV-cache blocks for running decode requests, unnecessarily blocking prefill task admission and reducing throughput. Additionally, get_new_block_nums could return a negative block count when a request already had sufficient blocks allocated, potentially leading to downstream scheduling errors.

## Modifications

- **fastdeploy/engine/sched/resource_manager_v1.py**
  1. `_get_can_schedule_prefill_threshold_block`: Return num_chunk_new_block directly when enabling prefill-decode disaggregation, skipping the reserve-block estimation for running requests.
  2. `get_new_block_nums`: Clamp the result to non-negative, preventing negative values when num_computed_tokens + num_new_tokens fits within already-allocated blocks.

## Usage or Command
No new configuration or command required. The fix applies automatically in disaggregated prefill-decode deployments.

## Accuracy Tests

This PR only modifies scheduling logic (block allocation thresholds) and does not affect model forward computation or kernel outputs, so accuracy is not impacted.

## Checklist

- [ ] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
