### PR TITLE
[Models] fix fleet model fallback ep init

### DIFF
--- a/fastdeploy/config.py
+++ b/fastdeploy/config.py
@@ -319,7 +319,7 @@ class ModelConfig:
         if self.runner_type == "generate" and not is_generative_model:
             if is_multimodal_model:
                 pass
-            elif self.model_impl in ("auto", "paddleformers"):
+            elif self.model_impl in ("auto", "paddleformers", "paddlefleet"):
                 # Skip check for auto/paddleformers - may fallback to paddleformers which supports any model
                 pass
             else:

--- a/fastdeploy/model_executor/models/paddleformers/base_fleet.py
+++ b/fastdeploy/model_executor/models/paddleformers/base_fleet.py
@@ -414,12 +414,24 @@ else:
                 f"ep={parallel_config.expert_parallel_size}, "
                 f"sp={parallel_config.sequence_parallel})"
             )
-
+            import paddle.distributed as dist
             from paddlefleet import parallel_state
 
-            if parallel_state._TENSOR_MODEL_PARALLEL_GROUP is None:
-                hcg = fleet.get_hybrid_communicate_group()
-                parallel_state.initialize_model_parallel(hcg)
+            tp_group = parallel_state._TENSOR_MODEL_PARALLEL_GROUP
+            current_tp_size = None
+            if tp_group is not None:
+                current_tp_size = getattr(tp_group, "nranks", None)
+                if current_tp_size is None:
+                    current_tp_size = getattr(tp_group, "world_size", None)
+
+            expected_tp_size = parallel_config.tensor_parallel_size
+            need_init = tp_group is None or current_tp_size != expected_tp_size
+            if need_init:
+                if expected_tp_size == 1:
+                    parallel_state._TENSOR_MODEL_PARALLEL_GROUP = dist.new_group(ranks=[dist.get_rank()])
+                else:
+                    hcg = fleet.get_hybrid_communicate_group()
+                    parallel_state.initialize_model_parallel(hcg)
 
             from paddlefleet.tensor_parallel.random import (
                 model_parallel_cuda_manual_seed,

--- a/fastdeploy/model_executor/models/paddleformers/base_fleet.py
+++ b/fastdeploy/model_executor/models/paddleformers/base_fleet.py
@@ -290,8 +290,6 @@ else:
 
             # Assign parallel config from fd_config.parallel_config to paddleformers_config
             parallel_config = fd_config.parallel_config
-            # parallel_config.tensor_parallel_size = 1
-            # parallel_config.expert_parallel_size = 2
             self.paddleformers_config.data_parallel_size = parallel_config.data_parallel_size
             self.paddleformers_config.tensor_model_parallel_size = parallel_config.tensor_parallel_size
             self.paddleformers_config.sequence_parallel = parallel_config.sequence_parallel
@@ -305,6 +303,8 @@ else:
             # self.paddleformers_config.moe_grouped_gemm = True
             self.paddleformers_config.moe_token_dispatcher_type = "deepep"
             # self.paddleformers_config.use_cpu_initialization = True
+            self.paddleformers_config.use_cpu_initialization = True
+            self.paddleformers_config.perform_initialization = False
             self.paddleformers_config.gated_attention = getattr(self.paddleformers_config, "use_gated_attn", False)
             if getattr(self.paddleformers_config, "multi_latent_attention", False):
                 self.paddleformers_config.qk_head_dim = (
@@ -396,6 +396,16 @@ else:
                     "mp",
                 ],
             }
+            # Reset parallel state so that PaddleFleet's fleet.init can reinitialize
+            # with the correct EP topology instead of reusing FastDeploy's.
+            import paddle.distributed.fleet.base.topology as tp_mod
+            import paddle.distributed.parallel_helper as ph
+
+            # 1) Reset hybrid parallel group so _init_hybrid_parallel_env runs again
+            tp_mod._HYBRID_PARALLEL_GROUP = None
+            # 2) Reset parallel context so init_parallel_env runs again
+            ph.__parallel_ctx__clz__ = None
+
             fleet.init(is_collective=True, strategy=strategy)
             logger.info(
                 f"Initialized PaddleFleet parallel_state via initialize_fleet "
@@ -405,40 +415,11 @@ else:
                 f"sp={parallel_config.sequence_parallel})"
             )
 
-            import paddle.distributed as dist
             from paddlefleet import parallel_state
 
-            hcg = fleet.get_hybrid_communicate_group()
-            expected_tp_size = parallel_config.tensor_parallel_size
-
-            # Check if we need to initialize or reinitialize TP group
-            need_init = False
             if parallel_state._TENSOR_MODEL_PARALLEL_GROUP is None:
-                need_init = True
-                reason = "TP group not initialized"
-            else:
-                # Check if current TP group size matches expected
-                current_tp_group = parallel_state._TENSOR_MODEL_PARALLEL_GROUP
-                current_tp_size = getattr(current_tp_group, "nranks", None)
-                if current_tp_size is None:
-                    current_tp_size = getattr(current_tp_group, "world_size", None)
-                if current_tp_size != expected_tp_size:
-                    need_init = True
-                    reason = f"TP group size mismatch: current={current_tp_size}, expected={expected_tp_size}"
-
-            if need_init:
-                logger.warning(f"{reason}, reinitializing TP group with size={expected_tp_size}")
-                if expected_tp_size == 1:
-                    # Single process TP group - create manually
-                    current_rank = dist.get_rank()
-                    tp_ranks = [current_rank]
-                    default_pg = dist.new_group(ranks=tp_ranks)
-                    parallel_state._TENSOR_MODEL_PARALLEL_GROUP = default_pg
-                    parallel_state._TENSOR_MODEL_PARALLEL_GLOBAL_RANKS = tp_ranks
-                    logger.info(f"Reinitialized TP group with size=1, rank={current_rank}, ranks={tp_ranks}")
-                else:
-                    # Multiple processes - use hcg's mp group
-                    parallel_state.initialize_model_parallel(hcg)
+                hcg = fleet.get_hybrid_communicate_group()
+                parallel_state.initialize_model_parallel(hcg)
 
             from paddlefleet.tensor_parallel.random import (
                 model_parallel_cuda_manual_seed,


### PR DESCRIPTION
## Motivation
修复 `--model-impl paddlefleet` fallback 场景下生成模型校验与 Expert Parallel 初始化状态复用问题，避免 PaddleFleet 初始化时使用不匹配的 TP/EP parallel state。

## Modifications
- `fastdeploy/config.py`：允许 `model_impl=paddlefleet` 在 `runner_type=generate` 且模型未被 FastDeploy 原生 registry 标记为生成模型时继续走 fallback。
- `fastdeploy/model_executor/models/paddleformers/base_fleet.py`：为 PaddleFleet fallback 配置 CPU 初始化和跳过参数初始化，并在 `fleet.init()` 前重置 Paddle Fleet hybrid topology。

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [x ] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
