### PR TITLE
[APIServer][BugFix] Fix gunicorn fork deadlock and multi-dp pipe issue in get_save_output_v1

### DIFF
--- a/fastdeploy/entrypoints/openai/api_server.py
+++ b/fastdeploy/entrypoints/openai/api_server.py
@@ -319,6 +319,8 @@ async def lifespan(app: FastAPI):
     try:
         if envs.FD_ENABLE_ASYNC_LLM:
             await llm_engine.shutdown()
+        else:
+            llm_engine._exit_sub_services()
         await engine_client.connection_manager.close()
         engine_client.zmq_client.close()
         from prometheus_client import multiprocess
@@ -801,8 +803,6 @@ def launch_api_server() -> None:
                 host=args.host,
                 port=args.port,
                 log_config=UVICORN_CONFIG,
-                timeout_keep_alive=args.timeout,
-                timeout_graceful_shutdown=args.timeout_graceful_shutdown,
             )
 
     except Exception as e:

--- a/fastdeploy/entrypoints/openai/api_server.py
+++ b/fastdeploy/entrypoints/openai/api_server.py
@@ -793,7 +793,18 @@ def launch_api_server() -> None:
     }
 
     try:
-        StandaloneApplication(app, options).run()
+        if args.workers > 1:
+            StandaloneApplication(app, options).run()
+        else:
+            uvicorn.run(
+                app,
+                host=args.host,
+                port=args.port,
+                log_config=UVICORN_CONFIG,
+                timeout_keep_alive=args.timeout,
+                timeout_graceful_shutdown=args.timeout_graceful_shutdown,
+            )
+
     except Exception as e:
         api_server_logger.error(f"launch sync http server error, {e}, {str(traceback.format_exc())}")
 

