### PR TITLE
[Cherry-Pick][RL] Allow configuring update weights timeout (#8073)

### DIFF
--- a/fastdeploy/engine/common_engine.py
+++ b/fastdeploy/engine/common_engine.py
@@ -1434,7 +1434,15 @@ class EngineService(EngineServicePrepareMixin):
                 error_msg = "Pause LLM Engine first before calling updating weights"
                 self.llm_logger.error(error_msg)
                 raise Exception(error_msg)
-        responses = self._call_worker(control_request, 60)
+        timeout = control_request.args.get("timeout", 180)
+        worker_args = copy.deepcopy(control_request.args)
+        worker_args.pop("timeout", None)
+        worker_request = ControlRequest(
+            request_id=control_request.request_id,
+            method=control_request.method,
+            args=worker_args,
+        )
+        responses = self._call_worker(worker_request, timeout)
 
         if responses:
             new_version = None
@@ -1452,11 +1460,13 @@ class EngineService(EngineServicePrepareMixin):
             update_cache_request = ControlRequest(
                 request_id=f"{control_request.request_id}_update_weights",
                 method="update_weights",
-                args=copy.deepcopy(control_request.args),
+                args=copy.deepcopy(worker_args),
             )
             self.cache_task_queue.put_transfer_task((CacheStatus.CTRL, update_cache_request))
             asyncio.run(
-                self._wait_for_control_responses(update_cache_request.request_id, 60, executors=["cache_transfer"])
+                self._wait_for_control_responses(
+                    update_cache_request.request_id, timeout, executors=["cache_transfer"]
+                )
             )
             self.llm_logger.info("Successfully updated cache-transfer metadata after weight update.")
 

--- a/fastdeploy/entrypoints/openai/api_server.py
+++ b/fastdeploy/entrypoints/openai/api_server.py
@@ -471,6 +471,22 @@ async def update_weights(request: Request) -> Response:
             )
         args["verify_checksum"] = request_data["verify_checksum"]
 
+    # Validate and extract timeout parameter
+    if "timeout" in request_data:
+        if not isinstance(request_data["timeout"], int) or isinstance(request_data["timeout"], bool):
+            return JSONResponse(
+                status_code=400,
+                content={"error": "Invalid parameter type", "message": "timeout must be an integer"},
+            )
+        if request_data["timeout"] <= 0:
+            return JSONResponse(
+                status_code=400,
+                content={"error": "Invalid parameter value", "message": "timeout must be positive"},
+            )
+        args["timeout"] = request_data["timeout"]
+    else:
+        args["timeout"] = 180
+
     control_request = ControlRequest(request_id, "update_weights", args)
     control_response = await app.state.engine_client.run_control_method(control_request)
     return control_response.to_api_json_response()

--- a/tests/engine/test_common_engine.py
+++ b/tests/engine/test_common_engine.py
@@ -1114,6 +1114,9 @@ class TestCommonEngineAdditionalCoverage(unittest.TestCase):
 
         result = eng._control_update_weights(ControlRequest(request_id="ctrl", method="update_weights"))
         self.assertEqual(result, {"ok": True})
+        worker_request = eng._call_worker.call_args.args[0]
+        self.assertEqual(worker_request.args, {})
+        self.assertEqual(eng._call_worker.call_args.args[1], 180)
         self._detach_finalizer(eng)
 
     def test_control_update_weights_updates_cfg_version(self):
@@ -1138,15 +1141,21 @@ class TestCommonEngineAdditionalCoverage(unittest.TestCase):
         eng.cache_task_queue = Mock(put_transfer_task=Mock())
         eng._wait_for_control_responses = AsyncMock(return_value=[{"ok": True}])
 
-        result = eng._control_update_weights(ControlRequest(request_id="ctrl", method="update_weights"))
+        result = eng._control_update_weights(
+            ControlRequest(request_id="ctrl", method="update_weights", args={"version": "v2", "timeout": 120})
+        )
 
         self.assertEqual(result, [{"version": "new-version"}])
+        worker_request = eng._call_worker.call_args.args[0]
+        self.assertEqual(worker_request.args, {"version": "v2"})
+        self.assertEqual(eng._call_worker.call_args.args[1], 120)
         payload = eng.cache_task_queue.put_transfer_task.call_args.args[0]
         self.assertEqual(payload[0], CacheStatus.CTRL)
         self.assertEqual(payload[1].method, "update_weights")
+        self.assertEqual(payload[1].args, {"version": "v2"})
         self.assertIn("update_weights", payload[1].request_id)
         eng._wait_for_control_responses.assert_awaited_once_with(
-            payload[1].request_id, 60, executors=["cache_transfer"]
+            payload[1].request_id, 120, executors=["cache_transfer"]
         )
         self._detach_finalizer(eng)
 

--- a/tests/entrypoints/openai/test_api_server.py
+++ b/tests/entrypoints/openai/test_api_server.py
@@ -610,7 +610,7 @@ async def test_update_weights_route_validation():
     assert valid_resp.status_code == 200
     control_request = api_server.app.state.engine_client.run_control_method.await_args.args[0]
     assert control_request.method == "update_weights"
-    assert control_request.args == {"version": "v2", "verify_checksum": True}
+    assert control_request.args == {"version": "v2", "verify_checksum": True, "timeout": 180}
 
     invalid_version_req = MagicMock()
     invalid_version_req.body = AsyncMock(return_value=b'{"version":1}')
@@ -623,6 +623,22 @@ async def test_update_weights_route_validation():
     invalid_checksum_req.json = AsyncMock(return_value={"verify_checksum": "true"})
     invalid_checksum_resp = await api_server.update_weights(invalid_checksum_req)
     assert invalid_checksum_resp.status_code == 400
+
+    api_server.app.state.engine_client.run_control_method.reset_mock()
+    custom_timeout_req = MagicMock()
+    custom_timeout_req.body = AsyncMock(return_value=b'{"timeout":120}')
+    custom_timeout_req.json = AsyncMock(return_value={"timeout": 120})
+    custom_timeout_resp = await api_server.update_weights(custom_timeout_req)
+    assert custom_timeout_resp.status_code == 200
+    control_request = api_server.app.state.engine_client.run_control_method.await_args.args[0]
+    assert control_request.args == {"timeout": 120}
+
+    for invalid_timeout in [True, 0, -1, "120", 1.5, None]:
+        invalid_timeout_req = MagicMock()
+        invalid_timeout_req.body = AsyncMock(return_value=b'{"timeout":null}')
+        invalid_timeout_req.json = AsyncMock(return_value={"timeout": invalid_timeout})
+        invalid_timeout_resp = await api_server.update_weights(invalid_timeout_req)
+        assert invalid_timeout_resp.status_code == 400
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

Support configuring the timeout for `update_weights` requests. This helps large weight updates avoid timing out with the fixed default timeout.

## Modifications

- Add `timeout` parameter validation in the OpenAI API `update_weights` endpoint.
- Use the configured timeout when updating worker weights and cache-transfer metadata.
- Keep `timeout` as a control-only parameter and do not forward it to workers.
- Add unit tests for default timeout, custom timeout, and invalid timeout values.

## Usage or Command

Example request body:

```json
{
  "timeout": 120
}
```

If `timeout` is not provided, the default value is `180` seconds.

## Accuracy Tests

Not applicable. This PR only changes control request timeout handling and does not affect model outputs.

## Checklist

- [x] Add at least a tag in the PR title.
  - Suggested title: `[Engine][APIServer] Allow configuring update weights timeout`
- [x] Format your code, run `pre-commit` before commit.
- [x] Add unit tests.
- [x] Provide accuracy results.
- [x] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
