### PR TITLE
[BugFix] fix non-stream serialization bug

### DIFF
--- a/fastdeploy/entrypoints/openai/api_server.py
+++ b/fastdeploy/entrypoints/openai/api_server.py
@@ -605,7 +605,7 @@ async def create_chat_completion(request: ChatCompletionRequest, req: Request):
             elif isinstance(generator, ChatCompletionResponse):
                 api_server_logger.debug(f"release: {connection_semaphore.status()}")
                 connection_semaphore.release()
-                return JSONResponse(content=generator.model_dump())
+                return Response(content=generator.model_dump_json(), media_type="application/json")
             else:
                 wrapped_generator = wrap_streaming_generator(generator)
                 return StreamingResponse(content=wrapped_generator(), media_type="text/event-stream")


### PR DESCRIPTION
## Motivation
修复 `/v1/chat/completions` 非流式返回中 `ChatCompletionResponse` 通过 `JSONResponse(content=generator.model_dump())` 序列化时可能触发的 JSON 序列化问题，使其与流式分支中直接使用 Pydantic `model_dump_json()` 的序列化行为保持一致。

## Modifications
- 在 `fastdeploy/entrypoints/openai/api_server.py` 中，将非流式 `ChatCompletionResponse` 的返回从 `JSONResponse(content=generator.model_dump())` 改为 `Response(content=generator.model_dump_json(), media_type="application/json")`。

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.