--- a/fastdeploy/output/token_processor.py
+++ b/fastdeploy/output/token_processor.py
@@ -422,21 +422,17 @@ class TokenProcessor:
         """
         if self.speculative_decoding:
             raise NotImplementedError("GET_SAVE_OUTPUT_V1 does not support speculative decoding")
-        rank_id = self.cfg.parallel_config.local_data_parallel_id
         while True:
             try:
-                if (
-                    self.cfg.parallel_config.enable_expert_parallel and self.cfg.parallel_config.data_parallel_size > 1
-                ) or (rank_id == 0):
-                    receive_datas = self.zmq_server.recv_pyobj()
-                    assert isinstance(receive_datas, list)
-                    if envs.FD_DEBUG:
-                        llm_logger.debug(f"token_processor receive_data {receive_datas}")
+                receive_datas = self.zmq_server.recv_pyobj()
+                assert isinstance(receive_datas, list)
+                if envs.FD_DEBUG:
+                    llm_logger.debug(f"token_processor receive_data {receive_datas}")
 
-                    self._reschedule_preempt_task_use_zmq(receive_datas)
+                self._reschedule_preempt_task_use_zmq(receive_datas)
 
-                    batch_result = self._process_batch_output_use_zmq(receive_datas)
-                    self.postprocess(batch_result)
+                batch_result = self._process_batch_output_use_zmq(receive_datas)
+                self.postprocess(batch_result)
             except Exception as e:
                 log_request_error(
                     message="Receive message:{receive_datas}, error:{error}, {traceback}",

--- a/fastdeploy/worker/gpu_model_runner.py
+++ b/fastdeploy/worker/gpu_model_runner.py
@@ -259,8 +259,9 @@ class GPUModelRunner(ModelRunnerBase):
         self.async_output_queue = None
         if envs.FD_USE_GET_SAVE_OUTPUT_V1:
             port = self.fd_config.parallel_config.local_engine_worker_queue_port
-            logger.info(f"zmq client get_save_output_rank{local_rank}_{port}")
-            self.zmq_client = ZmqIpcClient(name=f"get_save_output_rank{local_rank}_{port}", mode=zmq.PUSH)
+            rank = self.fd_config.parallel_config.local_data_parallel_id
+            logger.info(f"zmq client get_save_output_rank{rank}_{port}")
+            self.zmq_client = ZmqIpcClient(name=f"get_save_output_rank{rank}_{port}", mode=zmq.PUSH)
             self.zmq_client.connect()
             self.zmq_client.socket.SNDTIMEO = 3000
             self.async_output_queue: queue.Queue = queue.Queue()

--- a/fastdeploy/worker/metax_model_runner.py
+++ b/fastdeploy/worker/metax_model_runner.py
@@ -210,8 +210,9 @@ class MetaxModelRunner(ModelRunnerBase):
         self.async_output_queue = None
         if envs.FD_USE_GET_SAVE_OUTPUT_V1:
             port = self.fd_config.parallel_config.local_engine_worker_queue_port
-            logger.info(f"zmq client get_save_output_rank{local_rank}_{port}")
-            self.zmq_client = ZmqIpcClient(name=f"get_save_output_rank{local_rank}_{port}", mode=zmq.PUSH)
+            rank = self.fd_config.parallel_config.local_data_parallel_id
+            logger.info(f"zmq client get_save_output_rank{rank}_{port}")
+            self.zmq_client = ZmqIpcClient(name=f"get_save_output_rank{rank}_{port}", mode=zmq.PUSH)
             self.zmq_client.connect()
             self.zmq_client.socket.SNDTIMEO = 3000
             self.async_output_queue: queue.Queue = queue.Queue()

--- a/fastdeploy/worker/xpu_model_runner.py
+++ b/fastdeploy/worker/xpu_model_runner.py
@@ -197,8 +197,9 @@ class XPUModelRunner(ModelRunnerBase):
         self.async_output_queue = None
         if envs.FD_USE_GET_SAVE_OUTPUT_V1:
             port = self.fd_config.parallel_config.local_engine_worker_queue_port
-            logger.info(f"zmq client get_save_output_rank{local_rank}_{port}")
-            self.zmq_client = ZmqIpcClient(name=f"get_save_output_rank{local_rank}_{port}", mode=zmq.PUSH)
+            rank = self.fd_config.parallel_config.local_data_parallel_id
+            logger.info(f"zmq client get_save_output_rank{rank}_{port}")
+            self.zmq_client = ZmqIpcClient(name=f"get_save_output_rank{rank}_{port}", mode=zmq.PUSH)
             self.zmq_client.connect()
             self.zmq_client.socket.SNDTIMEO = 3000
             self.async_output_queue: queue.Queue = queue.Queue()

--- a/tests/entrypoints/openai/test_api_server.py
+++ b/tests/entrypoints/openai/test_api_server.py
@@ -667,11 +667,22 @@ def test_launchers_and_controller():
         with pytest.raises(Exception):
             api_server.launch_api_server()
 
+    # workers > 1 branch: StandaloneApplication
+    api_server.args.workers = 2
     with (
         patch("fastdeploy.entrypoints.openai.api_server.is_port_available", return_value=True),
         patch("fastdeploy.entrypoints.openai.api_server.StandaloneApplication.run", side_effect=RuntimeError("fail")),
     ):
         api_server.launch_api_server()
+
+    # workers == 1 branch: uvicorn.run
+    api_server.args.workers = 1
+    with (
+        patch("fastdeploy.entrypoints.openai.api_server.is_port_available", return_value=True),
+        patch("fastdeploy.entrypoints.openai.api_server.uvicorn.run", side_effect=RuntimeError("fail")) as uv_run,
+    ):
+        api_server.launch_api_server()
+        uv_run.assert_called_once()
 
     with patch("fastdeploy.entrypoints.openai.api_server.uvicorn.run") as uv_run:
         api_server.run_metrics_server()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

> :bulb: If this PR is a Cherry Pick, the PR title needs to follow the format by adding the [Cherry-Pick] label at the very beginning and appending the original PR ID at the end. For example, [Cherry-Pick][CI] Add check trigger and logic(#5191)

> :bulb: 如若此PR是Cherry Pick，PR标题需遵循格式，在最开始加上[Cherry-Pick]标签，以及最后面加上原PR ID，例如[Cherry-Pick][CI] Add check trigger and logic(#5191)

This PR fixes two issues related to process forking in the API server:

1. **Gunicorn fork deadlock**: When `workers=1`, gunicorn still forks a worker process, which can cause deadlock due to inherited resources (e.g., zmq sockets, CUDA contexts) not being fork-safe. When there is only one worker, uvicorn should be used directly to avoid the fork entirely.
2. **Multi-DP pipe block/data loss in `get_save_output_v1`**: Non-rank-0 token_processors skip receiving from their zmq pipes under multi-DP, causing pipes to block or lose data.

## Modifications

<!-- Detail the changes made in this pull request. -->

- **`fastdeploy/entrypoints/openai/api_server.py`**:
  - Changed server launch logic: use `StandaloneApplication` (gunicorn) when `workers > 1`, use `uvicorn.run` directly when `workers == 1`, avoiding unnecessary fork that can lead to deadlock.
  - Added `llm_engine._exit_sub_services()` call in the `lifespan` shutdown path for the non-async branch, ensuring sub-services exit properly in sync mode.

- **`fastdeploy/output/token_processor.py`**:
  - Removed the `rank_id`-based conditional check in `get_save_output_v1`, so that all token_processors receive and process data from their respective zmq pipes regardless of rank, ensuring pipes are properly consumed in multi-DP scenarios.

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

No extra configuration needed. Single-worker deployments will automatically use uvicorn instead of gunicorn.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

This PR does not modify model computation logic and does not affect accuracy.

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.