### PR TITLE
[BugFix][GCU] post_process call sites still use the renamed sampler_output kwarg

### DIFF
--- a/fastdeploy/worker/gcu_model_runner.py
+++ b/fastdeploy/worker/gcu_model_runner.py
@@ -835,7 +835,7 @@ class GCUModelRunner(ModelRunnerBase):
             )
 
             post_process(
-                sampler_output=sampler_output,
+                sampler_or_pooler_output=sampler_output,
                 model_output=model_output_data,
                 share_inputs=self.share_inputs,
                 block_size=self.cache_config.block_size,
@@ -1071,7 +1071,7 @@ class GCUModelRunner(ModelRunnerBase):
         else:
             skip_save_output = False
         post_process(
-            sampler_output=sampler_output,
+            sampler_or_pooler_output=sampler_output,
             model_output=model_output_data,
             share_inputs=self.share_inputs,
             block_size=self.cache_config.block_size,


### PR DESCRIPTION
## Motivation

`fastdeploy/worker/gcu_model_runner.py` calls `post_process` with `sampler_output=`, but `pre_and_post_process.post_process` names that parameter `sampler_or_pooler_output`:

```python
def post_process(
    sampler_or_pooler_output: Union[SamplerOutput, PoolerOutput],
    model_output: ModelOutputData,
    ...
```

so both GCU call sites raise on every step that reaches them:

```
TypeError: post_process() missing 1 required positional argument: 'sampler_or_pooler_output'
```

- `fastdeploy/worker/gcu_model_runner.py:837` (`_dummy_run`)
- `fastdeploy/worker/gcu_model_runner.py:1073` (`execute_model`)

The parameter was renamed when pooling support was added, and the GCU runner is the only backend that was not updated. Every sibling call site already uses the new name:

| runner | call sites | keyword used |
|---|---|---|
| `gpu_model_runner.py` | 1938, 2048, 2668, 2825 | `sampler_or_pooler_output=` ✅ |
| `metax_model_runner.py` | 1571, 1677, 2106, 2239 | `sampler_or_pooler_output=` ✅ |
| `gcu_model_runner.py` | 837, 1073 | `sampler_output=` ❌ |

## Modifications

Rename the keyword at the two GCU call sites. No other change.

Note: the GCU runner also does not forward some of the newer optional `post_process` kwargs that the GPU runner does (`sampling_metadata`, `async_output_queue`, `think_end_id`, `splitwise_role_is_decode`, `enable_entropy`, `routing_replay_manager`). Those all have defaults so they do not crash, and wiring them up is a behaviour change I cannot test on GCU hardware — deliberately out of scope here.

## Verification

No Enflame GCU device available, so I verified at the signature level rather than by running the runner: parsed `pre_and_post_process.py` with `ast`, rebuilt `post_process`'s `inspect.Signature`, and replayed every `post_process` call site in the three runners through `Signature.bind`.

Before:

```
def post_process(sampler_or_pooler_output, model_output, share_inputs, sampling_metadata='<d>', ...)
  worker/gcu_model_runner.py:837    TypeError: missing a required argument: 'sampler_or_pooler_output'
  worker/gcu_model_runner.py:1073   TypeError: missing a required argument: 'sampler_or_pooler_output'
  worker/gpu_model_runner.py:1938   OK
  worker/gpu_model_runner.py:2048   OK
  worker/gpu_model_runner.py:2668   OK
  worker/gpu_model_runner.py:2825   OK
  worker/metax_model_runner.py:1571 OK
  worker/metax_model_runner.py:1677 OK
  worker/metax_model_runner.py:2106 OK
  worker/metax_model_runner.py:2239 OK
```

After: all ten bind cleanly.

`black` (25.1.0 config, line-length 119) and `ruff check --config pyproject.toml` both report no changes for the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
