### PR TITLE
[CI][BugFix] Adapt test_token_penalty to Paddle uniform float16 behavior change

### DIFF
--- a/tests/cov_pytest.ini
+++ b/tests/cov_pytest.ini
@@ -14,4 +14,3 @@ addopts =
     --ignore=tests/graph_optimization/test_cuda_graph_dynamic_subgraph.py
     --ignore=tests/e2e/test_ernie_03b_pd_decode_unified_attention.py
     --ignore=tests/e2e/test_ernie_03b_pd_router_v1_ipc.py
-    --ignore=tests/operators/test_token_penalty.py

--- a/tests/operators/test_token_penalty.py
+++ b/tests/operators/test_token_penalty.py
@@ -44,8 +44,10 @@ class TestTokenPenalty(unittest.TestCase):
             for orig, penal in zip(original_values.numpy(), penalized_values.numpy()):
                 if orig < 0:
                     self.assertLess(penal, orig, "负值应该乘以惩罚因子")
-                else:
+                elif orig > 0:
                     self.assertLess(penal, orig, "正值应该除以惩罚因子")
+                else:
+                    self.assertEqual(penal, orig, "零值不受惩罚影响")
 
     def test_compare_with_naive_implementation(self):
         res = get_token_penalty_once(self.pre_ids, self.logits, self.penalty_scores)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

`tests/operators/test_token_penalty.py` fails after changes introduced in Paddle PR[ #79130](https://github.com/PaddlePaddle/Paddle/pull/79130), which modified `UniformKernel` behavior for `float16` precision.

Previously, `paddle.rand` in `float16` could produce values extremely close to `1.0` due to casting from `float32`. The test assumptions were based on this behavior.

After the fix in Paddle:

- When a sampled value equals `max (1.0)` after `float16` cast,
- It is now clamped back to `min (0.0)` to strictly enforce the half-open interval `[0, 1)`.

As a result, under fixed seed `2023`, some logits that were previously non-zero now become `0.0`.
This breaks the test assertion logic, which did not account for valid zero-valued logits.

## Modifications

- Updated `tests/operators/test_token_penalty.py` to adapt to new `float16` uniform sampling behavior.
- Adjusted assertion logic to handle cases where logits can be exactly `0.0`.
- Ensured compatibility with Paddle PR #79130 behavior change in `UniformKernel`.
- Preserved test correctness under revised random number distribution semantics.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
