### PR TITLE
[CI][BugFix] Isolate controller mock to instance level

### DIFF
--- a/tests/cache_manager/v1/test_cache_controller.py
+++ b/tests/cache_manager/v1/test_cache_controller.py
@@ -1457,20 +1457,17 @@ class TestFreeHostCache(unittest.TestCase):
 class TestDestructor(unittest.TestCase):
     """Test __del__ method (lines 1089-1090)."""
 
-    @patch("fastdeploy.cache_manager.v1.cache_controller.CacheController._free_host_cache")
-    def test_del_calls_free_host_cache(self, mock_free):
+    def test_del_calls_free_host_cache(self):
         """Lines 1089-1090: __del__ calls _free_host_cache."""
         controller = create_cache_controller()
-        mock_free.reset_mock()
+        controller._free_host_cache = MagicMock()
         controller.__del__()
-        mock_free.assert_called_once()
+        controller._free_host_cache.assert_called_once()
 
-    @patch(
-        "fastdeploy.cache_manager.v1.cache_controller.CacheController._free_host_cache", side_effect=Exception("err")
-    )
-    def test_del_swallows_exception(self, mock_free):
+    def test_del_swallows_exception(self):
         """Lines 1089-1090: __del__ swallows exceptions."""
         controller = create_cache_controller()
+        controller._free_host_cache = MagicMock(side_effect=Exception("err"))
         # Should not raise
         controller.__del__()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

The cache controller unit test was affected by cross-test interference caused by mocking `_free_host_cache` at the class level or in a shared scope.

When `MagicMock` is applied globally, previously created `controller` instances (from earlier tests or garbage collection remnants) may still reference the original method or a shared mock state. This leads to non-deterministic behavior in `__del__()` execution paths and inconsistent call tracking.

## Modifications

- Moved `MagicMock` assignment from global/class scope to instance scope:
  - `controller._free_host_cache = MagicMock()`
- Ensured the mock is stored in the instance `__dict__`, so only the current test instance is affected.
- Preserved original behavior for other controller instances that do not define `_free_host_cache`, allowing them to execute the real class method.
- Isolated destructor behavior (`__del__`) to avoid interference from stale or previously collected objects.
- Improved test determinism by fully decoupling mock lifecycle from other instances and tests.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
