### PR TITLE
[XPU] add fetch req log

### DIFF
--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -981,6 +981,8 @@ class EngineService:
                                 LoggingEventName.ASK_DECODE_RESOURCE_START, task.request_id, getattr(task, "user", "")
                             )
                             task.metrics.ask_decode_resource_start_time = time.time()
+                            if envs.FD_PD_LOG_REQUEST:
+                                self.llm_logger.info(f"[PD_LOG] P sends Request: {task.to_dict()}")
                             while True:
                                 self.split_connector.send_splitwise_tasks([task], task.idx)
                                 status, msg = self.split_connector.check_decode_allocated(task)
@@ -1011,6 +1013,8 @@ class EngineService:
                                 LoggingEventName.ASK_DECODE_RESOURCE_START, task.request_id, getattr(task, "user", "")
                             )
                             task.metrics.ask_decode_resource_start_time = time.time()
+                            if envs.FD_PD_LOG_REQUEST:
+                                self.llm_logger.info(f"[PD_LOG] P sends Request: {task.to_dict()}")
                             self.split_connector.send_splitwise_tasks([task], task.idx)
 
                         for task in tasks:
@@ -2095,6 +2099,8 @@ class EngineService:
                         f"D has received tasks to preallocate resource for tasks: {[task.request_id for task in tasks]}"
                     )
                     for task in tasks:
+                        if envs.FD_PD_LOG_REQUEST:
+                            self.llm_logger.info(f"[PD_LOG] D received Request: {task.to_dict()}")
                         task.metrics.decode_recv_req_time = time.time()
                     allocate_resource_requests.extend(tasks)
                 elif isinstance(tasks[0], RequestOutput):

--- a/fastdeploy/envs.py
+++ b/fastdeploy/envs.py
@@ -269,6 +269,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "FD_DETERMINISTIC_LOG_MODE": lambda: bool(int(os.getenv("FD_DETERMINISTIC_LOG_MODE", "0"))),
     # Whether to use PD REORDER, can set 0 or 1
     "FD_PD_REORDER": lambda: int(os.getenv("FD_PD_REORDER", "0")),
+    # Whether to enable PD disaggregation request logging on decode side
+    "FD_PD_LOG_REQUEST": lambda: int(os.getenv("FD_PD_LOG_REQUEST", "0")),
     # Whether to probe MoE routing probabilities and use Fleet's fused SwiGLU kernel.
     "FD_MOE_PROB_IN_ADVANCE": lambda: bool(int(os.getenv("FD_MOE_PROB_IN_ADVANCE", "0"))),
     # Whether to use batch send data in zmq


### PR DESCRIPTION
## Motivation
需要在 PD disaggregation 场景下定位 prefill 和 decode 之间的请求传递问题，通过环境变量控制是否输出请求调试日志。

## Modifications
- 在 `fastdeploy/envs.py` 中新增 `FD_PD_LOG_REQUEST` 环境变量，默认关闭。
- 在 `fastdeploy/engine/common_engine.py` 的 prefill 发送请求和 decode 接收请求路径增加 PD 请求日志。
- 日志内容需脱敏为请求摘要，避免记录原始 prompt、messages、token ids 或多模态数据。

## Usage or Command
设置 `FD_PD_LOG_REQUEST=1` 可启用 PD 请求日志；默认 `0` 关闭。

## Accuracy Tests
N/A（仅新增日志开关和日志输出，不改变模型计算结果。）

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.