### PR TITLE
remove useless code

### DIFF
--- a/fastdeploy/model_executor/models/deepseek_v3.py
+++ b/fastdeploy/model_executor/models/deepseek_v3.py
@@ -316,6 +316,10 @@ class DeepseekV3MLAAttention(nn.Layer):
                 ]
                 if key in self.rope_scaling
             }
+
+            # used for dsa attention.
+            self.rope_scaling_kwargs = rope_scaling_kwargs
+
             self.rope_scaling_factor = self.rope_scaling["factor"]
             self.rope_scaling_original_max_position_embeddings = self.rope_scaling["original_max_position_embeddings"]
             self.rotary_emb = DeepseekScalingRotaryEmbedding(
@@ -823,7 +827,7 @@ class Indexer(nn.Layer):
         return indexer_top_k
 
 
-class DeepseekV32DSAAttention(nn.Layer):
+class DeepseekV32DSAAttention(DeepseekV3MLAAttention):
     """
     DeepseekV32DSAAttention
     """
@@ -831,135 +835,26 @@ class DeepseekV32DSAAttention(nn.Layer):
     def __init__(self, fd_config: FDConfig, layer_id: int, prefix: str = "") -> None:
         super().__init__()
 
-        self.tp_size = fd_config.parallel_config.tensor_parallel_size
-        self.hidden_size = fd_config.model_config.hidden_size
-        self.num_attention_heads = fd_config.model_config.num_attention_heads
-        self.num_attention_heads_tp = self.num_attention_heads // self.tp_size
-
-        # MLA
-        self.qk_nope_head_dim = fd_config.model_config.qk_nope_head_dim
-        self.qk_rope_head_dim = fd_config.model_config.qk_rope_head_dim
-        self.qk_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
-        self.v_head_dim = fd_config.model_config.v_head_dim
-        self.q_lora_rank = fd_config.model_config.q_lora_rank
-        self.kv_lora_rank = fd_config.model_config.kv_lora_rank
-
         # Indexer
         self.index_head_dim = fd_config.model_config.index_head_dim
         self.index_n_heads = fd_config.model_config.index_n_heads
         self.index_topk = fd_config.model_config.index_topk
 
-        self.attn_softmax_scale = self.qk_head_dim**-0.5
-        self.rope_theta = fd_config.model_config.rope_theta
         if fd_config.model_config.model_type == "glm_moe_dsa":
             self.rope_theta = fd_config.model_config.rope_parameters["rope_theta"]
 
-        self.rms_norm_eps = fd_config.model_config.rms_norm_eps
-
-        assert self.q_lora_rank is not None, "self.q_lora_rank is None, Please Check your config."
-
-        self.qkv_a_proj_with_mqa = MergedReplicatedLinear(
-            fd_config=fd_config,
-            prefix=f"{prefix}.qkv_a_proj_with_mqa",
-            input_size=self.hidden_size,
-            output_sizes=[self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
-            with_bias=False,
-        )
-
-        self.q_a_layernorm = RMSNorm(
-            fd_config,
-            hidden_size=self.q_lora_rank,
-            eps=self.rms_norm_eps,
-            prefix=f"{prefix}.q_a_layernorm",
-        )
-
-        self.q_b_proj = ColumnParallelLinear(
-            fd_config=fd_config,
-            prefix=f"{prefix}.q_b_proj",
-            input_size=self.q_lora_rank,
-            output_size=self.num_attention_heads * self.qk_head_dim,
-            with_bias=False,
-        )
-
-        self.kv_a_layernorm = RMSNorm(
-            fd_config,
-            hidden_size=self.kv_lora_rank,
-            eps=self.rms_norm_eps,
-            prefix=f"{prefix}.kv_a_layernorm",
-        )
-
-        self.kv_b_proj = ColumnParallelLinear(
-            fd_config=fd_config,
-            prefix=f"{prefix}.kv_b_proj",
-            input_size=self.kv_lora_rank,
-            output_size=self.num_attention_heads * (self.qk_nope_head_dim + self.v_head_dim),
-            with_bias=False,
-        )
-
-        self.o_proj = RowParallelLinear(
-            fd_config,
-            prefix=f"{prefix}.o_proj",
-            input_size=self.num_attention_heads * self.v_head_dim,
-            output_size=self.hidden_size,
-            with_bias=False,
-            layer_id=layer_id,
-        )
-
-        self.kv_b_proj_bmm = KVBatchLinear(
-            fd_config=fd_config,
-            kv_b_proj=self.kv_b_proj,
-            prefix=f"{prefix}.kv_b_proj",
-            kv_lora_rank=self.kv_lora_rank,
-            num_attention_heads=self.num_attention_heads,
-            qk_nope_head_dim=self.qk_nope_head_dim,
-            v_head_dim=self.v_head_dim,
-        )
-        self.rope_scaling = getattr(fd_config.model_config, "rope_scaling", None)
         if self.rope_scaling and "factor" in self.rope_scaling:
-            mscale_all_dim = self.rope_scaling.get("mscale_all_dim", False)
-            scaling_factor = self.rope_scaling["factor"]
-            mscale = self.yarn_get_mscale(scaling_factor, float(mscale_all_dim))
-            self.attn_softmax_scale = self.attn_softmax_scale * mscale * mscale
-
-            rope_scaling_kwargs = {
-                key: self.rope_scaling[key]
-                for key in [
-                    "beta_fast",
-                    "beta_slow",
-                    "mscale",
-                    "mscale_all_dim",
-                ]
-                if key in self.rope_scaling
-            }
-            self.rope_scaling_factor = self.rope_scaling["factor"]
-            self.rope_scaling_original_max_position_embeddings = self.rope_scaling["original_max_position_embeddings"]
-            self.rotary_emb = DeepseekScalingRotaryEmbedding(
-                self.qk_rope_head_dim,
-                max_position_embeddings=self.rope_scaling_original_max_position_embeddings,
-                base=self.rope_theta,
-                scaling_factor=self.rope_scaling_factor,
-                **rope_scaling_kwargs,
-            )
             self.indexer_rotary_emb = DeepseekScalingRotaryEmbedding(
                 self.qk_rope_head_dim,
                 max_position_embeddings=self.rope_scaling_original_max_position_embeddings,
                 base=self.rope_theta,
                 scaling_factor=self.rope_scaling_factor,
-                **rope_scaling_kwargs,
+                **self.rope_scaling_kwargs,
             )
         else:
-            # Default rope without scaling
-            # The current `max_model_len` can cover the maximum context length.
-            max_position_embeddings = getattr(fd_config.model_config, "max_model_len", 8192)
-            self.rotary_emb = DeepseekScalingRotaryEmbedding(
-                self.qk_rope_head_dim,
-                max_position_embeddings=max_position_embeddings,
-                base=self.rope_theta,
-                scaling_factor=1.0,
-            )
             self.indexer_rotary_emb = DeepseekScalingRotaryEmbedding(
                 self.qk_rope_head_dim,
-                max_position_embeddings=max_position_embeddings,
+                max_position_embeddings=getattr(fd_config.model_config, "max_model_len", 8192),
                 base=self.rope_theta,
                 scaling_factor=1.0,
             )
@@ -975,15 +870,6 @@ class DeepseekV32DSAAttention(nn.Layer):
             prefix=prefix,
             use_neox_rotary_style=False,
         )
-
-        self.prefix = prefix
-
-    @staticmethod
-    def yarn_get_mscale(scale=1, mscale=1):
-        """ """
-        if scale <= 1:
-            return 1.0
-        return 0.1 * mscale * math.log(scale) + 1.0
 
     def forward(
         self,

--- a/fastdeploy/model_executor/models/deepseek_v3.py
+++ b/fastdeploy/model_executor/models/deepseek_v3.py
@@ -227,7 +227,12 @@ class DeepseekV3MLAAttention(nn.Layer):
         self.kv_lora_rank = fd_config.model_config.kv_lora_rank
 
         self.attn_softmax_scale = self.qk_head_dim**-0.5
-        self.rope_theta = fd_config.model_config.rope_theta
+
+        if fd_config.model_config.model_type == "glm_moe_dsa":
+            self.rope_theta = fd_config.model_config.rope_parameters["rope_theta"]
+        else:
+            self.rope_theta = fd_config.model_config.rope_theta
+
         self.rms_norm_eps = fd_config.model_config.rms_norm_eps
 
         assert self.q_lora_rank is not None, "self.q_lora_rank is None, Please Check your config."
@@ -833,9 +838,6 @@ class DeepseekV32DSAAttention(DeepseekV3MLAAttention):
         self.index_head_dim = fd_config.model_config.index_head_dim
         self.index_n_heads = fd_config.model_config.index_n_heads
         self.index_topk = fd_config.model_config.index_topk
-
-        if fd_config.model_config.model_type == "glm_moe_dsa":
-            self.rope_theta = fd_config.model_config.rope_parameters["rope_theta"]
 
         if self.rope_scaling and "factor" in self.rope_scaling:
             self.indexer_rotary_emb = DeepseekScalingRotaryEmbedding(

--- a/fastdeploy/model_executor/models/deepseek_v3.py
+++ b/fastdeploy/model_executor/models/deepseek_v3.py
@@ -833,7 +833,7 @@ class DeepseekV32DSAAttention(DeepseekV3MLAAttention):
     """
 
     def __init__(self, fd_config: FDConfig, layer_id: int, prefix: str = "") -> None:
-        super().__init__()
+        super().__init__(fd_config, layer_id, prefix)
 
         # Indexer
         self.index_head_dim = fd_config.model_config.index_head_dim

--- a/fastdeploy/model_executor/models/deepseek_v3.py
+++ b/fastdeploy/model_executor/models/deepseek_v3.py
@@ -201,9 +201,6 @@ class DeepSeekV3MoE(nn.Layer):
 
 
 class DeepseekV3MLAAttention(nn.Layer):
-    """
-    DeepseekV3MLAAttention
-    """
 
     def __init__(self, fd_config: FDConfig, layer_id: int, prefix: str = "") -> None:
         super().__init__()
@@ -828,9 +825,6 @@ class Indexer(nn.Layer):
 
 
 class DeepseekV32DSAAttention(DeepseekV3MLAAttention):
-    """
-    DeepseekV32DSAAttention
-    """
 
     def __init__(self, fd_config: FDConfig, layer_id: int, prefix: str = "") -> None:
         super().__init__(fd_config, layer_id, prefix)
@@ -927,9 +921,6 @@ class DeepseekV32DSAAttention(DeepseekV3MLAAttention):
 
 
 class DeepSeekV3DecoderLayer(nn.Layer):
-    """
-    DeepSeekV3DecoderLayer
-    """
 
     def __init__(
         self,
@@ -1007,9 +998,6 @@ class DeepSeekV3DecoderLayer(nn.Layer):
 
 @support_graph_optimization
 class DeepSeekV3Model(nn.Layer):
-    """
-    DeepSeekV3Model
-    """
 
     def __init__(
         self,
@@ -1077,9 +1065,6 @@ class DeepSeekV3Model(nn.Layer):
     primary_use=ModelCategory.TEXT_GENERATION,
 )
 class DeepseekV3ForCausalLM(ModelForCasualLM):
-    """
-    DeepseekV3ForCausalLM
-    """
 
     def __init__(self, fd_config: FDConfig):
         """
@@ -1228,9 +1213,6 @@ class DeepseekV3ForCausalLM(ModelForCasualLM):
 
 
 class DeepSeekV3PretrainedModel(PretrainedModel):
-    """
-    DeepSeekV3PretrainedModel
-    """
 
     config_class = FDConfig
 


### PR DESCRIPTION
> 🤖 Paddle-CI-Agent | pr_review | `2026-06-12 21:27:01`

## 📋 Review 摘要

**PR 概述**：复用 DeepseekV3MLAAttention 初始化 DSA attention，并移除空类 docstring。
**变更范围**：`fastdeploy/model_executor/models/deepseek_v3.py`
**影响面 Tag**：`[Models]`

### 问题

未发现阻塞性问题。PR 规范问题在下面章节报，不要在这里重复。

### 历史 Findings 修复情况

| Finding | 问题 | 状态 |
|---------|------|------|
| [F1](https://github.com/PaddlePaddle/FastDeploy/pull/8042#pullrequestreview-4484678149) | `glm_moe_dsa` 主 DSA rotary_emb 使用错误 `rope_theta` | ✅ 已修复 |

### 📝 PR 规范检查
标题缺少官方 Tag，PR 描述仍是空模板。建议替换为以下内容。

**标题建议**（可直接复制）：
- `[Models] Initialize DeepSeek V32 DSA attention correctly`

<details>
<summary><b>PR 描述建议</b>（点击展开，可直接复制）</summary>

```markdown
## Motivation
Initialize DeepseekV32DSAAttention through the MLA attention base class and remove empty class docstrings.

## Modifications
- `fastdeploy/model_executor/models/deepseek_v3.py`: pass `fd_config`, `layer_id`, and `prefix` to the parent attention initializer for DSA attention.
- Remove redundant empty class docstrings in DeepSeek V3 model classes.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
```

</details>

### 总体评价
当前代码在父类构造 `rotary_emb` 前按 `glm_moe_dsa` 改用 `rope_parameters` 下的 `rope_theta`，`DeepseekV32DSAAttention` 继承初始化后主 attention 与 indexer attention 使用同一个修正后的 RoPE base，历史问题已修复。未发现新的代码阻塞项；仍建议补齐 PR 标题、描述和测试/精度说明。

<!-- AI_CI_FINDING_STATUS_UPDATES
[
  {
    "id": "f_8112021e",
    "status": "resolved",
    "confidence": "high",
    "evidence": "当前 diff 在父类构造 rotary_emb 前先为 glm_moe_dsa 设置 rope_parameters 下的 rope_theta，并让 DSA 继承该初始化。"
  }
]
-->
