### PR TITLE
[Docs] Add Mooncake HA redis backend deployment example

### DIFF
--- a/docs/features/global_cache_pooling.md
+++ b/docs/features/global_cache_pooling.md
@@ -48,7 +48,8 @@ Ready-to-use example scripts are available in [examples/cache_storage/](../../..
 |--------|----------|-------------|
 | `run.sh` | Multi-Instance | Two standalone instances sharing cache |
 | `run_03b_pd_storage.sh` | PD Disaggregation | P+D instances with global cache pooling |
-| `run_ha.sh` | High Availability | etcd + multi-master leader election, verifies failover after killing the leader |
+| `run_ha.sh` | High Availability (etcd) | etcd + multi-master leader election, verifies failover after killing the leader |
+| `run_ha_redis.sh` | High Availability (redis) | single redis + multi-master leader election, verifies failover after killing the leader |
 
 ## Prerequisites
 
@@ -287,14 +288,19 @@ curl -X POST "http://0.0.0.0:52700/v1/chat/completions" \
 
 ### Scenario 3: High-Availability (HA) Deployment
 
-A single master is a single point of failure; if it crashes, cluster operations pause. For production, use the **etcd + multi-master** mode: multiple `mooncake_master` instances perform leader election through etcd. When the leader fails, a standby is automatically re-elected, transparently to clients.
+A single master is a single point of failure; if it crashes, cluster operations pause. For production, run multiple `mooncake_master` instances that perform leader election through a coordination backend. When the leader fails, a standby is automatically re-elected, transparently to clients.
+
+Two coordination backends are supported:
+
+- **etcd** (`run_ha.sh`): a 3-node etcd cluster does election and metadata storage.
+- **redis** (`run_ha_redis.sh`): a single redis instance does lease-based election. Use this to avoid introducing etcd as an extra component.
 
 **Architecture:**
 
 ```
             ┌──────────────────────────────────────┐
-            │           etcd cluster (3 nodes)      │
-            │     leader election / metadata store  │
+            │   coordination backend (etcd / redis) │
+            │     leader election (master_view)     │
             └───────────────────┬──────────────────┘
                                 │ election (master_view)
           ┌─────────────────────┼─────────────────────┐
@@ -304,13 +310,44 @@ A single master is a single point of failure; if it crashes, cluster operations 
    │ rpc:8081    │       │ rpc:8082    │       │ rpc:8083    │
    │ (leader)    │       │ (standby)   │       │ (standby)   │
    └──────┬──────┘       └─────────────┘       └─────────────┘
-          │  FastDeploy clients discover the current leader via etcd
+          │  FastDeploy clients discover the current leader via the backend
    ┌──────┴───────┐
    ▼              ▼
 server_0      server_1
 ```
 
-#### Prerequisites
+#### Build Mooncake from source
+
+HA mode requires Mooncake built with the matching backend enabled:
+
+- etcd: `-DSTORE_USE_ETCD=ON -DUSE_ETCD=ON`
+- redis: `-DSTORE_USE_REDIS=ON -DUSE_REDIS=ON` (build dependency: `libhiredis-dev`)
+
+```bash
+git clone https://github.com/kvcache-ai/Mooncake.git
+cd Mooncake
+bash dependencies.sh
+
+mkdir -p build && cd build
+cmake .. -DSTORE_USE_ETCD=ON -DUSE_ETCD=ON   # add -DSTORE_USE_REDIS=ON -DUSE_REDIS=ON for redis
+make -j
+sudo make install
+cd ..
+
+./scripts/build_wheel.sh
+pip install mooncake-wheel/dist/*.whl
+```
+
+For the CUDA 13 build, use the following instead:
+
+```bash
+cd Mooncake
+export CU13_BUILD=1
+./scripts/build_wheel.sh
+pip install mooncake-wheel/dist/mooncake_transfer_engine_cuda13-*.whl
+```
+
+#### Option A: etcd backend (`run_ha.sh`)
 
 **1. Install etcd**
 
@@ -325,42 +362,9 @@ export PATH=$PWD/etcd-${ETCD_VER}-linux-amd64:$PATH
 etcd --version
 ```
 
-**2. Build Mooncake from source (with etcd support)**
+**2. Client configuration** (`ha_mooncake_config.json`)
 
-HA mode requires Mooncake built with etcd support (`-DSTORE_USE_ETCD=ON -DUSE_ETCD=ON`). Install dependencies first, then build:
-
-```bash
-# Download the source
-git clone https://github.com/kvcache-ai/Mooncake.git
-cd Mooncake
-
-# Install system & third-party dependencies
-bash dependencies.sh
-
-# Build C++ components (including mooncake_master, with etcd enabled)
-mkdir -p build && cd build
-cmake .. -DSTORE_USE_ETCD=ON -DUSE_ETCD=ON
-make -j
-sudo make install
-cd ..
-
-# Build and install the Python wheel
-./scripts/build_wheel.sh
-pip install mooncake-wheel/dist/*.whl
-```
-
-For the CUDA 13 build, use the following instead:
-
-```bash
-cd Mooncake
-export CU13_BUILD=1
-./scripts/build_wheel.sh
-pip install mooncake-wheel/dist/mooncake_transfer_engine_cuda13-*.whl
-```
-
-#### HA Client Configuration
-
-In HA mode, both `metadata_server` and `master_server_addr` use the `etcd://` prefix pointing to the etcd cluster; clients discover the current leader through etcd (`ha_mooncake_config.json`):
+Both `metadata_server` and `master_server_addr` use the `etcd://` prefix; clients discover the current leader through etcd:
 
 ```json
 {
@@ -373,45 +377,77 @@ In HA mode, both `metadata_server` and `master_server_addr` use the `etcd://` pr
 }
 ```
 
-#### One-Command Launch & Failover Verification
-
-A single self-contained script `examples/cache_storage/run_ha.sh` handles the whole flow — it starts the etcd cluster and the HA master cluster inline (each via a 3-iteration loop), so no separate `start_*.sh` is needed.
-
-Run directly:
+**3. Run**
 
 ```bash
 cd examples/cache_storage
 bash run_ha.sh
 ```
 
-What `run_ha.sh` does:
+The script starts a 3-node etcd cluster (client ports 12379/22379/32379), 3 HA masters (rpc 8081/8082/8083), and 2 FastDeploy instances; the leader address is written to the etcd key `mooncake-store/mooncake_cluster/master_view`.
 
-1. **Start the etcd cluster**: a loop launches 3 etcd nodes (client ports 12379/22379/32379) forming a raft cluster, after a port check.
-2. **Start 3 HA masters**: a loop launches 3 `mooncake_master` (rpc 8081/8082/8083, metrics 9091/9092/9093), each with `--enable_ha --etcd_endpoints ... --rpc_port ...`, electing one leader via etcd. The leader address is written to the etcd key `mooncake-store/mooncake_cluster/master_view`.
-3. **Start 2 FastDeploy instances**, both joining the same cache pool with `--kvcache-storage-backend mooncake`.
-4. **Verify pooling (before failover)**: warm up prompt **A** on `server_0`, then send the same prompt to `server_1`, which should hit the global cache.
-5. **Kill the leader**: the script reads the current leader's `rpc_port` from etcd, `kill -9`s that process, triggering re-election.
-6. **Verify pooling (after failover)**: once etcd's `master_view` is updated to the new leader, warm up a **brand-new** prompt **B** (never sent before) on `server_0`, then reuse it on `server_1`. Using a fresh prompt ensures the hit on `server_1` can only come from the new leader's global pool, rather than stale local cache from step 4.
+Inspect the current leader manually:
 
-> Check the election state manually:
->
-> ```bash
-> # Current leader (rpc_address:rpc_port)
-> etcdctl --endpoints=http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379 \
->   get "mooncake-store/mooncake_cluster/master_view" --print-value-only
-> ```
->
-> Per-master roles can be seen in `log_master_1` / `log_master_2` / `log_master_3` (`role=leader` / `role=standby`), and etcd logs in `log_etcd_1` / `log_etcd_2` / `log_etcd_3`.
+```bash
+etcdctl --endpoints=http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379 \
+  get "mooncake-store/mooncake_cluster/master_view" --print-value-only
+```
+
+#### Option B: redis backend (`run_ha_redis.sh`)
+
+**1. Client configuration** (`ha_redis_mooncake_config.json`)
+
+Both `metadata_server` and `master_server_addr` use the `redis://` prefix pointing to the single redis instance:
+
+```json
+{
+  "metadata_server": "redis://127.0.0.1:6399",
+  "global_segment_size": 1000000000,
+  "local_buffer_size": 134217728,
+  "protocol": "rdma",
+  "rdma_devices": "",
+  "master_server_addr": "redis://127.0.0.1:6399"
+}
+```
+
+**2. Run**
+
+```bash
+cd examples/cache_storage
+bash run_ha_redis.sh
+```
+
+The script starts a single redis instance (port 6399), 3 HA masters (rpc 8081/8082/8083) launched with `--ha_backend_type redis --ha_backend_connstring redis://127.0.0.1:6399`, and 2 FastDeploy instances. The master_view is a redis HASH at `mooncake-store/{mooncake_cluster}/master_view`.
+
+Inspect the current leader manually:
+
+```bash
+redis-cli -p 6399 hget "mooncake-store/{mooncake_cluster}/master_view" leader_address
+```
+
+#### What the HA scripts verify
+
+Both scripts run the same flow and verify failover:
+
+1. Start the coordination backend (etcd cluster / single redis).
+2. Start 3 HA masters; one is elected leader and published to `master_view`.
+3. Start 2 FastDeploy instances, both joining the same cache pool with `--kvcache-storage-backend mooncake`.
+4. **Before failover**: warm up prompt **A** on `server_0`, then send the same prompt to `server_1`, which should hit the global cache.
+5. **Kill the leader**: read the current leader's `rpc_port` from the backend and `kill -9` it, triggering re-election.
+6. **After failover**: once `master_view` updates to the new leader, warm up a **brand-new** prompt **B** on `server_0`, then reuse it on `server_1`. Using a fresh prompt ensures the hit can only come from the new leader's global pool, not stale local cache from step 4.
+
+Per-master roles can be seen in `log_master_1` / `log_master_2` / `log_master_3` (`role=leader` / `role=standby`).
 
 #### Key HA Master Parameters
 
 | Parameter | Description |
 |-----------|-------------|
 | `--enable_ha` | Enable HA mode |
+| `--ha_backend_type` | Coordination backend: `etcd` (default) or `redis` |
 | `--etcd_endpoints` | etcd endpoints, semicolon separated (when `ha_backend_type=etcd`) |
+| `--ha_backend_connstring` | Backend connection string, e.g. `redis://127.0.0.1:6399` (when `ha_backend_type=redis`) |
 | `--rpc_address` / `--rpc_port` | This master's reachable RPC address and port (must be unique per instance) |
 | `--cluster_id` | Cluster identifier; masters in the same cluster must match |
-| `--root_fs_dir` | Storage root directory in HA mode (unique per instance) |
 
 ## FastDeploy Parameters for Mooncake
 

--- a/docs/zh/features/global_cache_pooling.md
+++ b/docs/zh/features/global_cache_pooling.md
@@ -48,7 +48,8 @@
 |------|------|------|
 | `run.sh` | 多实例缓存共享 | 两个独立实例共享缓存 |
 | `run_03b_pd_storage.sh` | PD 分离 | P+D 实例配合全局缓存池 |
-| `run_ha.sh` | 高可用（HA） | etcd + 多 Master 选主，杀掉 leader 后验证 failover |
+| `run_ha.sh` | 高可用（etcd） | etcd + 多 Master 选主，杀掉 leader 后验证 failover |
+| `run_ha_redis.sh` | 高可用（redis） | 单 redis + 多 Master 选主，杀掉 leader 后验证 failover |
 
 ## 环境要求
 
@@ -286,14 +287,19 @@ curl -X POST "http://0.0.0.0:52700/v1/chat/completions" \
 
 ### 场景三：高可用（HA）部署
 
-单 Master 是单点，崩溃后集群操作会暂停。生产环境推荐使用 **etcd + 多 Master** 模式：多个 `mooncake_master` 通过 etcd 进行 leader 选举，leader 故障后由备节点自动重新选主，客户端无感切换。
+单 Master 是单点，崩溃后集群操作会暂停。生产环境建议运行多个 `mooncake_master`，通过协调后端进行 leader 选举；leader 故障后由备节点自动重新选主，客户端无感切换。
+
+支持两种协调后端：
+
+- **etcd**（`run_ha.sh`）：3 节点 etcd 集群负责选主与元数据存储。
+- **redis**（`run_ha_redis.sh`）：单个 redis 实例做基于租约（lease）的选主。用它可以避免额外引入 etcd 组件。
 
 **架构图：**
 
 ```
             ┌──────────────────────────────────────┐
-            │            etcd 集群 (3 节点)         │
-            │       leader 选举 / 元数据存储        │
+            │     协调后端 (etcd / redis)           │
+            │       leader 选举 (master_view)       │
             └───────────────────┬──────────────────┘
                                 │ 选主 (master_view)
           ┌─────────────────────┼─────────────────────┐
@@ -303,13 +309,44 @@ curl -X POST "http://0.0.0.0:52700/v1/chat/completions" \
    │ rpc:8081    │       │ rpc:8082    │       │ rpc:8083    │
    │ (leader)    │       │ (standby)   │       │ (standby)   │
    └──────┬──────┘       └─────────────┘       └─────────────┘
-          │  FastDeploy 客户端通过 etcd 发现当前 leader
+          │  FastDeploy 客户端通过协调后端发现当前 leader
    ┌──────┴───────┐
    ▼              ▼
 server_0      server_1
 ```
 
-#### 前置准备
+#### 源码编译 Mooncake
+
+HA 模式需要 Mooncake 在编译时开启对应后端：
+
+- etcd：`-DSTORE_USE_ETCD=ON -DUSE_ETCD=ON`
+- redis：`-DSTORE_USE_REDIS=ON -DUSE_REDIS=ON`（编译依赖：`libhiredis-dev`）
+
+```bash
+git clone https://github.com/kvcache-ai/Mooncake.git
+cd Mooncake
+bash dependencies.sh
+
+mkdir -p build && cd build
+cmake .. -DSTORE_USE_ETCD=ON -DUSE_ETCD=ON   # redis 后端追加 -DSTORE_USE_REDIS=ON -DUSE_REDIS=ON
+make -j
+sudo make install
+cd ..
+
+./scripts/build_wheel.sh
+pip install mooncake-wheel/dist/*.whl
+```
+
+若需要 CUDA 13 版本，使用如下方式编译安装：
+
+```bash
+cd Mooncake
+export CU13_BUILD=1
+./scripts/build_wheel.sh
+pip install mooncake-wheel/dist/mooncake_transfer_engine_cuda13-*.whl
+```
+
+#### 方式 A：etcd 后端（`run_ha.sh`）
 
 **1. 安装 etcd**
 
@@ -324,42 +361,9 @@ export PATH=$PWD/etcd-${ETCD_VER}-linux-amd64:$PATH
 etcd --version
 ```
 
-**2. 源码编译安装 Mooncake（支持 etcd）**
+**2. 客户端配置**（`ha_mooncake_config.json`）
 
-HA 模式需要 Mooncake 在编译时开启 etcd 支持（`-DSTORE_USE_ETCD=ON -DUSE_ETCD=ON`）。先安装依赖再编译：
-
-```bash
-# 下载源码
-git clone https://github.com/kvcache-ai/Mooncake.git
-cd Mooncake
-
-# 安装系统及第三方依赖
-bash dependencies.sh
-
-# 编译 C++ 组件（含 mooncake_master，开启 etcd）
-mkdir -p build && cd build
-cmake .. -DSTORE_USE_ETCD=ON -DUSE_ETCD=ON
-make -j
-sudo make install
-cd ..
-
-# 编译并安装 Python wheel
-./scripts/build_wheel.sh
-pip install mooncake-wheel/dist/*.whl
-```
-
-若需要 CUDA 13 版本，使用如下方式编译安装：
-
-```bash
-cd Mooncake
-export CU13_BUILD=1
-./scripts/build_wheel.sh
-pip install mooncake-wheel/dist/mooncake_transfer_engine_cuda13-*.whl
-```
-
-#### HA 客户端配置
-
-HA 模式下，`metadata_server` 与 `master_server_addr` 都使用 `etcd://` 前缀指向 etcd 集群，由客户端通过 etcd 发现当前 leader（`ha_mooncake_config.json`）：
+`metadata_server` 与 `master_server_addr` 都使用 `etcd://` 前缀，由客户端通过 etcd 发现当前 leader：
 
 ```json
 {
@@ -372,45 +376,77 @@ HA 模式下，`metadata_server` 与 `master_server_addr` 都使用 `etcd://` �
 }
 ```
 
-#### 一键启动与 failover 验证
-
-单个自包含脚本 `examples/cache_storage/run_ha.sh` 负责整个流程 —— 它在脚本内部用循环分别拉起 etcd 集群和 HA master 集群，不再依赖单独的 `start_*.sh`。
-
-直接运行：
+**3. 运行**
 
 ```bash
 cd examples/cache_storage
 bash run_ha.sh
 ```
 
-`run_ha.sh` 的执行流程：
+脚本会启动 3 节点 etcd 集群（client 端口 12379/22379/32379）、3 个 HA Master（rpc 8081/8082/8083）和 2 个 FastDeploy 实例；leader 地址写入 etcd 的 `mooncake-store/mooncake_cluster/master_view`。
 
-1. **启动 etcd 集群**：端口检查后，用循环拉起 3 个 etcd 节点（client 端口 12379/22379/32379）组成 raft 集群。
-2. **启动 3 个 HA Master**：用循环拉起 3 个 `mooncake_master`（rpc 8081/8082/8083，metrics 9091/9092/9093），每个都带 `--enable_ha --etcd_endpoints ... --rpc_port ...`，通过 etcd 选出一个 leader。leader 地址写入 etcd 的 `mooncake-store/mooncake_cluster/master_view`。
-3. **启动 2 个 FastDeploy 实例**，均以 `--kvcache-storage-backend mooncake` 接入同一缓存池。
-4. **验证池化（failover 前）**：用 prompt **A** 在 `server_0` 预热，再向 `server_1` 发送相同 prompt，应命中全局缓存。
-5. **杀掉 leader**：脚本从 etcd 读取当前 leader 的 `rpc_port`，`kill -9` 对应进程，触发重新选主。
-6. **验证池化（failover 后）**：等待 etcd 中 `master_view` 更新为新 leader 后，用一条**全新的** prompt **B**（failover 前从未发过）在 `server_0` 预热，再在 `server_1` 复用。使用新 prompt 可确保 `server_1` 的命中只能来自新 leader 的全局池，而非步骤 4 残留的本地缓存。
+手动查看当前 leader：
 
-> 单独验证选主状态：
->
-> ```bash
-> # 查看当前 leader（rpc_address:rpc_port）
-> etcdctl --endpoints=http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379 \
->   get "mooncake-store/mooncake_cluster/master_view" --print-value-only
-> ```
->
-> 各 Master 角色可在 `log_master_1` / `log_master_2` / `log_master_3` 中查看（`role=leader` / `role=standby`），etcd 日志见 `log_etcd_1` / `log_etcd_2` / `log_etcd_3`。
+```bash
+etcdctl --endpoints=http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379 \
+  get "mooncake-store/mooncake_cluster/master_view" --print-value-only
+```
+
+#### 方式 B：redis 后端（`run_ha_redis.sh`）
+
+**1. 客户端配置**（`ha_redis_mooncake_config.json`）
+
+`metadata_server` 与 `master_server_addr` 都使用 `redis://` 前缀指向单个 redis 实例：
+
+```json
+{
+  "metadata_server": "redis://127.0.0.1:6399",
+  "global_segment_size": 1000000000,
+  "local_buffer_size": 134217728,
+  "protocol": "rdma",
+  "rdma_devices": "",
+  "master_server_addr": "redis://127.0.0.1:6399"
+}
+```
+
+**2. 运行**
+
+```bash
+cd examples/cache_storage
+bash run_ha_redis.sh
+```
+
+脚本会启动单个 redis 实例（端口 6399）、3 个用 `--ha_backend_type redis --ha_backend_connstring redis://127.0.0.1:6399` 拉起的 HA Master（rpc 8081/8082/8083）和 2 个 FastDeploy 实例。master_view 是 redis 中的一个 HASH，key 为 `mooncake-store/{mooncake_cluster}/master_view`。
+
+手动查看当前 leader：
+
+```bash
+redis-cli -p 6399 hget "mooncake-store/{mooncake_cluster}/master_view" leader_address
+```
+
+#### HA 脚本验证的内容
+
+两个脚本流程相同，均验证 failover：
+
+1. 启动协调后端（etcd 集群 / 单 redis）。
+2. 启动 3 个 HA Master，选出一个 leader 并写入 `master_view`。
+3. 启动 2 个 FastDeploy 实例，均以 `--kvcache-storage-backend mooncake` 接入同一缓存池。
+4. **failover 前**：用 prompt **A** 在 `server_0` 预热，再向 `server_1` 发送相同 prompt，应命中全局缓存。
+5. **杀掉 leader**：从后端读取当前 leader 的 `rpc_port`，`kill -9` 触发重新选主。
+6. **failover 后**：等待 `master_view` 更新为新 leader 后，用一条**全新的** prompt **B** 在 `server_0` 预热，再在 `server_1` 复用。使用新 prompt 可确保命中只能来自新 leader 的全局池，而非步骤 4 残留的本地缓存。
+
+各 Master 角色可在 `log_master_1` / `log_master_2` / `log_master_3` 中查看（`role=leader` / `role=standby`）。
 
 #### HA Master 关键参数
 
 | 参数 | 说明 |
 |------|------|
 | `--enable_ha` | 开启 HA 模式 |
+| `--ha_backend_type` | 协调后端：`etcd`（默认）或 `redis` |
 | `--etcd_endpoints` | etcd 端点，分号分隔（`ha_backend_type=etcd` 时） |
+| `--ha_backend_connstring` | 后端连接串，如 `redis://127.0.0.1:6399`（`ha_backend_type=redis` 时） |
 | `--rpc_address` / `--rpc_port` | 该 Master 对外可达的 RPC 地址与端口（每个实例需唯一） |
 | `--cluster_id` | 集群标识，同一集群的 Master 需一致 |
-| `--root_fs_dir` | HA 模式下的存储根目录（每个实例独立） |
 
 ## FastDeploy Mooncake 相关参数
 

--- a/examples/cache_storage/README.md
+++ b/examples/cache_storage/README.md
@@ -16,8 +16,9 @@ bash run.sh
 # PD disaggregation scenario
 bash run_03b_pd_storage.sh
 
-# High-availability (etcd + multi-master + failover) scenario
-bash run_ha.sh
+# High-availability scenario (multi-master + failover)
+bash run_ha.sh         # etcd backend
+bash run_ha_redis.sh   # redis backend
 ```
 
 ## Scripts
@@ -26,11 +27,13 @@ bash run_ha.sh
 |--------|----------|-------------|
 | `run.sh` | Multi-Instance | Two standalone instances sharing cache |
 | `run_03b_pd_storage.sh` | PD Disaggregation | P+D instances with global cache pooling |
-| `run_ha.sh` | High Availability | Self-contained: starts etcd + 3 masters with leader election, then kills the leader and re-verifies pooling with a fresh prompt after re-election |
+| `run_ha.sh` | High Availability (etcd) | Self-contained: starts etcd + 3 masters with leader election, then kills the leader and re-verifies pooling with a fresh prompt after re-election |
+| `run_ha_redis.sh` | High Availability (redis) | Same flow as `run_ha.sh`, but uses a single redis instead of etcd for leader election |
 
 ## Files
 
 - `mooncake_config.json` - Mooncake configuration file (single master)
 - `ha_mooncake_config.json` - Mooncake HA client config (etcd-based master discovery)
+- `ha_redis_mooncake_config.json` - Mooncake HA client config (redis-based master discovery)
 - `utils.sh` - Utility functions for scripts
 - `stop.sh` - Stop all running services

--- a/examples/cache_storage/ha_redis_mooncake_config.json
+++ b/examples/cache_storage/ha_redis_mooncake_config.json
@@ -1,0 +1,8 @@
+{
+  "metadata_server": "redis://127.0.0.1:6399",
+  "global_segment_size": 1000000000,
+  "local_buffer_size": 134217728,
+  "protocol": "rdma",
+  "rdma_devices": "",
+  "master_server_addr": "redis://127.0.0.1:6399"
+}

--- a/examples/cache_storage/run_ha_redis.sh
+++ b/examples/cache_storage/run_ha_redis.sh
@@ -1,26 +1,24 @@
 #!/bin/bash
 set -e
 # =============================================================================
-# HA Global Cache Pooling test script (etcd + multi-master + failover)
-# Aligned with the run.sh style. Self-contained: starts the etcd cluster and
-# the HA mooncake_master cluster inline (no external start_*.sh needed).
+# HA Global Cache Pooling test script — REDIS backend (single redis + multi-master + failover)
+# Mirror of run_ha.sh, but replaces the 3-node etcd cluster with a SINGLE redis
+# instance. The 3 mooncake_master use redis (lease-based leader election) instead
+# of etcd raft. Motivation: redis avoids introducing etcd as an extra component.
 #
-# Flow:
-#   1. start a 3-node etcd cluster
-#   2. start 3 HA masters (one is elected leader through etcd)
+# Flow (identical to run_ha.sh):
+#   1. start a single redis instance
+#   2. start 3 HA masters (one is elected leader via a redis lease)
 #   3. start 2 FastDeploy instances sharing the global cache pool
 #   4. verify pooling (before failover): warmup on server_0, reuse on server_1
 #   5. kill the leader master, wait for a standby to be re-elected
-#   6. verify pooling (after failover) with a BRAND-NEW prompt, so the hit on
-#      server_1 can only come from the (new leader's) global pool
+#   6. verify pooling (after failover) with a BRAND-NEW prompt
 # =============================================================================
 
 export PYTHONPATH="/workspace/mooncake-test/FastDeploy:$PYTHONPATH"
 export MODEL_NAME="/workspace/models/Ernie-0.3B"
-# export MODEL_NAME="/work/models/PaddlePaddle/ERNIE-4.5-0.3B-Paddle"
-export MOONCAKE_CONFIG_PATH=./ha_mooncake_config.json
+export MOONCAKE_CONFIG_PATH=./ha_redis_mooncake_config.json
 export FD_DEBUG=1
-export ETCDCTL_API=3
 
 unset http_proxy && unset https_proxy
 
@@ -28,26 +26,32 @@ echo "begin"
 source ./utils.sh
 
 # ---- topology ---------------------------------------------------------------
-# etcd node i (i=1,2,3): client port = ${i}2379, peer port = ${i}2380
-# master node i:         rpc port = 808${i},     metrics port = 909${i}
-ETCD_TOKEN="mooncake-test"
+# redis:        client port = 6399 (single instance)
+# master node i: rpc port = 808${i}, metrics port = 909${i}
+REDIS_PORT=6399
+REDIS_SERVER_BIN="$(command -v redis-server || echo /usr/local/redis/bin/redis-server)"
+REDIS_CLI_BIN="$(command -v redis-cli || echo /usr/local/redis/bin/redis-cli)"
+REDIS_CONN="redis://127.0.0.1:${REDIS_PORT}"          # for mooncake_master + client config
+
 CLUSTER_ID="mooncake_cluster"
-ETCD_INITIAL_CLUSTER="etcd1=http://127.0.0.1:12380,etcd2=http://127.0.0.1:22380,etcd3=http://127.0.0.1:32380"
-ETCD_ENDPOINTS_CTL="http://127.0.0.1:12379,http://127.0.0.1:22379,http://127.0.0.1:32379"   # comma-separated, for etcdctl
-ETCD_ENDPOINTS_HA="http://127.0.0.1:12379;http://127.0.0.1:22379;http://127.0.0.1:32379"    # semicolon-separated, for mooncake_master
-MASTER_VIEW_KEY="mooncake-store/${CLUSTER_ID}/master_view"
+# redis master_view key uses a hash-tag {cluster_id} so all related keys land in
+# the same Redis Cluster slot; it is a HASH with fields leader_address/view_version/owner_token.
+MASTER_VIEW_KEY="mooncake-store/{${CLUSTER_ID}}/master_view"
 
 S0_PORT=52700
 S1_PORT=52800
 
 # ---- helpers ----------------------------------------------------------------
 
-# Query etcd for the current leader's "rpc_address:rpc_port".
+# Query redis for the current leader's "rpc_address:rpc_port".
+# The master_view is a redis HASH; the leader endpoint lives in field leader_address.
+# redis-cli prints raw (unquoted) output when piped, so no extra unquoting needed.
 get_leader_addr() {
-    etcdctl --endpoints="${ETCD_ENDPOINTS_CTL}" get "${MASTER_VIEW_KEY}" --print-value-only 2>/dev/null | tr -d '[:space:]'
+    "${REDIS_CLI_BIN}" -p "${REDIS_PORT}" hget "${MASTER_VIEW_KEY}" leader_address 2>/dev/null \
+        | tr -d '[:space:]'
 }
 
-# Wait until a leader is elected and published into etcd.
+# Wait until a leader is elected and published into redis.
 wait_for_leader() {
     local timeout=${1:-60}
     local start_time=$(date +%s)
@@ -82,6 +86,7 @@ kill_master_by_rpc_port() {
     done
     echo "kill leader master pids=$(echo ${all_pids} | tr '\n' ' ')(rpc_port=${rpc_port})"
     kill -9 ${all_pids} 2>/dev/null || true
+
 }
 
 # Send a chat request to a FastDeploy server.
@@ -101,36 +106,25 @@ send_request() {
     echo
 }
 
-# ---- 1. start a 3-node etcd cluster -----------------------------------------
-echo "=== [1/6] start etcd cluster ==="
-pkill -9 -f "etcd --name etcd" || true
+# ---- 1. start a single redis instance ---------------------------------------
+echo "=== [1/6] start redis ==="
+pkill -9 -f "redis-server .*:${REDIS_PORT}" || true
 sleep 1
 
-etcd_ports=(12379 12380 22379 22380 32379 32380)
-check_ports "${etcd_ports[@]}" || {
-    echo "❌ Some etcd ports are in use. Please release them."
+check_ports "${REDIS_PORT}" || {
+    echo "❌ redis port ${REDIS_PORT} is in use. Please release it."
     exit 1
 }
 
-for i in 1 2 3; do
-    rm -rf /tmp/etcd${i}.data
-    etcd --name etcd${i} \
-        --listen-client-urls "http://127.0.0.1:${i}2379" \
-        --advertise-client-urls "http://127.0.0.1:${i}2379" \
-        --listen-peer-urls "http://127.0.0.1:${i}2380" \
-        --initial-advertise-peer-urls "http://127.0.0.1:${i}2380" \
-        --initial-cluster "${ETCD_INITIAL_CLUSTER}" \
-        --initial-cluster-state new \
-        --initial-cluster-token "${ETCD_TOKEN}" \
-        --data-dir /tmp/etcd${i}.data > log_etcd_${i} 2>&1 &
-done
+# disable persistence; this is a throwaway coordination store.
+"${REDIS_SERVER_BIN}" --port "${REDIS_PORT}" --save "" --appendonly no \
+    --daemonize no > log_redis 2>&1 &
+sleep 2
+echo "=== redis health check ==="
+"${REDIS_CLI_BIN}" -p "${REDIS_PORT}" ping
 
-sleep 3
-echo "=== etcd cluster health check ==="
-etcdctl --endpoints="${ETCD_ENDPOINTS_CTL}" endpoint health
-
-# ---- 2. start 3 HA masters --------------------------------------------------
-echo "=== [2/6] start 3 HA mooncake_master ==="
+# ---- 2. start 3 HA masters (redis backend) ----------------------------------
+echo "=== [2/6] start 3 HA mooncake_master (redis backend) ==="
 pkill -9 -f mooncake_master || true
 sleep 1
 
@@ -141,9 +135,11 @@ check_ports "${master_ports[@]}" || {
 }
 
 for i in 1 2 3; do
+    # --ha_backend_type redis + --ha_backend_connstring redis://...
     mooncake_master \
         --enable_ha \
-        --etcd_endpoints "${ETCD_ENDPOINTS_HA}" \
+        --ha_backend_type redis \
+        --ha_backend_connstring "${REDIS_CONN}" \
         --cluster_id "${CLUSTER_ID}" \
         --rpc_address "127.0.0.1" \
         --rpc_port 808${i} \
@@ -204,7 +200,6 @@ nohup python -m fastdeploy.entrypoints.openai.api_server \
 
 wait_for_health ${S0_PORT}
 wait_for_health ${S1_PORT}
-
 # ---- 4. verify pooling before failover (warmup on s0, reuse on s1) ----------
 # msg_a: warmed on server_0, then reused on server_1.
 msg_a="深圳是中国经济实力最强的城市之一。近年来，深圳GDP持续稳步增长，2023年突破3.4万亿元人民币，2024年接近3.7万亿元。长期位居全国城市前列。深圳经济以第二产业和第三产业为主，高端制造业、电子信息产业和现代服务业发达，形成了以科技创新为核心的产业结构。依托华为、腾讯、大疆等龙头企业，深圳在数字经济、人工智能、新能源等领域具有显著优势。同时，深圳进出口总额常年位居全国城市第一，是中国对外开放和高质量发展的重要引擎。深圳持续推进创新驱动发展战略，不断加大研发投入，全社会研发投入占GDP比重长期保持较高水平。深圳拥有完善的创业生态体系，吸引了大量科技企业和创新人才。近年来，深圳积极布局半导体、生物医药、低空经济和智能网联汽车等战略性新兴产业，进一步增强经济增长动能。请总结深圳经济发展的核心优势。"
@@ -258,7 +253,8 @@ echo ">>> reuse msg_b on server_1 (${S1_PORT}), expect cache hit via new leader"
 send_request ${S1_PORT} "${msg_b}"
 
 echo
-echo "=== HA test completed ==="
+echo "=== HA (redis) test completed ==="
 echo "Check cache hit:  grep -E 'storage_cache_token_num' log_*/cache_storage.log* "
 echo "Master logs:      log_master_1 / log_master_2 / log_master_3"
-echo "etcd logs:        log_etcd_1 / log_etcd_2 / log_etcd_3"
+echo "Redis log:        log_redis"
+echo "Current leader:   ${REDIS_CLI_BIN} -p ${REDIS_PORT} hget '${MASTER_VIEW_KEY}' leader_address"


### PR DESCRIPTION
## Motivation

The HA example added in #8051 only supports the **etcd** coordination backend, which forces every HA deployment to bring up and operate a 3-node etcd cluster. Some environments already run redis and prefer not to introduce etcd as an extra component.

This PR adds a **redis** coordination backend for the Mooncake HA example: multiple `mooncake_master` instances perform lease-based leader election through a single redis instance, and FastDeploy clients discover the current leader via redis. When the leader fails, a standby is automatically re-elected, transparently to clients — same guarantees as the etcd path, fewer moving parts.

## Modifications

- **`examples/cache_storage/run_ha_redis.sh`** (new): self-contained mirror of `run_ha.sh` that
  1. starts a single redis instance (port 6399),
  2. starts 3 `mooncake_master` with `--enable_ha --ha_backend_type redis --ha_backend_connstring redis://127.0.0.1:6399` (rpc 8081/8082/8083), one elected leader via a redis lease,
  3. launches 2 FastDeploy instances joining the same cache pool,
  4. verifies cache pooling before failover (prompt A on server_0 → hit on server_1),
  5. kills the current leader (read from the redis `master_view` HASH) to trigger re-election,
  6. re-verifies pooling after failover with a **brand-new** prompt B, so the hit on server_1 can only come from the new leader's global pool.
- **`examples/cache_storage/ha_redis_mooncake_config.json`** (new): HA client config; `metadata_server` and `master_server_addr` use the `redis://` prefix for leader discovery.
- **`examples/cache_storage/run_ha.sh`**: harden the leader teardown — `kill_master_by_rpc_port()` now also kills child PIDs (in case a child's cmdline didn't match the `--rpc_port` grep), and drop `--root_fs_dir` / `--enable_offload` from the master launch to align with the redis script.
- **`docs/features/global_cache_pooling.md`** & **`docs/zh/features/global_cache_pooling.md`**: restructure the HA section into two backend options — **Option A: etcd (`run_ha.sh`)** and **Option B: redis (`run_ha_redis.sh`)** — each with its own client config and run steps; add the redis build flags (`-DSTORE_USE_REDIS=ON -DUSE_REDIS=ON`, dep `libhiredis-dev`) and the `--ha_backend_type` / `--ha_backend_connstring` master parameters.
- **`examples/cache_storage/README.md`**: list `run_ha_redis.sh` and `ha_redis_mooncake_config.json`.

## Usage or Command

```bash
cd examples/cache_storage
bash run_ha_redis.sh
```

## Accuracy Tests

This PR is docs/examples only and does not change model outputs. Below is the full output of `run_ha_redis.sh` verifying cache pooling survives a leader failover on the **redis** backend.

The key signal is `prompt_tokens_details.cached_tokens`: it is `0` on the warm-up request and `128` on the reuse request — both **before** and **after** the leader is killed and a new leader is elected (`127.0.0.1:8081` → `127.0.0.1:8083`).

```text
=== [1/6] start redis ===
=== redis health check ===
PONG
=== [2/6] start 3 HA mooncake_master (redis backend) ===
waiting for leader election...
✅ current leader: 127.0.0.1:8081
=== [3/6] start FastDeploy instances ===
server 0 port: 52700
server 1 port: 52800
Port 52700: [OK]   200
All services are ready!    [29s]
Port 52800: [OK]   200
All services are ready!    [0s]
=== [4/6] verify pooling before failover ===
>>> warmup msg_a on server_0 (52700)
{... "usage":{"prompt_tokens":191,"total_tokens":241,"completion_tokens":50,"prompt_tokens_details":{"cached_tokens":0, ...}}}
>>> reuse msg_a on server_1 (52800), expect cache hit
{... "usage":{"prompt_tokens":191,"total_tokens":241,"completion_tokens":50,"prompt_tokens_details":{"cached_tokens":128, ...}}}
=== [5/6] kill leader and wait for failover ===
old leader: 127.0.0.1:8081 (rpc_port=8081)
kill leader master pids=104766 104796 104796 (rpc_port=8081)
waiting for a new leader to be elected...
✅ new leader: 127.0.0.1:8083 (was 127.0.0.1:8081)
=== [6/6] verify pooling after failover (new prompt msg_b) ===
>>> warmup msg_b on server_0 (52700)
{... "usage":{"prompt_tokens":147,"total_tokens":197,"completion_tokens":50,"prompt_tokens_details":{"cached_tokens":0, ...}}}
>>> reuse msg_b on server_1 (52800), expect cache hit via new leader
{... "usage":{"prompt_tokens":147,"total_tokens":197,"completion_tokens":50,"prompt_tokens_details":{"cached_tokens":128, ...}}}

=== HA (redis) test completed ===
Check cache hit:  grep -E 'storage_cache_token_num' log_*/cache_storage.log*
Master logs:      log_master_1 / log_master_2 / log_master_3
Redis log:        log_redis
Current leader:   redis-cli -p 6399 hget 'mooncake-store/{mooncake_cluster}/master_view' leader_address
```

Result: cache pooling works correctly before and after failover — `cached_tokens=128` on reuse in both phases, confirming the re-elected leader (`8083`) serves the global pool after the original leader (`8081`) is killed.

## Checklist

- [x] Add at least a tag in the PR title. (`[Docs]`)
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. — N/A: docs/examples only, no production code changed.
- [x] Provide accuracy results. — N/A for model outputs; included `run_ha_redis.sh` failover verification instead.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch first. — Targeting `develop`.
