### PR TITLE
[Cherry-Pick][BugFix] fix consume_signals barrier deadlock in PD separation(#8034)

### DIFF
--- a/fastdeploy/cache_manager/cache_messager.py
+++ b/fastdeploy/cache_manager/cache_messager.py
@@ -892,8 +892,6 @@ class CacheMessagerV1:
                 layer_id = kv_signal_data[1].item()
                 if layer_id == self.num_layers - 1:
                     logger.info(f"tasks_count: {tasks_count}, layer_id: {layer_id} self.rank_id {self.rank_id}")
-                ready_engine_signals = []
-                pending_engine_signals = []
                 # format for signal to put in cache_prefilled_engine_ids_queue: [(engine_idx1, prefilled_token_num1), (engine_idx2, prefilled_token_num2)]
                 with self.engine_cache_task_thread_lock:
                     for bi in range(tasks_count):
@@ -904,21 +902,19 @@ class CacheMessagerV1:
                         self.engine_cache_tasks[engine_idx]["prefilled_layer_idx"] = layer_id
                         self.engine_cache_tasks[engine_idx]["prefilled_token_num"] = prefilled_token_num
                         if layer_id == 0:
-                            if engine_idx in self.idx_cache_task_dict:
-                                ready_engine_signals.append((engine_idx, prefilled_token_num))
-                            else:
-                                pending_engine_signals.append((engine_idx, prefilled_token_num))
-                    if pending_engine_signals:
-                        with self.pending_layer0_signal_lock:
-                            for engine_idx, prefilled_token_num in pending_engine_signals:
+                            with self.pending_layer0_signal_lock:
                                 self.pending_layer0_signals[engine_idx] = (engine_idx, prefilled_token_num)
-                if pending_engine_signals:
-                    logger.debug(f"cache_task_pending_layer0_signal: {pending_engine_signals}")
-                if ready_engine_signals:
-                    logger.info(
-                        f"Put batch_engine_signals {ready_engine_signals} into cache_prefilled_engine_ids_queue"
-                    )
-                    self.cache_prefilled_engine_ids_queue.put(ready_engine_signals)
+                    # Recover signals for engine_idxs that already have cache_info registered.
+                    # This handles the case where cache_info arrives before layer0 signal.
+                    recovered_signals = []
+                    with self.pending_layer0_signal_lock:
+                        for engine_idx in list(self.pending_layer0_signals.keys()):
+                            if engine_idx in self.idx_cache_task_dict:
+                                recovered_signals.append(self.pending_layer0_signals.pop(engine_idx))
+                if recovered_signals:
+                    for signal in recovered_signals:
+                        logger.info(f"consume_signals recovered signal: {signal}")
+                        self.cache_prefilled_engine_ids_queue.put([signal])
             except Exception as e:
                 logger.error(f"Consume signals get exception: {e}")
 


### PR DESCRIPTION
Cherry-pick of https://github.com/PaddlePaddle/FastDeploy/pull/8034 to release/2.6.

## Problem

In PD separation mode, `consume_signals` thread splits layer0 signals into `ready_engine_signals` and `pending_engine_signals` based on whether `engine_idx` exists in `idx_cache_task_dict`. Since `_add_cache_task_thread` fills `idx_cache_task_dict` asynchronously, different ranks may see different states at the same moment, causing mismatched `finish_send_cache_barrier.wait()` calls and **deadlock**.

## Fix

Route all layer0 signals through `pending_layer0_signals` uniformly. The `_add_cache_task_thread` recovers them one-by-one after `cache_info` arrives, ensuring all ranks produce identical per-request signals into the queue.