### PR TITLE
[KVCache] Fix RDMA connection memory leak

### DIFF
--- a/fastdeploy/cache_manager/transfer_factory/kvcache_transfer/include/kvcache_rdma.h
+++ b/fastdeploy/cache_manager/transfer_factory/kvcache_transfer/include/kvcache_rdma.h
@@ -158,15 +158,16 @@ class RDMACommunicator {
 
   std::vector<std::string> main_ip_list;  // List of local IP addresses
   std::map<std::string, struct RdmaContext*>
-      conn_map;                        // Active connections map
-  std::mutex mutex_;                   // Thread synchronization mutex
-  int rdma_event_channel_epoll_fd;     // Epoll file descriptor
-  struct ibv_pd* g_pd = NULL;          // fd
+      conn_map;                              // Active connections map
+  std::mutex mutex_;                         // Thread synchronization mutex
+  int rdma_event_channel_epoll_fd;           // Epoll file descriptor
+  struct ibv_pd* g_pd = NULL;                // fd
   std::atomic<int> RDMACommunicator_status;  // Communicator status flag
   std::atomic<bool> start_client_listener{false};  // Client listener flag
-  std::thread server_thread_;          // Server listener thread handle
-  std::thread client_thread_;          // Client listener thread handle
-  std::atomic<bool> server_mr_owned_by_destructor_{false};  // True once destructor takes ownership of server MRs
+  std::thread server_thread_;  // Server listener thread handle
+  std::thread client_thread_;  // Client listener thread handle
+  std::atomic<bool> server_mr_owned_by_destructor_{
+      false};  // True once destructor takes ownership of server MRs
 
   bool has_value_cache_;  // MLA does not have value cache.
   bool has_key_scale_;

--- a/fastdeploy/cache_manager/transfer_factory/kvcache_transfer/include/kvcache_rdma.h
+++ b/fastdeploy/cache_manager/transfer_factory/kvcache_transfer/include/kvcache_rdma.h
@@ -4,9 +4,11 @@
 #pragma once
 
 #include <rdma/rdma_cma.h>
+#include <atomic>
 #include <map>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 #include "kvcache_connection.h"
 #include "log.h"
@@ -160,8 +162,11 @@ class RDMACommunicator {
   std::mutex mutex_;                   // Thread synchronization mutex
   int rdma_event_channel_epoll_fd;     // Epoll file descriptor
   struct ibv_pd* g_pd = NULL;          // fd
-  int RDMACommunicator_status;         // Communicator status flag
-  bool start_client_listener = false;  // Client listener flag
+  std::atomic<int> RDMACommunicator_status;  // Communicator status flag
+  std::atomic<bool> start_client_listener{false};  // Client listener flag
+  std::thread server_thread_;          // Server listener thread handle
+  std::thread client_thread_;          // Client listener thread handle
+  std::atomic<bool> server_mr_owned_by_destructor_{false};  // True once destructor takes ownership of server MRs
 
   bool has_value_cache_;  // MLA does not have value cache.
   bool has_key_scale_;

--- a/fastdeploy/cache_manager/transfer_factory/kvcache_transfer/src/kvcache_connection.cpp
+++ b/fastdeploy/cache_manager/transfer_factory/kvcache_transfer/src/kvcache_connection.cpp
@@ -20,6 +20,8 @@
 #include "kvcache_connection.h"
 #include "log.h"  // For logging system
 
+#include <algorithm>
+
 // Global variables
 pthread_mutex_t g_ib_lock = PTHREAD_MUTEX_INITIALIZER;
 std::vector<IbDeviceInfo> g_ib_all_devs;
@@ -312,10 +314,13 @@ QpStatus modify_qp_to_rts(struct RdmaContext *ctx,
     return QpStatus::kPortQueryFailed;
   }
 
-  if (dest->mtu > port_attr.active_mtu) {
-    ERR("Specified MTU (%d) is greater than active port MTU (%d)",
-        dest->mtu,
-        port_attr.active_mtu);
+  enum ibv_mtu path_mtu = static_cast<enum ibv_mtu>(std::min(
+      static_cast<int>(dest->mtu), static_cast<int>(port_attr.active_mtu)));
+  if (path_mtu < IBV_MTU_256 || path_mtu > IBV_MTU_4096) {
+    ERR("Invalid negotiated MTU: %d (local=%d, remote=%d)",
+        path_mtu,
+        port_attr.active_mtu,
+        dest->mtu);
     return QpStatus::kMtuMismatch;
   }
 
@@ -323,7 +328,7 @@ QpStatus modify_qp_to_rts(struct RdmaContext *ctx,
   memset(&attr, 0, sizeof(struct ibv_qp_attr));
 
   attr.qp_state = IBV_QPS_RTR;
-  attr.path_mtu = dest->mtu;
+  attr.path_mtu = path_mtu;
   attr.dest_qp_num = dest->qpn;
   attr.rq_psn = 0;
   attr.max_dest_rd_atomic = 1;
@@ -419,12 +424,14 @@ static std::shared_ptr<QpInfo> client_exch_dest(struct RdmaContext *ctx,
 
   if (write(sockfd, buffer, QpInfo::size) != QpInfo::size) {
     WARN("Failed to send local QP info to %s", dst_ip.c_str());
+    ctx->sock_fd = 0;
     close(sockfd);
     return nullptr;
   }
 
   if (read(sockfd, buffer, QpInfo::size) != QpInfo::size) {
     WARN("Failed to receive remote QP info from %s", dst_ip.c_str());
+    ctx->sock_fd = 0;
     close(sockfd);
     return nullptr;
   }
@@ -496,6 +503,7 @@ bool clear_qp_info(struct RdmaContext *ctx) {
       ERR("Failed to destroy QP.");
       success = false;
     }
+    ctx->qp = nullptr;
   }
 
   if (ctx->cq) {
@@ -503,6 +511,7 @@ bool clear_qp_info(struct RdmaContext *ctx) {
       ERR("Failed to deallocate cq Domain.");
       success = false;
     }
+    ctx->cq = nullptr;
   }
 
   if (ctx->channel) {
@@ -510,6 +519,7 @@ bool clear_qp_info(struct RdmaContext *ctx) {
       ERR("Failed to destroy Completion Channel.");
       success = false;
     }
+    ctx->channel = nullptr;
   }
 
   return success;
@@ -523,13 +533,15 @@ struct RdmaContext *create_qp(struct IbDeviceInfo *ib_dev,
   struct ibv_qp_init_attr qpInitAttr = {};
   ctx->context = ib_dev->context;
 
+  bool pd_newly_allocated = false;
   if (*g_pd == NULL) {
     *g_pd = ibv_alloc_pd(ctx->context);
     if (*g_pd == NULL) {
       ERR("failed to allocate protection domain");
-      free(ctx->context);
+      delete ctx;
       return NULL;
     }
+    pd_newly_allocated = true;
   }
   ctx->pd = *g_pd;
 
@@ -537,6 +549,10 @@ struct RdmaContext *create_qp(struct IbDeviceInfo *ib_dev,
   ctx->channel = ibv_create_comp_channel(ctx->context);
   if (!ctx->channel) {
     ERR("Failed to create completion channel: %s", strerror(errno));
+    if (pd_newly_allocated) {
+      ibv_dealloc_pd(*g_pd);
+      *g_pd = nullptr;
+    }
     delete ctx;
     return NULL;
   }
@@ -546,6 +562,10 @@ struct RdmaContext *create_qp(struct IbDeviceInfo *ib_dev,
   if (!ctx->cq) {
     ERR("Failed to create completion queue: %s", strerror(errno));
     ibv_destroy_comp_channel(ctx->channel);
+    if (pd_newly_allocated) {
+      ibv_dealloc_pd(*g_pd);
+      *g_pd = nullptr;
+    }
     delete ctx;
     return NULL;
   }
@@ -555,6 +575,10 @@ struct RdmaContext *create_qp(struct IbDeviceInfo *ib_dev,
     ERR("Failed to request CQ notifications: %s", strerror(errno));
     ibv_destroy_cq(ctx->cq);
     ibv_destroy_comp_channel(ctx->channel);
+    if (pd_newly_allocated) {
+      ibv_dealloc_pd(*g_pd);
+      *g_pd = nullptr;
+    }
     delete ctx;
     return NULL;
   }
@@ -575,6 +599,10 @@ struct RdmaContext *create_qp(struct IbDeviceInfo *ib_dev,
     ERR("Failed to create queue pair: %s", strerror(errno));
     ibv_destroy_cq(ctx->cq);
     ibv_destroy_comp_channel(ctx->channel);
+    if (pd_newly_allocated) {
+      ibv_dealloc_pd(*g_pd);
+      *g_pd = nullptr;
+    }
     delete ctx;
     return NULL;
   }
@@ -593,6 +621,10 @@ struct RdmaContext *create_qp(struct IbDeviceInfo *ib_dev,
     ibv_destroy_qp(ctx->qp);
     ibv_destroy_cq(ctx->cq);
     ibv_destroy_comp_channel(ctx->channel);
+    if (pd_newly_allocated) {
+      ibv_dealloc_pd(*g_pd);
+      *g_pd = nullptr;
+    }
     delete ctx;
     return NULL;
   }
@@ -972,6 +1004,7 @@ bool server_send_memory_region(struct RdmaContext *ctx,
   ctx->conn.wc_target_count = 0;
 
   if (!poll_cq_with_timeout(ctx, RDMA_POLL_CQE_TIMEOUT, 1)) {
+    ibv_dereg_mr(ctx->conn.send_mr);
     return false;
   }
 
@@ -1025,6 +1058,7 @@ bool client_receive_memory_region(struct RdmaContext *ctx,
   ctx->conn.wc_count = 0;
   ctx->conn.wc_target_count = 0;
   if (!poll_cq_with_timeout(ctx, RDMA_POLL_CQE_TIMEOUT, 1)) {
+    ibv_dereg_mr(ctx->conn.recv_mr);
     return false;
   }
 
@@ -1138,7 +1172,8 @@ int setup_listening_socket(int port) {
 int configure_epoll(int sockfd) {
   int epollfd = epoll_create1(0);
   if (epollfd == -1) {
-    ERR("epoll_create1");
+    ERR("epoll_create1 failed: %s", strerror(errno));
+    return -1;
   }
 
   // Initialize epoll for the listening socket
@@ -1147,6 +1182,7 @@ int configure_epoll(int sockfd) {
   ev.data.fd = sockfd;
   if (epoll_ctl(epollfd, EPOLL_CTL_ADD, sockfd, &ev) == -1) {
     ERR("Failed to add listening socket to epoll");
+    close(epollfd);
     close(sockfd);
     return -1;
   }
@@ -1216,8 +1252,13 @@ std::vector<std::string> get_net_ifname() {
 }
 
 Connection::~Connection() {
+  // Note: write_cache_*_server_mr_list are shallow copies of the class-level
+  // lists in RDMACommunicator. They must NOT be deregistered here - the
+  // class-level lists own the MRs and handle deregistration.
   write_cache_key_server_mr_list.clear();
   write_cache_value_server_mr_list.clear();
+  write_cache_key_scale_server_mr_list.clear();
+  write_cache_value_scale_server_mr_list.clear();
   write_cache_key_remote_ptr_list.clear();
   write_cache_key_remote_rkey_list.clear();
   write_cache_value_remote_ptr_list.clear();

--- a/fastdeploy/cache_manager/transfer_factory/kvcache_transfer/src/kvcache_rdma.cpp
+++ b/fastdeploy/cache_manager/transfer_factory/kvcache_transfer/src/kvcache_rdma.cpp
@@ -1089,10 +1089,14 @@ bool RDMACommunicator::server_mr_register_per_layer(RdmaContext* ctx) {
     }
     write_cache_key_server_mr_list.push_back(key_mr);
 
+    struct ibv_mr* value_mr = nullptr;
+    struct ibv_mr* key_scale_mr = nullptr;
+    struct ibv_mr* value_scale_mr = nullptr;
+
     if (has_value_cache_) {
       void* val_ptr =
           reinterpret_cast<void*>(local_cache_value_ptr_layer_head_[i]);
-      struct ibv_mr* value_mr = register_memory_region(
+      value_mr = register_memory_region(
           ctx->pd, val_ptr, size, "value_" + std::to_string(i), access_flags);
       if (!value_mr) {
         ERR("Failed to register value MR at layer %d", i);
@@ -1107,12 +1111,11 @@ bool RDMACommunicator::server_mr_register_per_layer(RdmaContext* ctx) {
       size_t scale_size =
           static_cast<size_t>(scale_block_size_byte) * block_number;
 
-      struct ibv_mr* key_scale_mr =
-          register_memory_region(ctx->pd,
-                                 key_scale_ptr,
-                                 scale_size,
-                                 "key_scale_" + std::to_string(i),
-                                 access_flags);
+      key_scale_mr = register_memory_region(ctx->pd,
+                                            key_scale_ptr,
+                                            scale_size,
+                                            "key_scale_" + std::to_string(i),
+                                            access_flags);
       if (!key_scale_mr) {
         ERR("Failed to register key scale MR at layer %d", i);
         goto fail;
@@ -1126,7 +1129,7 @@ bool RDMACommunicator::server_mr_register_per_layer(RdmaContext* ctx) {
       size_t scale_size =
           static_cast<size_t>(scale_block_size_byte) * block_number;
 
-      struct ibv_mr* value_scale_mr =
+      value_scale_mr =
           register_memory_region(ctx->pd,
                                  value_scale_ptr,
                                  scale_size,

--- a/fastdeploy/cache_manager/transfer_factory/kvcache_transfer/src/kvcache_rdma.cpp
+++ b/fastdeploy/cache_manager/transfer_factory/kvcache_transfer/src/kvcache_rdma.cpp
@@ -256,9 +256,21 @@ RDMACommunicator::~RDMACommunicator() {
     // Mark as closed/shutdown state
     RDMACommunicator_status = 0;
 
-    // Clean up all connections
+    // Clean up all client connections in conn_map
     {
       std::lock_guard<std::mutex> lock(mutex_);
+      for (auto& kv : conn_map) {
+        struct RdmaContext* ctx = kv.second;
+        if (ctx) {
+          for (size_t i = 0; i < ctx->conn.read_bufs.size(); ++i) {
+            if (ctx->conn.read_mrs[i]) ibv_dereg_mr(ctx->conn.read_mrs[i]);
+            if (ctx->conn.read_bufs[i]) free(ctx->conn.read_bufs[i]);
+          }
+          if (ctx->sock_fd > 0) close(ctx->sock_fd);
+          clear_qp_info(ctx);
+          delete ctx;
+        }
+      }
       conn_map.clear();
     }
 
@@ -274,8 +286,13 @@ RDMACommunicator::~RDMACommunicator() {
 
     deregister_mrs(write_mr_key_list, "write key");
     deregister_mrs(write_mr_value_list, "write value");
+    deregister_mrs(write_mr_key_scale_list, "write key scale");
+    deregister_mrs(write_mr_value_scale_list, "write value scale");
     deregister_mrs(write_cache_key_server_mr_list, "server key");
     deregister_mrs(write_cache_value_server_mr_list, "server value");
+    deregister_mrs(write_cache_key_scale_server_mr_list, "server key scale");
+    deregister_mrs(write_cache_value_scale_server_mr_list,
+                   "server value scale");
 
     // Clean up protection domain
     if (g_pd) {
@@ -309,6 +326,7 @@ int RDMACommunicator::start_server(int sport, int sgid_idx, int gpu_index) {
   if (g_ib_all_devs.size() == 0) {
     if (parse_port_ib_info() != 0) {
       ERR("decode parse_port_ib_info error, please set rdma nics info");
+      close(sockfd);
       return -1;
     }
   }
@@ -389,7 +407,8 @@ int RDMACommunicator::start_server(int sport, int sgid_idx, int gpu_index) {
         std::lock_guard<std::mutex> lock(mutex_);
         if (!server_mr_register_per_layer(ctx)) {
           ERR("server_mr_register_per_layer failed");
-          return -1;
+          close_server_connection(connfd, ctx, epollfd, connectionContexts);
+          continue;
         }
 
         if (get_port_info(ctx->context, ib_dev->port, &ctx->portinfo)) {
@@ -435,7 +454,11 @@ int RDMACommunicator::start_server(int sport, int sgid_idx, int gpu_index) {
           continue;
         }
 
-        server_exchange_mr(ctx);
+        if (!server_exchange_mr(ctx)) {
+          ERR("server_exchange_mr failed");
+          close_server_connection(connfd, ctx, epollfd, connectionContexts);
+          continue;
+        }
         INFO("connect successfully");
       } else {
         auto ctx_iter = connectionContexts.find(event_fd);
@@ -463,6 +486,32 @@ int RDMACommunicator::start_server(int sport, int sgid_idx, int gpu_index) {
     }
   }
 
+  // Clean up remaining connections when server loop exits
+  for (auto& kv : connectionContexts) {
+    struct RdmaContext* ctx = kv.second;
+    if (ctx) {
+      clear_qp_info(ctx);
+      delete ctx;
+    }
+    close(kv.first);
+  }
+  connectionContexts.clear();
+
+  // Deregister server MRs once (shared across all connections)
+  auto dereg_list = [](std::vector<ibv_mr*>& mrs, const char* name) {
+    for (auto*& mr : mrs) {
+      if (mr) {
+        ibv_dereg_mr(mr);
+        mr = nullptr;
+      }
+    }
+    mrs.clear();
+  };
+  dereg_list(write_cache_key_server_mr_list, "server key");
+  dereg_list(write_cache_value_server_mr_list, "server value");
+  dereg_list(write_cache_key_scale_server_mr_list, "server key scale");
+  dereg_list(write_cache_value_scale_server_mr_list, "server value scale");
+
   close(sockfd);
   close(epollfd);
   return 0;
@@ -474,11 +523,15 @@ void RDMACommunicator::close_server_connection(
     int epollfd,
     std::map<int, struct RdmaContext*>& connectionContexts) {
   if (ctx) {
-    if (!deregister_memory_regions(ctx)) {
-      WARN("Failed to clear memory regions for Connection fd %d", fd);
-    }
+    // Server MRs are shared across all connections (registered once, reused).
+    // Only clear the shallow copies in ctx->conn without deregistering.
+    ctx->conn.write_cache_key_server_mr_list.clear();
+    ctx->conn.write_cache_value_server_mr_list.clear();
+    ctx->conn.write_cache_key_scale_server_mr_list.clear();
+    ctx->conn.write_cache_value_scale_server_mr_list.clear();
+
     if (!clear_qp_info(ctx)) {
-      WARN("Failed to clear memory regions for Connection fd %d", fd);
+      WARN("Failed to clear QP info for Connection fd %d", fd);
     }
     delete ctx;
   }
@@ -524,32 +577,14 @@ bool RDMACommunicator::deregister_memory_regions(struct RdmaContext* ctx) {
     return false;
   }
 
-  if (!write_mr_key_list.empty()) {
-    for (int layer_idx = 0; layer_idx < layer_number; layer_idx++) {
-      if (write_mr_key_list[layer_idx]) {
-        if (ibv_dereg_mr(write_mr_key_list[layer_idx])) {
-          ERR("Failed to deregister memory region: write_mr_key_list, layer %d",
-              layer_idx);
-        }
-        write_mr_key_list[layer_idx] = nullptr;
-      }
-    }
-    write_mr_key_list.clear();
-  }
-
-  if (!write_mr_value_list.empty()) {
-    for (int layer_idx = 0; layer_idx < layer_number; layer_idx++) {
-      if (write_mr_value_list[layer_idx]) {
-        if (ibv_dereg_mr(write_mr_value_list[layer_idx])) {
-          ERR("Failed to deregister memory region: write_mr_value_list, layer "
-              "%d",
-              layer_idx);
-        }
-        write_mr_value_list[layer_idx] = nullptr;
-      }
-    }
-    write_mr_value_list.clear();
-  }
+  // Client write MRs and server MRs are class-level shared resources.
+  // They are registered once and reused across connections.
+  // Deregistration is only done in the destructor.
+  // Just clear the connection's shallow copies here.
+  ctx->conn.write_cache_key_server_mr_list.clear();
+  ctx->conn.write_cache_value_server_mr_list.clear();
+  ctx->conn.write_cache_key_scale_server_mr_list.clear();
+  ctx->conn.write_cache_value_scale_server_mr_list.clear();
 
   return true;
 }
@@ -638,11 +673,15 @@ int RDMACommunicator::connect(const std::string& dst_ip,
   // Get port information for the connection
   if (get_port_info(ctx->context, ib_dev->port, &ctx->portinfo)) {
     ERR("Couldn't get port info");
+    clear_qp_info(ctx);
+    delete ctx;
     return static_cast<int>(ConnStatus::kError);
   }
   // Register memory regions
   if (!client_mr_register_per_layer(ctx)) {
     ERR("client_mr_register_per_layer failed");
+    clear_qp_info(ctx);
+    delete ctx;
     return static_cast<int>(ConnStatus::kError);
   }
 
@@ -653,10 +692,21 @@ int RDMACommunicator::connect(const std::string& dst_ip,
           KVCacheConfig::getInstance().resolve_rdma_dest_port(dst_port),
           KVCacheConfig::getInstance().get_rdma_gid_index(),
           dst_ip)) {
-    ERR("Couldn't getexchange port infodestinations");
+    ERR("Couldn't exchange destinations with %s:%s",
+        dst_ip.c_str(),
+        dst_port.c_str());
+    if (ctx->sock_fd > 0) close(ctx->sock_fd);
+    clear_qp_info(ctx);
+    delete ctx;
     return static_cast<int>(ConnStatus::kError);
   } else {
-    client_exchange_mr(ctx);
+    if (!client_exchange_mr(ctx)) {
+      ERR("client_exchange_mr failed");
+      if (ctx->sock_fd > 0) close(ctx->sock_fd);
+      clear_qp_info(ctx);
+      delete ctx;
+      return static_cast<int>(ConnStatus::kError);
+    }
   }
 
   // Allocate RDMA read and register read buffers
@@ -668,6 +718,13 @@ int RDMACommunicator::connect(const std::string& dst_ip,
     ctx->conn.read_bufs[i] = malloc(block_size_byte);
     if (!ctx->conn.read_bufs[i]) {
       ERR("Failed to allocate read buffer");
+      for (size_t j = 0; j < i; ++j) {
+        if (ctx->conn.read_mrs[j]) ibv_dereg_mr(ctx->conn.read_mrs[j]);
+        free(ctx->conn.read_bufs[j]);
+      }
+      if (ctx->sock_fd > 0) close(ctx->sock_fd);
+      clear_qp_info(ctx);
+      delete ctx;
       return static_cast<int>(ConnStatus::kError);
     }
     // Register memory region for read buffer
@@ -677,6 +734,15 @@ int RDMACommunicator::connect(const std::string& dst_ip,
                                        IBV_ACCESS_LOCAL_WRITE);
     if (!ctx->conn.read_mrs[i]) {
       ERR("Failed to register memory for RDMA Read buffer");
+      free(ctx->conn.read_bufs[i]);
+      ctx->conn.read_bufs[i] = nullptr;
+      for (size_t j = 0; j < i; ++j) {
+        if (ctx->conn.read_mrs[j]) ibv_dereg_mr(ctx->conn.read_mrs[j]);
+        free(ctx->conn.read_bufs[j]);
+      }
+      if (ctx->sock_fd > 0) close(ctx->sock_fd);
+      clear_qp_info(ctx);
+      delete ctx;
       return static_cast<int>(ConnStatus::kError);
     }
   }
@@ -701,6 +767,13 @@ int RDMACommunicator::connect(const std::string& dst_ip,
         rdma_event_channel_epoll_fd, EPOLL_CTL_ADD, ctx->sock_fd, &ev);
     if (ret != 0) {
       ERR("failed to add event channel %d", ret);
+      for (size_t i = 0; i < block_number; ++i) {
+        if (ctx->conn.read_mrs[i]) ibv_dereg_mr(ctx->conn.read_mrs[i]);
+        free(ctx->conn.read_bufs[i]);
+      }
+      if (ctx->sock_fd > 0) close(ctx->sock_fd);
+      clear_qp_info(ctx);
+      delete ctx;
       return static_cast<int>(ConnStatus::kError);
     }
   }
@@ -778,7 +851,17 @@ void RDMACommunicator::remove_conn(const std::string& url) {
   if (conn_map.find(url) != conn_map.end()) {
     struct RdmaContext* ctx = conn_map[url];
     conn_map.erase(url);
-    free(ctx->context);
+    // Clean up read buffers and MRs
+    for (size_t i = 0; i < ctx->conn.read_bufs.size(); ++i) {
+      if (ctx->conn.read_mrs[i]) ibv_dereg_mr(ctx->conn.read_mrs[i]);
+      if (ctx->conn.read_bufs[i]) free(ctx->conn.read_bufs[i]);
+    }
+    ctx->conn.read_bufs.clear();
+    ctx->conn.read_mrs.clear();
+    if (ctx->sock_fd > 0) close(ctx->sock_fd);
+    deregister_memory_regions(ctx);
+    clear_qp_info(ctx);
+    delete ctx;
   }
 }
 
@@ -960,12 +1043,21 @@ bool RDMACommunicator::server_mr_register_per_layer(RdmaContext* ctx) {
     ERR("Invalid RDMA context");
     return false;
   }
-  LOGD("Start server memory region registration...");
 
-  write_cache_key_server_mr_list.clear();
-  write_cache_value_server_mr_list.clear();
-  write_cache_key_scale_server_mr_list.clear();
-  write_cache_value_scale_server_mr_list.clear();
+  // Reuse existing MRs if already registered (supports multi-P connections)
+  if (!write_cache_key_server_mr_list.empty()) {
+    ctx->conn.write_cache_key_server_mr_list = write_cache_key_server_mr_list;
+    ctx->conn.write_cache_value_server_mr_list =
+        write_cache_value_server_mr_list;
+    ctx->conn.write_cache_key_scale_server_mr_list =
+        write_cache_key_scale_server_mr_list;
+    ctx->conn.write_cache_value_scale_server_mr_list =
+        write_cache_value_scale_server_mr_list;
+    LOGD("Reusing existing server MRs for new connection");
+    return true;
+  }
+
+  LOGD("Start server memory region registration...");
 
   const uint32_t access_flags =
       IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ;
@@ -982,14 +1074,10 @@ bool RDMACommunicator::server_mr_register_per_layer(RdmaContext* ctx) {
     }
     write_cache_key_server_mr_list.push_back(key_mr);
 
-    struct ibv_mr* value_mr = nullptr;
-    struct ibv_mr* key_scale_mr = nullptr;
-    struct ibv_mr* value_scale_mr = nullptr;
-
     if (has_value_cache_) {
       void* val_ptr =
           reinterpret_cast<void*>(local_cache_value_ptr_layer_head_[i]);
-      value_mr = register_memory_region(
+      struct ibv_mr* value_mr = register_memory_region(
           ctx->pd, val_ptr, size, "value_" + std::to_string(i), access_flags);
       if (!value_mr) {
         ERR("Failed to register value MR at layer %d", i);
@@ -1004,11 +1092,12 @@ bool RDMACommunicator::server_mr_register_per_layer(RdmaContext* ctx) {
       size_t scale_size =
           static_cast<size_t>(scale_block_size_byte) * block_number;
 
-      key_scale_mr = register_memory_region(ctx->pd,
-                                            key_scale_ptr,
-                                            scale_size,
-                                            "key_scale_" + std::to_string(i),
-                                            access_flags);
+      struct ibv_mr* key_scale_mr =
+          register_memory_region(ctx->pd,
+                                 key_scale_ptr,
+                                 scale_size,
+                                 "key_scale_" + std::to_string(i),
+                                 access_flags);
       if (!key_scale_mr) {
         ERR("Failed to register key scale MR at layer %d", i);
         goto fail;
@@ -1022,7 +1111,7 @@ bool RDMACommunicator::server_mr_register_per_layer(RdmaContext* ctx) {
       size_t scale_size =
           static_cast<size_t>(scale_block_size_byte) * block_number;
 
-      value_scale_mr =
+      struct ibv_mr* value_scale_mr =
           register_memory_region(ctx->pd,
                                  value_scale_ptr,
                                  scale_size,

--- a/fastdeploy/cache_manager/transfer_factory/kvcache_transfer/src/kvcache_rdma.cpp
+++ b/fastdeploy/cache_manager/transfer_factory/kvcache_transfer/src/kvcache_rdma.cpp
@@ -135,6 +135,7 @@ RDMACommunicator::RDMACommunicator(std::string& role,
           ERR("Server thread failed: %s", e.what());
         }
       });
+      server_thread_.detach();
     }
     RDMACommunicator_status = 1;
     INFO("RDMA communicator initialized successfully");
@@ -258,15 +259,8 @@ RDMACommunicator::~RDMACommunicator() {
     // Signal server thread that destructor owns MR cleanup
     server_mr_owned_by_destructor_ = true;
 
-    // Wait for server thread to finish before touching any shared state
-    if (server_thread_.joinable()) {
-      server_thread_.join();
-    }
-
-    // Wait for client listener thread to finish
-    if (client_thread_.joinable()) {
-      client_thread_.join();
-    }
+    // Detached threads will notice status change on next epoll wake-up;
+    // no need to join — kernel reclaims resources on process exit.
 
     // Clean up all client connections in conn_map
     {
@@ -774,6 +768,7 @@ int RDMACommunicator::connect(const std::string& dst_ip,
     std::lock_guard<std::mutex> lock(mutex_);
     if (!start_client_listener.load()) {
       client_thread_ = std::thread([this]() { this->client_listener(); });
+      client_thread_.detach();
       start_client_listener = true;
     }
   }

--- a/fastdeploy/cache_manager/transfer_factory/kvcache_transfer/src/kvcache_rdma.cpp
+++ b/fastdeploy/cache_manager/transfer_factory/kvcache_transfer/src/kvcache_rdma.cpp
@@ -128,14 +128,13 @@ RDMACommunicator::RDMACommunicator(std::string& role,
 
     // Start the server thread (if in decode role)
     if (splitwise_role == "decode") {
-      std::thread server_thread([this]() {
+      server_thread_ = std::thread([this]() {
         try {
           this->init_server();
         } catch (const std::exception& e) {
           ERR("Server thread failed: %s", e.what());
         }
       });
-      server_thread.detach();
     }
     RDMACommunicator_status = 1;
     INFO("RDMA communicator initialized successfully");
@@ -253,8 +252,21 @@ RDMACommunicator::~RDMACommunicator() {
   try {
     WARN("Destroying RDMA communicator");
 
-    // Mark as closed/shutdown state
+    // Signal threads to exit
     RDMACommunicator_status = 0;
+
+    // Signal server thread that destructor owns MR cleanup
+    server_mr_owned_by_destructor_ = true;
+
+    // Wait for server thread to finish before touching any shared state
+    if (server_thread_.joinable()) {
+      server_thread_.join();
+    }
+
+    // Wait for client listener thread to finish
+    if (client_thread_.joinable()) {
+      client_thread_.join();
+    }
 
     // Clean up all client connections in conn_map
     {
@@ -288,11 +300,17 @@ RDMACommunicator::~RDMACommunicator() {
     deregister_mrs(write_mr_value_list, "write value");
     deregister_mrs(write_mr_key_scale_list, "write key scale");
     deregister_mrs(write_mr_value_scale_list, "write value scale");
-    deregister_mrs(write_cache_key_server_mr_list, "server key");
-    deregister_mrs(write_cache_value_server_mr_list, "server value");
-    deregister_mrs(write_cache_key_scale_server_mr_list, "server key scale");
-    deregister_mrs(write_cache_value_scale_server_mr_list,
-                   "server value scale");
+
+    // Server MRs may have already been deregistered by start_server() exit
+    // path. Only deregister if they are still populated (destructor won the
+    // race, or start_server never ran).
+    if (!write_cache_key_server_mr_list.empty()) {
+      deregister_mrs(write_cache_key_server_mr_list, "server key");
+      deregister_mrs(write_cache_value_server_mr_list, "server value");
+      deregister_mrs(write_cache_key_scale_server_mr_list, "server key scale");
+      deregister_mrs(write_cache_value_scale_server_mr_list,
+                     "server value scale");
+    }
 
     // Clean up protection domain
     if (g_pd) {
@@ -497,20 +515,24 @@ int RDMACommunicator::start_server(int sport, int sgid_idx, int gpu_index) {
   }
   connectionContexts.clear();
 
-  // Deregister server MRs once (shared across all connections)
-  auto dereg_list = [](std::vector<ibv_mr*>& mrs, const char* name) {
-    for (auto*& mr : mrs) {
-      if (mr) {
-        ibv_dereg_mr(mr);
-        mr = nullptr;
+  // Deregister server MRs only if the destructor hasn't claimed ownership.
+  // If the destructor is running, it will handle MR cleanup after joining
+  // this thread, avoiding concurrent or double ibv_dereg_mr.
+  if (!server_mr_owned_by_destructor_.load()) {
+    auto dereg_list = [](std::vector<ibv_mr*>& mrs, const char* name) {
+      for (auto*& mr : mrs) {
+        if (mr) {
+          ibv_dereg_mr(mr);
+          mr = nullptr;
+        }
       }
-    }
-    mrs.clear();
-  };
-  dereg_list(write_cache_key_server_mr_list, "server key");
-  dereg_list(write_cache_value_server_mr_list, "server value");
-  dereg_list(write_cache_key_scale_server_mr_list, "server key scale");
-  dereg_list(write_cache_value_scale_server_mr_list, "server value scale");
+      mrs.clear();
+    };
+    dereg_list(write_cache_key_server_mr_list, "server key");
+    dereg_list(write_cache_value_server_mr_list, "server value");
+    dereg_list(write_cache_key_scale_server_mr_list, "server key scale");
+    dereg_list(write_cache_value_scale_server_mr_list, "server value scale");
+  }
 
   close(sockfd);
   close(epollfd);
@@ -748,14 +770,12 @@ int RDMACommunicator::connect(const std::string& dst_ip,
   }
 
   // Start client listener thread if not already started
-  if (start_client_listener == false) {
-    std::thread client_thread =
-        std::thread([this]() { this->client_listener(); });
-    if (client_thread.joinable()) {
-      client_thread.detach();
-      std::lock_guard<std::mutex> lock(mutex_);
+  if (!start_client_listener.load()) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!start_client_listener.load()) {
+      client_thread_ = std::thread([this]() { this->client_listener(); });
+      start_client_listener = true;
     }
-    start_client_listener = true;
   }
 
   // Add socket to epoll for event monitoring


### PR DESCRIPTION
## Motivation

Fix RDMA KV cache connection cleanup to reduce resource leaks in connection failure, disconnect, and communicator destruction paths.

## Modifications

- Negotiate QP path MTU with the smaller local/remote MTU.
- Add cleanup for QP/CQ/channel/socket/read-buffer resources in RDMA connection failure and destruction paths.
- Reuse server-side KV cache MRs across multiple connections and add cleanup for key/value scale MRs.
- Handle `client_exchange_mr` and `server_exchange_mr` failures instead of continuing with incomplete MR exchange.

## Usage or Command

N/A

## Accuracy Tests

N/A. This PR changes RDMA resource cleanup and does not change model numerical computation.

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.