### PR TITLE
[BugFix] Fix attention buffer sizing for per-layer KV heads

### DIFF
--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -1749,7 +1749,8 @@ class GPUModelRunner(ModelRunnerBase):
             decoder_block_shape_q=decoder_block_shape_q,
             decoder_step_token_num=self.speculative_config.num_speculative_tokens + 1,
             num_heads=num_heads,
-            kv_num_heads=max(kv_num_heads_per_layer),
+            # This requires the largest possible group size, corresponding to the smallest kv-num-heads.
+            kv_num_heads=min(kv_num_heads_per_layer),
             block_size=self.fd_config.cache_config.block_size,
             head_dim=head_dim,
             dtype=self.model_config.dtype,


### PR DESCRIPTION
## Motivation
修复分层 `num_key_value_heads_list` 场景下 attention backend 共享 buffer 预分配容量不足的问题。

## Modifications
- `fastdeploy/worker/gpu_model_runner.py`：初始化 attention backend buffer 时，使用 per-layer KV heads 中的最小值计算最大 `group_size`，避免按较大的 KV head 数低估 `decoder_*` / `encoder_*` tile buffer。

## Usage or Command
N/A

## Accuracy Tests
N/A（未提供精度数据；本次 diff 仅调整 attention backend buffer 分配参数。）

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.