### PR TITLE
[CI][BugFix] Reset mock before destructor assertion in cache controller tests

### DIFF
--- a/tests/cache_manager/v1/test_cache_controller.py
+++ b/tests/cache_manager/v1/test_cache_controller.py
@@ -1461,6 +1461,7 @@ class TestDestructor(unittest.TestCase):
     def test_del_calls_free_host_cache(self, mock_free):
         """Lines 1089-1090: __del__ calls _free_host_cache."""
         controller = create_cache_controller()
+        mock_free.reset_mock()
         controller.__del__()
         mock_free.assert_called_once()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

The cache controller unit test may fail intermittently due to unexpected `mock_free` invocations from destructors of previously created objects.

When garbage collection triggers `__del__()` while the mock patch is still active, these stale destructor calls are also recorded by `mock_free`, causing the subsequent assertion to count more invocations than expected.

To make the test deterministic, only the explicit destructor invocation performed by the test itself should be included in the assertion.

## Modifications

- Added `mock_free.reset_mock()` after `create_cache_controller()` and before `controller.__del__()`.
- Cleared any `mock_free` call history introduced by destructors of previously collected objects.
- Ensured the assertion only counts the explicit `controller.__del__()` invocation.
- Improved the stability and determinism of the cache controller unit test.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
