### PR TITLE
[Cherry-Pick][CI] Remove deprecated IPC unit tests(#7974)

### DIFF
--- a/tests/cov_pytest.ini
+++ b/tests/cov_pytest.ini
@@ -12,3 +12,5 @@ addopts =
     --ignore=tests/e2e/golang_router
     --ignore=tests/v1/test_schedule_output.py
     --ignore=tests/graph_optimization/test_cuda_graph_dynamic_subgraph.py
+    --ignore=tests/e2e/test_ernie_03b_pd_decode_unified_attention.py
+    --ignore=tests/e2e/test_ernie_03b_pd_router_v1_ipc.py


### PR DESCRIPTION
Cherry-pick of #7974 (authored by @EmmonsCurse) to `release/2.6`.

devPR:https://github.com/PaddlePaddle/FastDeploy/pull/7974 <!-- For pass CI -->

---

<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

The IPC-related unit tests are no longer applicable and have been deprecated. Keeping these tests in CI introduces unnecessary maintenance overhead and execution time without providing meaningful validation coverage.

## Modifications

- Removed deprecated IPC-related unit tests.
- Cleaned up obsolete test coverage associated with IPC functionality.
- Reduced unnecessary CI execution workload and maintenance cost.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
- Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
- You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.