### PR TITLE
[Cherry-Pick][BugFix] RDMA: retry ibv_post_send from bad_wr and drain CQ on failure(#8091)

### DIFF
--- a/fastdeploy/cache_manager/transfer_factory/kvcache_transfer/src/kvcache_rdma.cpp
+++ b/fastdeploy/cache_manager/transfer_factory/kvcache_transfer/src/kvcache_rdma.cpp
@@ -1390,8 +1390,9 @@ bool RDMACommunicator::post_send_with_retry(struct RdmaContext* ctx,
     last_wr->send_flags |= IBV_SEND_SIGNALED;
   }
 
+  struct ibv_send_wr* cur_wr = wr_list;
   do {
-    ret = ibv_post_send(ctx->qp, wr_list, &bad_wr);
+    ret = ibv_post_send(ctx->qp, cur_wr, &bad_wr);
     if (ret == 0) {
       if (need_poll) {
         ctx->conn.wc_count = 0;
@@ -1408,8 +1409,22 @@ bool RDMACommunicator::post_send_with_retry(struct RdmaContext* ctx,
           errno,
           retries + 1,
           max_retries);
+      // Non-blocking CQ drain to free SQ slots before retrying.
+      // Do not use poll_cq_with_timeout here: ibv_post_send failure does not
+      // guarantee a CQE is available (e.g. sync errors, unsignaled WRs), so a
+      // blocking wait would stall the retry loop for up to
+      // RDMA_POLL_CQE_TIMEOUT per attempt (up to 210s total).
+      {
+        struct ibv_wc wc_array[32];
+        int n;
+        while ((n = ibv_poll_cq(ctx->cq, 32, wc_array)) > 0) {
+        }
+      }
       usleep(1000);
       retries++;
+      if (bad_wr)
+        cur_wr =
+            bad_wr;  // resume from the failed WR instead of retrying from head
     }
   } while (retries < max_retries);
 


### PR DESCRIPTION
Cherry-pick of #8091 (authored by @Sunny-bot1) to `release/2.6`.

devPR:https://github.com/PaddlePaddle/FastDeploy/pull/8091 <!-- For pass CI -->

---

<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

生产环境中 KV Cache RDMA 传输时出现报错：      

```                                                                                                                                                                        

KV_CACHE ERROR ibv_post_send failed: File name too long (errno: 36), retry 7/7          
KV_CACHE ERROR ibv_post_send failed after 7 retries: File name too long (errno: 36)      

```

errno 36 (ENAMETOOLONG) 在 RDMA 上下文中表示 ibv_post_send 向 Send Queue（SQ）提交 Work Request（WR）失败，根本原因是 SQ 堆积——inflight WR 累积速度超过 CQ 消费速度，导致 SQ 无可用 slot。

原有重试逻辑存在两个问题：

1. 每次重试都从 WR 链表头部重新提交，而不是从 bad_wr 续传，导致已成功入队的 WR 被重复提交，每次 retry 反而进一步加剧 SQ 压力。
2. retry 前没有排空 CQ，已完成的 WR 占用的 SQ slot 得不到释放，7 次重试全部因同一原因失败。

## Modifications

<!-- Detail the changes made in this pull request. -->

kvcache_rdma.cpp — post_send_with_retry

- 引入 cur_wr 指针初始化为 wr_list，失败时将其推进到 bad_wr，下次重试从第一个失败的 WR 开始，不重复提交已入队的 WR。
- 每次 retry 前调用 poll_cq_with_timeout 主动排空 CQ，释放 SQ slot。

为什么不用 poll_cq_with_timeout：
ibv_post_send 失败并不保证 CQ 里有可消费的 CQE（如参数/QP 状态类同步错误，或 bad_wr 之前的 WR 均为无信号 WR 尚未产生 completion）。使用 30s 超时的阻塞式 poll 会导致每次 retry 卡住最长 30s，7 次重试共阻塞最多 210 秒。

修改前后对比

```
// 修改前
do {
ret = ibv_post_send(ctx->qp, wr_list, &bad_wr);  // 始终从链表头重试
if (ret != 0) {
usleep(1000);
retries++;
}
} while (retries < max_retries);

// 修改后
struct ibv_send_wr* cur_wr = wr_list;
do {
ret = ibv_post_send(ctx->qp, cur_wr, &bad_wr);
if (ret != 0) {
// 非阻塞排空 CQ，释放 SQ slot，不阻塞等待 CQE
struct ibv_wc wc_array[32];
int n;
while ((n = ibv_poll_cq(ctx->cq, 32, wc_array)) > 0) {}
usleep(1000);
retries++;
if (bad_wr) cur_wr = bad_wr;  // 从失败的 WR 续传
}
} while (retries < max_retries);
```

## Usage or Command

<!-- You should provide the usage if this pr is about the new function. -->
<!-- You should provide the command to run if this pr is about the performance optimization or fixing bug. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [ ] Add at least a tag in the PR title.
- Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
- You can add new tags based on the PR content, but the semantics must be clear.
- [ ] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.