### PR TITLE
[CI] Disable all automatic workflow triggers

### DIFF
--- a/.github/workflows/CheckPRTemplate.yml
+++ b/.github/workflows/CheckPRTemplate.yml
@@ -1,10 +1,12 @@
 name: Check PR Template
 
 on:
-  pull_request:
-    branches:
-      - develop
-      - 'release/*'
+  # Repository is no longer maintained: automatic triggers are disabled.
+  # pull_request:
+  #   branches:
+  #     - develop
+  #     - 'release/*'
+  workflow_dispatch:
 
 jobs:
   check:

--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -1,10 +1,12 @@
 name: Codestyle-Check
 
 on:
-  pull_request:
-    branches:
-      - develop
-      - 'release/*'
+  # Repository is no longer maintained: automatic triggers are disabled.
+  # pull_request:
+  #   branches:
+  #     - develop
+  #     - 'release/*'
+  workflow_dispatch:
 
 jobs:
   pre-commit:

--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -1,10 +1,12 @@
 name: Approval
 
 on:
-  pull_request:
-    branches:
-      - develop
-      - 'release/*'
+  # Repository is no longer maintained: automatic triggers are disabled.
+  # pull_request:
+  #   branches:
+  #     - develop
+  #     - 'release/*'
+  workflow_dispatch:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cancel_ci_iluvatar.yml
+++ b/.github/workflows/cancel_ci_iluvatar.yml
@@ -1,9 +1,11 @@
 name: ILUVATAR-CI
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [develop, release/**]
+  # Repository is no longer maintained: automatic triggers are disabled.
+  # pull_request:
+  #   types: [closed]
+  #   branches: [develop, release/**]
+  workflow_dispatch:
 permissions: read-all
 
 concurrency:

--- a/.github/workflows/cancel_ci_xpu.yml
+++ b/.github/workflows/cancel_ci_xpu.yml
@@ -1,9 +1,11 @@
 name: CI_XPU
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [develop, release/**]
+  # Repository is no longer maintained: automatic triggers are disabled.
+  # pull_request:
+  #   types: [closed]
+  #   branches: [develop, release/**]
+  workflow_dispatch:
 permissions: read-all
 
 concurrency:

--- a/.github/workflows/cancel_pr_build_and_test.yml
+++ b/.github/workflows/cancel_pr_build_and_test.yml
@@ -1,8 +1,10 @@
 name: PR Build and Test
 on:
-  pull_request:
-    types: [closed]
-    branches: [develop, release/**]
+  # Repository is no longer maintained: automatic triggers are disabled.
+  # pull_request:
+  #   types: [closed]
+  #   branches: [develop, release/**]
+  workflow_dispatch:
 permissions: read-all
 
 concurrency:

--- a/.github/workflows/ce_job.yml
+++ b/.github/workflows/ce_job.yml
@@ -1,11 +1,11 @@
 name: CE Compile Job
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - develop
-      - 'release/*'
+  # Repository is no longer maintained: automatic triggers are disabled.
+  # push:
+  #   branches:
+  #     - develop
+  #     - 'release/*'
 permissions: read-all
 
 concurrency:

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,9 +1,11 @@
 name: Cherry Pick
 
 on:
-  pull_request_target:
-    branches: [develop]
-    types: [closed, labeled]
+  # Repository is no longer maintained: automatic triggers are disabled.
+  # pull_request_target:
+  #   branches: [develop]
+  #   types: [closed, labeled]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/ci_hpu.yml
+++ b/.github/workflows/ci_hpu.yml
@@ -2,9 +2,11 @@ name: CI_HPU
 
 on:
   pull_request:
-    branches:
-      - develop
-      - 'release/*'
+  # Repository is no longer maintained: automatic triggers are disabled.
+  # pull_request:
+  #   branches:
+  #     - develop
+  #     - 'release/*'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_iluvatar.yml
+++ b/.github/workflows/ci_iluvatar.yml
@@ -1,8 +1,10 @@
 name: ILUVATAR-CI
 on:
-  pull_request:
-    types: [opened, synchronize]
-    branches: [develop, release/**]
+  # Repository is no longer maintained: automatic triggers are disabled.
+  # pull_request:
+  #   types: [opened, synchronize]
+  #   branches: [develop, release/**]
+  workflow_dispatch:
 permissions: read-all
 
 concurrency:

--- a/.github/workflows/ci_image_update.yml
+++ b/.github/workflows/ci_image_update.yml
@@ -2,8 +2,9 @@ name: CI Images Build
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 18 * * *'   # 2:00 AM China Standard Time (UTC+8)
+  # Repository is no longer maintained: scheduled triggers are disabled.
+  # schedule:
+  #   - cron: '0 18 * * *'   # 2:00 AM China Standard Time (UTC+8)
 
 permissions: read-all
 

--- a/.github/workflows/ci_metax.yml
+++ b/.github/workflows/ci_metax.yml
@@ -1,12 +1,14 @@
 name: CI_METAX
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-    branches:
-      - develop
+  # Repository is no longer maintained: automatic triggers are disabled.
+  # pull_request_target:
+  #   types:
+  #     - opened
+  #     - synchronize
+  #   branches:
+  #     - develop
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci_xpu.yml
+++ b/.github/workflows/ci_xpu.yml
@@ -1,9 +1,11 @@
 name: CI_XPU
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-    branches: [develop, release/**]
+  # Repository is no longer maintained: automatic triggers are disabled.
+  # pull_request:
+  #   types: [opened, synchronize]
+  #   branches: [develop, release/**]
+  workflow_dispatch:
 permissions: read-all
 
 concurrency:

--- a/.github/workflows/pr_build_and_test.yml
+++ b/.github/workflows/pr_build_and_test.yml
@@ -1,8 +1,10 @@
 name: PR Build and Test
 on:
-  pull_request:
-    types: [opened, synchronize]
-    branches: [develop, release/**]
+  # Repository is no longer maintained: automatic triggers are disabled.
+  # pull_request:
+  #   types: [opened, synchronize]
+  #   branches: [develop, release/**]
+  workflow_dispatch:
 permissions: read-all
 
 concurrency:

--- a/.github/workflows/publish_job.yml
+++ b/.github/workflows/publish_job.yml
@@ -2,13 +2,14 @@ name: Publish Job
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 18 * * *'   # 2:00 AM China Standard Time (UTC+8)
-  push:
-    # branches:
-    #   - develop
-    tags:
-      - '*'
+  # Repository is no longer maintained: scheduled and push triggers are disabled.
+  # schedule:
+  #   - cron: '0 18 * * *'   # 2:00 AM China Standard Time (UTC+8)
+  # push:
+  #   branches:
+  #     - develop
+  #   tags:
+  #     - '*'
 
 permissions: read-all
 

--- a/.github/workflows/remove-skip-ci-labels.yml
+++ b/.github/workflows/remove-skip-ci-labels.yml
@@ -1,8 +1,10 @@
 name: Remove Skip-CI Labels
 
 on:
-  pull_request_target:
-    types: [synchronize]
+  # Repository is no longer maintained: automatic triggers are disabled.
+  # pull_request_target:
+  #   types: [synchronize]
+  workflow_dispatch:
 
 permissions:
   pull-requests: write

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,8 +1,10 @@
 name: Re-run
 
 on:
-  issue_comment:
-    types: [created]
+  # Repository is no longer maintained: automatic triggers are disabled.
+  # issue_comment:
+  #   types: [created]
+  workflow_dispatch:
 
 jobs:
   re-run:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/FastDeploy/blob/develop/.github/pull_request_template.md -->

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

FastDeploy is no longer under active development, so the repository no longer requires unattended CI execution.

Continuing to run scheduled and event-triggered workflows would unnecessarily consume CI runner resources and maintain workflows that are no longer actively used. At the same time, keeping `workflow_dispatch` allows workflows to be manually restored or executed if needed in the future.

## Modifications

- Disabled automatic triggers across the 18 affected workflows, including:
  - `pull_request`
  - `pull_request_target`
  - `push`
  - `schedule`
  - `issue_comment`
- Kept only `workflow_dispatch` for manual workflow execution.
- Stopped the two remaining daily scheduled jobs:
  - `ci_image_update.yml`
  - `publish_job.yml`
- Left reusable workflows using `workflow_call` unchanged, as they are no longer reachable from automatically triggered workflows.
- Preserved the existing workflow configuration in a recoverable form instead of deleting the workflows entirely.
- Prevented unattended CI jobs from continuing to consume runner resources.

## Usage or Command
N/A

## Accuracy Tests
N/A

## Checklist

- [x] Add at least a tag in the PR title.
  - Tag list: [`[FDConfig]`,`[APIServer]`,`[Engine]`, `[Scheduler]`, `[PD Disaggregation]`, `[Executor]`, `[Graph Optimization]`, `[Speculative Decoding]`, `[RL]`, `[Models]`, `[Quantization]`, `[Loader]`, `[OP]`, `[KVCache]`, `[DataProcessor]`, `[BugFix]`, `[Docs]`, `[CI]`, `[Optimization]`, `[Feature]`, `[Benchmark]`, `[Others]`, `[XPU]`, `[HPU]`, `[GCU]`, `[DCU]`, `[Iluvatar]`, `[Metax]`]
  - You can add new tags based on the PR content, but the semantics must be clear.
- [x] Format your code, run `pre-commit` before commit.
- [ ] Add unit tests. Please write the reason in this PR if no unit tests.
- [ ] Provide accuracy results.
- [ ] If the current PR is submitting to the `release` branch, make sure the PR has been submitted to the `develop` branch, then cherry-pick it to the `release` branch with the `[Cherry-Pick]` PR tag.
