### PR TITLE
[CI] DEBUG switch CI test env to new driver in release/2.6

### DIFF
--- a/.github/workflows/_build_linux.yml
+++ b/.github/workflows/_build_linux.yml
@@ -70,7 +70,7 @@ jobs:
       workflow-name: build_gpu
 
   fd-build:
-    runs-on: [self-hosted, GPU-Build]
+    runs-on: [self-hosted, GPU-h20-New-Driver]
     needs: check_bypass
     if: ${{ needs.check_bypass.outputs.can-skip != 'true' }}
     timeout-minutes: 360

--- a/.github/workflows/_pre_ce_test.yml
+++ b/.github/workflows/_pre_ce_test.yml
@@ -39,7 +39,7 @@ jobs:
       workflow-name: pre_ce_test
 
   run_ce_cases:
-    runs-on: [self-hosted, PRE_CE_RUN_2Card]
+    runs-on: [self-hosted, GPU-h20-New-Driver]
     needs: check_bypass
     if: ${{ inputs.FASTDEPLOY_WHEEL_URL != '' && needs.check_bypass.outputs.can-skip != 'true' }}
     timeout-minutes: 60


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

Temporarily switch CI test jobs to an environment with the new driver version for debugging and validation.

This change is intended to verify environment compatibility, test stability, and runtime behavior under the new driver stack before broader rollout.

## Modifications

- Updated CI test environment to use the new driver.
- Validated test execution and compatibility in the new driver environment.
- Used for debugging and environment verification only.
- No functional changes to CI logic or test cases.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
